### PR TITLE
Move type.{h,cc} and attr.{h,cc}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,4 +20,4 @@ set(SOURCES
   lib/parser/source.cc
 )
 add_executable(f18 ${SOURCES})
-add_executable(type-test type.cc attr.cc lib/parser/idioms.cc)
+add_executable(type-test lib/semantics/type.cc lib/semantics/attr.cc lib/parser/idioms.cc)

--- a/lib/semantics/attr.cc
+++ b/lib/semantics/attr.cc
@@ -4,6 +4,7 @@
 #include <string>
 
 namespace Fortran {
+namespace semantics {
 
 std::ostream &operator<<(std::ostream &o, Attr attr) {
   switch (attr) {
@@ -33,7 +34,9 @@ std::ostream &operator<<(std::ostream &o, Attr attr) {
 std::ostream &operator<<(std::ostream &o, const Attrs &attrs) {
   int n = 0;
   for (auto attr : attrs) {
-    if (n++) { o << ", "; }
+    if (n++) {
+      o << ", ";
+    }
     o << attr;
   }
   return o;
@@ -50,4 +53,5 @@ void checkAttrs(std::string className, Attrs attrs, Attrs allowed) {
   }
 }
 
+}  // namespace semantics
 }  // namespace Fortran

--- a/lib/semantics/attr.h
+++ b/lib/semantics/attr.h
@@ -1,12 +1,13 @@
 #ifndef FORTRAN_ATTR_H_
 #define FORTRAN_ATTR_H_
 
-#include "lib/parser/idioms.h"
+#include "../parser/idioms.h"
 #include <iostream>
 #include <set>
 #include <string>
 
 namespace Fortran {
+namespace semantics {
 
 // All available attributes.
 enum class Attr {
@@ -39,6 +40,7 @@ std::ostream &operator<<(std::ostream &o, const Attrs &attrs);
 // Report internal error if attrs is not a subset of allowed.
 void checkAttrs(std::string className, Attrs attrs, Attrs allowed);
 
+}  // namespace semantics
 }  // namespace Fortran
 
 #endif

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -4,6 +4,7 @@
 #include <iostream>
 
 namespace Fortran {
+namespace semantics {
 
 // Check that values specified for param defs are valid: they must match the
 // names of the params and any def that doesn't have a default value must have a
@@ -16,8 +17,8 @@ static void checkParams(
     Name name = def.name();
     validNames.insert(name);
     if (!def.defaultValue() && values.find(name) == values.end()) {
-      parser::die("no value or default value for %s parameter '%s'", kindOrLen.c_str(),
-          name.c_str());
+      parser::die("no value or default value for %s parameter '%s'",
+          kindOrLen.c_str(), name.c_str());
     }
   }
   for (auto pair : values) {
@@ -103,11 +104,15 @@ std::ostream &operator<<(std::ostream &o, const DerivedTypeDef &x) {
     o << '(';
     int n = 0;
     for (auto param : x.lenParams_) {
-      if (n++) { o << ", "; }
+      if (n++) {
+        o << ", ";
+      }
       o << param.name();
     }
     for (auto param : x.kindParams_) {
-      if (n++) { o << ", "; }
+      if (n++) {
+        o << ", ";
+      }
       o << param.name();
     }
     o << ')';
@@ -119,8 +124,12 @@ std::ostream &operator<<(std::ostream &o, const DerivedTypeDef &x) {
   for (auto param : x.kindParams_) {
     o << "  " << param.type() << ", KIND :: " << param.name() << "\n";
   }
-  if (x.private_) { o << "  PRIVATE\n"; }
-  if (x.sequence_) { o << "  SEQUENCE\n"; }
+  if (x.private_) {
+    o << "  PRIVATE\n";
+  }
+  if (x.sequence_) {
+    o << "  SEQUENCE\n";
+  }
   // components
   return o << "END TYPE\n";
 }
@@ -139,11 +148,15 @@ std::ostream &operator<<(std::ostream &o, const DerivedTypeSpec &x) {
     o << '(';
     int n = 0;
     for (auto pair : x.kindParamValues_) {
-      if (n++) { o << ", "; }
+      if (n++) {
+        o << ", ";
+      }
       o << pair.first << '=' << pair.second;
     }
     for (auto pair : x.lenParamValues_) {
-      if (n++) { o << ", "; }
+      if (n++) {
+        o << ", ";
+      }
       o << pair.first << '=' << pair.second;
     }
     o << ')';
@@ -171,16 +184,21 @@ std::ostream &operator<<(std::ostream &o, const ShapeSpec &x) {
     CHECK(x.ub_.isAssumed());
     o << "..";
   } else {
-    if (!x.lb_.isDeferred()) { o << x.lb_; }
+    if (!x.lb_.isDeferred()) {
+      o << x.lb_;
+    }
     o << ':';
-    if (!x.ub_.isDeferred()) { o << x.ub_; }
+    if (!x.ub_.isDeferred()) {
+      o << x.ub_;
+    }
   }
   return o;
 }
 
+}  // namespace semantics
 }  // namespace Fortran
 
-using namespace Fortran;
+using namespace Fortran::semantics;
 
 void testTypeSpec() {
   LogicalTypeSpec l1 = LogicalTypeSpec::make();

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -1,8 +1,8 @@
 #ifndef FORTRAN_TYPE_H_
 #define FORTRAN_TYPE_H_
 
+#include "../parser/idioms.h"
 #include "attr.h"
-#include "lib/parser/idioms.h"
 #include <algorithm>
 #include <list>
 #include <map>
@@ -41,6 +41,7 @@ that supplied attributes are among the allowed ones using checkAttrs().
 */
 
 namespace Fortran {
+namespace semantics {
 
 using Name = std::string;
 
@@ -65,6 +66,7 @@ public:
   virtual std::ostream &output(std::ostream &o) const {
     return o << this->value_;
   }
+
 private:
   static std::unordered_map<int, IntConst> cache;
   IntConst(int value) : value_{value} {}
@@ -388,6 +390,7 @@ private:
   const Bound ub_;
 };
 
+}  // namespace semantics
 }  // namespace Fortran
 
 #endif


### PR DESCRIPTION
The are now in new namespace and directory, "semantics", similar to
"parser".