### PR TITLE
Ensure that the parse tree visitation Walk template works on FORMAT.

### DIFF
--- a/lib/parser/format-specification.h
+++ b/lib/parser/format-specification.h
@@ -17,6 +17,7 @@
 #include <variant>
 
 namespace Fortran {
+namespace format {
 
 // R1307 data-edit-desc (part 1 of 2) ->
 //         I w [. m] | B w [. m] | O w [. m] | Z w [. m] | F w . d |
@@ -129,5 +130,6 @@ struct FormatSpecification {
     : items(std::move(is)), unlimitedItems(std::move(us)) {}
   std::list<FormatItem> items, unlimitedItems;
 };
+}  // namespace format
 }  // namespace Fortran
 #endif  // FORTRAN_FORMAT_SPECIFICATION_H_

--- a/lib/parser/parse-tree-visitor.h
+++ b/lib/parser/parse-tree-visitor.h
@@ -1,7 +1,6 @@
 #ifndef FORTRAN_PARSER_PARSE_TREE_VISITOR_H_
 #define FORTRAN_PARSER_PARSE_TREE_VISITOR_H_
 
-#include "format-specification.h"
 #include "parse-tree.h"
 #include <optional>
 #include <tuple>
@@ -27,6 +26,12 @@ Walk(const A &x, V &visitor) {
     visitor.Post(x);
   }
 }
+
+template<typename V> void Walk(const format::ControlEditDesc &, V &);
+template<typename V> void Walk(const format::DerivedTypeDataEditDesc &, V &);
+template<typename V> void Walk(const format::FormatItem &, V &);
+template<typename V> void Walk(const format::FormatSpecification &, V &);
+template<typename V> void Walk(const format::IntrinsicTypeDataEditDesc &, V &);
 
 // Traversal of needed STL template classes (optional, list, tuple, variant)
 template<typename T, typename V>
@@ -173,44 +178,6 @@ template<typename V> void Walk(const DeclarationTypeSpec::Type &x, V &visitor) {
     visitor.Post(x);
   }
 }
