### PR TITLE
Use braces in `auto` initializers in lib/{parser,common,evaluate}

### DIFF
--- a/documentation/C++style.md
+++ b/documentation/C++style.md
@@ -106,6 +106,7 @@ Use `{braced initializers}` in all circumstances where they work, including
 default data member initialization.  They inhibit implicit truncation.
 Don't use `= expr` initialization just to effect implicit truncation;
 prefer an explicit `static_cast<>`.
+With C++17, braced initializers work fine with `auto` too.
 1. Avoid unsigned types apart from `size_t`, which must be used with care.
 When `int` just obviously works, just use `int`.  When you need something
 bigger than `int`, use `std::int64_t` rather than `long` or `long long`.

--- a/lib/common/indirection.h
+++ b/lib/common/indirection.h
@@ -47,7 +47,7 @@ public:
   }
   Indirection &operator=(Indirection &&that) {
     CHECK(that.p_ && "move assignment of null Indirection to Indirection");
-    auto tmp = p_;
+    auto tmp{p_};
     p_ = that.p_;
     that.p_ = tmp;
     return *this;
@@ -95,7 +95,7 @@ public:
   }
   Indirection &operator=(Indirection &&that) {
     CHECK(that.p_ && "move assignment of null Indirection to Indirection");
-    auto tmp = p_;
+    auto tmp{p_};
     p_ = that.p_;
     that.p_ = tmp;
     return *this;

--- a/lib/evaluate/real.cc
+++ b/lib/evaluate/real.cc
@@ -123,7 +123,7 @@ ValueWithRealFlags<Real<W, P, IM>> Real<W, P, IM>::Add(
     yFraction = yFraction.NOT();
     carry = roundingBits.Negate();
   }
-  auto sum = fraction.AddUnsigned(yFraction, carry);
+  auto sum{fraction.AddUnsigned(yFraction, carry)};
   fraction = sum.value;
   if (isNegative == yIsNegative && sum.carry) {
     roundingBits.ShiftRight(sum.value.BTEST(0));
@@ -154,7 +154,7 @@ ValueWithRealFlags<Real<W, P, IM>> Real<W, P, IM>::Multiply(
         result.value.word_ = InfinityWord(isNegative);
       }
     } else {
-      auto product = GetFraction().MultiplyUnsigned(y.GetFraction());
+      auto product{GetFraction().MultiplyUnsigned(y.GetFraction())};
       std::int64_t exponent{CombineExponents(y, false)};
       if (exponent < 1) {
         int rshift = 1 - exponent;

--- a/lib/evaluate/real.h
+++ b/lib/evaluate/real.h
@@ -173,7 +173,7 @@ public:
         if (!fraction.IBITS(0, rshift).IsZero()) {
           result.flags.set(RealFlag::Inexact);
         }
-        auto truncated = result.value.ConvertUnsigned(fraction.SHIFTR(rshift));
+        auto truncated{result.value.ConvertUnsigned(fraction.SHIFTR(rshift))};
         if (truncated.overflow) {
           result.flags.set(RealFlag::Overflow);
         } else {
@@ -191,7 +191,7 @@ public:
       if (result.flags.test(RealFlag::Overflow)) {
         result.value = result.value.HUGE();
       } else if (isNegative) {
-        auto negated = result.value.Negate();
+        auto negated{result.value.Negate()};
         if (negated.overflow) {
           result.flags.set(RealFlag::Overflow);
           result.value = result.value.HUGE();

--- a/lib/evaluate/rounding-bits.h
+++ b/lib/evaluate/rounding-bits.h
@@ -39,7 +39,7 @@ public:
       if (rshift >= fraction.bits + 2) {
         sticky_ = !fraction.IsZero();
       } else {
-        auto mask = fraction.MASKR(rshift - 2);
+        auto mask{fraction.MASKR(rshift - 2)};
         sticky_ = !fraction.IAND(mask).IsZero();
       }
     }

--- a/lib/parser/basic-parsers.h
+++ b/lib/parser/basic-parsers.h
@@ -268,8 +268,8 @@ private:
           typename std::decay<decltype(parser)>::type::resultType>);
       result = parser.Parse(state);
       if (!result.has_value()) {
-        auto prevEnd = prevState.GetLocation();
-        auto lastEnd = state.GetLocation();
+        auto prevEnd{prevState.GetLocation()};
+        auto lastEnd{state.GetLocation()};
         if (prevEnd == lastEnd) {
           prevState.messages().Incorporate(state.messages());
           if (state.anyDeferredMessages()) {
@@ -327,8 +327,8 @@ public:
     }
     // Both alternatives failed.  Retain the state (and messages) from the
     // alternative parse that went the furthest.
-    auto paEnd = paState.GetLocation();
-    auto pbEnd = state.GetLocation();
+    auto paEnd{paState.GetLocation()};
+    auto pbEnd{state.GetLocation()};
     if (paEnd > pbEnd) {
       messages.Annex(paState.messages());
       state = std::move(paState);
@@ -421,7 +421,7 @@ public:
   constexpr ManyParser(const PA &parser) : parser_{parser} {}
   std::optional<resultType> Parse(ParseState &state) const {
     resultType result;
-    auto at = state.GetLocation();
+    auto at{state.GetLocation()};
     while (std::optional<paType> x{parser_.Parse(state)}) {
       result.emplace_back(std::move(*x));
       if (state.GetLocation() <= at) {
@@ -452,7 +452,7 @@ public:
   constexpr SomeParser(const SomeParser &) = default;
   constexpr SomeParser(const PA &parser) : parser_{parser} {}
   std::optional<resultType> Parse(ParseState &state) const {
-    auto start = state.GetLocation();
+    auto start{state.GetLocation()};
     if (std::optional<paType> first{parser_.Parse(state)}) {
       resultType result;
       result.emplace_back(std::move(*first));
@@ -479,7 +479,7 @@ public:
   constexpr SkipManyParser(const SkipManyParser &) = default;
   constexpr SkipManyParser(const PA &parser) : parser_{parser} {}
   std::optional<Success> Parse(ParseState &state) const {
-    for (auto at = state.GetLocation();
+    for (auto at{state.GetLocation()};
          parser_.Parse(state) && state.GetLocation() > at;
          at = state.GetLocation()) {
     }
@@ -954,7 +954,7 @@ public:
   constexpr explicit Construct1(const PA &parser) : parser_{parser} {}
   constexpr Construct1(const Construct1 &) = default;
   std::optional<T> Parse(ParseState &state) const {
-    if (auto ax = parser_.Parse(state)) {
+    if (auto ax{parser_.Parse(state)}) {
       return {T(std::move(*ax))};
     }
     return {};
@@ -988,8 +988,8 @@ public:
   constexpr Construct2(const PA &pa, const PB &pb) : pa_{pa}, pb_{pb} {}
   constexpr Construct2(const Construct2 &) = default;
   std::optional<T> Parse(ParseState &state) const {
-    if (auto ax = pa_.Parse(state)) {
-      if (auto bx = pb_.Parse(state)) {
+    if (auto ax{pa_.Parse(state)}) {
+      if (auto bx{pb_.Parse(state)}) {
         return {T{std::move(*ax), std::move(*bx)}};
       }
     }
@@ -1013,9 +1013,9 @@ public:
     : pa_{pa}, pb_{pb}, pc_{pc} {}
   constexpr Construct3(const Construct3 &) = default;
   std::optional<resultType> Parse(ParseState &state) const {
-    if (auto ax = pa_.Parse(state)) {
-      if (auto bx = pb_.Parse(state)) {
-        if (auto cx = pc_.Parse(state)) {
+    if (auto ax{pa_.Parse(state)}) {
+      if (auto bx{pb_.Parse(state)}) {
+        if (auto cx{pc_.Parse(state)}) {
           return {T{std::move(*ax), std::move(*bx), std::move(*cx)}};
         }
       }
@@ -1043,10 +1043,10 @@ public:
     : pa_{pa}, pb_{pb}, pc_{pc}, pd_{pd} {}
   constexpr Construct4(const Construct4 &) = default;
   std::optional<resultType> Parse(ParseState &state) const {
-    if (auto ax = pa_.Parse(state)) {
-      if (auto bx = pb_.Parse(state)) {
-        if (auto cx = pc_.Parse(state)) {
-          if (auto dx = pd_.Parse(state)) {
+    if (auto ax{pa_.Parse(state)}) {
+      if (auto bx{pb_.Parse(state)}) {
+        if (auto cx{pc_.Parse(state)}) {
+          if (auto dx{pd_.Parse(state)}) {
             return {T{std::move(*ax), std::move(*bx), std::move(*cx),
                 std::move(*dx)}};
           }
@@ -1079,11 +1079,11 @@ public:
     : pa_{pa}, pb_{pb}, pc_{pc}, pd_{pd}, pe_{pe} {}
   constexpr Construct5(const Construct5 &) = default;
   std::optional<resultType> Parse(ParseState &state) const {
-    if (auto ax = pa_.Parse(state)) {
-      if (auto bx = pb_.Parse(state)) {
-        if (auto cx = pc_.Parse(state)) {
-          if (auto dx = pd_.Parse(state)) {
-            if (auto ex = pe_.Parse(state)) {
+    if (auto ax{pa_.Parse(state)}) {
+      if (auto bx{pb_.Parse(state)}) {
+        if (auto cx{pc_.Parse(state)}) {
+          if (auto dx{pd_.Parse(state)}) {
+            if (auto ex{pe_.Parse(state)}) {
               return {T{std::move(*ax), std::move(*bx), std::move(*cx),
                   std::move(*dx), std::move(*ex)}};
             }
@@ -1119,12 +1119,12 @@ public:
     : pa_{pa}, pb_{pb}, pc_{pc}, pd_{pd}, pe_{pe}, pf_{pf} {}
   constexpr Construct6(const Construct6 &) = default;
   std::optional<resultType> Parse(ParseState &state) const {
-    if (auto ax = pa_.Parse(state)) {
-      if (auto bx = pb_.Parse(state)) {
-        if (auto cx = pc_.Parse(state)) {
-          if (auto dx = pd_.Parse(state)) {
-            if (auto ex = pe_.Parse(state)) {
-              if (auto fx = pf_.Parse(state)) {
+    if (auto ax{pa_.Parse(state)}) {
+      if (auto bx{pb_.Parse(state)}) {
+        if (auto cx{pc_.Parse(state)}) {
+          if (auto dx{pd_.Parse(state)}) {
+            if (auto ex{pe_.Parse(state)}) {
+              if (auto fx{pf_.Parse(state)}) {
                 return {T{std::move(*ax), std::move(*bx), std::move(*cx),
                     std::move(*dx), std::move(*ex), std::move(*fx)}};
               }
@@ -1242,8 +1242,8 @@ public:
     if (state.strictConformance()) {
       return {};
     }
-    auto at = state.GetLocation();
-    auto result = parser_.Parse(state);
+    auto at{state.GetLocation()};
+    auto result{parser_.Parse(state)};
     if (result.has_value()) {
       state.set_anyConformanceViolation();
       if (state.warnOnNonstandardUsage()) {
@@ -1274,8 +1274,8 @@ public:
     if (state.strictConformance()) {
       return {};
     }
-    auto at = state.GetLocation();
-    auto result = parser_.Parse(state);
+    auto at{state.GetLocation()};
+    auto result{parser_.Parse(state)};
     if (result) {
       state.set_anyConformanceViolation();
       if (state.warnOnDeprecatedUsage()) {
@@ -1301,7 +1301,7 @@ public:
   constexpr SourcedParser(const PA &parser) : parser_{parser} {}
   std::optional<resultType> Parse(ParseState &state) const {
     const char *start{state.GetLocation()};
-    auto result = parser_.Parse(state);
+    auto result{parser_.Parse(state)};
     if (result.has_value()) {
       result->source = CharBlock{start, state.GetLocation()};
     }

--- a/lib/parser/characters.cc
+++ b/lib/parser/characters.cc
@@ -84,7 +84,7 @@ std::optional<std::size_t> CountCharacters(
 
 std::string QuoteCharacterLiteral(const std::string &str) {
   std::string result{'"'};
-  const auto emit = [&](char ch) { result += ch; };
+  const auto emit{[&](char ch) { result += ch; }};
   for (char ch : str) {
     EmitQuotedChar(ch, emit, emit);
   }

--- a/lib/parser/debug-parser.cc
+++ b/lib/parser/debug-parser.cc
@@ -20,8 +20,8 @@
 namespace Fortran::parser {
 
 std::optional<Success> DebugParser::Parse(ParseState &state) const {
-  if (auto ustate = state.userState()) {
-    if (auto out = ustate->debugOutput()) {
+  if (auto ustate{state.userState()}) {
+    if (auto out{ustate->debugOutput()}) {
       std::string note{str_, length_};
       Message message{state.GetLocation(),
           MessageFormattedText{"parser debug: %s"_en_US, note.data()}};

--- a/lib/parser/grammar.h
+++ b/lib/parser/grammar.h
@@ -659,10 +659,11 @@ TYPE_PARSER(construct<PrivateOrSequence>(Parser<PrivateStmt>{}) ||
     construct<PrivateOrSequence>(Parser<SequenceStmt>{}))
 
 // R730 end-type-stmt -> END TYPE [type-name]
-constexpr auto missingOptionalName {defaulted(cut >> maybe(name))};
+constexpr auto missingOptionalName{defaulted(cut >> maybe(name))};
 constexpr auto noNameEnd{"END" >> missingOptionalName};
 constexpr auto bareEnd{noNameEnd / lookAhead(endOfStmt)};
-constexpr auto endStmtErrorRecovery{("END"_tok / SkipTo<'\n'>{} || consumedAllInput) >> missingOptionalName};
+constexpr auto endStmtErrorRecovery{
+    ("END"_tok / SkipTo<'\n'>{} || consumedAllInput) >> missingOptionalName};
 TYPE_PARSER(construct<EndTypeStmt>(
     recovery("END TYPE" >> maybe(name), endStmtErrorRecovery)))
 

--- a/lib/parser/grammar.h
+++ b/lib/parser/grammar.h
@@ -49,11 +49,11 @@ namespace Fortran::parser {
 // R507 declaration-construct ->
 //        specification-construct | data-stmt | format-stmt |
 //        entry-stmt | stmt-function-stmt
-constexpr auto execPartLookAhead = first(actionStmt >> ok, "ASSOCIATE ("_tok,
+constexpr auto execPartLookAhead{first(actionStmt >> ok, "ASSOCIATE ("_tok,
     "BLOCK"_tok, "SELECT"_tok, "CHANGE TEAM"_sptok, "CRITICAL"_tok, "DO"_tok,
-    "IF ("_tok, "WHERE ("_tok, "FORALL ("_tok);
-constexpr auto declErrorRecovery =
-    errorRecoveryStart >> !execPartLookAhead >> stmtErrorRecovery;
+    "IF ("_tok, "WHERE ("_tok, "FORALL ("_tok)};
+constexpr auto declErrorRecovery{
+    errorRecoveryStart >> !execPartLookAhead >> stmtErrorRecovery};
 TYPE_CONTEXT_PARSER("declaration construct"_en_US,
     recovery(
         first(construct<DeclarationConstruct>(specificationConstruct),
@@ -65,13 +65,13 @@ TYPE_CONTEXT_PARSER("declaration construct"_en_US,
         construct<DeclarationConstruct>(declErrorRecovery)))
 
 // R507 variant of declaration-construct for use in limitedSpecificationPart.
-constexpr auto limitedDeclarationConstruct =
+constexpr auto limitedDeclarationConstruct{
     inContext("declaration construct"_en_US,
         recovery(
             first(construct<DeclarationConstruct>(specificationConstruct),
                 construct<DeclarationConstruct>(statement(indirect(dataStmt)))),
             construct<DeclarationConstruct>(
-                errorRecoveryStart >> stmtErrorRecovery)));
+                errorRecoveryStart >> stmtErrorRecovery)))};
 
 // R508 specification-construct ->
 //        derived-type-def | enum-def | generic-stmt | interface-block |
@@ -137,8 +137,8 @@ TYPE_PARSER(construct<ConstantValue>(literalConstant) ||
 //        not-op | and-op | or-op | equiv-op
 // R610 extended-intrinsic-op -> intrinsic-operator
 // These parsers must be ordered carefully to avoid misrecognition.
-constexpr auto namedIntrinsicOperator = ".LT." >>
-        pure(DefinedOperator::IntrinsicOperator::LT) ||
+constexpr auto namedIntrinsicOperator{
+    ".LT." >> pure(DefinedOperator::IntrinsicOperator::LT) ||
     ".LE." >> pure(DefinedOperator::IntrinsicOperator::LE) ||
     ".EQ." >> pure(DefinedOperator::IntrinsicOperator::EQ) ||
     ".NE." >> pure(DefinedOperator::IntrinsicOperator::NE) ||
@@ -153,10 +153,10 @@ constexpr auto namedIntrinsicOperator = ".LT." >>
         ".N." >> pure(DefinedOperator::IntrinsicOperator::NOT) ||
         ".A." >> pure(DefinedOperator::IntrinsicOperator::AND) ||
         ".O." >> pure(DefinedOperator::IntrinsicOperator::OR) ||
-        ".X." >> pure(DefinedOperator::IntrinsicOperator::XOR));
+        ".X." >> pure(DefinedOperator::IntrinsicOperator::XOR))};
 
-constexpr auto intrinsicOperator = "**" >>
-        pure(DefinedOperator::IntrinsicOperator::Power) ||
+constexpr auto intrinsicOperator{
+    "**" >> pure(DefinedOperator::IntrinsicOperator::Power) ||
     "*" >> pure(DefinedOperator::IntrinsicOperator::Multiply) ||
     "//" >> pure(DefinedOperator::IntrinsicOperator::Concat) ||
     "/=" >> pure(DefinedOperator::IntrinsicOperator::NE) ||
@@ -169,7 +169,7 @@ constexpr auto intrinsicOperator = "**" >>
     "==" >> pure(DefinedOperator::IntrinsicOperator::EQ) ||
     ">=" >> pure(DefinedOperator::IntrinsicOperator::GE) ||
     ">" >> pure(DefinedOperator::IntrinsicOperator::GT) ||
-    namedIntrinsicOperator;
+    namedIntrinsicOperator};
 
 // R609 defined-operator ->
 //        defined-unary-op | defined-binary-op | extended-intrinsic-op
@@ -210,27 +210,26 @@ template<typename PA> inline constexpr auto defaultChar(const PA &p) {
 }
 
 // R1024 logical-expr -> expr
-constexpr auto logicalExpr = logical(indirect(expr));
-constexpr auto scalarLogicalExpr = scalar(logicalExpr);
+constexpr auto logicalExpr{logical(indirect(expr))};
+constexpr auto scalarLogicalExpr{scalar(logicalExpr)};
 
 // R1025 default-char-expr -> expr
-constexpr auto defaultCharExpr = defaultChar(indirect(expr));
-constexpr auto scalarDefaultCharExpr = scalar(defaultCharExpr);
+constexpr auto defaultCharExpr{defaultChar(indirect(expr))};
+constexpr auto scalarDefaultCharExpr{scalar(defaultCharExpr)};
 
 // R1026 int-expr -> expr
-constexpr auto intExpr = integer(indirect(expr));
-constexpr auto scalarIntExpr = scalar(intExpr);
+constexpr auto intExpr{integer(indirect(expr))};
+constexpr auto scalarIntExpr{scalar(intExpr)};
 
 // R1029 constant-expr -> expr
-constexpr auto constantExpr = constant(indirect(expr));
+constexpr auto constantExpr{constant(indirect(expr))};
 
 // R1030 default-char-constant-expr -> default-char-expr
-constexpr auto scalarDefaultCharConstantExpr =
-    scalar(defaultChar(constantExpr));
+constexpr auto scalarDefaultCharConstantExpr{scalar(defaultChar(constantExpr))};
 
 // R1031 int-constant-expr -> int-expr
-constexpr auto intConstantExpr = integer(constantExpr);
-constexpr auto scalarIntConstantExpr = scalar(intConstantExpr);
+constexpr auto intConstantExpr{integer(constantExpr)};
+constexpr auto scalarIntConstantExpr{scalar(intConstantExpr)};
 
 // R501 program -> program-unit [program-unit]...
 // This is the top-level production for the Fortran language.
@@ -263,10 +262,10 @@ TYPE_CONTEXT_PARSER("specification part"_en_US,
 // preclude FORMAT, ENTRY, and statement functions, and benefit from
 // specialized error recovery in the event of a spurious executable
 // statement.
-constexpr auto limitedSpecificationPart = inContext("specification part"_en_US,
+constexpr auto limitedSpecificationPart{inContext("specification part"_en_US,
     construct<SpecificationPart>(many(statement(indirect(Parser<UseStmt>{}))),
         many(statement(indirect(Parser<ImportStmt>{}))), implicitPart,
-        many(limitedDeclarationConstruct)));
+        many(limitedDeclarationConstruct)))};
 
 // R505 implicit-part -> [implicit-part-stmt]... implicit-stmt
 // TODO: Can overshoot; any trailing PARAMETER, FORMAT, & ENTRY
@@ -285,10 +284,10 @@ TYPE_PARSER(first(
     construct<ImplicitPartStmt>(statement(indirect(entryStmt)))))
 
 // R512 internal-subprogram -> function-subprogram | subroutine-subprogram
-constexpr auto internalSubprogram =
+constexpr auto internalSubprogram{
     (construct<InternalSubprogram>(indirect(functionSubprogram)) ||
         construct<InternalSubprogram>(indirect(subroutineSubprogram))) /
-    endOfStmt;
+    endOfStmt};
 
 // R511 internal-subprogram-part -> contains-stmt [internal-subprogram]...
 TYPE_CONTEXT_PARSER("internal subprogram part"_en_US,
@@ -361,7 +360,7 @@ TYPE_PARSER(first(construct<ActionStmt>(indirect(Parser<AllocateStmt>{})),
 //        case-construct | change-team-construct | critical-construct |
 //        do-construct | if-construct | select-rank-construct |
 //        select-type-construct | where-construct | forall-construct
-constexpr auto executableConstruct =
+constexpr auto executableConstruct{
     first(construct<ExecutableConstruct>(statement(actionStmt)),
         construct<ExecutableConstruct>(indirect(Parser<AssociateConstruct>{})),
         construct<ExecutableConstruct>(indirect(Parser<BlockConstruct>{})),
@@ -377,19 +376,18 @@ constexpr auto executableConstruct =
         construct<ExecutableConstruct>(indirect(whereConstruct)),
         construct<ExecutableConstruct>(indirect(forallConstruct)),
         construct<ExecutableConstruct>(indirect(openmpConstruct)),
-        construct<ExecutableConstruct>(indirect(compilerDirective)));
+        construct<ExecutableConstruct>(indirect(compilerDirective)))};
 
 // R510 execution-part-construct ->
 //        executable-construct | format-stmt | entry-stmt | data-stmt
 // Extension (PGI/Intel): also accept NAMELIST in execution part
-constexpr auto obsoleteExecutionPartConstruct = recovery(
-    ignoredStatementPrefix >>
+constexpr auto obsoleteExecutionPartConstruct{recovery(ignoredStatementPrefix >>
         fail<ExecutionPartConstruct>(
             "obsolete legacy extension is not supported"_err_en_US),
     construct<ExecutionPartConstruct>(
         statement("REDIMENSION" >> name >>
             parenthesized(nonemptyList(Parser<AllocateShapeSpec>{})) >> ok) >>
-        errorRecovery));
+        errorRecovery))};
 
 TYPE_CONTEXT_PARSER("execution part construct"_en_US,
     recovery(
@@ -423,7 +421,7 @@ TYPE_PARSER(
 TYPE_PARSER(construct<NamedConstant>(name))
 
 // R701 type-param-value -> scalar-int-expr | * | :
-constexpr auto star = construct<Star>("*"_tok);
+constexpr auto star{construct<Star>("*"_tok)};
 TYPE_PARSER(construct<TypeParamValue>(scalarIntExpr) ||
     construct<TypeParamValue>(star) ||
     construct<TypeParamValue>(construct<TypeParamValue::Deferred>(":"_tok)))
@@ -515,12 +513,12 @@ TYPE_PARSER(construct<KindParam>(digitString) ||
 // N.B. A sign constitutes a whole token, so a space is allowed in free form
 // after the sign and before a real-literal-constant or
 // complex-literal-constant.  A sign is not a unary operator in these contexts.
-constexpr auto sign = "+"_tok >> pure(Sign::Positive) ||
-    "-"_tok >> pure(Sign::Negative);
+constexpr auto sign{
+    "+"_tok >> pure(Sign::Positive) || "-"_tok >> pure(Sign::Negative)};
 
 // R713 signed-real-literal-constant -> [sign] real-literal-constant
-constexpr auto signedRealLiteralConstant =
-    construct<SignedRealLiteralConstant>(maybe(sign), realLiteralConstant);
+constexpr auto signedRealLiteralConstant{
+    construct<SignedRealLiteralConstant>(maybe(sign), realLiteralConstant)};
 
 // R714 real-literal-constant ->
 //        significand [exponent-letter exponent] [_ kind-param] |
@@ -529,8 +527,8 @@ constexpr auto signedRealLiteralConstant =
 // R716 exponent-letter -> E | D
 // Extension: Q
 // R717 exponent -> signed-digit-string
-constexpr auto exponentPart =
-    ("ed"_ch || extension("q"_ch)) >> SignedDigitString{};
+constexpr auto exponentPart{
+    ("ed"_ch || extension("q"_ch)) >> SignedDigitString{}};
 
 TYPE_CONTEXT_PARSER("REAL literal constant"_en_US,
     space >>
@@ -598,8 +596,8 @@ TYPE_PARSER(construct<CharLength>(parenthesized(typeParamValue)) ||
 // PGI extension: nc'...' is Kanji.
 // N.B. charLiteralConstantWithoutKind does not skip preceding space.
 // N.B. the parsing of "name" takes care to not consume the '_'.
-constexpr auto charLiteralConstantWithoutKind =
-    "'"_ch >> CharLiteral<'\''>{} || "\""_ch >> CharLiteral<'"'>{};
+constexpr auto charLiteralConstantWithoutKind{
+    "'"_ch >> CharLiteral<'\''>{} || "\""_ch >> CharLiteral<'"'>{}};
 
 TYPE_CONTEXT_PARSER("CHARACTER literal constant"_en_US,
     construct<CharLiteralConstant>(
@@ -612,7 +610,7 @@ TYPE_CONTEXT_PARSER("CHARACTER literal constant"_en_US,
             charLiteralConstantWithoutKind))
 
 // deprecated: Hollerith literals
-constexpr auto rawHollerithLiteral = deprecated(HollerithLiteral{});
+constexpr auto rawHollerithLiteral{deprecated(HollerithLiteral{})};
 
 TYPE_CONTEXT_PARSER(
     "Hollerith"_en_US, construct<HollerithLiteralConstant>(rawHollerithLiteral))
@@ -661,11 +659,10 @@ TYPE_PARSER(construct<PrivateOrSequence>(Parser<PrivateStmt>{}) ||
     construct<PrivateOrSequence>(Parser<SequenceStmt>{}))
 
 // R730 end-type-stmt -> END TYPE [type-name]
-constexpr auto missingOptionalName = defaulted(cut >> maybe(name));
-constexpr auto noNameEnd = "END" >> missingOptionalName;
-constexpr auto bareEnd = noNameEnd / lookAhead(endOfStmt);
-constexpr auto endStmtErrorRecovery =
-    ("END"_tok / SkipTo<'\n'>{} || consumedAllInput) >> missingOptionalName;
+constexpr auto missingOptionalName {defaulted(cut >> maybe(name))};
+constexpr auto noNameEnd{"END" >> missingOptionalName};
+constexpr auto bareEnd{noNameEnd / lookAhead(endOfStmt)};
+constexpr auto endStmtErrorRecovery{("END"_tok / SkipTo<'\n'>{} || consumedAllInput) >> missingOptionalName};
 TYPE_PARSER(construct<EndTypeStmt>(
     recovery("END TYPE" >> maybe(name), endStmtErrorRecovery)))
 
@@ -703,9 +700,9 @@ TYPE_PARSER(construct<DataComponentDefStmt>(declarationTypeSpec,
 //        access-spec | ALLOCATABLE |
 //        CODIMENSION lbracket coarray-spec rbracket |
 //        CONTIGUOUS | DIMENSION ( component-array-spec ) | POINTER
-constexpr auto allocatable = construct<Allocatable>("ALLOCATABLE"_tok);
-constexpr auto contiguous = construct<Contiguous>("CONTIGUOUS"_tok);
-constexpr auto pointer = construct<Pointer>("POINTER"_tok);
+constexpr auto allocatable{construct<Allocatable>("ALLOCATABLE"_tok)};
+constexpr auto contiguous{construct<Contiguous>("CONTIGUOUS"_tok)};
+constexpr auto pointer{construct<Pointer>("POINTER"_tok)};
 TYPE_PARSER(construct<ComponentAttrSpec>(accessSpec) ||
     construct<ComponentAttrSpec>(allocatable) ||
     construct<ComponentAttrSpec>("CODIMENSION" >> coarraySpec) ||
@@ -739,15 +736,15 @@ TYPE_CONTEXT_PARSER("PROCEDURE component definition statement"_en_US,
 
 // R742 proc-component-attr-spec ->
 //        access-spec | NOPASS | PASS [(arg-name)] | POINTER
-constexpr auto noPass = construct<NoPass>("NOPASS"_tok);
-constexpr auto pass = construct<Pass>("PASS" >> maybe(parenthesized(name)));
+constexpr auto noPass{construct<NoPass>("NOPASS"_tok)};
+constexpr auto pass{construct<Pass>("PASS" >> maybe(parenthesized(name)))};
 TYPE_PARSER(construct<ProcComponentAttrSpec>(accessSpec) ||
     construct<ProcComponentAttrSpec>(noPass) ||
     construct<ProcComponentAttrSpec>(pass) ||
     construct<ProcComponentAttrSpec>(pointer))
 
 // R744 initial-data-target -> designator
-constexpr auto initialDataTarget = indirect(designator);
+constexpr auto initialDataTarget{indirect(designator)};
 
 // R743 component-initialization ->
 //        = constant-expr | => null-init | => initial-data-target
@@ -876,7 +873,7 @@ TYPE_PARSER(recovery("END ENUM"_tok, "END" >> SkipTo<'\n'>{}) >>
 TYPE_PARSER(construct<BOZLiteralConstant>(BOZLiteral{}))
 
 // R1124 do-variable -> scalar-int-variable-name
-constexpr auto doVariable = scalar(integer(name));
+constexpr auto doVariable{scalar(integer(name))};
 
 template<typename PA> inline constexpr auto loopBounds(const PA &p) {
   return construct<LoopBounds<typename PA::resultType>>(
@@ -931,9 +928,9 @@ TYPE_PARSER(construct<TypeDeclarationStmt>(declarationTypeSpec,
 //        DIMENSION ( array-spec ) | EXTERNAL | INTENT ( intent-spec ) |
 //        INTRINSIC | language-binding-spec | OPTIONAL | PARAMETER | POINTER |
 //        PROTECTED | SAVE | TARGET | VALUE | VOLATILE
-constexpr auto optional = construct<Optional>("OPTIONAL"_tok);
-constexpr auto protectedAttr = construct<Protected>("PROTECTED"_tok);
-constexpr auto save = construct<Save>("SAVE"_tok);
+constexpr auto optional{construct<Optional>("OPTIONAL"_tok)};
+constexpr auto protectedAttr{construct<Protected>("PROTECTED"_tok)};
+constexpr auto save{construct<Save>("SAVE"_tok)};
 TYPE_PARSER(construct<AttrSpec>(accessSpec) ||
     construct<AttrSpec>(allocatable) ||
     construct<AttrSpec>(construct<Asynchronous>("ASYNCHRONOUS"_tok)) ||
@@ -952,7 +949,7 @@ TYPE_PARSER(construct<AttrSpec>(accessSpec) ||
     construct<AttrSpec>(construct<Volatile>("VOLATILE"_tok)))
 
 // R804 object-name -> name
-constexpr auto objectName = name;
+constexpr auto objectName{name};
 
 // R803 entity-decl ->
 //        object-name [( array-spec )] [lbracket coarray-spec rbracket]
@@ -1121,7 +1118,7 @@ TYPE_PARSER(construct<DataStmtValue>(
 
 // R847 constant-subobject -> designator
 // R846 int-constant-subobject -> constant-subobject
-constexpr auto constantSubobject = constant(indirect(designator));
+constexpr auto constantSubobject{constant(indirect(designator))};
 
 // R844 data-stmt-repeat -> scalar-int-constant | scalar-int-constant-subobject
 // R607 int-constant -> constant
@@ -1213,9 +1210,9 @@ TYPE_PARSER(construct<VolatileStmt>(
     "VOLATILE" >> maybe("::"_tok) >> nonemptyList(objectName)))
 
 // R866 implicit-name-spec -> EXTERNAL | TYPE
-constexpr auto implicitNameSpec = "EXTERNAL" >>
-        pure(ImplicitStmt::ImplicitNoneNameSpec::External) ||
-    "TYPE" >> pure(ImplicitStmt::ImplicitNoneNameSpec::Type);
+constexpr auto implicitNameSpec{
+    "EXTERNAL" >> pure(ImplicitStmt::ImplicitNoneNameSpec::External) ||
+    "TYPE" >> pure(ImplicitStmt::ImplicitNoneNameSpec::Type)};
 
 // R863 implicit-stmt ->
 //        IMPLICIT implicit-spec-list |
@@ -1233,8 +1230,8 @@ TYPE_CONTEXT_PARSER("IMPLICIT statement"_en_US,
 // IMPLICIT REAL(I-N).  The variant form needs to attempt to reparse only
 // types with optional parenthesized kind/length expressions, so derived
 // type specs, DOUBLE PRECISION, and DOUBLE COMPLEX need not be considered.
-constexpr auto noKindSelector = construct<std::optional<KindSelector>>();
-constexpr auto implicitSpecDeclarationTypeSpecRetry =
+constexpr auto noKindSelector{construct<std::optional<KindSelector>>()};
+constexpr auto implicitSpecDeclarationTypeSpecRetry{
     construct<DeclarationTypeSpec>(first(
         construct<IntrinsicTypeSpec>(
             construct<IntegerTypeSpec>("INTEGER" >> noKindSelector)),
@@ -1245,7 +1242,7 @@ constexpr auto implicitSpecDeclarationTypeSpecRetry =
         construct<IntrinsicTypeSpec>(construct<IntrinsicTypeSpec::Character>(
             "CHARACTER" >> construct<std::optional<CharSelector>>())),
         construct<IntrinsicTypeSpec>(construct<IntrinsicTypeSpec::Logical>(
-            "LOGICAL" >> noKindSelector))));
+            "LOGICAL" >> noKindSelector))))};
 
 TYPE_PARSER(construct<ImplicitSpec>(declarationTypeSpec,
                 parenthesized(nonemptyList(Parser<LetterSpec>{}))) ||
@@ -1316,9 +1313,9 @@ TYPE_PARSER(construct<CommonBlockObject>(name, maybe(arraySpec)))
 TYPE_CONTEXT_PARSER("designator"_en_US,
     construct<Designator>(substring) || construct<Designator>(dataRef))
 
-constexpr auto percentOrDot = "%"_tok ||
+constexpr auto percentOrDot{"%"_tok ||
     // legacy VAX extension for RECORD field access
-    extension("."_tok / lookAhead(OldStructureComponentName{}));
+    extension("."_tok / lookAhead(OldStructureComponentName{}))};
 
 // R902 variable -> designator | function-reference
 // This production appears to be left-recursive in the grammar via
@@ -1330,25 +1327,25 @@ constexpr auto percentOrDot = "%"_tok ||
 // that are NOPASS).  However, Fortran constrains the use of a variable in a
 // proc-component-ref to be a data-ref without coindices (C1027).
 // Some array element references will be misrecognized as function references.
-constexpr auto noMoreAddressing = !"("_tok >> !"["_tok >> !percentOrDot;
+constexpr auto noMoreAddressing{!"("_tok >> !"["_tok >> !percentOrDot};
 TYPE_CONTEXT_PARSER("variable"_en_US,
     construct<Variable>(indirect(functionReference / noMoreAddressing)) ||
         construct<Variable>(indirect(designator)))
 
 // R904 logical-variable -> variable
 // Appears only as part of scalar-logical-variable.
-constexpr auto scalarLogicalVariable = scalar(logical(variable));
+constexpr auto scalarLogicalVariable{scalar(logical(variable))};
 
 // R905 char-variable -> variable
-constexpr auto charVariable = construct<CharVariable>(variable);
+constexpr auto charVariable{construct<CharVariable>(variable)};
 
 // R906 default-char-variable -> variable
 // Appears only as part of scalar-default-char-variable.
-constexpr auto scalarDefaultCharVariable = scalar(defaultChar(variable));
+constexpr auto scalarDefaultCharVariable{scalar(defaultChar(variable))};
 
 // R907 int-variable -> variable
 // Appears only as part of scalar-int-variable.
-constexpr auto scalarIntVariable = scalar(integer(variable));
+constexpr auto scalarIntVariable{scalar(integer(variable))};
 
 // R908 substring -> parent-string ( substring-range )
 // R909 parent-string ->
@@ -1383,8 +1380,7 @@ TYPE_PARSER(construct<StructureComponent>(
 
 // R915 complex-part-designator -> designator % RE | designator % IM
 // %RE and %IM are initially recognized as structure components.
-constexpr auto complexPartDesignator =
-    construct<ComplexPartDesignator>(dataRef);
+constexpr auto complexPartDesignator{construct<ComplexPartDesignator>(dataRef)};
 
 // R916 type-param-inquiry -> designator % type-param-name
 // Type parameter inquiries are initially recognized as structure components.
@@ -1392,13 +1388,13 @@ TYPE_PARSER(construct<TypeParamInquiry>(structureComponent))
 
 // R918 array-section ->
 //        data-ref [( substring-range )] | complex-part-designator
-constexpr auto arraySection = construct<ArraySection>(designator);
+constexpr auto arraySection{construct<ArraySection>(designator)};
 
 // R919 subscript -> scalar-int-expr
-constexpr auto subscript = scalarIntExpr;
+constexpr auto subscript{scalarIntExpr};
 
 // R923 vector-subscript -> int-expr
-constexpr auto vectorSubscript = intExpr;
+constexpr auto vectorSubscript{intExpr};
 
 // R920 section-subscript -> subscript | subscript-triplet | vector-subscript
 // N.B. The distinction that needs to be made between "subscript" and
@@ -1412,7 +1408,7 @@ TYPE_PARSER(construct<SubscriptTriplet>(
     maybe(subscript), ":" >> maybe(subscript), maybe(":" >> subscript)))
 
 // R925 cosubscript -> scalar-int-expr
-constexpr auto cosubscript = scalarIntExpr;
+constexpr auto cosubscript{scalarIntExpr};
 
 // R924 image-selector ->
 //        lbracket cosubscript-list [, image-selector-spec-list] rbracket
@@ -1421,7 +1417,7 @@ TYPE_CONTEXT_PARSER("image selector"_en_US,
         defaulted("," >> nonemptyList(Parser<ImageSelectorSpec>{})) / "]"))
 
 // R1115 team-variable -> scalar-variable
-constexpr auto teamVariable = scalar(indirect(variable));
+constexpr auto teamVariable{scalar(indirect(variable))};
 
 // R926 image-selector-spec ->
 //        STAT = stat-variable | TEAM = team-variable |
@@ -1455,7 +1451,7 @@ TYPE_PARSER(construct<StatVariable>(scalar(integer(variable))))
 
 // R930 errmsg-variable -> scalar-default-char-variable
 // R1207 iomsg-variable -> scalar-default-char-variable
-constexpr auto msgVariable = construct<MsgVariable>(scalarDefaultCharVariable);
+constexpr auto msgVariable{construct<MsgVariable>(scalarDefaultCharVariable)};
 
 // R932 allocation ->
 //        allocate-object [( allocate-shape-spec-list )]
@@ -1472,7 +1468,7 @@ TYPE_PARSER(construct<AllocateObject>(structureComponent) ||
 
 // R935 lower-bound-expr -> scalar-int-expr
 // R936 upper-bound-expr -> scalar-int-expr
-constexpr auto boundExpr = scalarIntExpr;
+constexpr auto boundExpr{scalarIntExpr};
 
 // R934 allocate-shape-spec -> [lower-bound-expr :] upper-bound-expr
 // R938 allocate-coshape-spec -> [lower-bound-expr :] upper-bound-expr
@@ -1510,7 +1506,7 @@ TYPE_PARSER(construct<StatOrErrmsg>("STAT =" >> statVariable) ||
 //         literal-constant | designator | array-constructor |
 //         structure-constructor | function-reference | type-param-inquiry |
 //         type-param-name | ( expr )
-constexpr auto primary = instrumented("primary"_en_US,
+constexpr auto primary{instrumented("primary"_en_US,
     first(construct<Expr>(indirect(Parser<CharLiteralConstantSubstring>{})),
         construct<Expr>(literalConstant),
         construct<Expr>(construct<Expr::Parentheses>(parenthesized(expr))),
@@ -1523,15 +1519,15 @@ constexpr auto primary = instrumented("primary"_en_US,
         extension(construct<Expr>(parenthesized(
             construct<Expr::ComplexConstructor>(expr, "," >> expr)))),
         extension(construct<Expr>("%LOC" >>
-            parenthesized(construct<Expr::PercentLoc>(indirect(variable)))))));
+            parenthesized(construct<Expr::PercentLoc>(indirect(variable)))))))};
 
 // R1002 level-1-expr -> [defined-unary-op] primary
 // TODO: Reasonable extension: permit multiple defined-unary-ops
-constexpr auto level1Expr = first(
+constexpr auto level1Expr{first(
     construct<Expr>(construct<Expr::DefinedUnary>(definedOpName, primary)),
     primary,
     extension(construct<Expr>(construct<Expr::UnaryPlus>("+" >> primary))),
-    extension(construct<Expr>(construct<Expr::Negate>("-" >> primary))));
+    extension(construct<Expr>(construct<Expr::Negate>("-" >> primary))))};
 
 // R1004 mult-operand -> level-1-expr [power-op mult-operand]
 // R1007 power-op -> **
@@ -1545,7 +1541,7 @@ constexpr struct MultOperand {
 inline std::optional<Expr> MultOperand::Parse(ParseState &state) {
   std::optional<Expr> result{level1Expr.Parse(state)};
   if (result) {
-    static constexpr auto op = attempt("**"_tok);
+    static constexpr auto op{attempt("**"_tok)};
     if (op.Parse(state)) {
       std::function<Expr(Expr &&)> power{[&result](Expr &&right) {
         return Expr{Expr::Power(std::move(result).value(), std::move(right))};
@@ -1573,8 +1569,8 @@ constexpr struct AddOperand {
             return Expr{
                 Expr::Divide(std::move(result).value(), std::move(right))};
           }};
-      auto more = "*" >> applyLambda(multiply, multOperand) ||
-          "/" >> applyLambda(divide, multOperand);
+      auto more{"*" >> applyLambda(multiply, multOperand) ||
+          "/" >> applyLambda(divide, multOperand)};
       while (std::optional<Expr> next{attempt(more).Parse(state)}) {
         result = std::move(next);
       }
@@ -1594,10 +1590,10 @@ constexpr struct Level2Expr {
   using resultType = Expr;
   constexpr Level2Expr() {}
   static inline std::optional<Expr> Parse(ParseState &state) {
-    static constexpr auto unary =
+    static constexpr auto unary{
         construct<Expr>(construct<Expr::UnaryPlus>("+" >> addOperand)) ||
         construct<Expr>(construct<Expr::Negate>("-" >> addOperand)) ||
-        addOperand;
+        addOperand};
     std::optional<Expr> result{unary.Parse(state)};
     if (result) {
       std::function<Expr(Expr &&)> add{[&result](Expr &&right) {
@@ -1607,8 +1603,8 @@ constexpr struct Level2Expr {
             return Expr{
                 Expr::Subtract(std::move(result).value(), std::move(right))};
           }};
-      auto more = "+" >> applyLambda(add, addOperand) ||
-          "-" >> applyLambda(subtract, addOperand);
+      auto more{"+" >> applyLambda(add, addOperand) ||
+          "-" >> applyLambda(subtract, addOperand)};
       while (std::optional<Expr> next{attempt(more).Parse(state)}) {
         result = std::move(next);
       }
@@ -1630,7 +1626,7 @@ constexpr struct Level3Expr {
       std::function<Expr(Expr &&)> concat{[&result](Expr &&right) {
         return Expr{Expr::Concat(std::move(result).value(), std::move(right))};
       }};
-      auto more = "//" >> applyLambda(concat, level2Expr);
+      auto more{"//" >> applyLambda(concat, level2Expr)};
       while (std::optional<Expr> next{attempt(more).Parse(state)}) {
         result = std::move(next);
       }
@@ -1668,7 +1664,7 @@ constexpr struct Level4Expr {
           gt{[&result](Expr &&right) {
             return Expr{Expr::GT(std::move(result).value(), std::move(right))};
           }};
-      auto more = (".LT."_tok || "<"_tok) >> applyLambda(lt, level3Expr) ||
+      auto more{(".LT."_tok || "<"_tok) >> applyLambda(lt, level3Expr) ||
           (".LE."_tok || "<="_tok) >> applyLambda(le, level3Expr) ||
           (".EQ."_tok || "=="_tok) >> applyLambda(eq, level3Expr) ||
           (".NE."_tok || "/="_tok ||
@@ -1676,7 +1672,7 @@ constexpr struct Level4Expr {
                   "<>"_tok /* PGI/Cray extension; Cray also has .LG. */)) >>
               applyLambda(ne, level3Expr) ||
           (".GE."_tok || ">="_tok) >> applyLambda(ge, level3Expr) ||
-          (".GT."_tok || ">"_tok) >> applyLambda(gt, level3Expr);
+          (".GT."_tok || ">"_tok) >> applyLambda(gt, level3Expr)};
       if (std::optional<Expr> next{attempt(more).Parse(state)}) {
         return next;
       }
@@ -1696,7 +1692,7 @@ constexpr struct AndOperand {
 } andOperand;
 
 inline std::optional<Expr> AndOperand::Parse(ParseState &state) {
-  static constexpr auto op = attempt(".NOT."_tok);
+  static constexpr auto op{attempt(".NOT."_tok)};
   int complements{0};
   while (op.Parse(state)) {
     ++complements;
@@ -1722,7 +1718,7 @@ constexpr struct OrOperand {
       std::function<Expr(Expr &&)> logicalAnd{[&result](Expr &&right) {
         return Expr{Expr::AND(std::move(result).value(), std::move(right))};
       }};
-      auto more = ".AND." >> applyLambda(logicalAnd, andOperand);
+      auto more{".AND." >> applyLambda(logicalAnd, andOperand)};
       while (std::optional<Expr> next{attempt(more).Parse(state)}) {
         result = std::move(next);
       }
@@ -1743,7 +1739,7 @@ constexpr struct EquivOperand {
       std::function<Expr(Expr &&)> logicalOr{[&result](Expr &&right) {
         return Expr{Expr::OR(std::move(result).value(), std::move(right))};
       }};
-      auto more = ".OR." >> applyLambda(logicalOr, orOperand);
+      auto more{".OR." >> applyLambda(logicalOr, orOperand)};
       while (std::optional<Expr> next{attempt(more).Parse(state)}) {
         result = std::move(next);
       }
@@ -1772,9 +1768,9 @@ constexpr struct Level5Expr {
           logicalXor{[&result](Expr &&right) {
             return Expr{Expr::XOR(std::move(result).value(), std::move(right))};
           }};
-      auto more = ".EQV." >> applyLambda(eqv, equivOperand) ||
+      auto more{".EQV." >> applyLambda(eqv, equivOperand) ||
           ".NEQV." >> applyLambda(neqv, equivOperand) ||
-          extension(".XOR." >> applyLambda(logicalXor, equivOperand));
+          extension(".XOR." >> applyLambda(logicalXor, equivOperand))};
       while (std::optional<Expr> next{attempt(more).Parse(state)}) {
         result = std::move(next);
       }
@@ -1793,7 +1789,7 @@ template<> inline std::optional<Expr> Parser<Expr>::Parse(ParseState &state) {
           return Expr{Expr::DefinedBinary(
               std::move(op), std::move(result).value(), std::move(right))};
         }};
-    auto more = applyLambda(defBinOp, definedOpName, level5Expr);
+    auto more{applyLambda(defBinOp, definedOpName, level5Expr)};
     while (std::optional<Expr> next{attempt(more).Parse(state)}) {
       result = std::move(next);
     }
@@ -1921,7 +1917,7 @@ TYPE_CONTEXT_PARSER("FORALL statement"_en_US,
         "FORALL" >> indirect(concurrentHeader), forallAssignmentStmt))
 
 // R1101 block -> [execution-part-construct]...
-constexpr auto block = many(executionPartConstruct);
+constexpr auto block{many(executionPartConstruct)};
 
 // R1102 associate-construct -> associate-stmt block end-associate-stmt
 TYPE_CONTEXT_PARSER("ASSOCIATE construct"_en_US,
@@ -2130,13 +2126,13 @@ TYPE_PARSER(construct<EndSelectStmt>(
     recovery("END SELECT" >> maybe(name), endStmtErrorRecovery)))
 
 // R1145 case-selector -> ( case-value-range-list ) | DEFAULT
-constexpr auto defaultKeyword = construct<Default>("DEFAULT"_tok);
+constexpr auto defaultKeyword{construct<Default>("DEFAULT"_tok)};
 TYPE_PARSER(parenthesized(construct<CaseSelector>(
                 nonemptyList(Parser<CaseValueRange>{}))) ||
     construct<CaseSelector>(defaultKeyword))
 
 // R1147 case-value -> scalar-constant-expr
-constexpr auto caseValue = scalar(constantExpr);
+constexpr auto caseValue{scalar(constantExpr)};
 
 // R1146 case-value-range ->
 //         case-value | case-value : | : case-value | case-value : case-value
@@ -2265,7 +2261,7 @@ TYPE_CONTEXT_PARSER("EVENT WAIT statement"_en_US,
             ")"))
 
 // R1174 until-spec -> UNTIL_COUNT = scalar-int-expr
-constexpr auto untilSpec = "UNTIL_COUNT =" >> scalarIntExpr;
+constexpr auto untilSpec{"UNTIL_COUNT =" >> scalarIntExpr};
 
 // R1173 event-wait-spec -> until-spec | sync-stat
 TYPE_PARSER(construct<EventWaitStmt::EventWaitSpec>(untilSpec) ||
@@ -2286,7 +2282,7 @@ TYPE_PARSER(
     construct<FormTeamStmt::FormTeamSpec>(statOrErrmsg))
 
 // R1181 lock-variable -> scalar-variable
-constexpr auto lockVariable = scalar(variable);
+constexpr auto lockVariable{scalar(variable)};
 
 // R1178 lock-stmt -> LOCK ( lock-variable [, lock-stat-list] )
 TYPE_CONTEXT_PARSER("LOCK statement"_en_US,
@@ -2316,7 +2312,7 @@ TYPE_CONTEXT_PARSER("OPEN statement"_en_US,
     construct<OpenStmt>("OPEN (" >> nonemptyList(Parser<ConnectSpec>{}) / ")"))
 
 // R1206 file-name-expr -> scalar-default-char-expr
-constexpr auto fileNameExpr = scalarDefaultCharExpr;
+constexpr auto fileNameExpr{scalarDefaultCharExpr};
 
 // R1205 connect-spec ->
 //         [UNIT =] file-unit-number | ACCESS = scalar-default-char-expr |
@@ -2332,8 +2328,8 @@ constexpr auto fileNameExpr = scalarDefaultCharExpr;
 //         POSITION = scalar-default-char-expr | RECL = scalar-int-expr |
 //         ROUND = scalar-default-char-expr | SIGN = scalar-default-char-expr |
 //         STATUS = scalar-default-char-expr
-constexpr auto statusExpr = construct<StatusExpr>(scalarDefaultCharExpr);
-constexpr auto errLabel = construct<ErrLabel>(label);
+constexpr auto statusExpr{construct<StatusExpr>(scalarDefaultCharExpr)};
+constexpr auto errLabel{construct<ErrLabel>(label)};
 
 TYPE_PARSER(first(construct<ConnectSpec>(maybe("UNIT ="_tok) >> fileUnitNumber),
     construct<ConnectSpec>(construct<ConnectSpec::CharExpr>(
@@ -2393,12 +2389,12 @@ TYPE_PARSER(first(construct<ConnectSpec>(maybe("UNIT ="_tok) >> fileUnitNumber),
 //         [UNIT =] file-unit-number | IOSTAT = scalar-int-variable |
 //         IOMSG = iomsg-variable | ERR = label |
 //         STATUS = scalar-default-char-expr
-constexpr auto closeSpec = first(
+constexpr auto closeSpec{first(
     construct<CloseStmt::CloseSpec>(maybe("UNIT ="_tok) >> fileUnitNumber),
     construct<CloseStmt::CloseSpec>("IOSTAT =" >> statVariable),
     construct<CloseStmt::CloseSpec>("IOMSG =" >> msgVariable),
     construct<CloseStmt::CloseSpec>("ERR =" >> errLabel),
-    construct<CloseStmt::CloseSpec>("STATUS =" >> statusExpr));
+    construct<CloseStmt::CloseSpec>("STATUS =" >> statusExpr))};
 
 // R1208 close-stmt -> CLOSE ( close-spec-list )
 TYPE_CONTEXT_PARSER("CLOSE statement"_en_US,
@@ -2407,9 +2403,9 @@ TYPE_CONTEXT_PARSER("CLOSE statement"_en_US,
 // R1210 read-stmt ->
 //         READ ( io-control-spec-list ) [input-item-list] |
 //         READ format [, input-item-list]
-constexpr auto inputItemList =
+constexpr auto inputItemList{
     extension(some("," >> inputItem)) ||  // legacy extension: leading comma
-    optionalList(inputItem);
+    optionalList(inputItem)};
 
 TYPE_CONTEXT_PARSER("READ statement"_en_US,
     construct<ReadStmt>("READ (" >>
@@ -2429,7 +2425,7 @@ TYPE_CONTEXT_PARSER("READ statement"_en_US,
             construct<std::list<IoControlSpec>>(), many("," >> inputItem)))
 
 // R1214 id-variable -> scalar-int-variable
-constexpr auto idVariable = construct<IdVariable>(scalarIntVariable);
+constexpr auto idVariable{construct<IdVariable>(scalarIntVariable)};
 
 // R1213 io-control-spec ->
 //         [UNIT =] io-unit | [FMT =] format | [NML =] namelist-group-name |
@@ -2443,8 +2439,8 @@ constexpr auto idVariable = construct<IdVariable>(scalarIntVariable);
 //         POS = scalar-int-expr | REC = scalar-int-expr |
 //         ROUND = scalar-default-char-expr | SIGN = scalar-default-char-expr |
 //         SIZE = scalar-int-variable
-constexpr auto endLabel = construct<EndLabel>(label);
-constexpr auto eorLabel = construct<EorLabel>(label);
+constexpr auto endLabel{construct<EndLabel>(label)};
+constexpr auto eorLabel{construct<EorLabel>(label)};
 TYPE_PARSER(first(construct<IoControlSpec>("UNIT =" >> ioUnit),
     construct<IoControlSpec>("FMT =" >> format),
     construct<IoControlSpec>("NML =" >> name),
@@ -2487,9 +2483,9 @@ TYPE_PARSER(first(construct<IoControlSpec>("UNIT =" >> ioUnit),
         "SIZE =" >> construct<IoControlSpec::Size>(scalarIntVariable))))
 
 // R1211 write-stmt -> WRITE ( io-control-spec-list ) [output-item-list]
-constexpr auto outputItemList =
+constexpr auto outputItemList{
     extension(some("," >> outputItem)) ||  // legacy: allow leading comma
-    optionalList(outputItem);
+    optionalList(outputItem)};
 
 TYPE_CONTEXT_PARSER("WRITE statement"_en_US,
     construct<WriteStmt>("WRITE (" >>
@@ -2524,7 +2520,7 @@ TYPE_PARSER(construct<OutputItem>(expr) ||
 
 // R1220 io-implied-do-control ->
 //         do-variable = scalar-int-expr , scalar-int-expr [, scalar-int-expr]
-constexpr auto ioImpliedDoControl = loopBounds(scalarIntExpr);
+constexpr auto ioImpliedDoControl{loopBounds(scalarIntExpr)};
 
 // R1218 io-implied-do -> ( io-implied-do-object-list , io-implied-do-control )
 // R1219 io-implied-do-object -> input-item | output-item
@@ -2546,7 +2542,7 @@ TYPE_CONTEXT_PARSER("WAIT statement"_en_US,
 //         [UNIT =] file-unit-number | END = label | EOR = label | ERR = label |
 //         ID = scalar-int-expr | IOMSG = iomsg-variable |
 //         IOSTAT = scalar-int-variable
-constexpr auto idExpr = construct<IdExpr>(scalarIntExpr);
+constexpr auto idExpr{construct<IdExpr>(scalarIntExpr)};
 
 TYPE_PARSER(first(construct<WaitSpec>(maybe("UNIT ="_tok) >> fileUnitNumber),
     construct<WaitSpec>("END =" >> endLabel),
@@ -2561,11 +2557,11 @@ template<typename A> std::list<A> singletonList(A &&x) {
   result.push_front(std::move(x));
   return result;
 }
-constexpr auto bareUnitNumberAsList =
+constexpr auto bareUnitNumberAsList{
     applyFunction(singletonList<PositionOrFlushSpec>,
-        construct<PositionOrFlushSpec>(fileUnitNumber));
-constexpr auto positionOrFlushSpecList =
-    parenthesized(nonemptyList(positionOrFlushSpec)) || bareUnitNumberAsList;
+        construct<PositionOrFlushSpec>(fileUnitNumber))};
+constexpr auto positionOrFlushSpecList{
+    parenthesized(nonemptyList(positionOrFlushSpec)) || bareUnitNumberAsList};
 
 // R1224 backspace-stmt ->
 //         BACKSPACE file-unit-number | BACKSPACE ( position-spec-list )
@@ -2763,12 +2759,12 @@ TYPE_CONTEXT_PARSER("FORMAT statement"_en_US,
 
 // R1321 char-string-edit-desc
 // N.B. C1313 disallows any kind parameter on the character literal.
-constexpr auto charStringEditDesc = space >>
-    (charLiteralConstantWithoutKind || rawHollerithLiteral);
+constexpr auto charStringEditDesc{
+    space >> (charLiteralConstantWithoutKind || rawHollerithLiteral)};
 
 // R1303 format-items -> format-item [[,] format-item]...
-constexpr auto formatItems =
-    nonemptySeparated(space >> Parser<format::FormatItem>{}, maybe(","_tok));
+constexpr auto formatItems{
+    nonemptySeparated(space >> Parser<format::FormatItem>{}, maybe(","_tok))};
 
 // R1306 r -> digit-string
 constexpr DigitStringIgnoreSpaces repeat;
@@ -2796,11 +2792,11 @@ TYPE_PARSER(parenthesized(construct<format::FormatSpecification>(
 // R1309 m -> digit-string
 // R1310 d -> digit-string
 // R1311 e -> digit-string
-constexpr auto width = repeat;
-constexpr auto mandatoryWidth = construct<std::optional<int>>(width);
-constexpr auto digits = repeat;
-constexpr auto noInt = construct<std::optional<int>>();
-constexpr auto mandatoryDigits = construct<std::optional<int>>("." >> width);
+constexpr auto width{repeat};
+constexpr auto mandatoryWidth{construct<std::optional<int>>(width)};
+constexpr auto digits{repeat};
+constexpr auto noInt{construct<std::optional<int>>()};
+constexpr auto mandatoryDigits{construct<std::optional<int>>("." >> width)};
 
 // R1307 data-edit-desc ->
 //         I w [. m] | B w [. m] | O w [. m] | Z w [. m] | F w . d |
@@ -2964,9 +2960,9 @@ TYPE_PARSER(construct<ModuleSubprogram>(indirect(functionSubprogram)) ||
     construct<ModuleSubprogram>(indirect(Parser<SeparateModuleSubprogram>{})))
 
 // R1410 module-nature -> INTRINSIC | NON_INTRINSIC
-constexpr auto moduleNature = "INTRINSIC" >>
-        pure(UseStmt::ModuleNature::Intrinsic) ||
-    "NON_INTRINSIC" >> pure(UseStmt::ModuleNature::Non_Intrinsic);
+constexpr auto moduleNature{
+    "INTRINSIC" >> pure(UseStmt::ModuleNature::Intrinsic) ||
+    "NON_INTRINSIC" >> pure(UseStmt::ModuleNature::Non_Intrinsic)};
 
 // R1409 use-stmt ->
 //         USE [[, module-nature] ::] module-name [, rename-list] |
@@ -3056,7 +3052,7 @@ TYPE_CONTEXT_PARSER("interface body"_en_US,
             statement(endSubroutineStmt))))
 
 // R1507 specific-procedure -> procedure-name
-constexpr auto specificProcedure = name;
+constexpr auto specificProcedure{name};
 
 // R1506 procedure-stmt -> [MODULE] PROCEDURE [::] specific-procedure-list
 TYPE_PARSER(construct<ProcedureStmt>("MODULE PROCEDURE"_sptok >>
@@ -3273,12 +3269,12 @@ TYPE_CONTEXT_PARSER("statement function definition"_en_US,
 // Directives, extensions, and deprecated statements
 // !DIR$ IVDEP
 // !DIR$ IGNORE_TKR [ [(tkr...)] name ]...
-constexpr auto beginDirective = skipEmptyLines >> space >> "!"_ch;
-constexpr auto endDirective = space >> endOfLine;
-constexpr auto ivdep = construct<CompilerDirective::IVDEP>("DIR$ IVDEP"_tok);
-constexpr auto ignore_tkr = "DIR$ IGNORE_TKR" >>
-    optionalList(construct<CompilerDirective::IgnoreTKR>(
-        defaulted(parenthesized(some("tkr"_ch))), name));
+constexpr auto beginDirective{skipEmptyLines >> space >> "!"_ch};
+constexpr auto endDirective{space >> endOfLine};
+constexpr auto ivdep{construct<CompilerDirective::IVDEP>("DIR$ IVDEP"_tok)};
+constexpr auto ignore_tkr{
+    "DIR$ IGNORE_TKR" >> optionalList(construct<CompilerDirective::IgnoreTKR>(
+                             defaulted(parenthesized(some("tkr"_ch))), name))};
 TYPE_PARSER(beginDirective >> sourced(construct<CompilerDirective>(ivdep) ||
                                   construct<CompilerDirective>(ignore_tkr)) /
         endDirective)

--- a/lib/parser/instrumented-parser.cc
+++ b/lib/parser/instrumented-parser.cc
@@ -30,16 +30,16 @@ bool operator<(const MessageFixedText &x, const MessageFixedText &y) {
 
 bool ParsingLog::Fails(
     const char *at, const MessageFixedText &tag, ParseState &state) {
-  std::size_t offset = reinterpret_cast<std::size_t>(at);
-  auto posIter = perPos_.find(offset);
+  std::size_t offset{reinterpret_cast<std::size_t>(at)};
+  auto posIter{perPos_.find(offset)};
   if (posIter == perPos_.end()) {
     return false;
   }
-  auto tagIter = posIter->second.perTag.find(tag);
+  auto tagIter{posIter->second.perTag.find(tag)};
   if (tagIter == posIter->second.perTag.end()) {
     return false;
   }
-  auto &entry = tagIter->second;
+  auto &entry{tagIter->second};
   if (entry.deferred && !state.deferMessages()) {
     return false;  // don't fail fast, we want to generate messages
   }
@@ -52,8 +52,8 @@ bool ParsingLog::Fails(
 
 void ParsingLog::Note(const char *at, const MessageFixedText &tag, bool pass,
     const ParseState &state) {
-  std::size_t offset = reinterpret_cast<std::size_t>(at);
-  auto &entry = perPos_[offset].perTag[tag];
+  std::size_t offset{reinterpret_cast<std::size_t>(at)};
+  auto &entry{perPos_[offset].perTag[tag]};
   if (++entry.count == 1) {
     entry.pass = pass;
     entry.deferred = state.deferMessages();
@@ -74,7 +74,7 @@ void ParsingLog::Dump(std::ostream &o, const CookedSource &cooked) const {
     const char *at{reinterpret_cast<const char *>(posLog.first)};
     for (const auto &tagLog : posLog.second.perTag) {
       Message{at, tagLog.first}.Emit(o, cooked, true);
-      auto &entry = tagLog.second;
+      auto &entry{tagLog.second};
       o << "  " << (entry.pass ? "pass" : "fail") << " " << entry.count << '\n';
       entry.messages.Emit(o, cooked, "      ");
     }

--- a/lib/parser/openmp-grammar.h
+++ b/lib/parser/openmp-grammar.h
@@ -39,7 +39,7 @@
 // OpenMP Directives and Clauses
 namespace Fortran::parser {
 
-constexpr auto beginOmpDirective = skipEmptyLines >> space >> "!$OMP "_sptok;
+constexpr auto beginOmpDirective{skipEmptyLines >> space >> "!$OMP "_sptok};
 
 // OpenMP Clauses
 
@@ -108,21 +108,21 @@ TYPE_PARSER(construct<OmpIfClause>(
     scalarLogicalExpr))
 
 // REDUCTION(reduction-identifier: list)
-constexpr auto reductionBinaryOperator = "+" >>
-        pure(OmpReductionOperator::BinaryOperator::Add) ||
+constexpr auto reductionBinaryOperator{
+    "+" >> pure(OmpReductionOperator::BinaryOperator::Add) ||
     "-" >> pure(OmpReductionOperator::BinaryOperator::Subtract) ||
     "*" >> pure(OmpReductionOperator::BinaryOperator::Multiply) ||
     ".AND." >> pure(OmpReductionOperator::BinaryOperator::AND) ||
     ".OR." >> pure(OmpReductionOperator::BinaryOperator::OR) ||
     ".EQV." >> pure(OmpReductionOperator::BinaryOperator::EQV) ||
-    ".NEQV." >> pure(OmpReductionOperator::BinaryOperator::NEQV);
+    ".NEQV." >> pure(OmpReductionOperator::BinaryOperator::NEQV)};
 
-constexpr auto reductionProcedureOperator = "MIN" >>
-        pure(OmpReductionOperator::ProcedureOperator::MIN) ||
+constexpr auto reductionProcedureOperator{
+    "MIN" >> pure(OmpReductionOperator::ProcedureOperator::MIN) ||
     "MAX" >> pure(OmpReductionOperator::ProcedureOperator::MAX) ||
     "IAND" >> pure(OmpReductionOperator::ProcedureOperator::IAND) ||
     "IOR" >> pure(OmpReductionOperator::ProcedureOperator::IOR) ||
-    "IEOR" >> pure(OmpReductionOperator::ProcedureOperator::IEOR);
+    "IEOR" >> pure(OmpReductionOperator::ProcedureOperator::IEOR)};
 
 TYPE_PARSER(construct<OmpReductionOperator>(reductionBinaryOperator) ||
     construct<OmpReductionOperator>(reductionProcedureOperator))

--- a/lib/parser/parse-state.h
+++ b/lib/parser/parse-state.h
@@ -148,7 +148,7 @@ public:
   const char *GetLocation() const { return p_; }
 
   void PushContext(MessageFixedText text) {
-    auto m = new Message{p_, text};  // reference-counted
+    auto m{new Message{p_, text}};  // reference-counted
     m->SetContext(context_.get());
     context_ = Message::Reference{m};
   }

--- a/lib/parser/parse-tree.cc
+++ b/lib/parser/parse-tree.cc
@@ -74,7 +74,7 @@ static Designator MakeArrayElementRef(Name &name, std::list<Expr> &subscripts) {
 }
 
 Designator FunctionReference::ConvertToArrayElementRef() {
-  auto &name = std::get<parser::Name>(std::get<ProcedureDesignator>(v.t).u);
+  auto &name{std::get<parser::Name>(std::get<ProcedureDesignator>(v.t).u)};
   std::list<Expr> args;
   for (auto &arg : std::get<std::list<ActualArgSpec>>(v.t)) {
     std::visit(
@@ -104,15 +104,15 @@ Designator FunctionReference::ConvertToArrayElementRef() {
 // R1544 stmt-function-stmt
 // Convert this stmt-function-stmt to an array element assignment statement.
 Statement<ActionStmt> StmtFunctionStmt::ConvertToAssignment() {
-  auto &funcName = std::get<Name>(t);
-  auto &funcArgs = std::get<std::list<Name>>(t);
-  auto &funcExpr = std::get<Scalar<Expr>>(t).thing;
+  auto &funcName{std::get<Name>(t)};
+  auto &funcArgs{std::get<std::list<Name>>(t)};
+  auto &funcExpr{std::get<Scalar<Expr>>(t).thing};
   std::list<Expr> subscripts;
   for (Name &arg : funcArgs) {
     subscripts.push_back(Expr{common::Indirection{Designator{arg}}});
   }
-  auto &&variable =
-      Variable{common::Indirection{MakeArrayElementRef(funcName, subscripts)}};
+  auto variable{
+      Variable{common::Indirection{MakeArrayElementRef(funcName, subscripts)}}};
   return Statement{std::nullopt,
       ActionStmt{common::Indirection{
           AssignmentStmt{std::move(variable), std::move(funcExpr)}}}};

--- a/lib/parser/preprocessor.cc
+++ b/lib/parser/preprocessor.cc
@@ -68,7 +68,7 @@ TokenSequence Definition::Tokenize(const std::vector<std::string> &argNames,
   for (std::size_t j{0}; j < tokens; ++j) {
     CharBlock tok{token.TokenAt(firstToken + j)};
     if (IsLegalIdentifierStart(tok)) {
-      auto it = args.find(tok.ToString());
+      auto it{args.find(tok.ToString())};
       if (it != args.end()) {
         result.Put(it->second, token.GetTokenProvenance(j));
         continue;
@@ -245,7 +245,7 @@ std::optional<TokenSequence> Preprocessor::MacroReplacement(
       result.Put(input, j);
       continue;
     }
-    auto it = definitions_.find(token);
+    auto it{definitions_.find(token)};
     if (it == definitions_.end()) {
       result.Put(input, j);
       continue;
@@ -777,7 +777,7 @@ static std::int64_t ExpressionValue(const TokenSequence &token,
     op = NOT;
     *atToken += 2;
   } else {
-    auto it = opNameMap.find(t);
+    auto it{opNameMap.find(t)};
     if (it != opNameMap.end()) {
       op = it->second;
     } else {
@@ -831,7 +831,7 @@ static std::int64_t ExpressionValue(const TokenSequence &token,
     t += ToLowerCaseLetters(token.TokenAt(*atToken + 1).ToString()) + '.';
     advance = 3;
   }
-  auto it = opNameMap.find(t);
+  auto it{opNameMap.find(t)};
   if (it == opNameMap.end()) {
     return left;
   }

--- a/lib/parser/prescan.cc
+++ b/lib/parser/prescan.cc
@@ -197,7 +197,7 @@ void Prescanner::Statement() {
 
 TokenSequence Prescanner::TokenizePreprocessorDirective() {
   CHECK(lineStart_ < limit_ && !inPreprocessorDirective_);
-  auto saveAt = at_;
+  auto saveAt{at_};
   inPreprocessorDirective_ = true;
   BeginSourceLineAndAdvance();
   TokenSequence tokens;
@@ -324,7 +324,7 @@ bool Prescanner::NextToken(TokenSequence &tokens) {
   } else if (*at_ == ' ' || *at_ == '\t') {
     // Compress white space into a single space character.
     // Discard white space at the end of a line.
-    const auto theSpace = at_;
+    const auto theSpace{at_};
     NextChar();
     SkipSpaces();
     if (*at_ != '\n') {
@@ -448,8 +448,8 @@ bool Prescanner::ExponentAndKind(TokenSequence &tokens) {
 void Prescanner::QuotedCharacterLiteral(TokenSequence &tokens) {
   const char *start{at_}, quote{*start}, *end{at_ + 1};
   inCharLiteral_ = true;
-  const auto emit = [&](char ch) { EmitChar(tokens, ch); };
-  const auto insert = [&](char ch) { EmitInsertedChar(tokens, ch); };
+  const auto emit{[&](char ch) { EmitChar(tokens, ch); }};
+  const auto insert{[&](char ch) { EmitInsertedChar(tokens, ch); }};
   bool escape{false};
   while (true) {
     char ch{*at_};
@@ -681,7 +681,7 @@ bool Prescanner::SkipCommentLine() {
   if (lineStart_ >= limit_) {
     return false;
   }
-  auto lineClass = ClassifyLine(lineStart_);
+  auto lineClass{ClassifyLine(lineStart_)};
   if (lineClass.kind == LineClassification::Kind::Comment) {
     NextLine();
     return true;
@@ -932,7 +932,7 @@ const char *Prescanner::IsCompilerDirectiveSentinel(
       !compilerDirectiveBloomFilter_.test(packed % prime2)) {
     return nullptr;
   }
-  const auto iter = compilerDirectiveSentinels_.find(std::string(sentinel, n));
+  const auto iter{compilerDirectiveSentinels_.find(std::string(sentinel, n))};
   return iter == compilerDirectiveSentinels_.end() ? nullptr : iter->data();
 }
 

--- a/lib/parser/provenance.cc
+++ b/lib/parser/provenance.cc
@@ -175,10 +175,10 @@ void AllSources::EmitMessage(std::ostream &o, ProvenanceRange range,
               }
               o << '^';
               if (range.size() > 1) {
-                auto last = range.start() + range.size() - 1;
+                auto last{range.start() + range.size() - 1};
                 if (&MapToOrigin(last) == &origin) {
-                  auto endOffset = origin.covers.MemberOffset(last);
-                  auto endPos = inc.source.FindOffsetLineAndColumn(endOffset);
+                  auto endOffset{origin.covers.MemberOffset(last)};
+                  auto endPos{inc.source.FindOffsetLineAndColumn(endOffset)};
                   if (pos.first == endPos.first) {
                     for (int j{pos.second}; j < endPos.second; ++j) {
                       o << '^';
@@ -253,7 +253,7 @@ int AllSources::GetLineNumber(Provenance at) const {
 }
 
 Provenance AllSources::CompilerInsertionProvenance(char ch) {
-  auto iter = compilerInsertionProvenance_.find(ch);
+  auto iter{compilerInsertionProvenance_.find(ch)};
   if (iter != compilerInsertionProvenance_.end()) {
     return iter->second;
   }

--- a/lib/parser/source.cc
+++ b/lib/parser/source.cc
@@ -58,7 +58,7 @@ static std::vector<std::size_t> FindLineStarts(
 }
 
 std::string DirectoryName(std::string path) {
-  auto lastSlash = path.rfind("/");
+  auto lastSlash{path.rfind("/")};
   return lastSlash == std::string::npos ? path : path.substr(0, lastSlash);
 }
 
@@ -153,7 +153,7 @@ bool SourceFile::ReadFile(std::string errorPath, std::stringstream *error) {
         vp = mmap(vp, bytes_, PROT_READ | PROT_WRITE, MAP_PRIVATE,
             fileDescriptor_, 0);
         if (vp != MAP_FAILED) {
-          auto mutableContent = static_cast<char *>(vp);
+          auto mutableContent{static_cast<char *>(vp)};
           bytes_ = RemoveCarriageReturns(mutableContent, bytes_);
           if (bytes_ > 0) {
             if (mutableContent[bytes_ - 1] == '\n' ||

--- a/lib/parser/stmt-parser.h
+++ b/lib/parser/stmt-parser.h
@@ -27,7 +27,7 @@ namespace Fortran::parser {
 // end-of-statement markers.
 
 // R611 label -> digit [digit]...
-constexpr auto label = space >> digitString / spaceCheck;
+constexpr auto label{space >> digitString / spaceCheck};
 
 template<typename PA> inline constexpr auto unterminatedStatement(const PA &p) {
   return skipEmptyLines >>
@@ -35,34 +35,34 @@ template<typename PA> inline constexpr auto unterminatedStatement(const PA &p) {
           maybe(label), space >> p));
 }
 
-constexpr auto endOfLine = "\n"_ch / skipEmptyLines ||
+constexpr auto endOfLine{"\n"_ch / skipEmptyLines ||
     consumedAllInput >> pure("\n") ||
-    fail<const char *>("expected end of line"_err_en_US);
+    fail<const char *>("expected end of line"_err_en_US)};
 
-constexpr auto endOfStmt = space >>
-    (";"_ch / skipMany(";"_tok) / maybe(endOfLine) || endOfLine);
+constexpr auto endOfStmt{
+    space >> (";"_ch / skipMany(";"_tok) / maybe(endOfLine) || endOfLine)};
 
 template<typename PA> inline constexpr auto statement(const PA &p) {
   return unterminatedStatement(p) / endOfStmt;
 }
 
-constexpr auto ignoredStatementPrefix = skipEmptyLines >> maybe(label) >>
-    maybe(name / ":") >> space;
+constexpr auto ignoredStatementPrefix{
+    skipEmptyLines >> maybe(label) >> maybe(name / ":") >> space};
 
 // Error recovery within statements: skip to the end of the line,
 // but not over an END or CONTAINS statement.
-constexpr auto errorRecovery = construct<ErrorRecovery>();
-constexpr auto skipToEndOfLine = SkipTo<'\n'>{} >> errorRecovery;
-constexpr auto stmtErrorRecovery =
-    !"END"_tok >> !"CONTAINS"_tok >> skipToEndOfLine;
+constexpr auto errorRecovery{construct<ErrorRecovery>()};
+constexpr auto skipToEndOfLine{SkipTo<'\n'>{} >> errorRecovery};
+constexpr auto stmtErrorRecovery{
+    !"END"_tok >> !"CONTAINS"_tok >> skipToEndOfLine};
 
 // Error recovery across statements: skip the line, unless it looks
 // like it might end the containing construct.
-constexpr auto errorRecoveryStart = ignoredStatementPrefix;
-constexpr auto skipBadLine = SkipPast<'\n'>{} >> errorRecovery;
-constexpr auto executionPartErrorRecovery = errorRecoveryStart >> !"END"_tok >>
+constexpr auto errorRecoveryStart{ignoredStatementPrefix};
+constexpr auto skipBadLine{SkipPast<'\n'>{} >> errorRecovery};
+constexpr auto executionPartErrorRecovery{errorRecoveryStart >> !"END"_tok >>
     !"CONTAINS"_tok >> !"ELSE"_tok >> !"CASE"_tok >> !"TYPE IS"_tok >>
-    !"CLASS"_tok >> !"RANK"_tok >> skipBadLine;
+    !"CLASS"_tok >> !"RANK"_tok >> skipBadLine};
 
 }  // namespace Fortran::parser
 #endif  // FORTRAN_PARSER_STMT_PARSER_H_

--- a/lib/parser/token-parsers.h
+++ b/lib/parser/token-parsers.h
@@ -62,8 +62,8 @@ constexpr AnyOfChars operator""_ch(const char str[], std::size_t n) {
   return AnyOfChars{SetOfChars(str, n)};
 }
 
-constexpr auto letter = "abcdefghijklmnopqrstuvwxyz"_ch;
-constexpr auto digit = "0123456789"_ch;
+constexpr auto letter{"abcdefghijklmnopqrstuvwxyz"_ch};
+constexpr auto digit{"0123456789"_ch};
 
 // Skips over optional spaces.  Always succeeds.
 constexpr struct Space {
@@ -221,7 +221,7 @@ struct CharLiteralChar {
   };
   using resultType = Result;
   static std::optional<Result> Parse(ParseState &state) {
-    auto at = state.GetLocation();
+    auto at{state.GetLocation()};
     std::optional<const char *> och{nextCh.Parse(state)};
     if (!och.has_value()) {
       return {};
@@ -250,7 +250,7 @@ struct CharLiteralChar {
     if (IsOctalDigit(ch)) {
       ch -= '0';
       for (int j = (ch > 3 ? 1 : 2); j-- > 0;) {
-        static constexpr auto octalDigit = attempt("01234567"_ch);
+        static constexpr auto octalDigit{attempt("01234567"_ch)};
         och = octalDigit.Parse(state);
         if (och.has_value()) {
           ch = 8 * ch + **och - '0';
@@ -260,11 +260,11 @@ struct CharLiteralChar {
       }
     } else if (ch == 'x' || ch == 'X') {
       ch = 0;
-      static constexpr auto hexDigit = "0123456789abcdefABCDEF"_ch;
+      static constexpr auto hexDigit{"0123456789abcdefABCDEF"_ch};
       och = hexDigit.Parse(state);
       if (och.has_value()) {
         ch = HexadecimalDigitValue(**och);
-        static constexpr auto hexDigit2 = attempt("0123456789abcdefABCDEF"_ch);
+        static constexpr auto hexDigit2{attempt("0123456789abcdefABCDEF"_ch)};
         och = hexDigit2.Parse(state);
         if (och.has_value()) {
           ch = 16 * ch + HexadecimalDigitValue(**och);
@@ -283,10 +283,10 @@ template<char quote> struct CharLiteral {
   using resultType = std::string;
   static std::optional<std::string> Parse(ParseState &state) {
     std::string str;
-    static constexpr auto nextch = attempt(CharLiteralChar{});
+    static constexpr auto nextch{attempt(CharLiteralChar{})};
     while (std::optional<CharLiteralChar::Result> ch{nextch.Parse(state)}) {
       if (ch->ch == quote && !ch->wasEscaped) {
-        static constexpr auto doubled = attempt(AnyOfChars{SetOfChars{quote}});
+        static constexpr auto doubled{attempt(AnyOfChars{SetOfChars{quote}})};
         if (!doubled.Parse(state).has_value()) {
           return {str};
         }
@@ -315,7 +315,7 @@ struct BOZLiteral {
   using resultType = std::uint64_t;
   static std::optional<std::uint64_t> Parse(ParseState &state) {
     std::optional<int> shift;
-    auto baseChar = [&shift](char ch) -> bool {
+    auto baseChar{[&shift](char ch) -> bool {
       switch (ch) {
       case 'b': shift = 1; return true;
       case 'o': shift = 3; return true;
@@ -323,7 +323,7 @@ struct BOZLiteral {
       case 'x': shift = 4; return true;
       default: return false;
       }
-    };
+    }};
 
     space.Parse(state);
     const char *start{state.GetLocation()};
@@ -408,7 +408,7 @@ constexpr struct DigitString {
     }
     std::uint64_t value = **firstDigit - '0';
     bool overflow{false};
-    static constexpr auto getDigit = attempt(digit);
+    static constexpr auto getDigit{attempt(digit)};
     while (auto nextDigit{getDigit.Parse(state)}) {
       if (value > std::numeric_limits<std::uint64_t>::max() / 10) {
         overflow = true;
@@ -473,8 +473,8 @@ struct SignedIntLiteralConstantWithoutKind {
   using resultType = std::int64_t;
   static std::optional<std::int64_t> Parse(ParseState &state) {
     Location at{state.GetLocation()};
-    static constexpr auto minus = attempt("-"_tok);
-    static constexpr auto plus = maybe("+"_tok);
+    static constexpr auto minus{attempt("-"_tok)};
+    static constexpr auto plus{maybe("+"_tok)};
     bool negate{false};
     if (minus.Parse(state)) {
       negate = true;
@@ -508,14 +508,14 @@ struct SignedDigitString {
 struct DigitStringIgnoreSpaces {
   using resultType = std::uint64_t;
   static std::optional<std::uint64_t> Parse(ParseState &state) {
-    static constexpr auto getFirstDigit = space >> digit;
+    static constexpr auto getFirstDigit{space >> digit};
     std::optional<const char *> firstDigit{getFirstDigit.Parse(state)};
     if (!firstDigit.has_value()) {
       return {};
     }
     std::uint64_t value = **firstDigit - '0';
     bool overflow{false};
-    static constexpr auto getDigit = space >> attempt(digit);
+    static constexpr auto getDigit{space >> attempt(digit)};
     while (auto nextDigit{getDigit.Parse(state)}) {
       if (value > std::numeric_limits<std::uint64_t>::max() / 10) {
         overflow = true;
@@ -546,7 +546,7 @@ struct PositiveDigitStringIgnoreSpaces {
 struct SignedDigitStringIgnoreSpaces {
   using resultType = std::int64_t;
   static std::optional<std::int64_t> Parse(ParseState &state) {
-    static constexpr auto getSign = space >> attempt("+-"_ch);
+    static constexpr auto getSign{space >> attempt("+-"_ch)};
     bool negate{false};
     if (std::optional<const char *> sign{getSign.Parse(state)}) {
       negate = **sign == '-';
@@ -568,13 +568,13 @@ struct HollerithLiteral {
     if (!charCount.has_value() || *charCount < 1) {
       return {};
     }
-    static constexpr auto letterH = "h"_ch;
+    static constexpr auto letterH{"h"_ch};
     std::optional<const char *> h{letterH.Parse(state)};
     if (!h.has_value()) {
       return {};
     }
     std::string content;
-    for (auto j = *charCount; j-- > 0;) {
+    for (auto j{*charCount}; j-- > 0;) {
       int bytes{1};
       const char *p{state.GetLocation()};
       if (state.encoding() == Encoding::EUC_JP) {
@@ -707,7 +707,7 @@ constexpr struct FormDirectivesAndEmptyLines {
 } skipEmptyLines;
 
 // R602 underscore -> _
-constexpr auto underscore = "_"_ch;
+constexpr auto underscore{"_"_ch};
 
 // R516 keyword -> name
 // R601 alphanumeric-character -> letter | digit | underscore
@@ -717,18 +717,18 @@ constexpr auto underscore = "_"_ch;
 // PGI and ifort accept '$' in identifiers, even as the initial character.
 // Cray and gfortran accept '$', but not as the first character.
 // Cray accepts '@' as well.
-constexpr auto otherIdChar = underscore / !"'\""_ch || extension("$@"_ch);
-constexpr auto nonDigitIdChar = letter || otherIdChar;
-constexpr auto rawName = nonDigitIdChar >> many(nonDigitIdChar || digit);
+constexpr auto otherIdChar{underscore / !"'\""_ch || extension("$@"_ch)};
+constexpr auto nonDigitIdChar{letter || otherIdChar};
+constexpr auto rawName{nonDigitIdChar >> many(nonDigitIdChar || digit)};
 TYPE_PARSER(space >> sourced(rawName >> construct<Name>()))
-constexpr auto keyword = construct<Keyword>(name);
+constexpr auto keyword{construct<Keyword>(name)};
 
 // R1003 defined-unary-op -> . letter [letter]... .
 // R1023 defined-binary-op -> . letter [letter]... .
 // R1414 local-defined-operator -> defined-unary-op | defined-binary-op
 // R1415 use-defined-operator -> defined-unary-op | defined-binary-op
 // N.B. The name of the operator is captured without the periods around it.
-constexpr auto definedOpNameChar = letter || extension("$@"_ch);
+constexpr auto definedOpNameChar{letter || extension("$@"_ch)};
 TYPE_PARSER(space >> "."_ch >>
     construct<DefinedOpName>(
         sourced(some(definedOpNameChar) >> construct<Name>())) /

--- a/lib/parser/type-parsers.h
+++ b/lib/parser/type-parsers.h
@@ -37,7 +37,7 @@ template<typename A> struct Parser {
   template<> \
   inline std::optional<typename decltype(pexpr)::resultType> \
   Parser<typename decltype(pexpr)::resultType>::Parse(ParseState &state) { \
-    static constexpr auto parser = (pexpr); \
+    static constexpr auto parser{(pexpr)}; \
     return parser.Parse(state); \
   }
 

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -174,7 +174,7 @@ public:
         x.u);
   }
   void Unparse(const CharLiteralConstant &x) {  // R724
-    if (const auto &k = std::get<std::optional<KindParam>>(x.t)) {
+    if (const auto &k{std::get<std::optional<KindParam>>(x.t)}) {
       if (std::holds_alternative<KindParam::Kanji>(k->u)) {
         Word("NC");
       } else {
@@ -227,16 +227,16 @@ public:
     Walk("=", std::get<std::optional<ScalarIntConstantExpr>>(x.t));
   }
   void Unparse(const DataComponentDefStmt &x) {  // R737
-    const auto &dts = std::get<DeclarationTypeSpec>(x.t);
-    const auto &attrs = std::get<std::list<ComponentAttrSpec>>(x.t);
-    const auto &decls = std::get<std::list<ComponentDecl>>(x.t);
+    const auto &dts{std::get<DeclarationTypeSpec>(x.t)};
+    const auto &attrs{std::get<std::list<ComponentAttrSpec>>(x.t)};
+    const auto &decls{std::get<std::list<ComponentDecl>>(x.t)};
     Walk(dts), Walk(", ", attrs, ", ");
     if (!attrs.empty() ||
         (!std::holds_alternative<DeclarationTypeSpec::Record>(dts.u) &&
             std::none_of(
                 decls.begin(), decls.end(), [](const ComponentDecl &d) {
-                  const auto &init =
-                      std::get<std::optional<Initialization>>(d.t);
+                  const auto &init{
+                      std::get<std::optional<Initialization>>(d.t)};
                   return init.has_value() &&
                       std::holds_alternative<
                           std::list<common::Indirection<DataStmtValue>>>(
@@ -290,7 +290,7 @@ public:
   void Unparse(const Pass &x) { Word("PASS"), Walk("(", x.v, ")"); }
   void Unparse(const Initialization &x) {  // R743 & R805
     std::visit(
-        common::visitors{[&](const ConstantExpr &y) { Put(" = "), Walk(y); },
+        common::visitors{[&](const ConstantExpr &y) { Put("{"), Walk(y); },
             [&](const NullInit &y) { Put(" => "), Walk(y); },
             [&](const InitialDataTarget &y) { Put(" => "), Walk(y); },
             [&](const std::list<common::Indirection<DataStmtValue>> &y) {
@@ -389,26 +389,26 @@ public:
   }
 
   void Unparse(const TypeDeclarationStmt &x) {  // R801
-    const auto &dts = std::get<DeclarationTypeSpec>(x.t);
-    const auto &attrs = std::get<std::list<AttrSpec>>(x.t);
-    const auto &decls = std::get<std::list<EntityDecl>>(x.t);
+    const auto &dts{std::get<DeclarationTypeSpec>(x.t)};
+    const auto &attrs{std::get<std::list<AttrSpec>>(x.t)};
+    const auto &decls{std::get<std::list<EntityDecl>>(x.t)};
     Walk(dts), Walk(", ", attrs, ", ");
 
-    static const auto isInitializerOldStyle = [](const Initialization &i) {
+    static const auto isInitializerOldStyle{[](const Initialization &i) {
       return std::holds_alternative<
           std::list<common::Indirection<DataStmtValue>>>(i.u);
-    };
-    static const auto hasAssignmentInitializer = [](const EntityDecl &d) {
+    }};
+    static const auto hasAssignmentInitializer{[](const EntityDecl &d) {
       // Does a declaration have a new-style =x initializer?
-      const auto &init = std::get<std::optional<Initialization>>(d.t);
+      const auto &init{std::get<std::optional<Initialization>>(d.t)};
       return init.has_value() && !isInitializerOldStyle(*init);
-    };
-    static const auto hasSlashDelimitedInitializer = [](const EntityDecl &d) {
+    }};
+    static const auto hasSlashDelimitedInitializer{[](const EntityDecl &d) {
       // Does a declaration have an old-style /x/ initializer?
-      const auto &init = std::get<std::optional<Initialization>>(d.t);
+      const auto &init{std::get<std::optional<Initialization>>(d.t)};
       return init.has_value() && isInitializerOldStyle(*init);
-    };
-    const auto useDoubledColons = [&]() {
+    }};
+    const auto useDoubledColons{[&]() {
       bool isRecord{std::holds_alternative<DeclarationTypeSpec::Record>(dts.u)};
       if (!attrs.empty()) {
         // Attributes after the type require :: before the entities.
@@ -436,7 +436,7 @@ public:
       }
       // Don't use :: with intrinsic types.  Otherwise, use it.
       return !std::holds_alternative<IntrinsicTypeSpec>(dts.u);
-    };
+    }};
 
     if (useDoubledColons()) {
       Put(" ::");
@@ -475,7 +475,7 @@ public:
         x.u);
   }
   void Unparse(const DeferredCoshapeSpecList &x) {  // R810
-    for (auto j = x.v; j > 0; --j) {
+    for (auto j{x.v}; j > 0; --j) {
       Put(':');
       if (j > 1) {
         Put(',');
@@ -503,7 +503,7 @@ public:
   }
   void Post(const AssumedShapeSpec &) { Put(':'); }  // R819
   void Unparse(const DeferredShapeSpecList &x) {  // R820
-    for (auto j = x.v; j > 0; --j) {
+    for (auto j{x.v}; j > 0; --j) {
       Put(':');
       if (j > 1) {
         Put(',');
@@ -647,7 +647,7 @@ public:
   }
   void Unparse(const LetterSpec &x) {  // R865
     Put(*std::get<const char *>(x.t));
-    auto second = std::get<std::optional<const char *>>(x.t);
+    auto second{std::get<std::optional<const char *>>(x.t)};
     if (second.has_value()) {
       Put('-'), Put(**second);
     }
@@ -1558,8 +1558,8 @@ public:
     Put('('), Walk(std::get<std::list<ActualArgSpec>>(x.v.t), ", "), Put(')');
   }
   void Unparse(const CallStmt &x) {  // R1521
-    const auto &pd = std::get<ProcedureDesignator>(x.v.t);
-    const auto &args = std::get<std::list<ActualArgSpec>>(x.v.t);
+    const auto &pd{std::get<ProcedureDesignator>(x.v.t)};
+    const auto &args{std::get<std::list<ActualArgSpec>>(x.v.t)};
     Word("CALL "), Walk(pd);
     if (args.empty()) {
       if (std::holds_alternative<ProcComponentRef>(pd.u)) {
@@ -1608,8 +1608,8 @@ public:
   void Unparse(const SubroutineStmt &x) {  // R1535
     Walk("", std::get<std::list<PrefixSpec>>(x.t), " ", " ");
     Word("SUBROUTINE "), Walk(std::get<Name>(x.t));
-    const auto &args = std::get<std::list<DummyArg>>(x.t);
-    const auto &bind = std::get<std::optional<LanguageBindingSpec>>(x.t);
+    const auto &args{std::get<std::list<DummyArg>>(x.t)};
+    const auto &bind{std::get<std::optional<LanguageBindingSpec>>(x.t)};
     if (args.empty()) {
       Walk(" () ", bind);
     } else {
@@ -1659,7 +1659,7 @@ public:
     Put('\n');
   }
   void Unparse(const CompilerDirective::IgnoreTKR &x) {
-    const auto &list = std::get<std::list<const char *>>(x.t);
+    const auto &list{std::get<std::list<const char *>>(x.t)};
     if (!list.empty()) {
       Put("(");
       for (const char *tkr : list) {
@@ -2052,7 +2052,7 @@ public:
     Walk("(", std::get<std::optional<ArraySpec>>(x.t), ")"), Put(')');
   }
   void Post(const StructureField &x) {
-    if (const auto *def = std::get_if<Statement<DataComponentDefStmt>>(&x.u)) {
+    if (const auto *def{std::get_if<Statement<DataComponentDefStmt>>(&x.u)}) {
       for (const auto &decl :
           std::get<std::list<ComponentDecl>>(def->statement.t)) {
         structureComponents_.insert(std::get<Name>(decl.t).source);

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -290,7 +290,7 @@ public:
   void Unparse(const Pass &x) { Word("PASS"), Walk("(", x.v, ")"); }
   void Unparse(const Initialization &x) {  // R743 & R805
     std::visit(
-        common::visitors{[&](const ConstantExpr &y) { Put("{"), Walk(y); },
+        common::visitors{[&](const ConstantExpr &y) { Put(" = "), Walk(y); },
             [&](const NullInit &y) { Put(" => "), Walk(y); },
             [&](const InitialDataTarget &y) { Put(" => "), Walk(y); },
             [&](const std::list<common::Indirection<DataStmtValue>> &y) {

--- a/lib/parser/user-state.cc
+++ b/lib/parser/user-state.cc
@@ -24,7 +24,7 @@
 namespace Fortran::parser {
 
 std::optional<Success> StartNewSubprogram::Parse(ParseState &state) {
-  if (auto ustate = state.userState()) {
+  if (auto *ustate{state.userState()}) {
     ustate->NewSubprogram();
   }
   return {Success{}};
@@ -32,10 +32,10 @@ std::optional<Success> StartNewSubprogram::Parse(ParseState &state) {
 
 std::optional<CapturedLabelDoStmt::resultType> CapturedLabelDoStmt::Parse(
     ParseState &state) {
-  static constexpr auto parser = statement(indirect(Parser<LabelDoStmt>{}));
-  auto result = parser.Parse(state);
+  static constexpr auto parser{statement(indirect(Parser<LabelDoStmt>{}))};
+  auto result{parser.Parse(state)};
   if (result) {
-    if (auto ustate = state.userState()) {
+    if (auto *ustate{state.userState()}) {
       ustate->NewDoLabel(std::get<Label>(result->statement->t));
     }
   }
@@ -44,11 +44,11 @@ std::optional<CapturedLabelDoStmt::resultType> CapturedLabelDoStmt::Parse(
 
 std::optional<EndDoStmtForCapturedLabelDoStmt::resultType>
 EndDoStmtForCapturedLabelDoStmt::Parse(ParseState &state) {
-  static constexpr auto parser =
-      statement(indirect(construct<EndDoStmt>("END DO" >> maybe(name))));
-  if (auto enddo = parser.Parse(state)) {
+  static constexpr auto parser{
+      statement(indirect(construct<EndDoStmt>("END DO" >> maybe(name))))};
+  if (auto enddo{parser.Parse(state)}) {
     if (enddo->label.has_value()) {
-      if (auto ustate = state.userState()) {
+      if (const auto *ustate{state.userState()}) {
         if (!ustate->InNonlabelDoConstruct() &&
             ustate->IsDoLabel(enddo->label.value())) {
           return enddo;
@@ -60,14 +60,14 @@ EndDoStmtForCapturedLabelDoStmt::Parse(ParseState &state) {
 }
 
 std::optional<Success> EnterNonlabelDoConstruct::Parse(ParseState &state) {
-  if (auto ustate = state.userState()) {
+  if (auto *ustate{state.userState()}) {
     ustate->EnterNonlabelDoConstruct();
   }
   return {Success{}};
 }
 
 std::optional<Success> LeaveDoConstruct::Parse(ParseState &state) {
-  if (auto ustate = state.userState()) {
+  if (auto ustate{state.userState()}) {
     ustate->LeaveDoConstruct();
   }
   return {Success{}};
@@ -75,7 +75,7 @@ std::optional<Success> LeaveDoConstruct::Parse(ParseState &state) {
 
 std::optional<Name> OldStructureComponentName::Parse(ParseState &state) {
   if (std::optional<Name> n{name.Parse(state)}) {
-    if (const auto *ustate = state.userState()) {
+    if (const auto *ustate{state.userState()}) {
       if (ustate->IsOldStructureComponent(n->source)) {
         return n;
       }
@@ -86,10 +86,10 @@ std::optional<Name> OldStructureComponentName::Parse(ParseState &state) {
 
 std::optional<DataComponentDefStmt> StructureComponents::Parse(
     ParseState &state) {
-  static constexpr auto stmt = Parser<DataComponentDefStmt>{};
+  static constexpr auto stmt{Parser<DataComponentDefStmt>{}};
   std::optional<DataComponentDefStmt> defs{stmt.Parse(state)};
   if (defs.has_value()) {
-    if (auto ustate = state.userState()) {
+    if (auto *ustate{state.userState()}) {
       for (const auto &decl : std::get<std::list<ComponentDecl>>(defs->t)) {
         ustate->NoteOldStructureComponent(std::get<Name>(decl.t).source);
       }


### PR DESCRIPTION
As Tim and I discussed recently, C++ no longer misinterprets `auto foo{x}` as a declaration of `foo` as an `initializer_list`, and all of the `auto` declarations that use `=` can be normalized to look like the others with real types do.

So this is a big PR but it's basically a no-op.