### PR TITLE
Implement writing of .mod files.

### DIFF
--- a/documentation/mod-files.md
+++ b/documentation/mod-files.md
@@ -1,0 +1,124 @@
+# Module Files
+
+Module files hold information from a module that is necessary to compile 
+program units that depend on the module.
+
+## Name
+
+Module files must be searchable by module name. They are typically named
+`<modulename>.mod`. The advantage of using `.mod` is that it is consistent with
+other compilers so users will know what they are. Also, makefiles and scripts
+often use `rm *.mod` to clean up.
+
+The disadvantage of using the same name as other compilers is that it is not
+clear which compiler created a `.mod` file and files from multiple compilers
+cannot be in the same directory. This could be solved by adding something
+between the module name and extension, e.g. `<modulename>-f18.mod`.
+
+## Format
+
+The proposed format for module files is a Fortran source.
+Declarations of all visibile entities will be included, along with private
+entities that they depend on. Executable statements will be omitted.
+
+### Header
+
+There will be a header containing extra information that cannot be expressed
+in Fortran. This will take the form of a comment or directive
+at the beginning of the file.
+
+If it's a comment, the module file reader would have to strip it out and
+perform *ad hoc* parsing on it. If it's a directive the compiler could
+parse it like other directives as part of the grammar.
+Processing the header before parsing might result in better error messages
+when the `.mod` file is invalid.
+
+Regardless of whether the header is a comment or directive we can use the
+same string to introduce it: `!mod$`.
+
+Information in the header:
+- Magic string to confirm it is an f18 `.mod` file
+- Version information: to indicate the version of the file format, in case it changes,
+  and the version of the compiler that wrote the file, for diagnostics.
+- Checksum of the body of the current file
+- Modules we depend on and the checksum of their module file when the current
+  module file is created
+- Source file dependency information?
+- Compilation options?
+
+### Body
+
+The body will consist of minimal Fortran source for the required declarations.
+The order will match the order they first appeared in the source.
+
+Some normalization will take place:
+- extraneous spaces will be removed
+- implicit types will be made explicit
+- attributes will be written in a consistent order
+- entity declarations will be combined into a single declaration
+- function return types specified in a *prefix-spec* will be replaced by
+  an entity declaration
+- etc.
+
+#### Symbols included
+
+All public symbols from the module need to be included.
+
+In addition, some private symbols are needed:
+- private types that appear in the public API
+- private components of non-private derived types
+- private parameters used in non-private declarations (initial values, kind parameters)
+- others?
+
+It might be possible to anonymize private names if users don't want them exposed
+in the `.mod` file. (Currently they are readable in PGI `.mod` files.)
+
+#### USE associate
+
+A module that contains `USE` statements needs them represented in the
+`.mod` file.
+Each use-associated symbol will be written as a separate *use-only* statement,
+possibly with renaming.
+
+Alternatives:
+- Emit a single `USE` for each module, listing all of the symbols that were
+  use-associated in the *only-list*.
+- Detect when all of the symbols from a module are imported (either by a *use-stmt*
+  without an *only-list* or because all of the public symbols of the module
+  have been listed in *only-list*s). In that case collapse them into a single *use-stmt*.
+- Emit the *use-stmt*s that appeared in the original source.
+
+## Reading and writing module files
+
+A command-line option (e.g. `-module`) will specified a directory to
+search for `.mod` files and to write them to.
+If not specified it defaults to the current directory.
+
+### Writing modules files
+
+When writing a module file, if the existing one matches what would be written,
+the timestamp is not updated.
+
+Module files will be written after semantics, i.e. after the compiler has
+determined the module is valid Fortran.<br>
+**NOTE:** PGI does create `.mod` files sometimes even when the module has a
+compilation error.
+
+When the compiler can get far enough to determine it is compiling a module
+but then encounters an error, it will delete the existing `.mod` file
+if present.
+
+### Reading module files
+
+When the compiler finds a `.mod` file it needs to read, it firsts checks the first
+line and verifies it is a valid module file. It can also verify checksums of
+modules it depends on and report if they are out of date.
+
+If the header is valid, the module file will be run through the parser and name
+resolution to recreate the symbols from the module. Once the symbol table is
+populated the parse tree can be discarded.
+
+When processing `.mod` files we know they are valid Fortran with these properties:
+1. The input (without the header) is already in the "cooked input" format.
+2. No preprocessing is necessary.
+3. No errors can occur.

