### PR TITLE
Resolve array specifications of entities.

### DIFF
--- a/lib/semantics/make-types.cc
+++ b/lib/semantics/make-types.cc
@@ -189,7 +189,7 @@ public:
     // use the array spec in the decl if present
     const auto &arraySpec = arraySpec_ && !arraySpec_->empty()
         ? *arraySpec_
-        : attrArraySpec_ ? *attrArraySpec_ : ComponentArraySpec{};
+        : attrArraySpec_ ? *attrArraySpec_ : ArraySpec{};
     builder_->dataComponent(
         DataComponentDef(*declTypeSpec_, name.ToString(), *attrs_, arraySpec));
     arraySpec_.reset();

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -5,6 +5,32 @@
 
 namespace Fortran::semantics {
 
+void EntityDetails::set_type(const DeclTypeSpec &type) {
+  CHECK(!type_);
+  type_ = type;
+}
+
+void EntityDetails::set_shape(const ArraySpec &shape) {
+  CHECK(shape_.empty());
+  for (const auto &shapeSpec : shape) {
+    shape_.push_back(shapeSpec);
+  }
+}
+
+std::ostream &operator<<(std::ostream &os, const EntityDetails &x) {
+  os << "Entity";
+  if (x.type()) {
+    os << " type: " << *x.type();
+  }
+  if (!x.shape().empty()) {
+    os << " shape:";
+    for (const auto &s : x.shape()) {
+      os << ' ' << s;
+    }
+  }
+  return os;
+}
+
 std::ostream &operator<<(std::ostream &os, const Symbol &sym) {
   os << sym.name_.ToString();
   if (!sym.attrs().empty()) {
@@ -28,12 +54,7 @@ std::ostream &operator<<(std::ostream &os, const Symbol &sym) {
               os << " result(" << x.resultName()->ToString() << ')';
             }
           },
-          [&](const EntityDetails &x) {
-            os << " Entity";
-            if (x.type()) {
-              os << " type: " << *x.type();
-            }
-          },
+          [&](const EntityDetails &x) { os << ' ' << x; },
       },
       sym.details_);
   return os;

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -8,7 +8,7 @@
 namespace Fortran::semantics {
 
 /// A SourceName is a name in the cooked character stream,
-/// i.e. a range of characters with provenance.
+/// i.e. a range of lower-case characters with provenance.
 using SourceName = parser::CharBlock;
 
 /// A Symbol consists of common information (name, owner, and attributes)
@@ -49,12 +49,15 @@ class EntityDetails {
 public:
   EntityDetails(bool isDummy = false) : isDummy_{isDummy} {}
   const std::optional<DeclTypeSpec> &type() const { return type_; }
-  void set_type(const DeclTypeSpec &type) { type_ = type; };
+  void set_type(const DeclTypeSpec &type);
+  const ArraySpec &shape() const { return shape_; }
+  void set_shape(const ArraySpec &shape);
   bool isDummy() const { return isDummy_; }
 
 private:
   bool isDummy_;
   std::optional<DeclTypeSpec> type_;
+  ArraySpec shape_;
   friend std::ostream &operator<<(std::ostream &, const EntityDetails &);
 };
 
@@ -71,7 +74,7 @@ public:
     : owner_{owner}, name_{name}, attrs_{attrs},
       details_{std::move(details)} {}
   const Scope &owner() const { return owner_; }
-  const SourceName &name() { return name_; }
+  const SourceName &name() const { return name_; }
   Attrs &attrs() { return attrs_; }
   const Attrs &attrs() const { return attrs_; }
 

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -188,7 +188,7 @@ std::ostream &operator<<(std::ostream &o, const DataComponentDef &x) {
 }
 
 DataComponentDef::DataComponentDef(const DeclTypeSpec &type, const Name &name,
-    const Attrs &attrs, const ComponentArraySpec &arraySpec)
+    const Attrs &attrs, const ArraySpec &arraySpec)
   : type_{type}, name_{name}, attrs_{attrs}, arraySpec_{arraySpec} {
   attrs.CheckValid({Attr::PUBLIC, Attr::PRIVATE, Attr::ALLOCATABLE,
       Attr::POINTER, Attr::CONTIGUOUS});

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -334,7 +334,7 @@ private:
   friend std::ostream &operator<<(std::ostream &, const ShapeSpec &);
 };
 
-using ComponentArraySpec = std::list<ShapeSpec>;
+using ArraySpec = std::list<ShapeSpec>;
 
 class DataComponentDef {
 public:
@@ -344,9 +344,9 @@ public:
   // TODO: component-initialization
   DataComponentDef(
       const DeclTypeSpec &type, const Name &name, const Attrs &attrs)
-    : DataComponentDef(type, name, attrs, ComponentArraySpec{}) {}
+    : DataComponentDef(type, name, attrs, ArraySpec{}) {}
   DataComponentDef(const DeclTypeSpec &type, const Name &name,
-      const Attrs &attrs, const ComponentArraySpec &arraySpec);
+      const Attrs &attrs, const ArraySpec &arraySpec);
 
   const DeclTypeSpec &type() const { return type_; }
   const Name &name() const { return name_; }
@@ -357,7 +357,7 @@ private:
   const DeclTypeSpec type_;
   const Name name_;
   const Attrs attrs_;
-  const ComponentArraySpec arraySpec_;
+  const ArraySpec arraySpec_;
   friend std::ostream &operator<<(std::ostream &, const DataComponentDef &);
 };
 

--- a/test/semantics/resolve01.f90
+++ b/test/semantics/resolve01.f90
@@ -1,4 +1,4 @@
 integer :: x
-!ERROR: 'x' already has a type declared
+!ERROR: The type of 'x' has already been declared
 real :: x
 end

--- a/test/semantics/resolve07.f90
+++ b/test/semantics/resolve07.f90
@@ -1,0 +1,21 @@
+subroutine s1
+  integer :: x(2)
+  !ERROR: The dimensions of 'x' have already been declared
+  allocatable :: x(:)
+end
+
+subroutine s2
+  target :: x(1)
+  !ERROR: The dimensions of 'x' have already been declared
+  integer :: x(2)
+end
+
+subroutine s3
+  dimension :: x(4), y(8)
+  !ERROR: The dimensions of 'x' have already been declared
+  allocatable :: x(:)
+end
+
+subroutine s4
+  integer, dimension(10) :: x(2,2), y
+end


### PR DESCRIPTION
Add ArraySpecVisitor to recognize the various forms of array specifications.
They are tracked in arraySpec_ and attrArraySpec_. Both are needed because
a declaration like `integer, dimension(4) :: x(2,2), y` has two different
array-specs.

The method DeclareEntity was extracted out to handle the common part for
EntityDecl, ObjectDecl, and DimensionStmt. AllocatableStmt and TargetStmt
are now handled through their contained ObjectDecl.

The test resolve07 checks the interactions between these kinds of declarations.

Rename ComponentArraySpec to ArraySpec as it doesn't just occur in components.

Fix some 'begin' and 'end' methods to start with upper-case letters.