### PR TITLE
Implement reading of module files

### DIFF
--- a/documentation/mod-files.md
+++ b/documentation/mod-files.md
@@ -102,6 +102,11 @@ For PGI, `-I` specifies directories to search for include files and module
 files. `-module` specifics a directory to write module files in as well as to
 search for them. gfortran is similar except it uses `-J` instead of `-module`.
 
+The search order for module files is:
+1. The `-module` directory (Note: for gfortran the `-J` directory is not searched).
+2. The current directory
+3. The `-I` directories in the order they appear on the command line
+
 ### Writing module files
 
 When writing a module file, if the existing one matches what would be written,

--- a/lib/common/idioms.h
+++ b/lib/common/idioms.h
@@ -128,5 +128,14 @@ template<typename A> struct ListItemCount {
         static_cast<int>(e), #__VA_ARGS__); \
   }
 
+// If a variant holds a value of a particular type, return a copy in a
+// std::optional<>.
+template<typename A, typename VARIANT>
+std::optional<A> GetIf(const VARIANT &u) {
+  if (const A *x{std::get_if<A>(&u)}) {
+    return {*x};
+  }
+  return {};
+}
 }  // namespace Fortran::common
 #endif  // FORTRAN_COMMON_IDIOMS_H_

--- a/lib/evaluate/common.h
+++ b/lib/evaluate/common.h
@@ -115,6 +115,7 @@ using HostUnsignedInt =
 // - There are full copy and move semantics for construction and assignment.
 // - There's a Dump(std::ostream &) member function.
 #define CLASS_BOILERPLATE(t) \
+  t() = delete; \
   t(const t &) = default; \
   t(t &&) = default; \
   t &operator=(const t &) = default; \