--- a/documentation/mod-files.md
+++ b/documentation/mod-files.md
@@ -17,7 +17,7 @@ between the module name and extension, e.g. `<modulename>-f18.mod`.
 
 ## Format
 
-The proposed format for module files is a Fortran source.
+The proposed format for module files is Fortran source.
 Declarations of all visibile entities will be included, along with private
 entities that they depend on. Executable statements will be omitted.
 

--- a/lib/semantics/CMakeLists.txt
+++ b/lib/semantics/CMakeLists.txt
@@ -15,6 +15,7 @@
 
 add_library(FlangSemantics
   attr.cc
+  mod-file.cc
   resolve-names.cc
   rewrite-parse-tree.cc
   scope.cc

--- a/lib/semantics/attr.cc
+++ b/lib/semantics/attr.cc
@@ -24,8 +24,18 @@ void Attrs::CheckValid(const Attrs &allowed) const {
   }
 }
 
+std::string AttrToString(Attr attr) {
+  switch (attr) {
+  case Attr::BIND_C: return "BIND(C)";
+  case Attr::INTENT_IN: return "INTENT(IN)";
+  case Attr::INTENT_INOUT: return "INTENT(INOUT)";
+  case Attr::INTENT_OUT: return "INTENT(OUT)";
+  default: return EnumToString(attr);
+  }
+}
+
 std::ostream &operator<<(std::ostream &o, Attr attr) {
-  return o << EnumToString(attr);
+  return o << AttrToString(attr);
 }
 
 std::ostream &operator<<(std::ostream &o, const Attrs &attrs) {

--- a/lib/semantics/attr.h
+++ b/lib/semantics/attr.h
@@ -46,6 +46,9 @@ private:
   friend std::ostream &operator<<(std::ostream &, const Attrs &);
 };
 
