### PR TITLE
Fix test script portability problems.

### DIFF
--- a/test/semantics/test_modfile.sh
+++ b/test/semantics/test_modfile.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
 # Compile a source file and compare generated .mod files against expected.
 
 set -e
-PATH=/usr/bin
+PATH=/usr/bin:/bin
 srcdir=$(dirname $0)
 CMD="${F18:-../../../tools/f18/f18} -fdebug-resolve-names -fparse-only"
 
@@ -27,12 +27,10 @@ fi
 src=$srcdir/$1
 [[ ! -f $src ]] && echo "File not found: $src" && exit 1
 
-if [[ $KEEP ]]; then
-  temp=.
-else
-  temp=$(mktemp --directory --tmpdir=.)
-  trap "rm -rf $temp" EXIT
-fi
+temp=temp-$1
+rm -rf $temp
+mkdir $temp
+[[ $KEEP ]] || trap "rm -rf $temp" EXIT
 
 ( cd $temp && $CMD $src )
 

--- a/test/semantics/test_symbols.sh
+++ b/test/semantics/test_symbols.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 # Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +18,7 @@
 # the same as the input, except for the copyright comment.
 # Change the compiler by setting the F18 environment variable.
 
-PATH=/usr/bin
+PATH=/usr/bin:/bin
 srcdir=$(dirname $0)
 CMD="${F18:-../../tools/f18/f18} -funparse-with-symbols"
 
@@ -29,12 +29,11 @@ fi
 src=$srcdir/$1
 [[ ! -f $src ]] && echo "File not found: $src" && exit 1
 
-if [[ $KEEP ]]; then
-  temp=.
-else
-  temp=$(mktemp --directory --tmpdir=.)
-  trap "rm -rf $temp" EXIT
-fi
+temp=temp-$1
+rm -rf $temp
+mkdir $temp
+[[ $KEEP ]] || trap "rm -rf $temp" EXIT
+
 src1=$temp/1.f90
 src2=$temp/2.f90
 src3=$temp/3.f90


### PR DESCRIPTION
Allow for bash anywhere on path.

Allow for utilites to be in `/bin` as well as `/usr/bin`.

Don't count on `sed` understanding '\t'.

The options to `mktemp` aren't portable. Instead just create a per-test
temp directory in the working directory (i.e. `<build-dir>/test/semantics`).
Setting the `KEEP` environment variable causes them all to be kept to help
in investigating failures.

Fixes #128.