### PR TITLE
Avoid most uses of Boolean-valued Pre() callbacks in unparse.cc.

### DIFF
--- a/lib/parser/parse-tree-visitor.h
+++ b/lib/parser/parse-tree-visitor.h
@@ -9,7 +9,7 @@
 #include <variant>
 
 /// Parse tree visitor
-/// Call Walk(x, visitor) to visit each node under x.
+/// Call Walk(x, visitor) to visit x and, by default, each node under x.
 ///
 /// visitor.Pre(x) is called before visiting x and its children are not
 /// visited if it returns false.


### PR DESCRIPTION
I  found that I was prone to error with the Boolean result values returned from the Pre() callback functions in unparse.cc when I was completing that code, and had a mental TODO to see whether I could get the same job done by using distinct member function names instead of Boolean results.  This pull request replaces most of the Pre() callback member functions in unparse.cc with Before() and Unparse() member functions, and I think that it may avoid future bugs when these are updated.  The technique might also be of value to other clients of the parse tree walker that might be written.

No rush, this PR doesn't actually fix anything.