-template<typename V> void Walk(const Fortran::ControlEditDesc &x, V &visitor) {
-  if (visitor.Pre(x)) {
-    Walk(x.kind, visitor);
-    visitor.Post(x);
-  }
-}
-template<typename V>
-void Walk(const Fortran::DerivedTypeDataEditDesc &x, V &visitor) {
-  if (visitor.Pre(x)) {
-    Walk(x.type, visitor);
-    Walk(x.parameters, visitor);
-    visitor.Post(x);
-  }
-}
-template<typename V> void Walk(const Fortran::FormatItem &x, V &visitor) {
-  if (visitor.Pre(x)) {
-    Walk(x.repeatCount, visitor);
-    Walk(x.u, visitor);
-    visitor.Post(x);
-  }
-}
-template<typename V> void Walk(const FormatSpecification &x, V &visitor) {
-  if (visitor.Pre(x)) {
-    Walk(x.items, visitor);
-    Walk(x.unlimitedItems, visitor);
-    visitor.Post(x);
-  }
-}
-template<typename V>
-void Walk(const Fortran::IntrinsicTypeDataEditDesc &x, V &visitor) {
-  if (visitor.Pre(x)) {
-    Walk(x.kind, visitor);
-    Walk(x.width, visitor);
-    Walk(x.digits, visitor);
-    Walk(x.exponentWidth, visitor);
-    visitor.Post(x);
-  }
-}
 template<typename V> void Walk(const ImportStmt &x, V &visitor) {
   if (visitor.Pre(x)) {
     Walk(x.names, visitor);
@@ -324,6 +291,45 @@ template<typename V> void Walk(const WriteStmt &x, V &visitor) {
     Walk(x.format, visitor);
     Walk(x.controls, visitor);
     Walk(x.items, visitor);
+    visitor.Post(x);
+  }
+}
+template<typename V> void Walk(const format::ControlEditDesc &x, V &visitor) {
+  if (visitor.Pre(x)) {
+    Walk(x.kind, visitor);
+    visitor.Post(x);
+  }
+}
+template<typename V>
+void Walk(const format::DerivedTypeDataEditDesc &x, V &visitor) {
+  if (visitor.Pre(x)) {
+    Walk(x.type, visitor);
+    Walk(x.parameters, visitor);
+    visitor.Post(x);
+  }
+}
+template<typename V> void Walk(const format::FormatItem &x, V &visitor) {
+  if (visitor.Pre(x)) {
+    Walk(x.repeatCount, visitor);
+    Walk(x.u, visitor);
+    visitor.Post(x);
+  }
+}
+template<typename V>
+void Walk(const format::FormatSpecification &x, V &visitor) {
+  if (visitor.Pre(x)) {
+    Walk(x.items, visitor);
+    Walk(x.unlimitedItems, visitor);
+    visitor.Post(x);
+  }
+}
+template<typename V>
+void Walk(const format::IntrinsicTypeDataEditDesc &x, V &visitor) {
+  if (visitor.Pre(x)) {
+    Walk(x.kind, visitor);
+    Walk(x.width, visitor);
+    Walk(x.digits, visitor);
+    Walk(x.exponentWidth, visitor);
     visitor.Post(x);
   }
 }

--- a/lib/parser/parse-tree.cc
+++ b/lib/parser/parse-tree.cc
@@ -306,7 +306,8 @@ std::ostream &operator<<(std::ostream &o, const Rename::Names &x) {  // R1411
 #undef TUPLE_FORMATTER
 
 // R1302 format-specification
-std::ostream &operator<<(std::ostream &o, const FormatSpecification &x) {
+std::ostream &operator<<(
+    std::ostream &o, const format::FormatSpecification &x) {
   return o << "(FormatSpecification " << x.items << ' ' << x.unlimitedItems
            << ')';
 }
@@ -821,22 +822,23 @@ std::ostream &operator<<(std::ostream &o, const CaseValueRange::Range &x) {
 }
 
 // R1307 data-edit-desc (part 1 of 2)
-std::ostream &operator<<(std::ostream &o, const IntrinsicTypeDataEditDesc &x) {
+std::ostream &operator<<(
+    std::ostream &o, const format::IntrinsicTypeDataEditDesc &x) {
   o << "(IntrinsicTypeDataEditDesc ";
   switch (x.kind) {
-  case IntrinsicTypeDataEditDesc::Kind::I: o << "I "; break;
-  case IntrinsicTypeDataEditDesc::Kind::B: o << "B "; break;
-  case IntrinsicTypeDataEditDesc::Kind::O: o << "O "; break;
-  case IntrinsicTypeDataEditDesc::Kind::Z: o << "Z "; break;
-  case IntrinsicTypeDataEditDesc::Kind::F: o << "F "; break;
-  case IntrinsicTypeDataEditDesc::Kind::E: o << "E "; break;
-  case IntrinsicTypeDataEditDesc::Kind::EN: o << "EN "; break;
-  case IntrinsicTypeDataEditDesc::Kind::ES: o << "ES "; break;
-  case IntrinsicTypeDataEditDesc::Kind::EX: o << "EX "; break;
-  case IntrinsicTypeDataEditDesc::Kind::G: o << "G "; break;
-  case IntrinsicTypeDataEditDesc::Kind::L: o << "L "; break;
-  case IntrinsicTypeDataEditDesc::Kind::A: o << "A "; break;
-  case IntrinsicTypeDataEditDesc::Kind::D: o << "D "; break;
+  case format::IntrinsicTypeDataEditDesc::Kind::I: o << "I "; break;
+  case format::IntrinsicTypeDataEditDesc::Kind::B: o << "B "; break;
+  case format::IntrinsicTypeDataEditDesc::Kind::O: o << "O "; break;
+  case format::IntrinsicTypeDataEditDesc::Kind::Z: o << "Z "; break;
+  case format::IntrinsicTypeDataEditDesc::Kind::F: o << "F "; break;
+  case format::IntrinsicTypeDataEditDesc::Kind::E: o << "E "; break;
+  case format::IntrinsicTypeDataEditDesc::Kind::EN: o << "EN "; break;
+  case format::IntrinsicTypeDataEditDesc::Kind::ES: o << "ES "; break;
+  case format::IntrinsicTypeDataEditDesc::Kind::EX: o << "EX "; break;
+  case format::IntrinsicTypeDataEditDesc::Kind::G: o << "G "; break;
+  case format::IntrinsicTypeDataEditDesc::Kind::L: o << "L "; break;
+  case format::IntrinsicTypeDataEditDesc::Kind::A: o << "A "; break;
+  case format::IntrinsicTypeDataEditDesc::Kind::D: o << "D "; break;
   default: CRASH_NO_CASE;
   }
   return o << x.width << ' ' << x.digits << ' ' << x.exponentWidth << ')';
@@ -855,41 +857,42 @@ std::ostream &operator<<(std::ostream &o, const WriteStmt &x) {
 }
 
 // R1307 data-edit-desc (part 2 of 2)
-std::ostream &operator<<(std::ostream &o, const DerivedTypeDataEditDesc &x) {
+std::ostream &operator<<(
+    std::ostream &o, const format::DerivedTypeDataEditDesc &x) {
   return o << "(DerivedTypeDataEditDesc " << x.type << ' ' << x.parameters
            << ')';
 }
 
 // R1313 control-edit-desc
-std::ostream &operator<<(std::ostream &o, const ControlEditDesc &x) {
+std::ostream &operator<<(std::ostream &o, const format::ControlEditDesc &x) {
   o << "(ControlEditDesc ";
   switch (x.kind) {
-  case ControlEditDesc::Kind::T: o << "T "; break;
-  case ControlEditDesc::Kind::TL: o << "TL "; break;
-  case ControlEditDesc::Kind::TR: o << "TR "; break;
-  case ControlEditDesc::Kind::X: o << "X "; break;
-  case ControlEditDesc::Kind::Slash: o << "/ "; break;
-  case ControlEditDesc::Kind::Colon: o << ": "; break;
-  case ControlEditDesc::Kind::SS: o << "SS "; break;
-  case ControlEditDesc::Kind::SP: o << "SP "; break;
-  case ControlEditDesc::Kind::S: o << "S "; break;
-  case ControlEditDesc::Kind::P: o << "P "; break;
-  case ControlEditDesc::Kind::BN: o << "BN "; break;
-  case ControlEditDesc::Kind::BZ: o << "BZ "; break;
-  case ControlEditDesc::Kind::RU: o << "RU "; break;
-  case ControlEditDesc::Kind::RD: o << "RD "; break;
-  case ControlEditDesc::Kind::RN: o << "RN "; break;
-  case ControlEditDesc::Kind::RC: o << "RC "; break;
-  case ControlEditDesc::Kind::RP: o << "RP "; break;
-  case ControlEditDesc::Kind::DC: o << "DC "; break;
-  case ControlEditDesc::Kind::DP: o << "DP "; break;
+  case format::ControlEditDesc::Kind::T: o << "T "; break;
+  case format::ControlEditDesc::Kind::TL: o << "TL "; break;
+  case format::ControlEditDesc::Kind::TR: o << "TR "; break;
+  case format::ControlEditDesc::Kind::X: o << "X "; break;
+  case format::ControlEditDesc::Kind::Slash: o << "/ "; break;
+  case format::ControlEditDesc::Kind::Colon: o << ": "; break;
+  case format::ControlEditDesc::Kind::SS: o << "SS "; break;
+  case format::ControlEditDesc::Kind::SP: o << "SP "; break;
+  case format::ControlEditDesc::Kind::S: o << "S "; break;
+  case format::ControlEditDesc::Kind::P: o << "P "; break;
+  case format::ControlEditDesc::Kind::BN: o << "BN "; break;
+  case format::ControlEditDesc::Kind::BZ: o << "BZ "; break;
+  case format::ControlEditDesc::Kind::RU: o << "RU "; break;
+  case format::ControlEditDesc::Kind::RD: o << "RD "; break;
+  case format::ControlEditDesc::Kind::RN: o << "RN "; break;
+  case format::ControlEditDesc::Kind::RC: o << "RC "; break;
+  case format::ControlEditDesc::Kind::RP: o << "RP "; break;
+  case format::ControlEditDesc::Kind::DC: o << "DC "; break;
+  case format::ControlEditDesc::Kind::DP: o << "DP "; break;
   default: CRASH_NO_CASE;
   }
   return o << x.count << ')';
 }
 
 // R1304 format-item
-std::ostream &operator<<(std::ostream &o, const FormatItem &x) {
+std::ostream &operator<<(std::ostream &o, const format::FormatItem &x) {
   o << "(FormatItem " << x.repeatCount;
   std::visit([&o](const auto &y) { o << y; }, x.u);
   return o << ')';

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -7,7 +7,7 @@
 // that are transcribed here and referenced via their requirement numbers.
 // The representations of some productions that may also be of use in the
 // run-time I/O support library have been isolated into a distinct header file
-// (viz. format-specification.h).
+// (viz., format-specification.h).
 
 #include "format-specification.h"
 #include "idioms.h"
@@ -118,7 +118,6 @@ struct WhereConstruct;  // R1042
 struct ForallConstruct;  // R1050
 struct InputImpliedDo;  // R1218
 struct OutputImpliedDo;  // R1218
-struct FormatItems;  // R1303
 struct FunctionReference;  // R1520
 struct FunctionSubprogram;  // R1529
 struct SubroutineSubprogram;  // R1534
@@ -2706,7 +2705,7 @@ struct InquireStmt {
 };
 
 // R1301 format-stmt -> FORMAT format-specification
-WRAPPER_CLASS(FormatStmt, FormatSpecification);
+WRAPPER_CLASS(FormatStmt, format::FormatSpecification);
 
 // R1402 program-stmt -> PROGRAM program-name
 WRAPPER_CLASS(ProgramStmt, Name);

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -1,6 +1,4 @@
 #include "unparse.h"
-
-#include "format-specification.h"
 #include "idioms.h"
 #include "indirection.h"
 #include "parse-tree-visitor.h"


### PR DESCRIPTION
The classes that were segregated into format-specification.h have
also been grouped into a new Fortran::format namespace.
Code added to tools/f18/f18.cc to run a minimal visitor over
the parse trees resulting from successful parses so that any
future build problems with Walk() will be caught earlier.