+// Return string representation of attr that matches Fortran source.
+std::string AttrToString(Attr attr);
+
 std::ostream &operator<<(std::ostream &o, Attr attr);
 std::ostream &operator<<(std::ostream &o, const Attrs &attrs);
 

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -1,0 +1,356 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mod-file.h"
+#include "scope.h"
+#include "symbol.h"
+#include "../parser/message.h"
+#include <algorithm>
+#include <cerrno>
+#include <fstream>
+#include <functional>
+#include <ostream>
+#include <set>
+#include <sstream>
+#include <vector>
+
+namespace Fortran::semantics {
+
+using namespace parser::literals;
+
+class ModFileWriter {
+public:
+  // The initial characters of a file that identify it as a .mod file.
+  static constexpr auto magic{"!mod$"};
+  static constexpr auto extension{".mod"};
+
+  // The .mod file format version number.
+  void set_version(int version) { version_ = version; }
+  // The directory to write .mod files in.
+  void set_directory(const std::string &dir) { dir_ = dir; }
+
+  // Errors encountered during writing. Non-empty if WriteAll returns false.
+  const std::list<parser::MessageFormattedText> &errors() const {
+    return errors_;
+  }
+
+  // Write out all .mod files; if error return false and report them on ostream.
+  bool WriteAll(std::ostream &);
+  // Write out all .mod files; if error return false.
+  bool WriteAll();
+  // Write out .mod file for one module; if error return false.
+  bool WriteOne(const Symbol &);
+
+private:
+  using symbolSet = std::set<const Symbol *>;
+  using symbolVector = std::vector<const Symbol *>;
+
+  int version_{1};
+  std::string dir_{"."};
+  // The mod file consists of uses, declarations, and contained subprograms:
+  std::stringstream uses_;
+  std::stringstream decls_;
+  std::stringstream contains_;
+  // Any errors encountered during writing:
+  std::list<parser::MessageFormattedText> errors_;
+
+  std::string GetAsString(const std::string &);
+  std::string GetHeader(const std::string &);
+  void PutSymbols(const Scope &);
+  symbolVector SortSymbols(const symbolSet);
+  symbolSet CollectSymbols(const Scope &);
+  void PutSymbol(const Symbol &);
+  void PutDerivedType(const Symbol &);
+  void PutSubprogram(const Symbol &);
+  void PutUse(const Symbol &);
+  static void PutEntity(std::ostream &, const Symbol &);
+  static void PutObjectEntity(std::ostream &, const Symbol &);
+  static void PutProcEntity(std::ostream &, const Symbol &);
+  static void PutEntity(std::ostream &, const Symbol &, std::function<void()>);
+  static std::ostream &PutAttrs(std::ostream &, Attrs,
+      std::string before = ","s, std::string after = ""s);
+  static std::ostream &PutLower(std::ostream &, const Symbol &);
+  static std::ostream &PutLower(std::ostream &, const DeclTypeSpec &);
+  static std::ostream &PutLower(std::ostream &, const std::string &);
+  static std::string CheckSum(const std::string &);
+};
+
+bool ModFileWriter::WriteAll(std::ostream &os) {
+  if (!WriteAll()) {
+    for (auto &message : errors()) {
+      std::cerr << message.string() << '\n';
+    }
+    return false;
+  }
+  return true;
+}
+
+bool ModFileWriter::WriteAll() {
+  for (const auto &scope : Scope::globalScope.children()) {
+    if (scope.kind() == Scope::Kind::Module) {
+      auto &symbol{*scope.symbol()};  // symbol must be present for module
+      WriteOne(symbol);
+    }
+  }
+  return errors_.empty();
+}
+
+bool ModFileWriter::WriteOne(const Symbol &modSymbol) {
+  CHECK(modSymbol.has<ModuleDetails>());
+  auto name{parser::ToLowerCaseLetters(modSymbol.name().ToString())};
+  std::string path{dir_ + '/' + name + extension};
+  std::ofstream os{path};
+  PutSymbols(*modSymbol.scope());
+  std::string all{std::move(GetAsString(name))};
+  auto header{GetHeader(all)};
+  os << header << all;
+  os.close();
+  if (!os) {
+    errors_.emplace_back(
+        "Error writing %s: %s"_err_en_US, path.c_str(), std::strerror(errno));
+    return false;
+  }
+  return true;
+}
+
+// Return the entire body of the module file
+// and clear saved uses, decls, and contains.
+std::string ModFileWriter::GetAsString(const std::string &name) {
+  std::stringstream all;
+  all << "module " << name << '\n';
+  all << uses_.str();
+  uses_.str(""s);
+  all << decls_.str();
+  decls_.str(""s);
+  auto str{contains_.str()};
+  contains_.str(""s);
+  if (!str.empty()) {
+    all << "contains\n" << str;
+  }
+  all << "end\n";
+  return all.str();
+}
+
+// Return the header for this mod file.
+std::string ModFileWriter::GetHeader(const std::string &all) {
+  std::stringstream ss;
+  ss << magic << " v" << version_ << " sum:" << CheckSum(all) << '\n';
+  return ss.str();
+}
+
+// Put out the visible symbols from scope.
+void ModFileWriter::PutSymbols(const Scope &scope) {
+  for (const auto *symbol : SortSymbols(CollectSymbols(scope))) {
+    PutSymbol(*symbol);
+  }
+}
+
+// Sort symbols by their original order, not by name.
+ModFileWriter::symbolVector ModFileWriter::SortSymbols(
+    const ModFileWriter::symbolSet symbols) {
+  ModFileWriter::symbolVector sorted;
+  sorted.reserve(symbols.size());
+  for (const auto *symbol : symbols) {
+    sorted.push_back(symbol);
+  }
+  auto compare{[](const Symbol *x, const Symbol *y) {
+    return x->name().begin() < y->name().begin();
+  }};
+  std::sort(sorted.begin(), sorted.end(), compare);
+  return sorted;
+}
+
+// Return all symbols needed from this scope.
+ModFileWriter::symbolSet ModFileWriter::CollectSymbols(const Scope &scope) {
+  ModFileWriter::symbolSet symbols;
+  for (const auto &pair : scope) {
+    auto *symbol{pair.second};
+    // include all components of derived types and other non-private symbols
+    if (scope.kind() == Scope::Kind::DerivedType ||
+        !symbol->attrs().test(Attr::PRIVATE)) {
+      symbols.insert(symbol);
+      // ensure the type symbol is included too, even if private
+      if (const auto *type{symbol->GetType()}) {
+        auto category{type->category()};
+        if (category == DeclTypeSpec::TypeDerived ||
+            category == DeclTypeSpec::ClassDerived) {
+          auto *typeSymbol{type->derivedTypeSpec().scope()->symbol()};
+          symbols.insert(typeSymbol);
+        }
+      }
+      // TODO: other related symbols, e.g. in initial values
+    }
+  }
+  return symbols;
+}
+
+void ModFileWriter::PutSymbol(const Symbol &symbol) {
+  std::visit(
+      common::visitors{
+          [&](const ModuleDetails &) { /* should be current module */ },
+          [&](const DerivedTypeDetails &) { PutDerivedType(symbol); },
+          [&](const SubprogramDetails &) { PutSubprogram(symbol); },
+          [&](const UseDetails &) { PutUse(symbol); },
+          [&](const UseErrorDetails &) {},
+          [&](const auto &) { PutEntity(decls_, symbol); }},
+      symbol.details());
+}
+
+void ModFileWriter::PutDerivedType(const Symbol &typeSymbol) {
+  PutAttrs(decls_ << "type", typeSymbol.attrs(), ","s, ""s);
+  PutLower(decls_ << "::", typeSymbol) << '\n';
+  PutSymbols(*typeSymbol.scope());
+  decls_ << "end type\n";
+}
+
+void ModFileWriter::PutSubprogram(const Symbol &symbol) {
+  auto attrs{symbol.attrs()};
+  Attrs bindAttrs{};
+  if (attrs.test(Attr::BIND_C)) {
+    // bind(c) is a suffix, not prefix
+    bindAttrs.set(Attr::BIND_C, true);
+    attrs.set(Attr::BIND_C, false);
+  }
+  PutAttrs(contains_, attrs, ""s, " "s);
+  auto &details{symbol.get<SubprogramDetails>()};
+  contains_ << (details.isFunction() ? "function " : "subroutine ");
+  PutLower(contains_, symbol) << '(';
+  int n = 0;
+  for (const auto &dummy : details.dummyArgs()) {
+    if (n++ > 0) contains_ << ',';
+    PutLower(contains_, *dummy);
+  }
+  contains_ << ')';
+  PutAttrs(contains_, bindAttrs, " "s, ""s);
+  if (details.isFunction()) {
+    const Symbol &result{details.result()};
+    if (result.name() != symbol.name()) {
+      PutLower(contains_ << " result(", result) << ')';
+    }
+    contains_ << '\n';
+    PutEntity(contains_, details.result());
+  } else {
+    contains_ << '\n';
+  }
+  for (const auto &dummy : details.dummyArgs()) {
+    PutEntity(contains_, *dummy);
+  }
+  contains_ << "end\n";
+}
+
+void ModFileWriter::PutUse(const Symbol &symbol) {
+  auto &details{symbol.get<UseDetails>()};
+  PutLower(uses_ << "use ", details.module());
+  PutLower(uses_ << ",only:", symbol);
+  if (details.symbol().name() != symbol.name()) {
+    PutLower(uses_ << "=>", details.symbol());
+  }
+  uses_ << '\n';
+}
+
+void ModFileWriter::PutEntity(std::ostream &os, const Symbol &symbol) {
+  std::visit(
+      common::visitors{
+          [&](const EntityDetails &) { PutObjectEntity(os, symbol); },
+          [&](const ObjectEntityDetails &) { PutObjectEntity(os, symbol); },
+          [&](const ProcEntityDetails &) { PutProcEntity(os, symbol); },
+          [](const auto &) { CHECK(!"invalid details"); },
+      },
+      symbol.details());
+}
+
+void ModFileWriter::PutObjectEntity(std::ostream &os, const Symbol &symbol) {
+  PutEntity(os, symbol, [&]() {
+    auto *type{symbol.GetType()};
+    CHECK(type);
+    PutLower(os, *type);
+  });
+}
+
+void ModFileWriter::PutProcEntity(std::ostream &os, const Symbol &symbol) {
+  const ProcInterface &interface{symbol.get<ProcEntityDetails>().interface()};
+  PutEntity(os, symbol, [&]() {
+    os << "procedure(";
+    if (interface.symbol()) {
+      PutLower(os, *interface.symbol());
+    } else if (interface.type()) {
+      PutLower(os, *interface.type());
+    }
+    os << ')';
+  });
+}
+
+// Write an entity (object or procedure) declaration.
+// writeType is called to write out the type.
+void ModFileWriter::PutEntity(
+    std::ostream &os, const Symbol &symbol, std::function<void()> writeType) {
+  writeType();
+  PutAttrs(os, symbol.attrs());
+  PutLower(os << "::", symbol) << '\n';
+}
+
+// Put out each attribute to os, surrounded by `before` and `after` and
+// mapped to lower case.
+std::ostream &ModFileWriter::PutAttrs(
+    std::ostream &os, Attrs attrs, std::string before, std::string after) {
+  attrs.set(Attr::PUBLIC, false);  // no need to write PUBLIC
+  attrs.set(Attr::EXTERNAL, false);  // no need to write EXTERNAL
+  for (std::size_t i{0}; i < Attr_enumSize; ++i) {
+    Attr attr{static_cast<Attr>(i)};
+    if (attrs.test(attr)) {
+      PutLower(os << before, AttrToString(attr)) << after;
+    }
+  }
+  return os;
+}
+
+std::ostream &ModFileWriter::PutLower(std::ostream &os, const Symbol &symbol) {
+  return PutLower(os, symbol.name().ToString());
+}
+
+std::ostream &ModFileWriter::PutLower(
+    std::ostream &os, const DeclTypeSpec &type) {
+  std::stringstream s;
+  s << type;
+  return PutLower(os, s.str());
+}
+
+std::ostream &ModFileWriter::PutLower(
+    std::ostream &os, const std::string &str) {
+  for (char c : str) {
+    os << parser::ToLowerCaseLetter(c);
+  }
+  return os;
+}
+
+// Compute a simple hash of the contents of a module file and
+// return it as a string of hex digits.
+// This uses the Fowler-Noll-Vo hash function.
+std::string ModFileWriter::CheckSum(const std::string &str) {
+  std::uint64_t hash{0xcbf29ce484222325ull};
+  for (char c : str) {
+    hash ^= c & 0xff;
+    hash *= 0x100000001b3;
+  }
+  static const char *digits = "0123456789abcdef";
+  std::string result(16, '0');
+  for (size_t i{16}; hash != 0; hash >>= 4) {
+    result[--i] = digits[hash & 0xf];
+  }
+  return result;
+}
+
+void WriteModFiles() { ModFileWriter{}.WriteAll(std::cerr); }
+
+}  // namespace Fortran::semantics

