### PR TITLE
Roll up parsing changes for several topics

### DIFF
--- a/documentation/extensions.md
+++ b/documentation/extensions.md
@@ -2,20 +2,26 @@
 Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
 -->
 
-Extensions, deletions, and legacy features supported
-====================================================
+As a general principle, this compiler will accept by default and
+without complaint many legacy features, extensions to the standard
+language, and features that have been deleted from the standard,
+so long as the recognition of those features would not cause a
+standard-conforming program to be rejected or misinterpreted.
 
+Other non-standard features, which do conflict with the current
+standard specification of the Fortran programming language, are
+accepted if enabled by command-line options.
+
+Extensions, deletions, and legacy features supported by default
+===============================================================
 * Tabs in source
 * `<>` as synonym for `.NE.` and `/=`
 * `$` and `@` as legal characters in names
-* `.T.` and `.F.`
 * Initialization in type declaration statements using `/values/`
 * Kind specification with `*`, e.g. `REAL*4`
 * `DOUBLE COMPLEX`
 * Signed complex literal constants
-* `.XOR.` as predefined operator (can be overridden)
-* `.N.`, `.A.`, `.O.`, `.X.` predefined operator synonyms
-* `STRUCTURE`, `RECORD`, `UNION`, and `MAP`
+* DEC `STRUCTURE`, `RECORD`, `UNION`, and `MAP`
 * Structure field access with `.field`
 * `NCHARACTER` type and `NC` Kanji character literals
 * `BYTE` as synonym for `INTEGER(KIND=1)`
@@ -29,7 +35,7 @@ Extensions, deletions, and legacy features supported
 * Empty parentheses allowed in `PROGRAM P()`
 * Missing parentheses allowed in `FUNCTION F`
 * Cray based `POINTER(p,x)`
-* Arithmetic `IF`.  (Which branch with NaN take?)
+* Arithmetic `IF`.  (Which branch should NaN take? Fall through?)
 * `ASSIGN` statement, assigned `GO TO`, and assigned format
 * `PAUSE` statement
 * Hollerith literals and edit descriptors
@@ -41,11 +47,20 @@ Extensions, deletions, and legacy features supported
 * `NAME=` as synonym for `FILE=`
 * `DISPOSE=`
 * Data edit descriptors without width or other details
-* Backslash escape character sequences in quoted character literals
 * `D` lines in fixed form as comments or debug code
 * `CONVERT=` on the OPEN statement
 * Leading semicolons are ignored before any statement that
   could have a label
+* The character `&` in column 1 in fixed form source is a variant form
+  of continuation line.
+
+Extensions supported when enabled by options
+--------------------------------------------
+* C-style backslash escape sequences in quoted CHARACTER literals
+  (but not Hollerith) [-fbackslash]
+* Logical abbreviations `.T.`, `.F.`, `.N.`, `.A.`, `.O.`, and `.X.`
+  [-flogical-abbreviations]
+* `.XOR.` as a synonym for `.NEQV.` [-fxor-operator]
 
 Extensions and legacy features deliberately not supported
 ---------------------------------------------------------

--- a/documentation/extensions.md
+++ b/documentation/extensions.md
@@ -29,7 +29,7 @@ Extensions, deletions, and legacy features supported by default
 * `X` prefix/suffix as synonym for `Z` on hexadecimal literals
 * `B`, `O`, `Z`, and `X` accepted as suffixes as well as prefixes
 * Triplets allowed in array constructors
-* Old-style `PARAMETER pi=3.14` statement (no parentheses)
+* Old-style `PARAMETER pi=3.14` statement without parentheses
 * `%LOC`, `%VAL`, and `%REF`
 * Leading comma allowed before I/O item list
 * Empty parentheses allowed in `PROGRAM P()`

--- a/lib/common/enum-set.h
+++ b/lib/common/enum-set.h
@@ -149,8 +149,8 @@ public:
     bitset_.reset();
     return *this;
   }
