### PR TITLE
Improve include file sorting.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,6 +12,15 @@ AlignTrailingComments: false
 ConstructorInitializerIndentWidth: 2
 SpaceAfterTemplateKeyword: false
 SpacesBeforeTrailingComments: 2
+IncludeCategories:
+  - Regex:           '^<'
+    Priority:        4
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        3
+  - Regex:           '^"\.\./'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        1
 ...
 
 # vim:set filetype=yaml:

--- a/lib/semantics/LabelTable.h
+++ b/lib/semantics/LabelTable.h
@@ -1,8 +1,8 @@
 #ifndef  FORTRAN_LABEL_TABLE_H_
 #define  FORTRAN_LABEL_TABLE_H_
 
-#include <stack>
 #include <cassert>
+#include <stack>
 
 namespace Fortran::semantics {
 

--- a/lib/semantics/ParseTreeDump.h
+++ b/lib/semantics/ParseTreeDump.h
@@ -7,11 +7,10 @@
 #include "../parser/parse-tree-visitor.h"
 #include "../parser/parse-tree.h"
 
-
-#include <string>
 #include <cstring>
-#include <iostream>
 #include <iomanip>
+#include <iostream>
+#include <string>
 
 namespace Fortran::semantics {
 

--- a/lib/semantics/attr.cc
+++ b/lib/semantics/attr.cc
@@ -1,5 +1,5 @@
-#include "../parser/idioms.h"
 #include "attr.h"
+#include "../parser/idioms.h"
 #include <stddef.h>
 
 namespace Fortran {

--- a/lib/semantics/attr.h
+++ b/lib/semantics/attr.h
@@ -1,8 +1,8 @@
 #ifndef FORTRAN_ATTR_H_
 #define FORTRAN_ATTR_H_
 
-#include "../parser/idioms.h"
 #include "enum-set.h"
+#include "../parser/idioms.h"
 #include <cinttypes>
 #include <iostream>
 #include <string>

--- a/lib/semantics/make-types.cc
+++ b/lib/semantics/make-types.cc
@@ -1,7 +1,6 @@
 #include "make-types.h"
 #include "attr.h"
 #include "type.h"
-
 #include "../parser/idioms.h"
 #include "../parser/parse-tree-visitor.h"
 #include "../parser/parse-tree.h"

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -1,10 +1,10 @@
-#include "../parser/indirection.h"
-#include "../parser/parse-tree-visitor.h"
-#include "../parser/parse-tree.h"
 #include "attr.h"
 #include "scope.h"
 #include "symbol.h"
 #include "type.h"
+#include "../parser/indirection.h"
+#include "../parser/parse-tree-visitor.h"
+#include "../parser/parse-tree.h"
 #include <iostream>
 #include <list>
 #include <memory>

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -1,10 +1,10 @@
 #ifndef FORTRAN_SEMANTICS_SCOPE_H_
 #define FORTRAN_SEMANTICS_SCOPE_H_
 
-#include "../parser/idioms.h"
-#include "../parser/parse-tree.h"
 #include "attr.h"
 #include "symbol.h"
+#include "../parser/idioms.h"
+#include "../parser/parse-tree.h"
 #include <list>
 #include <map>
 #include <string>

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -1,6 +1,6 @@
 #include "symbol.h"
-#include "../parser/idioms.h"
 #include "scope.h"
+#include "../parser/idioms.h"
 #include <memory>
 
 namespace Fortran::semantics {

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -1,9 +1,9 @@
 #ifndef FORTRAN_TYPE_H_
 #define FORTRAN_TYPE_H_
 
+#include "attr.h"
 #include "../parser/idioms.h"
 #include "../parser/parse-tree.h"
-#include "attr.h"
 #include <list>
 #include <map>
 #include <memory>

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -2,8 +2,8 @@
 
 #include "../../lib/parser/characters.h"
 #include "../../lib/parser/message.h"
-#include "../../lib/parser/parse-tree.h"
 #include "../../lib/parser/parse-tree-visitor.h"
+#include "../../lib/parser/parse-tree.h"
 #include "../../lib/parser/parsing.h"
 #include "../../lib/parser/provenance.h"
 #include "../../lib/parser/unparse.h"
@@ -15,11 +15,11 @@
 #include <list>
 #include <memory>
 #include <optional>
-#include <string>
-#include <vector>
 #include <stdlib.h>
-#include <unistd.h>
+#include <string>
 #include <sys/wait.h>
+#include <unistd.h>
+#include <vector>
 
 static std::list<std::string> argList(int argc, char *const argv[]) {
   std::list<std::string> result;

--- a/tools/f18/test-sema.cc
+++ b/tools/f18/test-sema.cc
@@ -6,8 +6,8 @@
 #include <list>
 #include <optional>
 #include <sstream>
-#include <string>
 #include <stddef.h>
+#include <string>
 
 using namespace Fortran;
 using namespace parser;


### PR DESCRIPTION
Includes like "../dir/file.h" should sort after local includes.
This change fixes that and applies the new formatting.

Now the order (in reverse) is:
- system includes
- includes from llvm or clang (this is from the default IncludeCategories)
- includes of ../something
- everything else