### PR TITLE
issue#152 and a little clean-up

### DIFF
--- a/lib/parser/prescan.h
+++ b/lib/parser/prescan.h
@@ -140,6 +140,7 @@ private:
   void SkipToEndOfLine();
   void NextChar();
   void SkipSpaces();
+  static const char *SkipWhiteSpace(const char *);
   bool NextToken(TokenSequence &);
   bool ExponentAndKind(TokenSequence &);
   void QuotedCharacterLiteral(TokenSequence &);


### PR DESCRIPTION
Don't mistokenize a Hollerith constant in the context of a labeled DO loop, e.g. `DO 10 H=1,N`.