### PR TITLE
Fix two problems described in issue#121

### DIFF
--- a/documentation/FortranForCProgrammers.md
+++ b/documentation/FortranForCProgrammers.md
@@ -63,6 +63,7 @@ in particular ways that might be unfamiliar.
 | Deferred | Some attribute of a variable that is not known until an allocation or assignment |
 | Derived type | C++ class |
 | Dummy argument | C++ reference argument |
+| Final procedure | C++ destructor |
 | Generic | Overloaded function, resolved by actual arguments |
 | Host procedure | The subprogram that contains this nested one |
 | Implied DO | There's a loop inside a statement |

--- a/documentation/ParserCombinators.md
+++ b/documentation/ParserCombinators.md
@@ -88,7 +88,9 @@ They are `constexpr`, so they should be viewed as type-safe macros.
    or with a warning if nonstandard usage warnings are enabled.
 * `deprecated(p)` parses p if strict standard compliance is disabled,
   with a warning if deprecated usage warnings are enabled.
-* `inContext(msg, p)` runs p within an error message context.
+* `inContext(msg, p)` runs p within an error message context; any
+  message that `p` generates will be tagged with `msg` as its
+  context.  Contexts may nest.
 * `withMessage(msg, p)` succeeds if `p` does, and if it does not,
   it discards the messages from `p` and fails with the specified message.
 * `recovery(p, q)` is equivalent to `p || q`, except that error messages

--- a/documentation/ParserCombinators.md
+++ b/documentation/ParserCombinators.md
@@ -88,7 +88,9 @@ They are `constexpr`, so they should be viewed as type-safe macros.
    or with a warning if nonstandard usage warnings are enabled.
 * `deprecated(p)` parses p if strict standard compliance is disabled,
   with a warning if deprecated usage warnings are enabled.
-* `inContext(..., p)` runs p within an error message context.
+* `inContext(msg, p)` runs p within an error message context.
+* `withMessage(msg, p)` succeeds if `p` does, and if it does not,
+  it discards the messages from `p` and fails with the specified message.
 * `recovery(p, q)` is equivalent to `p || q`, except that error messages
   generated from the first parser are retained, and a flag is set in
   the ParseState to remember that error recovery was necessary.

--- a/documentation/extensions.md
+++ b/documentation/extensions.md
@@ -44,6 +44,8 @@ Extensions, deletions, and legacy features supported
 * Backslash escape character sequences in quoted character literals
 * `D` lines in fixed form as comments or debug code
 * `CONVERT=` on the OPEN statement
+* Leading semicolons are ignored before any statement that
+  could have a label
 
 Extensions and legacy features deliberately not supported
 ---------------------------------------------------------

--- a/lib/parser/basic-parsers.h
+++ b/lib/parser/basic-parsers.h
@@ -198,17 +198,17 @@ public:
     std::optional<resultType> result{parser_.Parse(state)};
     if (result.has_value()) {
       messages.Annex(state.messages());
-      state.messages() = std::move(messages);
-      return result;
     }
     state.messages() = std::move(messages);
-    state.Say(text_);
-    return {};
+    if (!result.has_value()) {
+      state.Say(text_);
+    }
+    return result;
   }
 
 private:
   const MessageFixedText text_;
-  const BacktrackingParser<PA> parser_;
+  const PA parser_;
 };
 
 template<typename PA>

--- a/lib/parser/message.h
+++ b/lib/parser/message.h
@@ -204,9 +204,8 @@ public:
   bool AnyFatalError() const;
 
 private:
-  using listType = std::forward_list<Message>;
-  listType messages_;
-  listType::iterator last_{messages_.before_begin()};
+  std::forward_list<Message> messages_;
+  std::forward_list<Message>::iterator last_{messages_.before_begin()};
 };
 
 }  // namespace Fortran::parser

--- a/lib/parser/openmp-grammar.h
+++ b/lib/parser/openmp-grammar.h
@@ -39,7 +39,7 @@
 // OpenMP Directives and Clauses
 namespace Fortran::parser {
 
-constexpr auto beginOmpDirective{skipEmptyLines >> space >> "!$OMP "_sptok};
+constexpr auto beginOmpDirective{skipStuffBeforeStatement >> "!$OMP "_sptok};
 
 // OpenMP Clauses
 
@@ -248,7 +248,7 @@ TYPE_PARSER(
     construct<OmpClause>(
         "SCHEDULE"_tok >> parenthesized(Parser<OmpScheduleClause>{})))
 
-TYPE_PARSER(skipEmptyLines >> space >> "!$OMP END"_sptok >>
+TYPE_PARSER(skipStuffBeforeStatement >> "!$OMP END"_sptok >>
     (construct<OmpEndDirective>(Parser<OmpLoopDirective>{})))
 
 // Omp directives enclosing do loop


### PR DESCRIPTION
Allow empty statements to appear as a language extension.
Improve error messages in error recovery situations.