--- a/lib/evaluate/expression-forward.h
+++ b/lib/evaluate/expression-forward.h
@@ -24,21 +24,21 @@
 namespace Fortran::evaluate {
 
 // An expression of some specific result type.
-template<Category CAT, int KIND> struct Expr;
-
-// An expression of some supported kind of a category of result type.
-template<Category CAT> struct CategoryExpr;
-
-template<int KIND> using IntegerExpr = Expr<Category::Integer, KIND>;
+template<typename A> class Expr;
+template<int KIND> using IntegerExpr = Expr<Type<Category::Integer, KIND>>;
 using DefaultIntegerExpr = IntegerExpr<DefaultInteger::kind>;
-template<int KIND> using RealExpr = Expr<Category::Real, KIND>;
-template<int KIND> using ComplexExpr = Expr<Category::Complex, KIND>;
-template<int KIND> using CharacterExpr = Expr<Category::Character, KIND>;
-using LogicalExpr = Expr<Category::Logical, 1>;
-using GenericIntegerExpr = CategoryExpr<Category::Integer>;
-using GenericRealExpr = CategoryExpr<Category::Real>;
-using GenericComplexExpr = CategoryExpr<Category::Complex>;
-using GenericCharacterExpr = CategoryExpr<Category::Character>;
+template<int KIND> using RealExpr = Expr<Type<Category::Real, KIND>>;
+template<int KIND> using ComplexExpr = Expr<Type<Category::Complex, KIND>>;
+template<int KIND> using CharacterExpr = Expr<Type<Category::Character, KIND>>;
+template<int KIND> using LogicalExpr = Expr<Type<Category::Logical, KIND>>;
+
+// An expression whose result is within one particular type category and
+// of any supported kind.
+using AnyKindIntegerExpr = Expr<AnyKindType<Category::Integer>>;
+using AnyKindRealExpr = Expr<AnyKindType<Category::Real>>;
+using AnyKindComplexExpr = Expr<AnyKindType<Category::Complex>>;
+using AnyKindCharacterExpr = Expr<AnyKindType<Category::Character>>;
+using AnyKindLogicalExpr = Expr<AnyKindType<Category::Logical>>;
 
 // A completely generic expression.
 struct GenericExpr;

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -16,6 +16,7 @@
 #include "variable.h"
 #include "../common/idioms.h"
 #include "../parser/characters.h"
+#include "../parser/message.h"
 #include <ostream>
 #include <string>
 #include <type_traits>
@@ -24,6 +25,7 @@ using namespace Fortran::parser::literals;
 
 namespace Fortran::evaluate {
 
+// Dumping
 template<typename... A>
 std::ostream &DumpExprWithType(std::ostream &o, const std::variant<A...> &u) {
   std::visit(
@@ -42,7 +44,7 @@ std::ostream &DumpExpr(std::ostream &o, const std::variant<A...> &u) {
 }
 
 template<Category CAT>
-std::ostream &CategoryExpr<CAT>::Dump(std::ostream &o) const {
+std::ostream &Expr<AnyKindType<CAT>>::Dump(std::ostream &o) const {
   return DumpExpr(o, u);
 }
 
@@ -55,37 +57,45 @@ std::ostream &GenericExpr::Dump(std::ostream &o) const {
   return DumpExpr(o, u);
 }
 
-template<typename A>
-std::ostream &Unary<A>::Dump(std::ostream &o, const char *opr) const {
-  return x->Dump(o << opr) << ')';
+template<typename CRTP, typename RESULT, typename A>
+std::ostream &Unary<CRTP, RESULT, A>::Dump(
+    std::ostream &o, const char *opr) const {
+  return operand().Dump(o << opr) << ')';
 }
 
-template<typename A, typename B>
-std::ostream &Binary<A, B>::Dump(std::ostream &o, const char *opr) const {
-  return y->Dump(x->Dump(o << '(') << opr) << ')';
+template<typename CRTP, typename RESULT, typename A, typename B>
+std::ostream &Binary<CRTP, RESULT, A, B>::Dump(
+    std::ostream &o, const char *opr, const char *before) const {
+  return right().Dump(left().Dump(o << before) << opr) << ')';
 }
 
 template<int KIND>
-std::ostream &Expr<Category::Integer, KIND>::Dump(std::ostream &o) const {
-  std::visit(
-      common::visitors{[&](const Constant &n) { o << n.SignedDecimal(); },
-          [&](const CopyableIndirection<Designator> &d) { d->Dump(o); },
-          [&](const Parentheses &p) { p.Dump(o, "("); },
-          [&](const Negate &n) { n.Dump(o, "(-"); },
-          [&](const Add &a) { a.Dump(o, "+"); },
-          [&](const Subtract &s) { s.Dump(o, "-"); },
-          [&](const Multiply &m) { m.Dump(o, "*"); },
-          [&](const Divide &d) { d.Dump(o, "/"); },
-          [&](const Power &p) { p.Dump(o, "**"); },
-          [&](const auto &convert) { DumpExprWithType(o, convert.x->u); }},
-      u);
+std::ostream &IntegerExpr<KIND>::Dump(std::ostream &o) const {
+  std::visit(common::visitors{[&](const Scalar &n) { o << n.SignedDecimal(); },
+                 [&](const CopyableIndirection<DataRef> &d) { d->Dump(o); },
+                 [&](const CopyableIndirection<FunctionRef> &d) { d->Dump(o); },
+                 [&](const Parentheses &p) { p.Dump(o, "("); },
+                 [&](const Negate &n) { n.Dump(o, "(-"); },
+                 [&](const Add &a) { a.Dump(o, "+"); },
+                 [&](const Subtract &s) { s.Dump(o, "-"); },
+                 [&](const Multiply &m) { m.Dump(o, "*"); },
+                 [&](const Divide &d) { d.Dump(o, "/"); },
+                 [&](const Power &p) { p.Dump(o, "**"); },
+                 [&](const Max &m) { m.Dump(o, ",", "MAX("); },
+                 [&](const Min &m) { m.Dump(o, ",", "MIN("); },
+                 [&](const auto &convert) {
+                   DumpExprWithType(o, convert.operand().u);
+                 }},
+      u_);
   return o;
 }
 
-template<int KIND>
-std::ostream &Expr<Category::Real, KIND>::Dump(std::ostream &o) const {
+template<int KIND> std::ostream &RealExpr<KIND>::Dump(std::ostream &o) const {
   std::visit(
-      common::visitors{[&](const Constant &n) { o << n.DumpHexadecimal(); },
+      common::visitors{[&](const Scalar &n) { o << n.DumpHexadecimal(); },
+          [&](const CopyableIndirection<DataRef> &d) { d->Dump(o); },
+          [&](const CopyableIndirection<ComplexPart> &d) { d->Dump(o); },
+          [&](const CopyableIndirection<FunctionRef> &d) { d->Dump(o); },
           [&](const Parentheses &p) { p.Dump(o, "("); },
           [&](const Negate &n) { n.Dump(o, "(-"); },
           [&](const Add &a) { a.Dump(o, "+"); },
@@ -94,17 +104,23 @@ std::ostream &Expr<Category::Real, KIND>::Dump(std::ostream &o) const {
           [&](const Divide &d) { d.Dump(o, "/"); },
           [&](const Power &p) { p.Dump(o, "**"); },
           [&](const IntPower &p) { p.Dump(o, "**"); },
+          [&](const Max &m) { m.Dump(o, ",", "MAX("); },
+          [&](const Min &m) { m.Dump(o, ",", "MIN("); },
           [&](const RealPart &z) { z.Dump(o, "REAL("); },
           [&](const AIMAG &p) { p.Dump(o, "AIMAG("); },
-          [&](const auto &convert) { DumpExprWithType(o, convert.x->u); }},
-      u);
+          [&](const auto &convert) {
+            DumpExprWithType(o, convert.operand().u);
+          }},
+      u_);
   return o;
 }
 
 template<int KIND>
-std::ostream &Expr<Category::Complex, KIND>::Dump(std::ostream &o) const {
+std::ostream &ComplexExpr<KIND>::Dump(std::ostream &o) const {
   std::visit(
-      common::visitors{[&](const Constant &n) { o << n.DumpHexadecimal(); },
+      common::visitors{[&](const Scalar &n) { o << n.DumpHexadecimal(); },
+          [&](const CopyableIndirection<DataRef> &d) { d->Dump(o); },
+          [&](const CopyableIndirection<FunctionRef> &d) { d->Dump(o); },
           [&](const Parentheses &p) { p.Dump(o, "("); },
           [&](const Negate &n) { n.Dump(o, "(-"); },
           [&](const Add &a) { a.Dump(o, "+"); },
@@ -114,150 +130,585 @@ std::ostream &Expr<Category::Complex, KIND>::Dump(std::ostream &o) const {
           [&](const Power &p) { p.Dump(o, "**"); },
           [&](const IntPower &p) { p.Dump(o, "**"); },
           [&](const CMPLX &c) { c.Dump(o, ","); }},
-      u);
+      u_);
   return o;
 }
 
 template<int KIND>
-std::ostream &Expr<Category::Character, KIND>::Dump(std::ostream &o) const {
-  std::visit(common::visitors{[&](const Constant &s) {
+std::ostream &CharacterExpr<KIND>::Dump(std::ostream &o) const {
+  std::visit(common::visitors{[&](const Scalar &s) {
                                 o << parser::QuoteCharacterLiteral(s);
                               },
-                 [&](const auto &concat) {
-                   concat.y->Dump(concat.x->Dump(o) << "//");
-                 }},
-      u);
+                 [&](const Concat &concat) { concat.Dump(o, "//"); },
+                 [&](const Max &m) { m.Dump(o, ",", "MAX("); },
+                 [&](const Min &m) { m.Dump(o, ",", "MIN("); },
+                 [&](const auto &ind) { ind->Dump(o); }},
+      u_);
   return o;
 }
 
 template<typename A> std::ostream &Comparison<A>::Dump(std::ostream &o) const {
-  using Ty = typename A::Result;
-  o << '(' << Ty::Dump() << "::";
-  this->x->Dump(o);
+  o << '(' << A::Dump() << "::";
+  this->left().Dump(o);
   o << '.' << EnumToString(this->opr) << '.';
-  return this->y->Dump(o) << ')';
+  return this->right().Dump(o) << ')';
 }
 
-std::ostream &Expr<Category::Logical, 1>::Dump(std::ostream &o) const {
-  std::visit(
-      common::visitors{[&](const bool &tf) { o << (tf ? ".T." : ".F."); },
-          [&](const Not &n) { n.Dump(o, "(.NOT."); },
-          [&](const And &a) { a.Dump(o, ".AND."); },
-          [&](const Or &a) { a.Dump(o, ".OR."); },
-          [&](const Eqv &a) { a.Dump(o, ".EQV."); },
-          [&](const Neqv &a) { a.Dump(o, ".NEQV."); },
-          [&](const auto &comparison) { comparison.Dump(o); }},
-      u);
+template<int KIND>
+std::ostream &LogicalExpr<KIND>::Dump(std::ostream &o) const {
+  std::visit(common::visitors{[&](const Scalar &tf) {
+                                o << (tf.IsTrue() ? ".TRUE." : ".FALSE.");
+                              },
+                 [&](const CopyableIndirection<DataRef> &d) { d->Dump(o); },
+                 [&](const CopyableIndirection<FunctionRef> &d) { d->Dump(o); },
+                 [&](const Not &n) { n.Dump(o, "(.NOT."); },
+                 [&](const And &a) { a.Dump(o, ".AND."); },
+                 [&](const Or &a) { a.Dump(o, ".OR."); },
+                 [&](const Eqv &a) { a.Dump(o, ".EQV."); },
+                 [&](const Neqv &a) { a.Dump(o, ".NEQV."); },
+                 [&](const auto &comparison) { comparison.Dump(o); }},
+      u_);
   return o;
 }
 
-template<int KIND>
-void Expr<Category::Integer, KIND>::Fold(FoldingContext &context) {
-  std::visit(common::visitors{[&](Parentheses &p) {
-                                p.x->Fold(context);
-                                if (auto c{std::get_if<Constant>(&p.x->u)}) {
-                                  u = std::move(*c);
-                                }
-                              },
-                 [&](Negate &n) {
-                   n.x->Fold(context);
-                   if (auto c{std::get_if<Constant>(&n.x->u)}) {
-                     auto negated{c->Negate()};
-                     if (negated.overflow && context.messages != nullptr) {
-                       context.messages->Say(
-                           context.at, "integer negation overflowed"_en_US);
-                     }
-                     u = std::move(negated.value);
-                   }
-                 },
-                 [&](Add &a) {
-                   a.x->Fold(context);
-                   a.y->Fold(context);
-                   if (auto xc{std::get_if<Constant>(&a.x->u)}) {
-                     if (auto yc{std::get_if<Constant>(&a.y->u)}) {
-                       auto sum{xc->AddSigned(*yc)};
-                       if (sum.overflow && context.messages != nullptr) {
-                         context.messages->Say(
-                             context.at, "integer addition overflowed"_en_US);
-                       }
-                       u = std::move(sum.value);
-                     }
-                   }
-                 },
-                 [&](Multiply &a) {
-                   a.x->Fold(context);
-                   a.y->Fold(context);
-                   if (auto xc{std::get_if<Constant>(&a.x->u)}) {
-                     if (auto yc{std::get_if<Constant>(&a.y->u)}) {
-                       auto product{xc->MultiplySigned(*yc)};
-                       if (product.SignedMultiplicationOverflowed() &&
-                           context.messages != nullptr) {
-                         context.messages->Say(context.at,
-                             "integer multiplication overflowed"_en_US);
-                       }
-                       u = std::move(product.lower);
-                     }
-                   }
-                 },
-                 [&](Bin &b) {
-                   b.x->Fold(context);
-                   b.y->Fold(context);
-                 },
-                 [&](const auto &) {  // TODO: more
-                 }},
-      u);
+// LEN()
+template<int KIND> SubscriptIntegerExpr CharacterExpr<KIND>::LEN() const {
+  return std::visit(
+      common::visitors{
+          [](const Scalar &c) { return SubscriptIntegerExpr{c.size()}; },
+          [](const Concat &c) { return c.left().LEN() + c.right().LEN(); },
+          [](const Max &c) {
+            return SubscriptIntegerExpr{
+                SubscriptIntegerExpr::Max{c.left().LEN(), c.right().LEN()}};
+          },
+          [](const Min &c) {
+            return SubscriptIntegerExpr{
+                SubscriptIntegerExpr::Max{c.left().LEN(), c.right().LEN()}};
+          },
+          [](const CopyableIndirection<DataRef> &dr) { return dr->LEN(); },
+          [](const CopyableIndirection<Substring> &ss) { return ss->LEN(); },
+          [](const CopyableIndirection<FunctionRef> &fr) {
+            return fr->proc().LEN();
+          }},
+      u_);
+}
+
+// Rank
+template<typename CRTP, typename RESULT, typename A, typename B>
+int Binary<CRTP, RESULT, A, B>::Rank() const {
+  int lrank{left_.Rank()};
+  if (lrank > 0) {
+    return lrank;
+  }
+  return right_.Rank();
+}
+
+// Folding
+template<typename CRTP, typename RESULT, typename A>
+auto Unary<CRTP, RESULT, A>::Fold(FoldingContext &context)
+    -> std::optional<Scalar> {
+  if (std::optional<OperandScalarConstant> c{operand_->Fold(context)}) {
+    return static_cast<CRTP *>(this)->FoldScalar(context, *c);
+  }
+  return {};
+}
+
+template<typename CRTP, typename RESULT, typename A, typename B>
+auto Binary<CRTP, RESULT, A, B>::Fold(FoldingContext &context)
+    -> std::optional<Scalar> {
+  std::optional<LeftScalar> lc{left_->Fold(context)};
+  std::optional<RightScalar> rc{right_->Fold(context)};
+  if (lc.has_value() && rc.has_value()) {
+    return static_cast<CRTP *>(this)->FoldScalar(context, *lc, *rc);
+  }
+  return {};
 }
 
 template<int KIND>
-typename CharacterExpr<KIND>::LengthExpr CharacterExpr<KIND>::LEN() const {
-  // Written thus, instead of with common::visitors{}, to dodge a
-  // bug in g++ 7.2.0 that failed to direct the std::string case to its
-  // specific alternative.
+auto IntegerExpr<KIND>::ConvertInteger::FoldScalar(FoldingContext &context,
+    const ScalarConstant<Category::Integer> &c) -> std::optional<Scalar> {
   return std::visit(
-      [](const auto &x) {
-        if constexpr (std::is_same_v<
-                          const typename CharacterExpr<KIND>::Constant &,
-                          decltype(x)>) {
-          return LengthExpr{static_cast<std::uint64_t>(x.size())};
-        } else {
-          return LengthExpr{LengthExpr::Add{x.x->LEN(), x.y->LEN()}};
+      [&](auto &x) -> std::optional<Scalar> {
+        auto converted{Scalar::ConvertSigned(x)};
+        if (converted.overflow) {
+          context.messages.Say("integer conversion overflowed"_en_US);
+          return {};
         }
+        return {std::move(converted.value)};
+      },
+      c.u);
+}
+
+template<int KIND>
+auto IntegerExpr<KIND>::ConvertReal::FoldScalar(FoldingContext &context,
+    const ScalarConstant<Category::Real> &c) -> std::optional<Scalar> {
+  return std::visit(
+      [&](auto &x) -> std::optional<Scalar> {
+        auto converted{x.template ToInteger<Scalar>()};
+        if (converted.flags.test(RealFlag::Overflow)) {
+          context.messages.Say("real->integer conversion overflowed"_en_US);
+          return {};
+        }
+        if (converted.flags.test(RealFlag::InvalidArgument)) {
+          context.messages.Say(
+              "real->integer conversion: invalid argument"_en_US);
+          return {};
+        }
+        return {std::move(converted.value)};
+      },
+      c.u);
+}
+
+template<int KIND>
+auto IntegerExpr<KIND>::Negate::FoldScalar(
+    FoldingContext &context, const Scalar &c) -> std::optional<Scalar> {
+  auto negated{c.Negate()};
+  if (negated.overflow) {
+    context.messages.Say("integer negation overflowed"_en_US);
+    return {};
+  }
+  return {std::move(negated.value)};
+}
+
+template<int KIND>
+auto IntegerExpr<KIND>::Add::FoldScalar(FoldingContext &context,
+    const Scalar &a, const Scalar &b) -> std::optional<Scalar> {
+  auto sum{a.AddSigned(b)};
+  if (sum.overflow) {
+    context.messages.Say("integer addition overflowed"_en_US);
+    return {};
+  }
+  return {std::move(sum.value)};
+}
+
+template<int KIND>
+auto IntegerExpr<KIND>::Subtract::FoldScalar(FoldingContext &context,
+    const Scalar &a, const Scalar &b) -> std::optional<Scalar> {
+  auto diff{a.SubtractSigned(b)};
+  if (diff.overflow) {
+    context.messages.Say("integer subtraction overflowed"_en_US);
+    return {};
+  }
+  return {std::move(diff.value)};
+}
+
+template<int KIND>
+auto IntegerExpr<KIND>::Multiply::FoldScalar(FoldingContext &context,
+    const Scalar &a, const Scalar &b) -> std::optional<Scalar> {
+  auto product{a.MultiplySigned(b)};
+  if (product.SignedMultiplicationOverflowed()) {
+    context.messages.Say("integer multiplication overflowed"_en_US);
+    return {};
+  }
+  return {std::move(product.lower)};
+}
+
+template<int KIND>
+auto IntegerExpr<KIND>::Divide::FoldScalar(FoldingContext &context,
+    const Scalar &a, const Scalar &b) -> std::optional<Scalar> {
+  auto qr{a.DivideSigned(b)};
+  if (qr.divisionByZero) {
+    context.messages.Say("integer division by zero"_en_US);
+    return {};
+  }
+  if (qr.overflow) {
+    context.messages.Say("integer division overflowed"_en_US);
+    return {};
+  }
+  return {std::move(qr.quotient)};
+}
+
+template<int KIND>
+auto IntegerExpr<KIND>::Power::FoldScalar(FoldingContext &context,
+    const Scalar &a, const Scalar &b) -> std::optional<Scalar> {
+  typename Scalar::PowerWithErrors power{a.Power(b)};
+  if (power.divisionByZero) {
+    context.messages.Say("zero to negative power"_en_US);
+    return {};
+  }
+  if (power.overflow) {
+    context.messages.Say("integer power overflowed"_en_US);
+    return {};
+  }
+  if (power.zeroToZero) {
+    context.messages.Say("integer 0**0"_en_US);
+    return {};
+  }
+  return {std::move(power.power)};
+}
+
+template<int KIND>
+auto IntegerExpr<KIND>::Max::FoldScalar(FoldingContext &context,
+    const Scalar &a, const Scalar &b) -> std::optional<Scalar> {
+  if (a.CompareSigned(b) == Ordering::Greater) {
+    return {a};
+  }
+  return {b};
+}
+
+template<int KIND>
+auto IntegerExpr<KIND>::Min::FoldScalar(FoldingContext &context,
+    const Scalar &a, const Scalar &b) -> std::optional<Scalar> {
+  if (a.CompareSigned(b) == Ordering::Less) {
+    return {a};
+  }
+  return {b};
+}
+
+template<int KIND>
+auto IntegerExpr<KIND>::Fold(FoldingContext &context) -> std::optional<Scalar> {
+  return std::visit(
+      [&](auto &x) -> std::optional<Scalar> {
+        using Ty = typename std::decay<decltype(x)>::type;
+        if constexpr (std::is_same_v<Ty, Scalar>) {
+          return {x};
+        }
+        if constexpr (evaluate::FoldableTrait<Ty>) {
+          auto c{x.Fold(context)};
+          if (c.has_value()) {
+            u_ = *c;
+            return c;
+          }
+        }
+        return {};
+      },
+      u_);
+}
+
+static void RealFlagWarnings(
+    FoldingContext &context, const RealFlags &flags, const char *operation) {
+  if (flags.test(RealFlag::Overflow)) {
+    context.messages.Say(
+        parser::MessageFormattedText("overflow on %s"_en_US, operation));
+  }
+  if (flags.test(RealFlag::DivideByZero)) {
+    context.messages.Say(parser::MessageFormattedText(
+        "division by zero on %s"_en_US, operation));
+  }
+  if (flags.test(RealFlag::InvalidArgument)) {
+    context.messages.Say(parser::MessageFormattedText(
+        "invalid argument on %s"_en_US, operation));
+  }
+  if (flags.test(RealFlag::Underflow)) {
+    context.messages.Say(
+        parser::MessageFormattedText("underflow on %s"_en_US, operation));
+  }
+}
+
+template<int KIND>
+auto RealExpr<KIND>::ConvertInteger::FoldScalar(FoldingContext &context,
+    const ScalarConstant<Category::Integer> &c) -> std::optional<Scalar> {
+  return std::visit(
+      [&](auto &x) -> std::optional<Scalar> {
+        auto converted{Scalar::FromInteger(x)};
+        RealFlagWarnings(context, converted.flags, "integer->real conversion");
+        return {std::move(converted.value)};
+      },
+      c.u);
+}
+
+template<int KIND>
+auto RealExpr<KIND>::ConvertReal::FoldScalar(FoldingContext &context,
+    const ScalarConstant<Category::Real> &c) -> std::optional<Scalar> {
+  return std::visit(
+      [&](auto &x) -> std::optional<Scalar> {
+        auto converted{Scalar::Convert(x)};
+        RealFlagWarnings(context, converted.flags, "real conversion");
+        return {std::move(converted.value)};
+      },
+      c.u);
+}
+
+template<int KIND>
+auto RealExpr<KIND>::Negate::FoldScalar(
+    FoldingContext &context, const Scalar &c) -> std::optional<Scalar> {
+  return {c.Negate()};
+}
+
+template<int KIND>
+auto RealExpr<KIND>::Add::FoldScalar(FoldingContext &context, const Scalar &a,
+    const Scalar &b) -> std::optional<Scalar> {
+  auto sum{a.Add(b, context.rounding)};
+  RealFlagWarnings(context, sum.flags, "real addition");
+  return {std::move(sum.value)};
+}
+
+template<int KIND>
+auto RealExpr<KIND>::Subtract::FoldScalar(FoldingContext &context,
+    const Scalar &a, const Scalar &b) -> std::optional<Scalar> {
+  auto difference{a.Subtract(b, context.rounding)};
+  RealFlagWarnings(context, difference.flags, "real subtraction");
+  return {std::move(difference.value)};
+}
+
+template<int KIND>
+auto RealExpr<KIND>::Multiply::FoldScalar(FoldingContext &context,
+    const Scalar &a, const Scalar &b) -> std::optional<Scalar> {
+  auto product{a.Multiply(b, context.rounding)};
+  RealFlagWarnings(context, product.flags, "real multiplication");
+  return {std::move(product.value)};
+}
+
+template<int KIND>
+auto RealExpr<KIND>::Divide::FoldScalar(FoldingContext &context,
+    const Scalar &a, const Scalar &b) -> std::optional<Scalar> {
+  auto quotient{a.Divide(b, context.rounding)};
+  RealFlagWarnings(context, quotient.flags, "real division");
+  return {std::move(quotient.value)};
+}
+
+template<int KIND>
+auto RealExpr<KIND>::Power::FoldScalar(FoldingContext &context, const Scalar &a,
+    const Scalar &b) -> std::optional<Scalar> {
+  return {};  // TODO
+}
+
+template<int KIND>
+auto RealExpr<KIND>::IntPower::FoldScalar(FoldingContext &context,
+    const Scalar &a, const ScalarConstant<Category::Integer> &b)
+    -> std::optional<Scalar> {
+  return {};  // TODO
+}
+
+template<int KIND>
+auto RealExpr<KIND>::Max::FoldScalar(FoldingContext &context, const Scalar &a,
+    const Scalar &b) -> std::optional<Scalar> {
+  if (b.IsNotANumber() || a.Compare(b) == Relation::Less) {
+    return {b};
+  }
+  return {a};
+}
+
+template<int KIND>
+auto RealExpr<KIND>::Min::FoldScalar(FoldingContext &context, const Scalar &a,
+    const Scalar &b) -> std::optional<Scalar> {
+  if (b.IsNotANumber() || a.Compare(b) == Relation::Greater) {
+    return {b};
+  }
+  return {a};
+}
+
+template<int KIND>
+auto RealExpr<KIND>::RealPart::FoldScalar(
+    FoldingContext &context, const CplxScalar &z) -> std::optional<Scalar> {
+  return {z.REAL()};
+}
+
+template<int KIND>
+auto RealExpr<KIND>::AIMAG::FoldScalar(
+    FoldingContext &context, const CplxScalar &z) -> std::optional<Scalar> {
+  return {z.AIMAG()};
+}
+
+// TODO: generalize over Expr<A> rather than instantiating same for each
+template<int KIND>
+auto RealExpr<KIND>::Fold(FoldingContext &context) -> std::optional<Scalar> {
+  return std::visit(
+      [&](auto &x) -> std::optional<Scalar> {
+        using Ty = typename std::decay<decltype(x)>::type;
+        if constexpr (std::is_same_v<Ty, Scalar>) {
+          return {x};
+        }
+        if constexpr (evaluate::FoldableTrait<Ty>) {
+          auto c{x.Fold(context)};
+          if (c.has_value()) {
+            u_ = *c;
+            return c;
+          }
+        }
+        return {};
+      },
+      u_);
+}
+
+template<int KIND>
+auto ComplexExpr<KIND>::Fold(FoldingContext &context) -> std::optional<Scalar> {
+  return {};  // TODO
+}
+
+template<int KIND>
+auto CharacterExpr<KIND>::Fold(FoldingContext &context)
+    -> std::optional<Scalar> {
+  return {};  // TODO
+}
+
+template<typename A>
+auto Comparison<A>::FoldScalar(FoldingContext &c,
+    const OperandScalarConstant &a, const OperandScalarConstant &b)
+    -> std::optional<Scalar> {
+  if constexpr (A::category == Category::Integer) {
+    switch (a.CompareSigned(b)) {
+    case Ordering::Less:
+      return {opr == RelationalOperator::LE || opr == RelationalOperator::LE ||
+          opr == RelationalOperator::NE};
+    case Ordering::Equal:
+      return {opr == RelationalOperator::LE || opr == RelationalOperator::EQ ||
+          opr == RelationalOperator::GE};
+    case Ordering::Greater:
+      return {opr == RelationalOperator::NE || opr == RelationalOperator::GE ||
+          opr == RelationalOperator::GT};
+    }
+  }
+  if constexpr (A::category == Category::Real) {
+    switch (a.Compare(b)) {
+    case Relation::Less:
+      return {opr == RelationalOperator::LE || opr == RelationalOperator::LE ||
+          opr == RelationalOperator::NE};
+    case Relation::Equal:
+      return {opr == RelationalOperator::LE || opr == RelationalOperator::EQ ||
+          opr == RelationalOperator::GE};
+    case Relation::Greater:
+      return {opr == RelationalOperator::NE || opr == RelationalOperator::GE ||
+          opr == RelationalOperator::GT};
+    case Relation::Unordered: return {};
+    }
+  }
+  // TODO complex and character comparisons
+  return {};
+}
+
+template<int KIND>
+auto LogicalExpr<KIND>::Not::FoldScalar(
+    FoldingContext &context, const Scalar &x) -> std::optional<Scalar> {
+  return {Scalar{!x.IsTrue()}};
+}
+
+template<int KIND>
+auto LogicalExpr<KIND>::And::FoldScalar(FoldingContext &context,
+    const Scalar &a, const Scalar &b) -> std::optional<Scalar> {
+  return {Scalar{a.IsTrue() && b.IsTrue()}};
+}
+
+template<int KIND>
+auto LogicalExpr<KIND>::Or::FoldScalar(FoldingContext &context, const Scalar &a,
+    const Scalar &b) -> std::optional<Scalar> {
+  return {Scalar{a.IsTrue() || b.IsTrue()}};
+}
+
+template<int KIND>
+auto LogicalExpr<KIND>::Eqv::FoldScalar(FoldingContext &context,
+    const Scalar &a, const Scalar &b) -> std::optional<Scalar> {
+  return {Scalar{a.IsTrue() == b.IsTrue()}};
+}
+
+template<int KIND>
+auto LogicalExpr<KIND>::Neqv::FoldScalar(FoldingContext &context,
+    const Scalar &a, const Scalar &b) -> std::optional<Scalar> {
+  return {Scalar{a.IsTrue() != b.IsTrue()}};
+}
+
+template<int KIND>
+auto LogicalExpr<KIND>::Fold(FoldingContext &context) -> std::optional<Scalar> {
+  return std::visit(
+      [&](auto &x) -> std::optional<Scalar> {
+        using Ty = typename std::decay<decltype(x)>::type;
+        if constexpr (std::is_same_v<Ty, Scalar>) {
+          return {x};
+        }
+        if constexpr (evaluate::FoldableTrait<Ty>) {
+          std::optional<Scalar> c{x.Fold(context)};
+          if (c.has_value()) {
+            u_ = *c;
+            return c;
+          }
+        }
+        return {};
+      },
+      u_);
+}
+
+std::optional<GenericScalar> GenericExpr::ScalarValue() const {
+  return std::visit(
+      [](const auto &x) -> std::optional<GenericScalar> {
+        if (auto c{x.ScalarValue()}) {
+          return {GenericScalar{std::move(*c)}};
+        }
+        return {};
       },
       u);
 }
 
-template struct Expr<Category::Integer, 1>;
-template struct Expr<Category::Integer, 2>;
-template struct Expr<Category::Integer, 4>;
-template struct Expr<Category::Integer, 8>;
-template struct Expr<Category::Integer, 16>;
-template struct Expr<Category::Real, 2>;
-template struct Expr<Category::Real, 4>;
-template struct Expr<Category::Real, 8>;
-template struct Expr<Category::Real, 10>;
-template struct Expr<Category::Real, 16>;
-template struct Expr<Category::Complex, 2>;
-template struct Expr<Category::Complex, 4>;
-template struct Expr<Category::Complex, 8>;
-template struct Expr<Category::Complex, 10>;
-template struct Expr<Category::Complex, 16>;
-template struct Expr<Category::Character, 1>;
-template struct Expr<Category::Logical, 1>;
+template<Category CAT>
+auto Expr<AnyKindType<CAT>>::ScalarValue() const -> std::optional<Scalar> {
+  return std::visit(
+      [](const auto &x) -> std::optional<Scalar> {
+        if (auto c{x.ScalarValue()}) {
+          return {Scalar{std::move(*c)}};
+        }
+        std::optional<Scalar> avoidBogusGCCWarning;  // ... with return {};
+        return avoidBogusGCCWarning;
+        ;
+      },
+      u);
+}
 
-template struct Comparison<IntegerExpr<1>>;
-template struct Comparison<IntegerExpr<2>>;
-template struct Comparison<IntegerExpr<4>>;
-template struct Comparison<IntegerExpr<8>>;
-template struct Comparison<IntegerExpr<16>>;
-template struct Comparison<RealExpr<2>>;
-template struct Comparison<RealExpr<4>>;
-template struct Comparison<RealExpr<8>>;
-template struct Comparison<RealExpr<10>>;
-template struct Comparison<RealExpr<16>>;
-template struct Comparison<ComplexExpr<2>>;
-template struct Comparison<ComplexExpr<4>>;
-template struct Comparison<ComplexExpr<8>>;
-template struct Comparison<ComplexExpr<10>>;
-template struct Comparison<ComplexExpr<16>>;
-template struct Comparison<CharacterExpr<1>>;
+template<Category CAT>
+auto Expr<AnyKindType<CAT>>::Fold(FoldingContext &context)
+    -> std::optional<Scalar> {
+  return std::visit(
+      [&](auto &x) -> std::optional<Scalar> {
+        if (auto c{x.Fold(context)}) {
+          return {Scalar{std::move(*c)}};
+        }
+        std::optional<Scalar> avoidBogusGCCWarning;  // ... with return {};
+        return avoidBogusGCCWarning;
+        ;
+      },
+      u);
+}
+
+std::optional<GenericScalar> GenericExpr::Fold(FoldingContext &context) {
+  return std::visit(
+      [&](auto &x) -> std::optional<GenericScalar> {
+        if (auto c{x.Fold(context)}) {
+          return {GenericScalar{std::move(*c)}};
+        }
+        return {};
+      },
+      u);
+}
+
+template class Expr<AnyKindType<Category::Integer>>;
+template class Expr<AnyKindType<Category::Real>>;
+template class Expr<AnyKindType<Category::Complex>>;
+template class Expr<AnyKindType<Category::Character>>;
+template class Expr<AnyKindType<Category::Logical>>;
+
+template class Expr<Type<Category::Integer, 1>>;
+template class Expr<Type<Category::Integer, 2>>;
+template class Expr<Type<Category::Integer, 4>>;
+template class Expr<Type<Category::Integer, 8>>;
+template class Expr<Type<Category::Integer, 16>>;
+template class Expr<Type<Category::Real, 2>>;
+template class Expr<Type<Category::Real, 4>>;
+template class Expr<Type<Category::Real, 8>>;
+template class Expr<Type<Category::Real, 10>>;
+template class Expr<Type<Category::Real, 16>>;
+template class Expr<Type<Category::Complex, 2>>;
+template class Expr<Type<Category::Complex, 4>>;
+template class Expr<Type<Category::Complex, 8>>;
+template class Expr<Type<Category::Complex, 10>>;
+template class Expr<Type<Category::Complex, 16>>;
+template class Expr<Type<Category::Character, 1>>;
+template class Expr<Type<Category::Logical, 1>>;
+template class Expr<Type<Category::Logical, 2>>;
+template class Expr<Type<Category::Logical, 4>>;
+template class Expr<Type<Category::Logical, 8>>;
+
+template struct Comparison<Type<Category::Integer, 1>>;
+template struct Comparison<Type<Category::Integer, 2>>;
+template struct Comparison<Type<Category::Integer, 4>>;
+template struct Comparison<Type<Category::Integer, 8>>;
+template struct Comparison<Type<Category::Integer, 16>>;
+template struct Comparison<Type<Category::Real, 2>>;
+template struct Comparison<Type<Category::Real, 4>>;
+template struct Comparison<Type<Category::Real, 8>>;
+template struct Comparison<Type<Category::Real, 10>>;
+template struct Comparison<Type<Category::Real, 16>>;
+template struct Comparison<Type<Category::Complex, 2>>;
+template struct Comparison<Type<Category::Complex, 4>>;
+template struct Comparison<Type<Category::Complex, 8>>;
+template struct Comparison<Type<Category::Complex, 10>>;
+template struct Comparison<Type<Category::Complex, 16>>;
+template struct Comparison<Type<Category::Character, 1>>;
 }  // namespace Fortran::evaluate

--- a/lib/evaluate/integer.h
+++ b/lib/evaluate/integer.h
@@ -100,6 +100,11 @@ public:
     bool divisionByZero, overflow;
   };
 
+  struct PowerWithErrors {
+    Integer power;
+    bool divisionByZero, overflow, zeroToZero;
+  };
+
   // Constructors and value-generating static functions
   constexpr Integer() { Clear(); }  // default constructor: zero
   constexpr Integer(const Integer &) = default;
@@ -236,6 +241,21 @@ public:
           result.overflow = (field >> (bits - j)) != 0;
         }
       }
+    }
+    return result;
+  }
+
+  template<typename FROM>
+  static constexpr ValueWithOverflow ConvertSigned(const FROM &that) {
+    ValueWithOverflow result{ConvertUnsigned(that)};
+    if constexpr (bits > FROM::bits) {
+      if (that.IsNegative()) {
+        result.value = result.value.IOR(MASKL(bits - FROM::bits));
+      }
+    } else if constexpr (bits < FROM::bits) {
+      auto back{FROM::template ConvertSigned(result.value)};
+      result.overflow |=
+          back.overflow || back.value.CompareUnsigned(that) != Ordering::Equal;
     }
     return result;
   }
@@ -863,6 +883,49 @@ public:
     } else {
       return {divided.remainder, divided.overflow};
     }
+  }
+
+  constexpr PowerWithErrors Power(const Integer &exponent) const {
+    PowerWithErrors result{1, false, false, false};
+    if (exponent.IsZero()) {
+      // x**0 -> 1, including the case 0**0, which is not defined specifically
+      // in F'18 afaict; however, other Fortrans tested all produce 1, not 0,
+      // apart from nagfor, which stops with an error at runtime.
+      // Ada, APL, C's pow(), Haskell, Julia, MATLAB, and R all produce 1 too.
+      // F'77 explicitly states that 0**0 is mathematically undefined and
+      // therefore prohibited.
+      result.zeroToZero = IsZero();
+    } else if (exponent.IsNegative()) {
+      if (IsZero()) {
+        result.divisionByZero = true;
+        result.power = MASKR(bits - 1);
+      } else if (CompareSigned(Integer{1}) == Ordering::Equal) {
+        result.power = *this;  // 1**x -> 1
+      } else if (CompareSigned(Integer{-1}) == Ordering::Equal) {
+        if (exponent.BTEST(0)) {
+          result.power = *this;  // (-1)**x -> -1 if x is odd
+        }
+      } else {
+        result.power.Clear();  // j**k -> 0 if |j| > 1 and k < 0
+      }
+    } else {
+      Integer shifted{*this};
+      Integer pow{exponent};
+      int nbits{bits - pow.LEADZ()};
+      for (int j{0}; j < nbits; ++j) {
+        if (pow.BTEST(j)) {
+          Product product{result.power.MultiplySigned(shifted)};
+          result.power = product.lower;
+          result.overflow |= product.SignedMultiplicationOverflowed();
+        }
+        if (j + 1 < nbits) {
+          ValueWithOverflow doubled{shifted.AddSigned(shifted)};
+          result.overflow |= doubled.overflow;
+          shifted = doubled.value;
+        }
+      }
+    }
+    return result;
   }
 
 private:

--- a/lib/evaluate/intrinsics.h
+++ b/lib/evaluate/intrinsics.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_EVALUATE_INTRINSICS_H_
+#define FORTRAN_EVALUATE_INTRINSICS_H_
+
+#include "../common/idioms.h"
+
+namespace Fortran::evaluate {
+
+ENUM_CLASS(IntrinsicProcedure, LEN, MAX, MIN)
+
+}  // namespace Fortran::evaluate
+#endif  // FORTRAN_EVALUATE_INTRINSICS_H_

--- a/lib/evaluate/logical.h
+++ b/lib/evaluate/logical.h
@@ -24,7 +24,9 @@ template<int BITS> class Logical {
 public:
   static constexpr int bits{BITS};
   constexpr Logical() {}  // .FALSE.
+  constexpr Logical(const Logical &that) = default;
   constexpr Logical(bool truth) : word_{-std::uint64_t{truth}} {}
+  constexpr Logical &operator=(const Logical &) = default;
 
   // For static expression evaluation, all the bits will have the same value.
   constexpr bool IsTrue() const { return word_.BTEST(0); }

--- a/lib/evaluate/type.h
+++ b/lib/evaluate/type.h
@@ -30,7 +30,7 @@
 
 namespace Fortran::evaluate {
 
-ENUM_CLASS(Category, Integer, Real, Complex, Logical, Character, Derived)
+ENUM_CLASS(Category, Integer, Real, Complex, Character, Logical, Derived)
 
 template<Category C, int KIND> struct TypeBase {
   static constexpr Category category{C};
@@ -84,12 +84,6 @@ struct Type<Category::Complex, KIND>
   using Value = value::Complex<typename Part::Value>;
 };
 
-template<int KIND>
-struct Type<Category::Logical, KIND>
-  : public TypeBase<Category::Logical, KIND> {
-  using Value = value::Logical<8 * KIND>;
-};
-
 template<int KIND> struct Type<Category::Character, KIND> {
   static constexpr Category category{Category::Character};
   static constexpr int kind{KIND};
@@ -98,6 +92,12 @@ template<int KIND> struct Type<Category::Character, KIND> {
   static std::string Dump() {
     return EnumToString(category) + '(' + std::to_string(kind) + ')';
   }
+};
+
+template<int KIND>
+struct Type<Category::Logical, KIND>
+  : public TypeBase<Category::Logical, KIND> {
+  using Value = value::Logical<8 * KIND>;
 };
 
 // Default REAL just simply has to be IEEE-754 single precision today.
@@ -117,24 +117,73 @@ using DefaultCharacter = Type<Category::Character, 1>;
 
 using SubscriptInteger = Type<Category::Integer, 8>;
 
+// These macros invoke other macros on each of the supported kinds of
+// a given category.
+// TODO larger CHARACTER kinds, incl. Kanji
+#define COMMA ,
+#define FOR_EACH_INTEGER_KIND(M, SEP) M(1) SEP M(2) SEP M(4) SEP M(8) SEP M(16)
+#define FOR_EACH_REAL_KIND(M, SEP) M(2) SEP M(4) SEP M(8) SEP M(10) SEP M(16)
+#define FOR_EACH_COMPLEX_KIND(M, SEP) M(2) SEP M(4) SEP M(8) SEP M(10) SEP M(16)
+#define FOR_EACH_CHARACTER_KIND(M, SEP) M(1)
+#define FOR_EACH_LOGICAL_KIND(M, SEP) M(1) SEP M(2) SEP M(4) SEP M(8)
+
 // These templates create instances of std::variant<> that can contain
 // applications of some class template to all of the supported kinds of
 // a category of intrinsic type.
+#define TKIND(K) T<K>
 template<Category CAT, template<int> class T> struct KindsVariant;
 template<template<int> class T> struct KindsVariant<Category::Integer, T> {
-  using type = std::variant<T<1>, T<2>, T<4>, T<8>, T<16>>;
+  using type = std::variant<FOR_EACH_INTEGER_KIND(TKIND, COMMA)>;
 };
 template<template<int> class T> struct KindsVariant<Category::Real, T> {
-  using type = std::variant<T<2>, T<4>, T<8>, T<10>, T<16>>;
+  using type = std::variant<FOR_EACH_REAL_KIND(TKIND, COMMA)>;
 };
 template<template<int> class T> struct KindsVariant<Category::Complex, T> {
-  using type = typename KindsVariant<Category::Real, T>::type;
+  using type = std::variant<FOR_EACH_COMPLEX_KIND(TKIND, COMMA)>;
 };
 template<template<int> class T> struct KindsVariant<Category::Character, T> {
-  using type = std::variant<T<1>>;  // TODO larger CHARACTER kinds, incl. Kanji
+  using type = std::variant<FOR_EACH_CHARACTER_KIND(TKIND, COMMA)>;
 };
 template<template<int> class T> struct KindsVariant<Category::Logical, T> {
-  using type = std::variant<T<1>, T<2>, T<4>, T<8>>;
+  using type = std::variant<FOR_EACH_LOGICAL_KIND(TKIND, COMMA)>;
+};
+#undef TKIND
+
+// Holds a scalar constant of any kind within a particular intrinsic type
+// category.
+template<Category CAT> struct ScalarConstant {
+  CLASS_BOILERPLATE(ScalarConstant)
+  template<int KIND> using KindScalar = typename Type<CAT, KIND>::Value;
+  template<typename A> ScalarConstant(const A &x) : u{x} {}
+  template<typename A>
+  ScalarConstant(std::enable_if_t<!std::is_reference_v<A>, A> &&x)
+    : u{std::move(x)} {}
+  typename KindsVariant<CAT, KindScalar>::type u;
+};
+
+// Holds a scalar constant of any intrinsic category and size.
+struct GenericScalar {
+  CLASS_BOILERPLATE(GenericScalar)
+  template<Category CAT, int KIND>
+  GenericScalar(const typename Type<CAT, KIND>::Value &x)
+    : u{ScalarConstant<CAT>{x}} {}
+  template<Category CAT, int KIND>
+  GenericScalar(typename Type<CAT, KIND>::Value &&x)
+    : u{ScalarConstant<CAT>{std::move(x)}} {}
+  template<typename A> GenericScalar(const A &x) : u{x} {}
+  template<typename A>
+  GenericScalar(std::enable_if_t<!std::is_reference_v<A>, A> &&x)
+    : u{std::move(x)} {}
+  std::variant<ScalarConstant<Category::Integer>,
+      ScalarConstant<Category::Real>, ScalarConstant<Category::Complex>,
+      ScalarConstant<Category::Character>, ScalarConstant<Category::Logical>>
+      u;
+};
+
+// Represents a type of any supported kind within a particular category.
+template<Category CAT> struct AnyKindType {
+  static constexpr Category category{CAT};
+  using Value = ScalarConstant<CAT>;
 };
 }  // namespace Fortran::evaluate
 #endif  // FORTRAN_EVALUATE_TYPE_H_

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -23,6 +23,7 @@
 
 #include "common.h"
 #include "expression-forward.h"
+#include "intrinsics.h"
 #include "../common/idioms.h"
 #include "../semantics/symbol.h"
 #include <optional>
@@ -35,46 +36,65 @@ namespace Fortran::evaluate {
 using semantics::Symbol;
 
 // Forward declarations
-struct DataRef;
-struct Variable;
-struct ActualFunctionArg;
+class DataRef;
+class Variable;
+class ActualFunctionArg;
 
 // Subscript and cosubscript expressions are of a kind that matches the
 // address size, at least at the top level.
-using SubscriptIntegerExpr =
-    CopyableIndirection<IntegerExpr<SubscriptInteger::kind>>;
+using SubscriptIntegerExpr = IntegerExpr<SubscriptInteger::kind>;
+using IndirectSubscriptIntegerExpr = CopyableIndirection<SubscriptIntegerExpr>;
 
 // R913 structure-component & C920: Defined to be a multi-part
 // data-ref whose last part has no subscripts (or image-selector, although
 // that isn't explicit in the document).  Pointer and allocatable components
 // are not explicitly indirected in this representation.
 // Complex components (%RE, %IM) are isolated below in ComplexPart.
-struct Component {
+class Component {
+public:
   CLASS_BOILERPLATE(Component)
-  Component(const DataRef &b, const Symbol &c) : base{b}, sym{&c} {}
+  Component(const DataRef &b, const Symbol &c) : base_{b}, symbol_{&c} {}
+  Component(DataRef &&b, const Symbol &c) : base_{std::move(b)}, symbol_{&c} {}
   Component(CopyableIndirection<DataRef> &&b, const Symbol &c)
-    : base{std::move(b)}, sym{&c} {}
-  CopyableIndirection<DataRef> base;
-  const Symbol *sym;
+    : base_{std::move(b)}, symbol_{&c} {}
+  const DataRef &base() const { return *base_; }
+  DataRef &base() { return *base_; }
+  const Symbol &symbol() const { return *symbol_; }
+  SubscriptIntegerExpr LEN() const;
+
+private:
+  CopyableIndirection<DataRef> base_;
+  const Symbol *symbol_;
 };
 
 // R921 subscript-triplet
-struct Triplet {
+class Triplet {
+public:
   CLASS_BOILERPLATE(Triplet)
   Triplet(std::optional<SubscriptIntegerExpr> &&,
       std::optional<SubscriptIntegerExpr> &&,
       std::optional<SubscriptIntegerExpr> &&);
-  std::optional<SubscriptIntegerExpr> lower, upper, stride;
+  std::optional<SubscriptIntegerExpr> lower() const;
+  std::optional<SubscriptIntegerExpr> upper() const;
+  std::optional<SubscriptIntegerExpr> stride() const;
+
+private:
+  std::optional<IndirectSubscriptIntegerExpr> lower_, upper_, stride_;
 };
 
 // R919 subscript when rank 0, R923 vector-subscript when rank 1
-struct Subscript {
+class Subscript {
+public:
   CLASS_BOILERPLATE(Subscript)
-  explicit Subscript(const SubscriptIntegerExpr &s) : u{s} {}
-  explicit Subscript(SubscriptIntegerExpr &&s) : u{std::move(s)} {}
-  explicit Subscript(const Triplet &t) : u{t} {}
-  explicit Subscript(Triplet &&t) : u{std::move(t)} {}
-  std::variant<SubscriptIntegerExpr, Triplet> u;
+  explicit Subscript(const SubscriptIntegerExpr &s)
+    : u_{IndirectSubscriptIntegerExpr::Make(s)} {}
+  explicit Subscript(SubscriptIntegerExpr &&s)
+    : u_{IndirectSubscriptIntegerExpr::Make(std::move(s))} {}
+  explicit Subscript(const Triplet &t) : u_{t} {}
+  explicit Subscript(Triplet &&t) : u_{std::move(t)} {}
+
+private:
+  std::variant<IndirectSubscriptIntegerExpr, Triplet> u_;
 };
 
 // R917 array-element, R918 array-section; however, the case of an
@@ -82,14 +102,18 @@ struct Subscript {
 // as a ComplexPart instead.  C919 & C925 require that at most one set of
 // subscripts have rank greater than 0, but that is not explicit in
 // these types.
-struct ArrayRef {
+class ArrayRef {
+public:
   CLASS_BOILERPLATE(ArrayRef)
   ArrayRef(const Symbol &n, std::vector<Subscript> &&ss)
-    : u{&n}, subscript(std::move(ss)) {}
+    : u_{&n}, subscript_(std::move(ss)) {}
   ArrayRef(Component &&c, std::vector<Subscript> &&ss)
-    : u{std::move(c)}, subscript(std::move(ss)) {}
-  std::variant<const Symbol *, Component> u;
-  std::vector<Subscript> subscript;
+    : u_{std::move(c)}, subscript_(std::move(ss)) {}
+  SubscriptIntegerExpr LEN() const;
+
+private:
+  std::variant<const Symbol *, Component> u_;
+  std::vector<Subscript> subscript_;
 };
 
 // R914 coindexed-named-object
@@ -99,101 +123,138 @@ struct ArrayRef {
 // function results.  They can be components of other derived types.
 // C930 precludes having both TEAM= and TEAM_NUMBER=.
 // TODO C931 prohibits the use of a coindexed object as a stat-variable.
-struct CoarrayRef {
+class CoarrayRef {
+public:
   CLASS_BOILERPLATE(CoarrayRef)
-  CoarrayRef(std::vector<const Symbol *> &&c,
-      std::vector<SubscriptIntegerExpr> &&ss,
-      std::vector<SubscriptIntegerExpr> &&css)
-    : base(std::move(c)), subscript(std::move(ss)),
-      cosubscript(std::move(css)) {}
-  std::vector<const Symbol *> base;
-  std::vector<SubscriptIntegerExpr> subscript, cosubscript;
-  std::optional<CopyableIndirection<Variable>> stat, team;
-  bool teamIsTeamNumber{false};  // false: TEAM=, true: TEAM_NUMBER=
+  CoarrayRef(std::vector<const Symbol *> &&,
+      std::vector<SubscriptIntegerExpr> &&,
+      std::vector<SubscriptIntegerExpr> &&);  // TODO: stat & team?
+  CoarrayRef &setStat(Variable &&);
+  CoarrayRef &setTeam(Variable &&, bool isTeamNumber = false);
+  SubscriptIntegerExpr LEN() const;
+
+private:
+  std::vector<const Symbol *> base_;
+  std::vector<SubscriptIntegerExpr> subscript_, cosubscript_;
+  std::optional<CopyableIndirection<Variable>> stat_, team_;
+  bool teamIsTeamNumber_{false};  // false: TEAM=, true: TEAM_NUMBER=
 };
 
 // R911 data-ref is defined syntactically as a series of part-refs, which
-// is far too expressive if the constraints are ignored.  Here, the possible
-// outcomes are spelled out.  Note that a data-ref cannot include a terminal
-// substring range or complex component designator; use R901 designator
-// for that.
-struct DataRef {
+// would be far too expressive if the constraints were ignored.  Here, the
+// possible outcomes are spelled out.  Note that a data-ref cannot include
+// a terminal substring range or complex component designator; use
+// R901 designator for that.
+class DataRef {
+public:
   CLASS_BOILERPLATE(DataRef)
-  explicit DataRef(const Symbol &n) : u{&n} {}
-  explicit DataRef(Component &&c) : u{std::move(c)} {}
-  explicit DataRef(ArrayRef &&a) : u{std::move(a)} {}
-  explicit DataRef(CoarrayRef &&a) : u{std::move(a)} {}
-  std::variant<const Symbol *, Component, ArrayRef, CoarrayRef> u;
+  explicit DataRef(const Symbol &n) : u_{&n} {}
+  explicit DataRef(Component &&c) : u_{std::move(c)} {}
+  explicit DataRef(ArrayRef &&a) : u_{std::move(a)} {}
+  explicit DataRef(CoarrayRef &&a) : u_{std::move(a)} {}
+  SubscriptIntegerExpr LEN() const;
+
+private:
+  std::variant<const Symbol *, Component, ArrayRef, CoarrayRef> u_;
 };
 
 // R908 substring, R909 parent-string, R910 substring-range.
 // The base object of a substring can be a literal.
 // In the F2018 standard, substrings of array sections are parsed as
 // variants of sections instead.
-struct Substring {
+class Substring {
+public:
   CLASS_BOILERPLATE(Substring)
-  Substring(DataRef &&d, std::optional<SubscriptIntegerExpr> &&f,
-      std::optional<SubscriptIntegerExpr> &&l)
-    : u{std::move(d)}, first{std::move(f)}, last{std::move(l)} {}
-  Substring(std::string &&s, std::optional<SubscriptIntegerExpr> &&f,
-      std::optional<SubscriptIntegerExpr> &&l)
-    : u{std::move(s)}, first{std::move(f)}, last{std::move(l)} {}
-  std::variant<DataRef, std::string> u;
-  std::optional<SubscriptIntegerExpr> first, last;
+  Substring(DataRef &&, std::optional<SubscriptIntegerExpr> &&,
+      std::optional<SubscriptIntegerExpr> &&);
+  Substring(std::string &&, std::optional<SubscriptIntegerExpr> &&,
+      std::optional<SubscriptIntegerExpr> &&);
+
+  SubscriptIntegerExpr first() const;
+  SubscriptIntegerExpr last() const;
+  SubscriptIntegerExpr LEN() const;
+
+private:
+  std::variant<DataRef, std::string> u_;
+  std::optional<IndirectSubscriptIntegerExpr> first_, last_;
 };
 
 // R915 complex-part-designator
 // In the F2018 standard, complex parts of array sections are parsed as
 // variants of sections instead.
-struct ComplexPart {
+class ComplexPart {
+public:
   ENUM_CLASS(Part, RE, IM)
   CLASS_BOILERPLATE(ComplexPart)
-  ComplexPart(DataRef &&z, Part p) : complex{std::move(z)}, part{p} {}
-  DataRef complex;
-  Part part;
+  ComplexPart(DataRef &&z, Part p) : complex_{std::move(z)}, part_{p} {}
+  const DataRef &complex() const { return complex_; }
+  Part part() const { return part_; }
+
+private:
+  DataRef complex_;
+  Part part_;
 };
 
 // R901 designator is the most general data reference object, apart from
 // calls to pointer-valued functions.
-struct Designator {
+class Designator {
+public:
   CLASS_BOILERPLATE(Designator)
-  explicit Designator(DataRef &&d) : u{std::move(d)} {}
-  explicit Designator(Substring &&s) : u{std::move(s)} {}
-  explicit Designator(ComplexPart &&c) : u{std::move(c)} {}
-  std::variant<DataRef, Substring, ComplexPart> u;
+  explicit Designator(DataRef &&d) : u_{std::move(d)} {}
+  explicit Designator(Substring &&s) : u_{std::move(s)} {}
+  explicit Designator(ComplexPart &&c) : u_{std::move(c)} {}
+
+private:
+  std::variant<DataRef, Substring, ComplexPart> u_;
 };
 
-struct ProcedureDesignator {
+class ProcedureDesignator {
+public:
   CLASS_BOILERPLATE(ProcedureDesignator)
-  explicit ProcedureDesignator(const Symbol &n) : u{&n} {}
-  explicit ProcedureDesignator(const Component &c) : u{c} {}
-  explicit ProcedureDesignator(Component &&c) : u{std::move(c)} {}
-  std::variant<const Symbol *, Component> u;
+  explicit ProcedureDesignator(IntrinsicProcedure p) : u_{p} {}
+  explicit ProcedureDesignator(const Symbol &n) : u_{&n} {}
+  explicit ProcedureDesignator(const Component &c) : u_{c} {}
+  explicit ProcedureDesignator(Component &&c) : u_{std::move(c)} {}
+  SubscriptIntegerExpr LEN() const;
+
+private:
+  std::variant<IntrinsicProcedure, const Symbol *, Component> u_;
 };
 
-template<typename ARG> struct ProcedureRef {
+template<typename ARG> class ProcedureRef {
+public:
   using ArgumentType = CopyableIndirection<ARG>;
   CLASS_BOILERPLATE(ProcedureRef)
   ProcedureRef(ProcedureDesignator &&p, std::vector<ArgumentType> &&a)
-    : proc{std::move(p)}, argument(std::move(a)) {}
-  ProcedureDesignator proc;
-  std::vector<ArgumentType> argument;
+    : proc_{std::move(p)}, argument_(std::move(a)) {}
+  const ProcedureDesignator &proc() const { return proc_; }
+  const std::vector<ArgumentType> &argument() const { return argument_; }
+
+private:
+  ProcedureDesignator proc_;
+  std::vector<ArgumentType> argument_;
 };
 
 using FunctionRef = ProcedureRef<ActualFunctionArg>;
 
-struct Variable {
+class Variable {
+public:
   CLASS_BOILERPLATE(Variable)
-  explicit Variable(Designator &&d) : u{std::move(d)} {}
-  explicit Variable(FunctionRef &&p) : u{std::move(p)} {}
-  std::variant<Designator, FunctionRef> u;
+  explicit Variable(Designator &&d) : u_{std::move(d)} {}
+  explicit Variable(FunctionRef &&p) : u_{std::move(p)} {}
+
+private:
+  std::variant<Designator, FunctionRef> u_;
 };
 
-struct ActualFunctionArg {
+class ActualFunctionArg {
+public:
   CLASS_BOILERPLATE(ActualFunctionArg)
-  explicit ActualFunctionArg(GenericExpr &&x) : u{std::move(x)} {}
-  explicit ActualFunctionArg(Variable &&x) : u{std::move(x)} {}
-  std::variant<CopyableIndirection<GenericExpr>, Variable> u;
+  explicit ActualFunctionArg(GenericExpr &&x) : u_{std::move(x)} {}
+  explicit ActualFunctionArg(Variable &&x) : u_{std::move(x)} {}
+
+private:
+  std::variant<CopyableIndirection<GenericExpr>, Variable> u_;
 };
 
 struct Label {  // TODO: this is a placeholder
@@ -202,12 +263,15 @@ struct Label {  // TODO: this is a placeholder
   int label;
 };
 
-struct ActualSubroutineArg {
+class ActualSubroutineArg {
+public:
   CLASS_BOILERPLATE(ActualSubroutineArg)
-  explicit ActualSubroutineArg(GenericExpr &&x) : u{std::move(x)} {}
-  explicit ActualSubroutineArg(Variable &&x) : u{std::move(x)} {}
-  explicit ActualSubroutineArg(const Label &l) : u{&l} {}
-  std::variant<CopyableIndirection<GenericExpr>, Variable, const Label *> u;
+  explicit ActualSubroutineArg(GenericExpr &&x) : u_{std::move(x)} {}
+  explicit ActualSubroutineArg(Variable &&x) : u_{std::move(x)} {}
+  explicit ActualSubroutineArg(const Label &l) : u_{&l} {}
+
+private:
+  std::variant<CopyableIndirection<GenericExpr>, Variable, const Label *> u_;
 };
 
 using SubroutineRef = ProcedureRef<ActualSubroutineArg>;

--- a/lib/parser/message.h
+++ b/lib/parser/message.h
@@ -113,6 +113,8 @@ public:
 
   Message(ProvenanceRange pr, const MessageFixedText &t)
     : location_{pr}, text_{t} {}
+  Message(ProvenanceRange pr, const MessageFormattedText &s)
+    : location_{pr}, text_{std::move(s)} {}
   Message(ProvenanceRange pr, MessageFormattedText &&s)
     : location_{pr}, text_{std::move(s)} {}
   Message(ProvenanceRange pr, const MessageExpectedText &t)
@@ -120,6 +122,8 @@ public:
 
   Message(CharBlock csr, const MessageFixedText &t)
     : location_{csr}, text_{t} {}
+  Message(CharBlock csr, const MessageFormattedText &s)
+    : location_{csr}, text_{std::move(s)} {}
   Message(CharBlock csr, MessageFormattedText &&s)
     : location_{csr}, text_{std::move(s)} {}
   Message(CharBlock csr, const MessageExpectedText &t)
@@ -213,5 +217,18 @@ private:
   std::forward_list<Message>::iterator last_{messages_.before_begin()};
 };
 
+class ContextualMessages {
+public:
+  ContextualMessages(CharBlock at, Messages *m) : at_{at}, messages_{m} {}
+  template<typename... A> void Say(A &&... args) {
+    if (messages_ != nullptr) {
+      messages_->Say(at_, std::forward<A>(args)...);
+    }
+  }
+
+private:
+  CharBlock at_;
+  Messages *messages_{nullptr};
+};
 }  // namespace Fortran::parser
 #endif  // FORTRAN_PARSER_MESSAGE_H_

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -54,11 +54,16 @@ CLASS_TRAIT(WrapperTrait);
 CLASS_TRAIT(UnionTrait);
 CLASS_TRAIT(TupleTrait);
 
-namespace Fortran {
-namespace semantics {
+// Some parse tree nodes have fields in them to cache the results of a
+// successful semantic analysis later.  Their types are forward declared
+// here.
+namespace Fortran::semantics {
 class Symbol;
-}  // namespace semantics
-}  // namespace Fortran
+}  // namespace Fortran::semantics
+
+namespace Fortran::evaluate {
+struct GenericExpr;
+}  // namespace Fortran::evaluate
 
 // Most non-template classes in this file use these default definitions
 // for their move constructor and move assignment operator=, and disable
@@ -530,7 +535,7 @@ struct Name {
   COPY_AND_ASSIGN_BOILERPLATE(Name);
   std::string ToString() const { return source.ToString(); }
   CharBlock source;
-  semantics::Symbol *symbol{nullptr};
+  semantics::Symbol *symbol{nullptr};  // filled in later by semantic analysis
 };
 
 // R516 keyword -> name

--- a/lib/parser/provenance.cc
+++ b/lib/parser/provenance.cc
@@ -303,11 +303,12 @@ const AllSources::Origin &AllSources::MapToOrigin(Provenance at) const {
 }
 
 ProvenanceRange CookedSource::GetProvenanceRange(CharBlock cookedRange) const {
-  ProvenanceRange range{provenanceMap_.Map(cookedRange.begin() - &data_[0])};
-  if (cookedRange.size() < range.size()) {
-    return {range.start(), cookedRange.size()};
+  ProvenanceRange first{provenanceMap_.Map(cookedRange.begin() - &data_[0])};
+  if (cookedRange.size() <= first.size()) {
+    return first.Prefix(cookedRange.size());
   }
-  return range;
+  ProvenanceRange last{provenanceMap_.Map(cookedRange.end() - &data_[0])};
+  return {first.start(), last.start() - first.start()};
 }
 
 void CookedSource::Marshal() {

--- a/lib/semantics/CMakeLists.txt
+++ b/lib/semantics/CMakeLists.txt
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 
-add_library(FlangSemantics
+add_library(FortranSemantics
   attr.cc
+  expression.cc
   mod-file.cc
   resolve-names.cc
   rewrite-parse-tree.cc
@@ -24,7 +25,7 @@ add_library(FlangSemantics
   unparse-with-symbols.cc
 )
 
-target_link_libraries(FlangSemantics
+target_link_libraries(FortranSemantics
   FortranCommon
   clangBasic
 )

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1,0 +1,149 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "expression.h"
+#include "../common/idioms.h"
+
+using namespace Fortran::parser::literals;
+
+namespace Fortran::semantics {
+
+template<typename A>
+std::optional<evaluate::GenericExpr> AnalyzeHelper(
+    ExpressionAnalyzer &ea, const A &tree) {
+  return ea.Analyze(tree);
+}
+
+template<typename A>
+std::optional<evaluate::GenericExpr> AnalyzeHelper(
+    ExpressionAnalyzer &ea, const parser::Scalar<A> &tree) {
+  std::optional<evaluate::GenericExpr> result{AnalyzeHelper(ea, tree.thing)};
+  if (result.has_value()) {
+    if (result->Rank() > 1) {
+      ea.context().messages.Say("must be scalar"_err_en_US);
+      return {};
+    }
+  }
+  return result;
+}
+
+template<typename A>
+std::optional<evaluate::GenericExpr> AnalyzeHelper(
+    ExpressionAnalyzer &ea, const parser::Constant<A> &tree) {
+  std::optional<evaluate::GenericExpr> result{AnalyzeHelper(ea, tree.thing)};
+  if (result.has_value()) {
+    result->Fold(ea.context());
+    if (!result->ScalarValue().has_value()) {
+      ea.context().messages.Say("must be constant"_err_en_US);
+      return {};
+    }
+  }
+  return result;
+}
+
+template<typename A>
+std::optional<evaluate::GenericExpr> AnalyzeHelper(
+    ExpressionAnalyzer &ea, const parser::Integer<A> &tree) {
+  std::optional<evaluate::GenericExpr> result{AnalyzeHelper(ea, tree.thing)};
+  if (result.has_value() &&
+      !std::holds_alternative<evaluate::AnyKindIntegerExpr>(result->u)) {
+    ea.context().messages.Say("must be integer"_err_en_US);
+    return {};
+  }
+  return result;
+}
+
+template<>
+std::optional<evaluate::GenericExpr> AnalyzeHelper(
+    ExpressionAnalyzer &ea, const parser::Name &n) {
+  // TODO
+  return {};
+}
+
+ExpressionAnalyzer::KindParam ExpressionAnalyzer::Analyze(
+    const std::optional<parser::KindParam> &kindParam, KindParam defaultKind,
+    KindParam kanjiKind) {
+  if (!kindParam.has_value()) {
+    return defaultKind;
+  }
+  return std::visit(
+      common::visitors{
+          [](std::uint64_t k) { return static_cast<KindParam>(k); },
+          [&](const parser::Scalar<
+              parser::Integer<parser::Constant<parser::Name>>> &n) {
+            if (std::optional<evaluate::GenericExpr> oge{
+                    AnalyzeHelper(*this, n)}) {
+              if (std::optional<evaluate::GenericScalar> ogs{
+                      oge->ScalarValue()}) {
+                // TODO pmk more here next
+              }
+            }
+            return defaultKind;
+          },
+          [&](parser::KindParam::Kanji) {
+            if (kanjiKind >= 0) {
+              return kanjiKind;
+            }
+            context().messages.Say("Kanji not allowed here"_err_en_US);
+            return defaultKind;
+          }},
+      kindParam->u);
+}
+
+template<>
+std::optional<evaluate::GenericExpr> AnalyzeHelper(
+    ExpressionAnalyzer &ea, const parser::IntLiteralConstant &x) {
+  auto kind{ea.Analyze(std::get<std::optional<parser::KindParam>>(x.t),
+      ea.defaultIntegerKind())};
+  std::uint64_t value{std::get<std::uint64_t>(x.t)};
+  switch (kind) {
+#define CASE(k) \
+  case k: \
+    return {evaluate::GenericExpr{ \
+        evaluate::AnyKindIntegerExpr{evaluate::IntegerExpr<k>{value}}}};
+    FOR_EACH_INTEGER_KIND(CASE, )
+#undef CASE
+  default:
+    ea.context().messages.Say(parser::MessageFormattedText{
+        "unimplemented INTEGER kind (%ju)"_err_en_US,
+        static_cast<std::uintmax_t>(kind)});
+    return {};
+  }
+}
+
+template<>
+std::optional<evaluate::GenericExpr> AnalyzeHelper(
+    ExpressionAnalyzer &ea, const parser::LiteralConstant &x) {
+  return std::visit(
+      common::visitors{[&](const parser::IntLiteralConstant &c) {
+                         return AnalyzeHelper(ea, c);
+                       },
+          // TODO next [&](const parser::RealLiteralConstant &c) { return
+          // AnalyzeHelper(ea, c); },
+          // TODO: remaining cases
+          [&](const auto &) { return std::optional<evaluate::GenericExpr>{}; }},
+      x.u);
+}
+
+std::optional<evaluate::GenericExpr> ExpressionAnalyzer::Analyze(
+    const parser::Expr &x) {
+  return std::visit(
+      common::visitors{[&](const parser::LiteralConstant &c) {
+                         return AnalyzeHelper(*this, c);
+                       },
+          // TODO: remaining cases
+          [&](const auto &) { return std::optional<evaluate::GenericExpr>{}; }},
+      x.u);
+}
+}  // namespace Fortran::semantics

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_SEMANTICS_EXPRESSION_H_
+#define FORTRAN_SEMANTICS_EXPRESSION_H_
+
+#include "../evaluate/expression.h"
+#include "../parser/message.h"
+#include "../parser/parse-tree.h"
+#include <cinttypes>
+#include <optional>
+
+namespace Fortran::semantics {
+
+class ExpressionAnalyzer {
+public:
+  using KindParam = std::int64_t;
+  ExpressionAnalyzer(evaluate::FoldingContext &c, KindParam dIK)
+    : context_{c}, defaultIntegerKind_{dIK} {}
+
+  evaluate::FoldingContext &context() { return context_; }
+  KindParam defaultIntegerKind() const { return defaultIntegerKind_; }
+
+  // Performs semantic checking on an expression.  If successful,
+  // returns its typed expression representation.
+  std::optional<evaluate::GenericExpr> Analyze(const parser::Expr &);
+  KindParam Analyze(const std::optional<parser::KindParam> &,
+      KindParam defaultKind, KindParam kanjiKind = -1 /* not allowed here */);
+
+private:
+  evaluate::FoldingContext context_;
+  KindParam defaultIntegerKind_{4};
+};
+}  // namespace Fortran::semantics
+#endif  // FORTRAN_SEMANTICS_EXPRESSION_H_

--- a/lib/semantics/mod-file.h
+++ b/lib/semantics/mod-file.h
@@ -15,9 +15,42 @@
 #ifndef FORTRAN_SEMANTICS_MOD_FILE_H_
 #define FORTRAN_SEMANTICS_MOD_FILE_H_
 
+#include "resolve-names.h"
+#include "../parser/char-block.h"
+#include "../parser/message.h"
+#include "../parser/parse-tree.h"
+#include "../parser/parsing.h"
+#include "../parser/provenance.h"
+#include <iostream>
+#include <string>
+
 namespace Fortran::semantics {
 
+using SourceName = parser::CharBlock;
+
 void WriteModFiles();
+
+class ModFileReader {
+public:
+  // directories specifies where to search for module files
+  ModFileReader(const std::vector<std::string> &directories)
+    : directories_{directories} {}
+
+  // Find and read the module file for modName.
+  // Return true on success; otherwise errors() reports the problems.
+  bool Read(const SourceName &modName);
+  std::list<parser::Message> &errors() { return errors_; }
+
+private:
+  std::vector<std::string> directories_;
+  parser::AllSources allSources_;
+  std::unique_ptr<parser::CookedSource> cooked_{
+      std::make_unique<parser::CookedSource>(allSources_)};
+  std::list<parser::Message> errors_;
+
+  std::optional<std::string> FindModFile(const SourceName &);
+  bool Prescan(const SourceName &, const std::string &);
+};
 
 }  // namespace Fortran::semantics
 

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -2138,7 +2138,7 @@ const Symbol *ResolveNamesVisitor::ResolveDataRef(const parser::DataRef &x) {
                 ApplyImplicitRules(y.source, *symbol);
               }
             }
-            return static_cast<const Symbol *>(symbol);
+            return const_cast<const Symbol *>(symbol);
           },
           [=](const common::Indirection<parser::StructureComponent> &y) {
             return ResolveStructureComponent(*y);
@@ -2424,7 +2424,7 @@ void ResolveNamesVisitor::Post(const parser::Program &) {
 void ResolveNames(
     parser::Program &program, const parser::CookedSource &cookedSource) {
   ResolveNamesVisitor visitor;
-  parser::Walk(static_cast<const parser::Program &>(program), visitor);
+  parser::Walk(const_cast<const parser::Program &>(program), visitor);
   if (!visitor.messages().empty()) {
     visitor.messages().Emit(std::cerr, cookedSource);
     return;

--- a/lib/semantics/resolve-names.h
+++ b/lib/semantics/resolve-names.h
@@ -16,6 +16,7 @@
 #define FORTRAN_SEMANTICS_RESOLVE_NAMES_H_
 
 #include <iosfwd>
+#include <vector>
 
 namespace Fortran::parser {
 struct Program;
@@ -24,7 +25,8 @@ class CookedSource;
 
 namespace Fortran::semantics {
 
-void ResolveNames(parser::Program &, const parser::CookedSource &);
+void ResolveNames(parser::Program &, const parser::CookedSource &,
+    const std::vector<std::string> &);
 void DumpSymbols(std::ostream &);
 
 }  // namespace Fortran::semantics

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -60,8 +60,8 @@ std::ostream &operator<<(std::ostream &os, const Scope &scope) {
   }
   os << scope.children_.size() << " children\n";
   for (const auto &pair : scope.symbols_) {
-    const auto &symbol{pair.second};
-    os << "  " << symbol << '\n';
+    const auto *symbol{pair.second};
+    os << "  " << *symbol << '\n';
   }
   return os;
 }

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -106,6 +106,11 @@ public:
 
   DerivedTypeSpec &MakeDerivedTypeSpec(const SourceName &);
 
+  std::unique_ptr<parser::CookedSource> cooked_;
+  void set_cookedSource(std::unique_ptr<parser::CookedSource> cooked) {
+    cooked_ = std::move(cooked);
+  }
+
 private:
   Scope &parent_;
   const Kind kind_;

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -233,7 +233,7 @@ std::string DetailsToString(const Details &);
 
 class Symbol {
 public:
-  ENUM_CLASS(Flag, Function, Subroutine, Implicit);
+  ENUM_CLASS(Flag, Function, Subroutine, Implicit, ModFile);
   using Flags = common::EnumSet<Flag, Flag_enumSize>;
 
   const Scope &owner() const { return *owner_; }

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -41,7 +41,7 @@ leaves are concrete types:
         ComplexTypeSpec
     DerivedTypeSpec
 
-TypeSpec classes are immutable. For instrinsic types (except character) there
+TypeSpec classes are immutable. For intrinsic types (except character) there
 is a limited number of instances -- one for each kind.
 
 A DerivedTypeSpec is based on a DerivedTypeDef (from a derived type statement)

--- a/test/evaluate/expression.cc
+++ b/test/evaluate/expression.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "../../lib/evaluate/expression.h"
+#include "../../lib/parser/message.h"
 #include "testing.h"
 #include <cstdio>
 #include <cstdlib>
@@ -34,7 +35,8 @@ int main() {
   auto ex1{DefaultIntegerExpr{2} + DefaultIntegerExpr{3} * -DefaultIntegerExpr{4}};
   MATCH("(2+(3*(-4)))", Dump(ex1));
   Fortran::parser::CharBlock src;
-  FoldingContext context{src, nullptr};
+  Fortran::parser::ContextualMessages messages{src, nullptr};
+  FoldingContext context{messages};
   ex1.Fold(context);
   MATCH("-10", Dump(ex1));
   MATCH("(Integer(4)::6.LE.7)", Dump(DefaultIntegerExpr{6} <= DefaultIntegerExpr{7}));

--- a/test/semantics/resolve12.f90
+++ b/test/semantics/resolve12.f90
@@ -19,7 +19,7 @@ subroutine sub
 end
 
 use m1
-!ERROR: Module 'm2' not found
+!ERROR: Cannot find module file for 'm2'
 use m2
 !ERROR: 'sub' is not a module
 use sub

--- a/test/semantics/test_errors.sh
+++ b/test/semantics/test_errors.sh
@@ -18,7 +18,7 @@
 
 PATH=/usr/bin:/bin
 srcdir=$(dirname $0)
-CMD="${F18:-../../tools/f18/f18} -fdebug-resolve-names -fparse-only"
+CMD="${F18:-../../../tools/f18/f18} -fdebug-resolve-names -fparse-only"
 
 if [[ $# != 1 ]]; then
   echo "Usage: $0 <fortran-source>"
@@ -38,7 +38,7 @@ expect=$temp/expect
 diffs=$temp/diffs
 
 cmd="$CMD $src"
-$cmd > $log 2>&1
+( cd $temp; $cmd ) > $log 2>&1
 [[ $? -ge 128 ]] && exit 1
 
 # $actual has errors from the compiler; $expect has them from !ERROR comments in source

--- a/tools/f18/CMakeLists.txt
+++ b/tools/f18/CMakeLists.txt
@@ -19,5 +19,5 @@ add_executable(f18
 
 target_link_libraries(f18
   FortranParser
-  FlangSemantics
+  FortranSemantics
 )

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -206,7 +206,9 @@ std::string CompileFortran(
   }
   if (driver.debugResolveNames || driver.dumpSymbols ||
       driver.dumpUnparseWithSymbols) {
-    Fortran::semantics::ResolveNames(parseTree, parsing.cooked());
+    std::vector<std::string> directories{options.searchDirectories};
+    directories.insert(directories.begin(), "."s);
+    Fortran::semantics::ResolveNames(parseTree, parsing.cooked(), directories);
     Fortran::semantics::WriteModFiles();
     if (driver.dumpSymbols) {
       Fortran::semantics::DumpSymbols(std::cout);
@@ -452,7 +454,8 @@ int main(int argc, char *const argv[]) {
   if (options.isStrictlyStandard) {
     options.features.WarnOnAllNonstandard();
   }
-  if (!options.features.IsEnabled(Fortran::parser::LanguageFeature::BackslashEscapes)) {
+  if (!options.features.IsEnabled(
+          Fortran::parser::LanguageFeature::BackslashEscapes)) {
     driver.pgf90Args.push_back("-Mbackslash");
   }
 


### PR DESCRIPTION
When a use-stmt is encountered for a module that isn't in the global
scope, search for and read the appropriate `.mod` file. To perform the
search, pass the search directories in to ResolveNames.

For modules that were read from `.mod` files, we have to keep the cooked
source from being deleted so that the names so that references to names
stay valid. So we store the cooked source in the Scope of the module as
a `unique_ptr`.

Add `Symbol::Flag::ModFile` to distinguish module symbols that were read
from a `.mod` file rather than from the current compilation. Use it to
prevent writing those back out.

Fix `test_errors.sh` to run the compiler in the temp subdirectory --
otherwise tests could be affected by `.mod` files left from previous
tests.