-  constexpr EnumSet &reset(enumerationType x, bool value = true) {
-    bitset_.reset(static_cast<std::size_t>(x), value);
+  constexpr EnumSet &reset(enumerationType x) {
+    bitset_.reset(static_cast<std::size_t>(x));
     return *this;
   }
   constexpr EnumSet &flip() {

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -218,7 +218,7 @@ typename CharacterExpr<KIND>::LengthExpr CharacterExpr<KIND>::LEN() const {
         if constexpr (std::is_same_v<
                           const typename CharacterExpr<KIND>::Constant &,
                           decltype(x)>) {
-          return LengthExpr{x.size()};
+          return LengthExpr{static_cast<std::uint64_t>(x.size())};
         } else {
           return LengthExpr{LengthExpr::Add{x.x->LEN(), x.y->LEN()}};
         }

--- a/lib/parser/basic-parsers.h
+++ b/lib/parser/basic-parsers.h
@@ -1325,7 +1325,7 @@ private:
   const PA parser_;
 };
 
-template<LanguageFeature LF = LanguageFeature::Extension, typename PA>
+template<LanguageFeature LF, typename PA>
 inline constexpr auto extension(const PA &parser) {
   return NonstandardParser<LF, PA>(parser);
 }
@@ -1357,7 +1357,7 @@ private:
   const PA parser_;
 };
 
-template<LanguageFeature LF = LanguageFeature::Deprecation, typename PA>
+template<LanguageFeature LF, typename PA>
 inline constexpr auto deprecated(const PA &parser) {
   return DeprecatedParser<LF, PA>(parser);
 }

--- a/lib/parser/basic-parsers.h
+++ b/lib/parser/basic-parsers.h
@@ -1308,7 +1308,7 @@ public:
   constexpr NonstandardParser(const PA &parser) : parser_{parser} {}
   std::optional<resultType> Parse(ParseState &state) const {
     if (UserState * ustate{state.userState()}) {
-      if (!ustate->IsEnabled(LF)) {
+      if (!ustate->features().IsEnabled(LF)) {
         return {};
       }
     }
@@ -1340,7 +1340,7 @@ public:
   constexpr DeprecatedParser(const PA &parser) : parser_{parser} {}
   std::optional<resultType> Parse(ParseState &state) const {
     if (UserState * ustate{state.userState()}) {
-      if (!ustate->IsEnabled(LF)) {
+      if (!ustate->features().IsEnabled(LF)) {
         return {};
       }
     }

--- a/lib/parser/features.h
+++ b/lib/parser/features.h
@@ -30,7 +30,9 @@ using LanguageFeatures = common::EnumSet<LanguageFeature, 32>;
 class LanguageFeatureControl {
 public:
   LanguageFeatureControl() {
+    // These features must be explicitly enabled by command line options.
     disable_.set(LanguageFeature::OldDebugLines);
+    disable_.set(LanguageFeature::OpenMP);
     // These features, if enabled, conflict with valid standard usage.
     disable_.set(LanguageFeature::LogicalAbbreviations);
     disable_.set(LanguageFeature::XOROperator);

--- a/lib/parser/features.h
+++ b/lib/parser/features.h
@@ -20,11 +20,35 @@
 
 namespace Fortran::parser {
 
-ENUM_CLASS(LanguageFeature, BackslashEscapes, LogicalAbbreviations, XOROperator,
-    PunctuationInNames, OptionalFreeFormSpace, BOZExtensions, EmptyStatement,
-    OldDebugLines, OpenMP, Extension, Deprecation)
+ENUM_CLASS(LanguageFeature, BackslashEscapes, OldDebugLines,
+    FixedFormContinuationWithColumn1Ampersand, LogicalAbbreviations,
+    XOROperator, PunctuationInNames, OptionalFreeFormSpace, BOZExtensions,
+    EmptyStatement, OpenMP, Extension, Deprecation)
 
 using LanguageFeatures = common::EnumSet<LanguageFeature, 32>;
+
+class LanguageFeatureControl {
+public:
+  LanguageFeatureControl() {
+    disable_.set(LanguageFeature::OldDebugLines);
+    // These features, if enabled, conflict with valid standard usage.
+    disable_.set(LanguageFeature::LogicalAbbreviations);
+    disable_.set(LanguageFeature::XOROperator);
+  }
+  LanguageFeatureControl(const LanguageFeatureControl &) = default;
+  void Enable(LanguageFeature f, bool yes = true) { disable_.set(f, !yes); }
+  void EnableWarning(LanguageFeature f, bool yes = true) { warn_.set(f, yes); }
+  void WarnOnAllNonstandard(bool yes = true) { warnAll_ = yes; }
+  bool IsEnabled(LanguageFeature f) const { return !disable_.test(f); }
+  bool ShouldWarn(LanguageFeature f) const {
+    return (warnAll_ && f != LanguageFeature::OpenMP) || warn_.test(f);
+  }
+
+private:
+  LanguageFeatures disable_;
+  LanguageFeatures warn_;
+  bool warnAll_{false};
+};
 
 }  // namespace Fortran::parser
 #endif  // FORTRAN_PARSER_FEATURES_H_

--- a/lib/parser/features.h
+++ b/lib/parser/features.h
@@ -23,9 +23,15 @@ namespace Fortran::parser {
 ENUM_CLASS(LanguageFeature, BackslashEscapes, OldDebugLines,
     FixedFormContinuationWithColumn1Ampersand, LogicalAbbreviations,
     XOROperator, PunctuationInNames, OptionalFreeFormSpace, BOZExtensions,
-    EmptyStatement, OpenMP, Extension, Deprecation)
+    EmptyStatement, AlternativeNE, ExecutionPartNamelist, DECStructures,
+    DoubleComplex, Kanji, Byte, StarKind, QuadPrecision, SlashInitialization,
+    TripletInArrayConstructor, MissingColons, SignedComplexLiteral,
+    OldStyleParameter, ComplexConstructor, PercentLOC, SignedPrimary, FileName,
+    Convert, Dispose, IOListLeadingComma, AbbreviatedEditDescriptor,
+    ProgramParentheses, PercentRefAndVal, OmitFunctionDummies, CrayPointer,
+    Hollerith, ArithmeticIF, Assign, AssignedGOTO, Pause, OpenMP)
 
-using LanguageFeatures = common::EnumSet<LanguageFeature, 32>;
+using LanguageFeatures = common::EnumSet<LanguageFeature, 64>;
 
 class LanguageFeatureControl {
 public:

--- a/lib/parser/features.h
+++ b/lib/parser/features.h
@@ -1,0 +1,30 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_PARSER_FEATURES_H_
+#define FORTRAN_PARSER_FEATURES_H_
+
+#include "../common/enum-set.h"
+#include "../common/idioms.h"
+
+namespace Fortran::parser {
+
+ENUM_CLASS(LanguageFeature, BackslashEscapes, LogicalAbbreviations, XOROperator,
+    PunctuationInNames, OptionalFreeFormSpace, BOZExtensions, EmptyStatement,
+    OldDebugLines, OpenMP, Extension, Deprecation)
+
+using LanguageFeatures = common::EnumSet<LanguageFeature, 32>;
+
+}  // namespace Fortran::parser
+#endif  // FORTRAN_PARSER_FEATURES_H_

--- a/lib/parser/grammar.h
+++ b/lib/parser/grammar.h
@@ -152,7 +152,9 @@ constexpr auto namedIntrinsicOperator{
     ".OR." >> pure(DefinedOperator::IntrinsicOperator::OR) ||
     ".EQV." >> pure(DefinedOperator::IntrinsicOperator::EQV) ||
     ".NEQV." >> pure(DefinedOperator::IntrinsicOperator::NEQV) ||
-    extension(".XOR." >> pure(DefinedOperator::IntrinsicOperator::XOR) ||
+    extension<LanguageFeature::XOROperator>(
+        ".XOR." >> pure(DefinedOperator::IntrinsicOperator::XOR)) ||
+    extension<LanguageFeature::LogicalAbbreviations>(
         ".N." >> pure(DefinedOperator::IntrinsicOperator::NOT) ||
         ".A." >> pure(DefinedOperator::IntrinsicOperator::AND) ||
         ".O." >> pure(DefinedOperator::IntrinsicOperator::OR) ||
@@ -635,11 +637,16 @@ TYPE_CONTEXT_PARSER(
 // R725 logical-literal-constant ->
 //        .TRUE. [_ kind-param] | .FALSE. [_ kind-param]
 // Also accept .T. and .F. as extensions.
-TYPE_PARSER(construct<LogicalLiteralConstant>(
-                (".TRUE."_tok || extension(".T."_tok)) >> pure(true),
-                maybe(underscore >> kindParam)) ||
+TYPE_PARSER(
     construct<LogicalLiteralConstant>(
-        (".FALSE."_tok || extension(".F."_tok)) >> pure(false),
+        (".TRUE."_tok ||
+            extension<LanguageFeature::LogicalAbbreviations>(".T."_tok)) >>
+            pure(true),
+        maybe(underscore >> kindParam)) ||
+    construct<LogicalLiteralConstant>(
+        (".FALSE."_tok ||
+            extension<LanguageFeature::LogicalAbbreviations>(".F."_tok)) >>
+            pure(false),
         maybe(underscore >> kindParam)))
 
 // R726 derived-type-def ->
@@ -1792,7 +1799,8 @@ constexpr struct Level5Expr {
           }};
       auto more{".EQV." >> applyLambda(eqv, equivOperand) ||
           ".NEQV." >> applyLambda(neqv, equivOperand) ||
-          extension(".XOR." >> applyLambda(logicalXor, equivOperand))};
+          extension<LanguageFeature::XOROperator>(
+              ".XOR." >> applyLambda(logicalXor, equivOperand))};
       while (std::optional<Expr> next{attempt(more).Parse(state)}) {
         result = std::move(next);
       }

--- a/lib/parser/parse-state.h
+++ b/lib/parser/parse-state.h
@@ -179,9 +179,16 @@ public:
   void Nonstandard(
       CharBlock range, LanguageFeature lf, const MessageFixedText &msg) {
     anyConformanceViolation_ = true;
-    if (userState_ != nullptr && userState_->Warn(lf)) {
+    if (userState_ != nullptr && userState_->features().ShouldWarn(lf)) {
       Say(range, msg);
     }
+  }
+  bool IsNonstandardOk(LanguageFeature lf, const MessageFixedText &msg) {
+    if (userState_ != nullptr && !userState_->features().IsEnabled(lf)) {
+      return false;
+    }
+    Nonstandard(lf, msg);
+    return true;
   }
 
   bool IsAtEnd() const { return p_ >= limit_; }

--- a/lib/parser/parse-state.h
+++ b/lib/parser/parse-state.h
@@ -49,8 +49,9 @@ public:
       warnOnDeprecatedUsage_{that.warnOnDeprecatedUsage_},
       anyErrorRecovery_{that.anyErrorRecovery_},
       anyConformanceViolation_{that.anyConformanceViolation_},
-      deferMessages_{that.deferMessages_}, anyDeferredMessages_{
-                                               that.anyDeferredMessages_} {}
+      deferMessages_{that.deferMessages_},
+      anyDeferredMessages_{that.anyDeferredMessages_},
+      tokensMatched_{that.tokensMatched_} {}
   ParseState(ParseState &&that)
     : p_{that.p_}, limit_{that.limit_}, messages_{std::move(that.messages_)},
       context_{std::move(that.context_)}, userState_{that.userState_},
@@ -60,8 +61,9 @@ public:
       warnOnDeprecatedUsage_{that.warnOnDeprecatedUsage_},
       anyErrorRecovery_{that.anyErrorRecovery_},
       anyConformanceViolation_{that.anyConformanceViolation_},
-      deferMessages_{that.deferMessages_}, anyDeferredMessages_{
-                                               that.anyDeferredMessages_} {}
+      deferMessages_{that.deferMessages_},
+      anyDeferredMessages_{that.anyDeferredMessages_},
+      tokensMatched_{that.tokensMatched_} {}
   ParseState &operator=(const ParseState &that) {
     p_ = that.p_, limit_ = that.limit_, context_ = that.context_;
     userState_ = that.userState_, inFixedForm_ = that.inFixedForm_;
@@ -72,6 +74,7 @@ public:
     anyConformanceViolation_ = that.anyConformanceViolation_;
     deferMessages_ = that.deferMessages_;
     anyDeferredMessages_ = that.anyDeferredMessages_;
+    tokensMatched_ = that.tokensMatched_;
     return *this;
   }
   ParseState &operator=(ParseState &&that) {
@@ -85,6 +88,7 @@ public:
     anyConformanceViolation_ = that.anyConformanceViolation_;
     deferMessages_ = that.deferMessages_;
     anyDeferredMessages_ = that.anyDeferredMessages_;
+    tokensMatched_ = that.tokensMatched_;
     return *this;
   }
 
@@ -107,25 +111,25 @@ public:
   }
 
   bool inFixedForm() const { return inFixedForm_; }
-  ParseState &set_inFixedForm(bool yes) {
+  ParseState &set_inFixedForm(bool yes = true) {
     inFixedForm_ = yes;
     return *this;
   }
 
   bool strictConformance() const { return strictConformance_; }
-  ParseState &set_strictConformance(bool yes) {
+  ParseState &set_strictConformance(bool yes = true) {
     strictConformance_ = yes;
     return *this;
   }
 
   bool warnOnNonstandardUsage() const { return warnOnNonstandardUsage_; }
-  ParseState &set_warnOnNonstandardUsage(bool yes) {
+  ParseState &set_warnOnNonstandardUsage(bool yes = true) {
     warnOnNonstandardUsage_ = yes;
     return *this;
   }
 
   bool warnOnDeprecatedUsage() const { return warnOnDeprecatedUsage_; }
-  ParseState &set_warnOnDeprecatedUsage(bool yes) {
+  ParseState &set_warnOnDeprecatedUsage(bool yes = true) {
     warnOnDeprecatedUsage_ = yes;
     return *this;
   }
@@ -137,13 +141,26 @@ public:
   }
 
   bool deferMessages() const { return deferMessages_; }
-  ParseState &set_deferMessages(bool yes) {
+  ParseState &set_deferMessages(bool yes = true) {
     deferMessages_ = yes;
     return *this;
   }
 
   bool anyDeferredMessages() const { return anyDeferredMessages_; }
-  void set_anyDeferredMessages() { anyDeferredMessages_ = true; }
+  ParseState &set_anyDeferredMessages(bool yes = true) {
+    anyDeferredMessages_ = yes;
+    return *this;
+  }
+
+  std::size_t tokensMatched() const { return tokensMatched_; }
+  ParseState &set_tokensMatched(std::size_t n) {
+    tokensMatched_ = n;
+    return *this;
+  }
+  ParseState &TokenMatched() {
+    ++tokensMatched_;
+    return *this;
+  }
 
   const char *GetLocation() const { return p_; }
 
@@ -230,6 +247,7 @@ private:
   bool anyConformanceViolation_{false};
   bool deferMessages_{false};
   bool anyDeferredMessages_{false};
+  std::size_t tokensMatched_{0};
   // NOTE: Any additions or modifications to these data members must also be
   // reflected in the copy and move constructors defined at the top of this
   // class definition!

--- a/lib/parser/parsing.cc
+++ b/lib/parser/parsing.cc
@@ -67,11 +67,13 @@ void Parsing::Prescan(const std::string &path, Options options) {
   prescanner.set_fixedForm(options.isFixedForm)
       .set_fixedFormColumnLimit(options.fixedFormColumns)
       .set_encoding(options.encoding)
-      .set_enableBackslashEscapesInCharLiterals(options.enableBackslashEscapes)
-      .set_enableOldDebugLines(options.enableOldDebugLines)
+      .set_enableBackslashEscapesInCharLiterals(  // TODO pmk
+          options.enabled.test(LanguageFeature::BackslashEscapes))
+      .set_enableOldDebugLines(
+          options.enabled.test(LanguageFeature::OldDebugLines))
       .set_warnOnNonstandardUsage(options_.isStrictlyStandard)
       .AddCompilerDirectiveSentinel("dir$");
-  if (options.enableOpenMP) {
+  if (options.enabled.test(LanguageFeature::OpenMP)) {
     prescanner.AddCompilerDirectiveSentinel("$omp");
   }
   ProvenanceRange range{
@@ -100,11 +102,11 @@ void Parsing::Parse(std::ostream *out) {
   userState.set_debugOutput(out)
       .set_instrumentedParse(options_.instrumentedParse)
       .set_log(&log_);
+  userState.Enable(options_.enabled);
+  userState.EnableWarnings(options_.warning);
   ParseState parseState{cooked_};
   parseState.set_inFixedForm(options_.isFixedForm)
       .set_encoding(options_.encoding)
-      .set_warnOnNonstandardUsage(options_.isStrictlyStandard)
-      .set_warnOnDeprecatedUsage(options_.isStrictlyStandard)
       .set_userState(&userState);
   parseTree_ = program.Parse(parseState);
   CHECK(

--- a/lib/parser/parsing.cc
+++ b/lib/parser/parsing.cc
@@ -63,17 +63,12 @@ void Parsing::Prescan(const std::string &path, Options options) {
       preprocessor.Undefine(predef.first);
     }
   }
-  Prescanner prescanner{messages_, cooked_, preprocessor};
+  Prescanner prescanner{messages_, cooked_, preprocessor, options.features};
   prescanner.set_fixedForm(options.isFixedForm)
       .set_fixedFormColumnLimit(options.fixedFormColumns)
       .set_encoding(options.encoding)
-      .set_enableBackslashEscapesInCharLiterals(  // TODO pmk
-          options.enabled.test(LanguageFeature::BackslashEscapes))
-      .set_enableOldDebugLines(
-          options.enabled.test(LanguageFeature::OldDebugLines))
-      .set_warnOnNonstandardUsage(options_.isStrictlyStandard)
       .AddCompilerDirectiveSentinel("dir$");
-  if (options.enabled.test(LanguageFeature::OpenMP)) {
+  if (options.features.IsEnabled(LanguageFeature::OpenMP)) {
     prescanner.AddCompilerDirectiveSentinel("$omp");
   }
   ProvenanceRange range{
@@ -83,7 +78,7 @@ void Parsing::Prescan(const std::string &path, Options options) {
 }
 
 void Parsing::DumpCookedChars(std::ostream &out) const {
-  UserState userState{cooked_};
+  UserState userState{cooked_, LanguageFeatureControl{}};
   ParseState parseState{cooked_};
   parseState.set_inFixedForm(options_.isFixedForm).set_userState(&userState);
   while (std::optional<const char *> p{parseState.GetNextChar()}) {
@@ -98,12 +93,10 @@ void Parsing::DumpParsingLog(std::ostream &out) const {
 }
 
 void Parsing::Parse(std::ostream *out) {
-  UserState userState{cooked_};
+  UserState userState{cooked_, options_.features};
   userState.set_debugOutput(out)
       .set_instrumentedParse(options_.instrumentedParse)
       .set_log(&log_);
-  userState.Enable(options_.enabled);
-  userState.EnableWarnings(options_.warning);
   ParseState parseState{cooked_};
   parseState.set_inFixedForm(options_.isFixedForm)
       .set_encoding(options_.encoding)

--- a/lib/parser/parsing.h
+++ b/lib/parser/parsing.h
@@ -16,6 +16,7 @@
 #define FORTRAN_PARSER_PARSING_H_
 
 #include "characters.h"
+#include "features.h"
 #include "instrumented-parser.h"
 #include "message.h"
 #include "parse-tree.h"
@@ -35,10 +36,8 @@ struct Options {
 
   bool isFixedForm{false};
   int fixedFormColumns{72};
-  bool enableBackslashEscapes{true};
-  bool enableOldDebugLines{false};
   bool isStrictlyStandard{false};
-  bool enableOpenMP{false};
+  LanguageFeatures enabled, warning;
   Encoding encoding{Encoding::UTF8};
   std::vector<std::string> searchDirectories;
   std::vector<Predefinition> predefinitions;

--- a/lib/parser/parsing.h
+++ b/lib/parser/parsing.h
@@ -37,7 +37,7 @@ struct Options {
   bool isFixedForm{false};
   int fixedFormColumns{72};
   bool isStrictlyStandard{false};
-  LanguageFeatures enabled, warning;
+  LanguageFeatureControl features;
   Encoding encoding{Encoding::UTF8};
   std::vector<std::string> searchDirectories;
   std::vector<Predefinition> predefinitions;

--- a/lib/parser/prescan.h
+++ b/lib/parser/prescan.h
@@ -23,6 +23,7 @@
 // inclusion, and driving the Fortran source preprocessor.
 
 #include "characters.h"
+#include "features.h"
 #include "message.h"
 #include "provenance.h"
 #include "token-sequence.h"
@@ -38,7 +39,8 @@ class Preprocessor;
 
 class Prescanner {
 public:
-  Prescanner(Messages &, CookedSource &, Preprocessor &);
+  Prescanner(
+      Messages &, CookedSource &, Preprocessor &, LanguageFeatureControl);
   Prescanner(const Prescanner &);
 
   Messages &messages() const { return messages_; }
@@ -51,20 +53,8 @@ public:
     encoding_ = code;
     return *this;
   }
-  Prescanner &set_enableOldDebugLines(bool yes) {
-    enableOldDebugLines_ = yes;
-    return *this;
-  }
-  Prescanner &set_enableBackslashEscapesInCharLiterals(bool yes) {
-    enableBackslashEscapesInCharLiterals_ = yes;
-    return *this;
-  }
   Prescanner &set_fixedFormColumnLimit(int limit) {
     fixedFormColumnLimit_ = limit;
-    return *this;
-  }
-  Prescanner &set_warnOnNonstandardUsage(bool yes) {
-    warnOnNonstandardUsage_ = yes;
     return *this;
   }
 
@@ -176,12 +166,10 @@ private:
   Messages &messages_;
   CookedSource &cooked_;
   Preprocessor &preprocessor_;
+  LanguageFeatureControl features_;
   bool inFixedForm_{false};
   int fixedFormColumnLimit_{72};
   Encoding encoding_{Encoding::UTF8};
-  bool enableOldDebugLines_{false};
-  bool enableBackslashEscapesInCharLiterals_{false};
-  bool warnOnNonstandardUsage_{false};
   int delimiterNesting_{0};
   int prescannerNesting_{0};
 

--- a/lib/parser/prescan.h
+++ b/lib/parser/prescan.h
@@ -180,7 +180,7 @@ private:
   int fixedFormColumnLimit_{72};
   Encoding encoding_{Encoding::UTF8};
   bool enableOldDebugLines_{false};
-  bool enableBackslashEscapesInCharLiterals_{true};
+  bool enableBackslashEscapesInCharLiterals_{false};
   bool warnOnNonstandardUsage_{false};
   int delimiterNesting_{0};
   int prescannerNesting_{0};

--- a/lib/parser/stmt-parser.h
+++ b/lib/parser/stmt-parser.h
@@ -46,6 +46,23 @@ template<typename PA> inline constexpr auto statement(const PA &p) {
   return unterminatedStatement(p) / endOfStmt;
 }
 
+// This unambiguousStatement() variant of statement() provides better error
+// recovery for contexts containing statements that might have trailing
+// garbage, but it must be used only when no instance of the statement in
+// question could also be a legal prefix of some other statement that might
+// be valid at that point.  It only makes sense to use this within "some()"
+// or "many()" so as to not end the list of statements.
+template<typename PA> inline constexpr auto unambiguousStatement(const PA &p) {
+  return unterminatedStatement(p) /
+      recovery(space >>
+              withMessage("expected end of statement"_err_en_US, endOfStmt),
+          SkipPast<'\n'>{});
+}
+
+constexpr auto forceEndOfStmt{recovery(space >>
+        withMessage("expected end of statement"_err_en_US, lookAhead(";\n"_ch)),
+    SkipTo<'\n'>{})};
+
 constexpr auto ignoredStatementPrefix{
     skipStuffBeforeStatement >> maybe(label) >> maybe(name / ":") >> space};
 

--- a/lib/parser/token-parsers.h
+++ b/lib/parser/token-parsers.h
@@ -162,6 +162,7 @@ public:
         return {};
       }
     }
+    state.TokenMatched();
     if (IsLegalInIdentifier(p[-1])) {
       return spaceCheck.Parse(state);
     } else {
@@ -633,6 +634,21 @@ template<char goal> struct SkipPast {
       if (**p == goal) {
         return {Success{}};
       }
+    }
+    return {};
+  }
+};
+
+template<char goal> struct SkipTo {
+  using resultType = Success;
+  constexpr SkipTo() {}
+  constexpr SkipTo(const SkipTo &) {}
+  static std::optional<Success> Parse(ParseState &state) {
+    while (std::optional<const char *> p{state.PeekAtNextChar()}) {
+      if (**p == goal) {
+        return {Success{}};
+      }
+      state.UncheckedAdvance();
     }
     return {};
   }

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -1474,7 +1474,7 @@ public:
             }},
         x.u);
   }
-  void Before(const SubmoduleStmt &x) {  // R1417
+  void Unparse(const SubmoduleStmt &x) {  // R1417
     Word("SUBMODULE ("), WalkTupleElements(x.t, ")"), Indent();
   }
   void Unparse(const ParentIdentifier &x) {  // R1418

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -1475,7 +1475,7 @@ public:
         x.u);
   }
   void Before(const SubmoduleStmt &x) {  // R1417
-    Word("SUBMODULE "), Indent();
+    Word("SUBMODULE "), WalkTupleElements(x.t, ")"), Indent();
   }
   void Unparse(const ParentIdentifier &x) {  // R1418
     Walk(std::get<Name>(x.t)), Walk(":", std::get<std::optional<Name>>(x.t));

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -1475,7 +1475,7 @@ public:
         x.u);
   }
   void Before(const SubmoduleStmt &x) {  // R1417
-    Word("SUBMODULE "), WalkTupleElements(x.t, ")"), Indent();
+    Word("SUBMODULE ("), WalkTupleElements(x.t, ")"), Indent();
   }
   void Unparse(const ParentIdentifier &x) {  // R1418
     Walk(std::get<Name>(x.t)), Walk(":", std::get<std::optional<Name>>(x.t));

--- a/lib/parser/user-state.h
+++ b/lib/parser/user-state.h
@@ -40,9 +40,11 @@ class Success {};  // for when one must return something that's present
 
 class UserState {
 public:
-  explicit UserState(const CookedSource &cooked) : cooked_{cooked} {}
+  UserState(const CookedSource &cooked, LanguageFeatureControl features)
+    : cooked_{cooked}, features_{features} {}
 
   const CookedSource &cooked() const { return cooked_; }
+  const LanguageFeatureControl &features() const { return features_; }
 
   std::ostream *debugOutput() const { return debugOutput_; }
   UserState &set_debugOutput(std::ostream *out) {
@@ -91,41 +93,6 @@ public:
     return oldStructureComponents_.find(name) != oldStructureComponents_.end();
   }
 
-  UserState &Enable(LanguageFeature f) {
-    enabled_.set(f);
-    return *this;
-  }
-  UserState &Enable(LanguageFeatures fs) {
-    enabled_ |= fs;
-    return *this;
-  }
-  UserState &Disable(LanguageFeature f) {
-    enabled_.reset(f);
-    return *this;
-  }
-  UserState &Disable(LanguageFeatures fs) {
-    enabled_ &= ~fs;
-    return *this;
-  }
-  bool IsEnabled(LanguageFeature f) { return enabled_.test(f); }
-  UserState &EnableWarning(LanguageFeature f) {
-    warning_.set(f);
-    return *this;
-  }
-  UserState &EnableWarnings(LanguageFeatures fs) {
-    warning_ |= fs;
-    return *this;
-  }
-  UserState &DisableWarning(LanguageFeature f) {
-    warning_.reset(f);
-    return *this;
-  }
-  UserState &DisableWarnings(LanguageFeatures fs) {
-    warning_ &= ~fs;
-    return *this;
-  }
-  bool Warn(LanguageFeature f) { return warning_.test(f); }
-
 private:
   const CookedSource &cooked_;
 
@@ -139,7 +106,7 @@ private:
 
   std::set<CharBlock> oldStructureComponents_;
 
-  LanguageFeatures enabled_, warning_;
+  LanguageFeatureControl features_;
 };
 
 // Definitions of parser classes that manipulate the UserState.

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -114,7 +114,7 @@ bool ModFileWriter::WriteOne(const Symbol &modSymbol) {
   std::string path{dir_ + '/' + name + extension};
   std::ofstream os{path};
   PutSymbols(*modSymbol.scope());
-  std::string all{std::move(GetAsString(name))};
+  std::string all{GetAsString(name)};
   auto header{GetHeader(all)};
   os << header << all;
   os.close();

--- a/lib/semantics/mod-file.h
+++ b/lib/semantics/mod-file.h
@@ -15,9 +15,6 @@
 #ifndef FORTRAN_SEMANTICS_MOD_FILE_H_
 #define FORTRAN_SEMANTICS_MOD_FILE_H_
 
-#include <filesystem>
-#include <iosfwd>
-
 namespace Fortran::semantics {
 
 void WriteModFiles();

--- a/test/evaluate/integer.cc
+++ b/test/evaluate/integer.cc
@@ -262,7 +262,8 @@ int main() {
   TEST(Integer<128>{123456789}.UnsignedDecimal() == "123456789");
   TEST(Integer<128>{123456789}.SignedDecimal() == "123456789");
   TEST(Integer<128>{-123456789}.SignedDecimal() == "-123456789");
-  TEST(Integer<128>{0x123456789abcdef}.Hexadecimal() == "123456789abcdef");
+  std::uint64_t big{0x123456789abcdef};
+  TEST(Integer<128>{big}.Hexadecimal() == "123456789abcdef");
   exhaustiveTesting<1>();
   exhaustiveTesting<2>();
   exhaustiveTesting<7>();

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -300,13 +300,6 @@ int main(int argc, char *const argv[]) {
   options.predefinitions.emplace_back("__F18_MINOR__", "1");
   options.predefinitions.emplace_back("__F18_PATCHLEVEL__", "1");
 
-  options.enabled.set(Fortran::parser::LanguageFeature::PunctuationInNames);
-  options.enabled.set(Fortran::parser::LanguageFeature::OptionalFreeFormSpace);
-  options.enabled.set(Fortran::parser::LanguageFeature::BOZExtensions);
-  options.enabled.set(Fortran::parser::LanguageFeature::EmptyStatement);
-  options.enabled.set(Fortran::parser::LanguageFeature::Extension);  // pmk
-  options.enabled.set(Fortran::parser::LanguageFeature::Deprecation);
-
   std::vector<std::string> fortranSources, otherSources, relocatables;
   bool anyFiles{false};
 
@@ -350,23 +343,27 @@ int main(int argc, char *const argv[]) {
     } else if (arg == "-Mextend") {
       options.fixedFormColumns = 132;
     } else if (arg == "-Mbackslash") {
-      options.enabled.reset(Fortran::parser::LanguageFeature::BackslashEscapes);
+      options.features.Enable(
+          Fortran::parser::LanguageFeature::BackslashEscapes, false);
     } else if (arg == "-Mnobackslash") {
-      options.enabled.set(Fortran::parser::LanguageFeature::BackslashEscapes);
+      options.features.Enable(
+          Fortran::parser::LanguageFeature::BackslashEscapes);
     } else if (arg == "-Mstandard") {
-      options.isStrictlyStandard = true;
+      options.features.WarnOnAllNonstandard();
     } else if (arg == "-fopenmp") {
-      options.enabled.set(Fortran::parser::LanguageFeature::OpenMP);
+      options.features.Enable(Fortran::parser::LanguageFeature::OpenMP);
     } else if (arg == "-Werror") {
       driver.warningsAreErrors = true;
     } else if (arg == "-ed") {
-      options.enabled.set(Fortran::parser::LanguageFeature::OldDebugLines);
+      options.features.Enable(Fortran::parser::LanguageFeature::OldDebugLines);
     } else if (arg == "-E") {
       driver.dumpCookedChars = true;
     } else if (arg == "-fbackslash") {
-      options.enabled.set(Fortran::parser::LanguageFeature::BackslashEscapes);
+      options.features.Enable(
+          Fortran::parser::LanguageFeature::BackslashEscapes);
     } else if (arg == "-fno-backslash") {
-      options.enabled.reset(Fortran::parser::LanguageFeature::BackslashEscapes);
+      options.features.Enable(
+          Fortran::parser::LanguageFeature::BackslashEscapes, false);
     } else if (arg == "-fdebug-dump-provenance") {
       driver.dumpProvenance = true;
     } else if (arg == "-fdebug-dump-parse-tree") {
@@ -448,8 +445,7 @@ int main(int argc, char *const argv[]) {
   driver.encoding = options.encoding;
 
   if (options.isStrictlyStandard) {
-    options.warning |= options.enabled;
-    options.warning.reset(Fortran::parser::LanguageFeature::OpenMP);
+    options.features.WarnOnAllNonstandard();
   }
 
   if (!anyFiles) {

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -15,6 +15,7 @@
 // Temporary Fortran front end driver main program for development scaffolding.
 
 #include "../../lib/parser/characters.h"
+#include "../../lib/parser/features.h"
 #include "../../lib/parser/message.h"
 #include "../../lib/parser/parse-tree-visitor.h"
 #include "../../lib/parser/parse-tree.h"
@@ -298,6 +299,14 @@ int main(int argc, char *const argv[]) {
   options.predefinitions.emplace_back("__F18_MAJOR__", "1");
   options.predefinitions.emplace_back("__F18_MINOR__", "1");
   options.predefinitions.emplace_back("__F18_PATCHLEVEL__", "1");
+
+  options.enabled.set(Fortran::parser::LanguageFeature::PunctuationInNames);
+  options.enabled.set(Fortran::parser::LanguageFeature::OptionalFreeFormSpace);
+  options.enabled.set(Fortran::parser::LanguageFeature::BOZExtensions);
+  options.enabled.set(Fortran::parser::LanguageFeature::EmptyStatement);
+  options.enabled.set(Fortran::parser::LanguageFeature::Extension);  // pmk
+  options.enabled.set(Fortran::parser::LanguageFeature::Deprecation);
+
   std::vector<std::string> fortranSources, otherSources, relocatables;
   bool anyFiles{false};
 
@@ -341,19 +350,23 @@ int main(int argc, char *const argv[]) {
     } else if (arg == "-Mextend") {
       options.fixedFormColumns = 132;
     } else if (arg == "-Mbackslash") {
-      options.enableBackslashEscapes = false;
+      options.enabled.reset(Fortran::parser::LanguageFeature::BackslashEscapes);
     } else if (arg == "-Mnobackslash") {
-      options.enableBackslashEscapes = true;
+      options.enabled.set(Fortran::parser::LanguageFeature::BackslashEscapes);
     } else if (arg == "-Mstandard") {
       options.isStrictlyStandard = true;
     } else if (arg == "-fopenmp") {
-      options.enableOpenMP = true;
+      options.enabled.set(Fortran::parser::LanguageFeature::OpenMP);
     } else if (arg == "-Werror") {
       driver.warningsAreErrors = true;
     } else if (arg == "-ed") {
-      options.enableOldDebugLines = true;
+      options.enabled.set(Fortran::parser::LanguageFeature::OldDebugLines);
     } else if (arg == "-E") {
       driver.dumpCookedChars = true;
+    } else if (arg == "-fbackslash") {
+      options.enabled.set(Fortran::parser::LanguageFeature::BackslashEscapes);
+    } else if (arg == "-fno-backslash") {
+      options.enabled.reset(Fortran::parser::LanguageFeature::BackslashEscapes);
     } else if (arg == "-fdebug-dump-provenance") {
       driver.dumpProvenance = true;
     } else if (arg == "-fdebug-dump-parse-tree") {
@@ -393,6 +406,7 @@ int main(int argc, char *const argv[]) {
           << "f18 options:\n"
           << "  -Mfixed | -Mfree     force the source form\n"
           << "  -Mextend             132-column fixed form\n"
+          << "  -f[no-]backslash     enable[disable] \\escapes in literals\n"
           << "  -M[no]backslash      disable[enable] \\escapes in literals\n"
           << "  -Mstandard           enable conformance warnings\n"
           << "  -Mx,125,4            set bit 2 in xflag[125] (all Kanji mode)\n"
@@ -432,6 +446,11 @@ int main(int argc, char *const argv[]) {
     }
   }
   driver.encoding = options.encoding;
+
+  if (options.isStrictlyStandard) {
+    options.warning |= options.enabled;
+    options.warning.reset(Fortran::parser::LanguageFeature::OpenMP);
+  }
 
   if (!anyFiles) {
     driver.measureTree = true;


### PR DESCRIPTION
More improvements to error recovery robustness.

Create `enum class LanguageFeatures` and use it to control all conditional parsing and warning message generation.  This is a general solution to issue#40 and issue#124 and can be extended to resolve issue#44 with some driver work (not done here).

Clean up build with clang.

Fix unparsing of SUBMODULE statement.