--- a/lib/semantics/mod-file.h
+++ b/lib/semantics/mod-file.h
@@ -1,0 +1,27 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_SEMANTICS_MOD_FILE_H_
+#define FORTRAN_SEMANTICS_MOD_FILE_H_
+
+#include <filesystem>
+#include <iosfwd>
+
+namespace Fortran::semantics {
+
+void WriteModFiles();
+
+}  // namespace Fortran::semantics
+
+#endif

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -250,10 +250,10 @@ public:
   }
 
   // Return a reference to the details which must be of type D.
-  template<typename D> D &details() {
-    return const_cast<D &>(static_cast<const Symbol *>(this)->details<D>());
+  template<typename D> D &get() {
+    return const_cast<D &>(static_cast<const Symbol *>(this)->get<D>());
   }
-  template<typename D> const D &details() const {
+  template<typename D> const D &get() const {
     if (const auto p = detailsIf<D>()) {
       return *p;
     } else {
@@ -262,6 +262,7 @@ public:
     }
   }
 
+  const Details &details() const { return details_; }
   // Assign the details of the symbol from one of the variants.
   // Only allowed in certain cases.
   void set_details(Details &&details);

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -60,6 +60,7 @@ set(MODFILE_TESTS
   modfile01.f90
   modfile02.f90
   modfile03.f90
+  modfile04.f90
 )
 
 foreach(test ${ERROR_TESTS})

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -61,6 +61,7 @@ set(MODFILE_TESTS
   modfile02.f90
   modfile03.f90
   modfile04.f90
+  modfile05.f90
 )
 
 foreach(test ${ERROR_TESTS})

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -55,10 +55,21 @@ set(SYMBOL_TESTS
   symbol01.f90
 )
 
+# These test files have expected .mod file contents in the source
+set(MODFILE_TESTS
+  modfile01.f90
+  modfile02.f90
+  modfile03.f90
+)
+
 foreach(test ${ERROR_TESTS})
   add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_errors.sh ${test})
 endforeach()
 
 foreach(test ${SYMBOL_TESTS})
   add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_symbols.sh ${test})
