### PR TITLE
OpenMP conditional compilation lines

### DIFF
--- a/lib/parser/parsing.cc
+++ b/lib/parser/parsing.cc
@@ -70,6 +70,7 @@ void Parsing::Prescan(const std::string &path, Options options) {
       .AddCompilerDirectiveSentinel("dir$");
   if (options.features.IsEnabled(LanguageFeature::OpenMP)) {
     prescanner.AddCompilerDirectiveSentinel("$omp");
+    prescanner.AddCompilerDirectiveSentinel("$");  // OMP conditional line
   }
   ProvenanceRange range{
       allSources_.AddIncludedFile(*sourceFile, ProvenanceRange{})};

--- a/lib/parser/prescan.h
+++ b/lib/parser/prescan.h
@@ -136,7 +136,7 @@ private:
     return inFixedForm_ && !inPreprocessorDirective_ && !InCompilerDirective();
   }
 
-  void LabelField(TokenSequence &);
+  void LabelField(TokenSequence &, int outCol = 1);
   void SkipToEndOfLine();
   void NextChar();
   void SkipSpaces();


### PR DESCRIPTION
Support OpenMP conditional compilation lines (e.g., `!$ print *, 'compiled with OpenMP'`) in the prescanner.