### PR TITLE
issue#153

### DIFF
--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -174,8 +174,12 @@ std::ostream &LogicalExpr<KIND>::Dump(std::ostream &o) const {
 // LEN()
 template<int KIND> SubscriptIntegerExpr CharacterExpr<KIND>::LEN() const {
   return std::visit(
-      common::visitors{
-          [](const Scalar &c) { return SubscriptIntegerExpr{c.size()}; },
+      common::visitors{[](const Scalar &c) {
+                         // std::string::size_type isn't convertible to uint64_t
+                         // on Darwin
+                         return SubscriptIntegerExpr{
+                             static_cast<std::uint64_t>(c.size())};
+                       },
           [](const Concat &c) { return c.left().LEN() + c.right().LEN(); },
           [](const Max &c) {
             return SubscriptIntegerExpr{

--- a/lib/evaluate/variable.cc
+++ b/lib/evaluate/variable.cc
@@ -110,10 +110,14 @@ SubscriptIntegerExpr Substring::last() const {
   if (last_.has_value()) {
     return **last_;
   }
-  return std::visit(common::visitors{[](const std::string &s) {
-                                       return SubscriptIntegerExpr{s.size()};
-                                     },
-                        [](const DataRef &x) { return x.LEN(); }},
+  return std::visit(
+      common::visitors{[](const std::string &s) {
+                         // std::string::size_type isn't convertible to uint64_t
+                         // on Darwin
+                         return SubscriptIntegerExpr{
+                             static_cast<std::uint64_t>(s.size())};
+                       },
+          [](const DataRef &x) { return x.LEN(); }},
       u_);
 }
 


### PR DESCRIPTION
Insert explicit casts to std::uint64_t of the results of calls to std::string::size(), whose type (std::string::size_type) turns out to not be convertible to uint64_t on Darwin.  This build issue has come up before and I've added some comments this time so that I can maybe avoid another recrudescence of the bug.