+endforeach()
+
+foreach(test ${MODFILE_TESTS})
+  add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_modfile.sh ${test})
 endforeach()

--- a/test/semantics/modfile01.f90
+++ b/test/semantics/modfile01.f90
@@ -1,0 +1,36 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check correct modfile generation for type with private component.
+module m
+  integer :: i
+  integer, private :: j
+  type :: t
+    integer :: i
+    integer, private :: j
+  end type
+  type, private :: u
+  end type
+  type(t) :: x
+end
+
+!Expect: m.mod
+!module m
+!integer::i
+!type::t
+!integer::i
+!integer,private::j
+!end type
+!type(t)::x
+!end

--- a/test/semantics/modfile02.f90
+++ b/test/semantics/modfile02.f90
@@ -1,0 +1,34 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check modfile generation for private type in public API.
+
+module m
+  type, private :: t1
+    integer :: i
+  end type
+  type, private :: t2
+    integer :: i
+  end type
+  type(t1) :: x1
+  type(t2), private :: x2
+end
+
+!Expect: m.mod
+!module m
+!type,private::t1
+!integer::i
+!end type
+!type(t1)::x1
+!end

--- a/test/semantics/modfile03.f90
+++ b/test/semantics/modfile03.f90
@@ -1,0 +1,57 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check modfile generation with use-association.
+
+module m1
+  integer :: x1
+  integer, private :: x2
+end
+
+module m2
+  use m1
+  integer :: y1
+end
+
+module m3
+  use m2, z1 => x1
+end
+
+module m4
+  use m1
+  use m2
+end
+
+!Expect: m1.mod
+!module m1
+!integer::x1
+!end
+
+!Expect: m2.mod
+!module m2
+!use m1,only:x1
+!integer::y1
+!end
+
+!Expect: m3.mod
+!module m3
+!use m2,only:y1
+!use m2,only:z1=>x1
+!end
+
+!Expect: m4.mod
+!module m4
+!use m1,only:x1
+!use m2,only:y1
+!end

