### PR TITLE
Add Visit() helper to replace std::visit+visitors.

### DIFF
--- a/lib/parser/idioms.h
+++ b/lib/parser/idioms.h
@@ -50,6 +50,20 @@ template<typename... LAMBDAS> struct visitors : LAMBDAS... {
 
 template<typename... LAMBDAS> visitors(LAMBDAS... x)->visitors<LAMBDAS...>;
 
+// Helper function for common case of std::vist with visitors.
+// E.g.: Visit(structure.unionMember,
+//         [&](const UnaryExpr &x) { ... },
+//         [&](const BinaryExpr &x) { ... },
+//         ...);
+template<typename... Ts, typename... LAMBDAS>
+constexpr decltype(auto) Visit(std::variant<Ts...> &u, LAMBDAS... x) {
+  return std::visit(visitors<LAMBDAS...>{x...}, u);
+}
+template<typename... Ts, typename... LAMBDAS>
+constexpr decltype(auto) Visit(const std::variant<Ts...> &u, LAMBDAS... x) {
+  return std::visit(visitors<LAMBDAS...>{x...}, u);
+}
+
 // Calls std::fprintf(stderr, ...), then abort().
 [[noreturn]] void die(const char *, ...);
 


### PR DESCRIPTION
`Visit(variant, lambda1, lambda2, ...)` is a utility function that is
equivalent to `std::visit(visitors{lambda1, lambda2, ...}, variant)`.

The advantages of using it are:
- clang-format is less likely to make a mess formatting them
- it saves 4 spaces of indentation (or more) and 2 or 3 lines when formatted
- the variant argument is at the beginning instead of lost after the lambdas

The disadvantage is that it is not standard like `std::visit` is. But in
order to use `std::visit` we have to use the non-standard `visitors` class,
so it's not fully standard anyway.