### PR TITLE
Support writing interfaces in module files.

### DIFF
--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -265,11 +265,15 @@ void ModFileWriter::PutSubprogram(const Symbol &symbol) {
 
 void ModFileWriter::PutGeneric(const Symbol &symbol) {
   auto &details{symbol.get<GenericDetails>()};
-  PutLower(decls_ << "interface ", symbol) << '\n';
+  decls_ << "generic";
+  PutAttrs(decls_, symbol.attrs());
+  PutLower(decls_ << "::", symbol) << "=>";
+  int n = 0;
   for (auto *specific : details.specificProcs()) {
-    PutLower(decls_ << "procedure::", *specific) << '\n';
+    if (n++ > 0) decls_ << ',';
+    PutLower(decls_, *specific);
   }
-  decls_ << "end interface\n";
+  decls_ << '\n';
 }
 
 void ModFileWriter::PutUse(const Symbol &symbol) {

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -84,7 +84,7 @@ const Symbol *GenericDetails::CheckSpecific() const {
 
 // The name of the kind of details for this symbol.
 // This is primarily for debugging.
-static std::string DetailsToString(const Details &details) {
+std::string DetailsToString(const Details &details) {
   return std::visit(
       common::visitors{
           [](const UnknownDetails &) { return "Unknown"; },

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -184,12 +184,20 @@ private:
 class GenericDetails {
 public:
   using listType = std::list<const Symbol *>;
+  using procNamesType = std::list<std::pair<const SourceName *, bool>>;
+
   GenericDetails() {}
   GenericDetails(const listType &specificProcs);
   GenericDetails(Symbol *specific) : specific_{specific} {}
 
   const listType specificProcs() const { return specificProcs_; }
+  const procNamesType specificProcNames() const { return specificProcNames_; }
+
   void add_specificProc(const Symbol *proc) { specificProcs_.push_back(proc); }
+  void add_specificProcName(const SourceName &name, bool isModuleProc) {
+    specificProcNames_.emplace_back(&name, isModuleProc);
+  }
+  void ClearSpecificProcNames() { specificProcNames_.clear(); }
 
   Symbol *specific() { return specific_; }
   void set_specific(Symbol &specific);
@@ -206,6 +214,8 @@ public:
 private:
   // all of the specific procedures for this generic
   listType specificProcs_;
+  // specific procs referenced by name and whether it's a module proc
+  procNamesType specificProcNames_;
   // a specific procedure with the same name as this generic, if any
   Symbol *specific_{nullptr};
   // a derived type with the same name as this generic, if any

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -219,6 +219,7 @@ using Details = std::variant<UnknownDetails, MainProgramDetails, ModuleDetails,
     ObjectEntityDetails, ProcEntityDetails, DerivedTypeDetails, UseDetails,
     UseErrorDetails, GenericDetails>;
 std::ostream &operator<<(std::ostream &, const Details &);
+std::string DetailsToString(const Details &);
 
 class Symbol {
 public:

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -48,6 +48,7 @@ set(ERROR_TESTS
   resolve22.f90
   resolve23.f90
   resolve24.f90
+  resolve25.f90
 )
 
 # These test files have expected symbols in the source

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -62,6 +62,9 @@ set(MODFILE_TESTS
   modfile03.f90
   modfile04.f90
   modfile05.f90
+  modfile06.f90
+  modfile07.f90
+  modfile08.f90
 )
 
 foreach(test ${ERROR_TESTS})

--- a/test/semantics/modfile06.f90
+++ b/test/semantics/modfile06.f90
@@ -1,0 +1,41 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check modfile generation for external interface
+module m
+  interface
+    integer function f(x)
+    end function
+    subroutine s(y, z)
+      logical y
+      complex z
+    end subroutine
+  end interface
+end
+
+!Expect: m.mod
+!module m
+! interface
+!  function f(x)
+!   integer::f
+!   real::x
+!  end
+! end interface
+! interface
+!  subroutine s(y,z)
+!   logical::y
+!   complex::z
+!  end
+! end interface
+!end

--- a/test/semantics/modfile07.f90
+++ b/test/semantics/modfile07.f90
@@ -1,0 +1,69 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check modfile generation for generic interfaces
+module m
+  interface foo
+    subroutine s1(x)
+      real x
+    end subroutine
+    subroutine s2(x)
+      complex x
+    end subroutine
+  end interface
+  interface bar
+    procedure :: s1
+    procedure :: s2
+    procedure :: s3
+    procedure :: s4
+  end interface
+contains
+  subroutine s3(x)
+    logical x
+  end
+  subroutine s4(x)
+    integer x
+  end
+end
+
+!Expect: m.mod
+!module m
+! interface foo
+!  procedure::s1
+!  procedure::s2
+! end interface
+! interface
+!  subroutine s1(x)
+!   real::x
+!  end
+! end interface
+! interface
+!  subroutine s2(x)
+!   complex::x
+!  end
+! end interface
+! interface bar
+!  procedure::s1
+!  procedure::s2
+!  procedure::s3
+!  procedure::s4
+! end interface
+!contains
+! subroutine s3(x)
+!  logical::x
+! end
+! subroutine s4(x)
+!  integer::x
+! end
+!end

--- a/test/semantics/modfile08.f90
+++ b/test/semantics/modfile08.f90
@@ -1,0 +1,34 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check modfile generation for external declarations
+module m
+  real, external :: a
+  logical b
+  external c
+  complex c
+  external b, d
+  procedure() :: e
+  procedure(real) :: f
+end
+
+!Expect: m.mod
+!module m
+! procedure(real)::a
+! procedure(logical)::b
+! procedure(complex)::c
+! procedure()::d
+! procedure()::e
+! procedure(real)::f
+!end

--- a/test/semantics/resolve15.f90
+++ b/test/semantics/resolve15.f90
@@ -27,6 +27,7 @@ end
 
 subroutine s
   interface i
+    !ERROR: 'sub' is not a module procedure
     module procedure :: sub
   end interface
 contains

--- a/test/semantics/resolve25.f90
+++ b/test/semantics/resolve25.f90
@@ -12,50 +12,28 @@
 ! See the License for the specific language governing permissions and
 ! limitations under the License.
 
-! Check modfile generation for generic interfaces
 module m
   interface foo
     subroutine s1(x)
+      real x
+    end
+    !ERROR: 's2' is not a module procedure
+    module procedure s2
+    !ERROR: Procedure 's3' not found
+    procedure s3
+    !ERROR: Procedure 's1' is already specified in generic 'foo'
+    procedure s1
+  end interface
+  interface
+    subroutine s4(x)
       real x
     end subroutine
     subroutine s2(x)
       complex x
     end subroutine
   end interface
-  interface bar
-    procedure :: s1
-    procedure :: s2
-    procedure :: s3
-    procedure :: s4
-  end interface
-contains
-  subroutine s3(x)
-    logical x
-  end
-  subroutine s4(x)
-    integer x
-  end
-end
-
-!Expect: m.mod
-!module m
-! generic::foo=>s1,s2
-! interface
-!  subroutine s1(x)
-!   real::x
-!  end
-! end interface
-! interface
-!  subroutine s2(x)
-!   complex::x
-!  end
-! end interface
-! generic::bar=>s1,s2,s3,s4
-!contains
-! subroutine s3(x)
-!  logical::x
-! end
-! subroutine s4(x)
-!  integer::x
-! end
-!end
+  generic :: bar => s4
+  generic :: bar => s2
+  !ERROR: Procedure 's4' is already specified in generic 'bar'
+  generic :: bar => s4
+end module

--- a/test/semantics/test_errors.sh
+++ b/test/semantics/test_errors.sh
@@ -39,6 +39,7 @@ diffs=$temp/diffs
 
 cmd="$CMD $src"
 $cmd > $log 2>&1
+[[ $? -ge 128 ]] && exit 1
 
 # $actual has errors from the compiler; $expect has them from !ERROR comments in source
 # Format both as "<line>: <text>" so they can be diffed.

--- a/test/semantics/test_modfile.sh
+++ b/test/semantics/test_modfile.sh
@@ -54,7 +54,7 @@ for mod in $expected_files; do
     exit 1
   fi
   sed '/^!mod\$/d' $temp/$mod > $actual
-  sed '1,/^!Expect: '"$mod"'/d' $src | sed -e '/^$/,$d' -e 's/^!//' > $expect
+  sed '1,/^!Expect: '"$mod"'/d' $src | sed -e '/^$/,$d' -e 's/^! *//' > $expect
   if ! diff -U999999 $actual $expect > $diffs; then
     echo "Module file $mod differs from expected:"
     sed '1,2d' $diffs


### PR DESCRIPTION
Write symbols for external subprogram interfaces as interface-stmts.
Those go in the decls part of the module file, as opposed to contained
subprograms which go in the contains part. See modfile06.f90.

Write symbols with GenericDetails to module files. The specific
procedures of a generic interface are always written as procedure-stmts.
If they also have specific interfaces those are written in a separate
interface-stmt. See modfile07.f90.

Fix a bug where `real, external :: f` was not written like
`real f; external f`. We have to notice the EXTERNAL attribute on the
type-declaration-stmt and convert the entity to a procedure entity.
See modfile08.f90.

Fix a bug where a use-associated symbol is referenced in a
procedure-designator. We were not resolving that correctly.

Change ModFileWriter::PutEntity to include the kind of Details when
it reports an internal error due to a kind it can't handle.
Make DetailsToString public to support that.

Change test_errors.sh to fail if the f18 command exits due to a signal.
We were missing bugs where the correct errors were written out but then
module file writing crashed (due to failure to handle generics mentioned
above). Non-zero exit status is okay because we are expecting
compilation errors.

Change test_modfile.sh to allow for the expected module file contents to
be indented so the tests are easier to read.