--- a/test/semantics/modfile04.f90
+++ b/test/semantics/modfile04.f90
@@ -1,0 +1,51 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! modfile with subprograms
+
+module m
+contains
+
+  pure subroutine s(x, y) bind(c)
+    logical x
+    intent(inout) y
+    intent(in) x
+  end subroutine
+
+  real function f1() result(x)
+    x = 1.0
+  end function
+
+  function f2(y)
+    complex y
+    f2 = 2.0
+  end function
+
+end
+
+!Expect: m.mod
+!module m
+!contains
+!pure subroutine s(x,y) bind(c)
+!logical,intent(in)::x
+!real,intent(inout)::y
+!end
+!function f1() result(x)
+!real::x
+!end
+!function f2(y)
+!real::f2
+!complex::y
+!end
+!end

--- a/test/semantics/modfile05.f90
+++ b/test/semantics/modfile05.f90
@@ -1,0 +1,44 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Use-association with VOLATILE or ASYNCHRONOUS
+
+module m1
+  real x
+  integer y
+  volatile z
+contains
+end
+
+module m2
+  use m1
+  volatile x
+  asynchronous y
+end
+
+!Expect: m1.mod
+!module m1
+!real::x
+!integer::y
+!real,volatile::z
+!end
+
+!Expect: m2.mod
+!module m2
+!use m1,only:x
+!use m1,only:y
+!use m1,only:z
+!volatile::x
+!asynchronous::y
+!end

