### PR TITLE
Create Message instances with provenance range.

### DIFF
--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -681,18 +681,18 @@ void MessageHandler::Say(Message &&x) { messages_.Put(std::move(x)); }
 
 void MessageHandler::Say(parser::MessageFixedText &&x) {
   CHECK(currStmtSource_);
-  messages_.Put(Message{currStmtSource_->begin(), std::move(x)});
+  messages_.Put(Message{*currStmtSource_, std::move(x)});
 }
 
 void MessageHandler::Say(parser::MessageFormattedText &&x) {
   CHECK(currStmtSource_);
-  messages_.Put(Message{currStmtSource_->begin(), std::move(x)});
+  messages_.Put(Message{*currStmtSource_, std::move(x)});
 }
 
 void MessageHandler::Say(
     const parser::CharBlock &source, parser::MessageFixedText &&msg) {
-  Say(parser::Message{source.begin(),
-      parser::MessageFormattedText{msg, source.ToString().c_str()}});
+  Say(parser::Message{
+      source, parser::MessageFormattedText{msg, source.ToString().c_str()}});
 }
 void MessageHandler::Say(
     const parser::Name &name, parser::MessageFixedText &&msg) {


### PR DESCRIPTION
This allows the message to point to the full name or statement
rather than just the first character.