--- a/test/semantics/symbol01.f90
+++ b/test/semantics/symbol01.f90
@@ -19,9 +19,9 @@ module m
  !DEF: /m/f PRIVATE, PURE, RECURSIVE Subprogram
  private :: f
 contains
- !DEF: /m/s BIND_C, PUBLIC, PURE Subprogram
- !DEF: /m/s/x INTENT_IN Entity
- !DEF: /m/s/y INTENT_INOUT Entity
+ !DEF: /m/s BIND(C), PUBLIC, PURE Subprogram
+ !DEF: /m/s/x INTENT(IN) (implicit) ObjectEntity REAL
+ !DEF: /m/s/y INTENT(INOUT) (implicit) ObjectEntity REAL
  pure subroutine s (x, y) bind(c)
   intent(in) :: x
   intent(inout) :: y

--- a/test/semantics/test_modfile.sh
+++ b/test/semantics/test_modfile.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/bash
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Compile a source file and compare generated .mod files against expected.
+
+set -e
+PATH=/usr/bin
+srcdir=$(dirname $0)
+CMD="${F18:-../../../tools/f18/f18} -fdebug-resolve-names -fparse-only"
+
+if [[ $# != 1 ]]; then
+  echo "Usage: $0 <fortran-source>"
+  exit 1
+fi
+src=$srcdir/$1
+[[ ! -f $src ]] && echo "File not found: $src" && exit 1
+
+if [[ $KEEP ]]; then
+  temp=.
+else
+  temp=$(mktemp --directory --tmpdir=.)
+  trap "rm -rf $temp" EXIT
+fi
+
+( cd $temp && $CMD $src )
+
+actual=$temp/actual.mod
+expect=$temp/expect.mod
+actual_files=$temp/actual_files
+diffs=$temp/diffs
+
+( cd $temp && ls -1 *.mod ) > $actual_files
+expected_files=$(sed -n 's/^!Expect: \(.*\)/\1/p' $src)
+extra_files=$(echo "$expected_files" | comm -23 $actual_files -)
+if [[ ! -z "$extra_files" ]]; then
+  echo "Unexpected .mod files produced:" $extra_files
+  echo FAIL
+  exit 1
+fi
+for mod in $expected_files; do
+  if [[ ! -f $temp/$mod ]]; then
+    echo "Compilation did not produce expected mod file: $mod"
+    echo FAIL
+    exit 1
+  fi
+  sed '/^!mod\$/d' $temp/$mod > $actual
+  sed '1,/^!Expect: '"$mod"'/d' $src | sed -e '/^$/,$d' -e 's/^!//' > $expect
+  if ! diff -U999999 $actual $expect > $diffs; then
+    echo "Module file $mod differs from expected:"
+    sed '1,2d' $diffs
+    echo FAIL
+    exit 1
+  fi
+done
+echo PASS

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -22,6 +22,7 @@
 #include "../../lib/parser/provenance.h"
 #include "../../lib/parser/unparse.h"
 #include "../../lib/semantics/dump-parse-tree.h"
+#include "../../lib/semantics/mod-file.h"
 #include "../../lib/semantics/resolve-names.h"
 #include "../../lib/semantics/unparse-with-symbols.h"
 #include <cerrno>
@@ -205,6 +206,7 @@ std::string CompileFortran(
   if (driver.debugResolveNames || driver.dumpSymbols ||
       driver.dumpUnparseWithSymbols) {
     Fortran::semantics::ResolveNames(parseTree, parsing.cooked());
+    Fortran::semantics::WriteModFiles();
     if (driver.dumpSymbols) {
       Fortran::semantics::DumpSymbols(std::cout);
     }


### PR DESCRIPTION
Module file writing is implemented in `mod-file.cc`. They need to be
written after all semantic checking. Until then, for testing, write
them out whenever names are resolved.

There is a header comment in the .mod files but it is mostly a
placeholder until we can read them in and do something with it.

Rename `Symbol::details<D>` to `Symbol::get<D>`. This asserts that the
details of the symbol match D and returns that type. But we need a way
to access the details as a variant as well (not just one of its types).
`details()` is the best name for that, especially as we already have
`set_details()`. Renaming the old `details` to `get` also better matches
`has` which is used to check which variant is present.

Include tests and documentation.