### PR TITLE
 Add support for submodules

### DIFF
--- a/lib/semantics/mod-file.h
+++ b/lib/semantics/mod-file.h
@@ -49,8 +49,6 @@ public:
 
   // Write out all .mod files; if error return false.
   bool WriteAll();
-  // Write out .mod file for one module; if error return false.
-  bool WriteOne(const Symbol &);
 
 private:
   using symbolSet = std::set<const Symbol *>;
@@ -66,7 +64,9 @@ private:
   // Any errors encountered during writing:
   std::vector<parser::MessageFormattedText> errors_;
 
-  std::string GetAsString(const std::string &);
+  void WriteChildren(const Scope &);
+  void WriteOne(const Scope &);
+  std::string GetAsString(const Symbol &);
   std::string GetHeader(const std::string &);
   void PutSymbols(const Scope &);
   symbolVector SortSymbols(const symbolSet);
@@ -84,18 +84,19 @@ public:
   // directories specifies where to search for module files
   ModFileReader(const std::vector<std::string> &directories)
     : directories_{directories} {}
-
-  // Find and read the module file for modName.
-  // Return true on success; otherwise errors() reports the problems.
-  bool Read(const SourceName &modName);
+  // Find and read the module file for a module or submodule.
+  // If ancestor is specified, look for a submodule of that module.
+  // Return the Scope for that module/submodule or nullptr on error.
+  Scope *Read(const SourceName &, Scope *ancestor = nullptr);
+  // Errors that occurred when Read returns nullptr.
   std::vector<parser::Message> &errors() { return errors_; }
 
 private:
   std::vector<std::string> directories_;
   std::vector<parser::Message> errors_;
 
-  std::optional<std::string> FindModFile(const SourceName &);
-  bool Prescan(const SourceName &, const std::string &);
+  std::optional<std::string> FindModFile(
+      const SourceName &, const std::string &);
 };
 
 }  // namespace Fortran::semantics

--- a/lib/semantics/mod-file.h
+++ b/lib/semantics/mod-file.h
@@ -66,6 +66,7 @@ private:
 
   void WriteChildren(const Scope &);
   void WriteOne(const Scope &);
+  void Write(const Symbol &);
   std::string GetAsString(const Symbol &);
   std::string GetHeader(const std::string &);
   void PutSymbols(const Scope &);

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -415,7 +415,7 @@ private:
       const SourceName &useName);
   Symbol &BeginModule(const SourceName &, bool isSubmodule,
       const std::optional<parser::ModuleSubprogramPart> &);
-  Scope *FindModule(const SourceName &, Scope * = nullptr);
+  Scope *FindModule(const SourceName &, Scope *ancestor = nullptr);
 };
 
 class InterfaceVisitor : public virtual ScopeHandler {
@@ -1333,7 +1333,7 @@ bool ModuleVisitor::Pre(const parser::Submodule &x) {
   }
   PushScope(*parentScope);  // submodule is hosted in parent
   auto &symbol{BeginModule(name, true, subpPart)};
-  if (ancestor->AddSubmodule(name, &CurrScope())) {
+  if (!ancestor->AddSubmodule(name, &CurrScope())) {
     Say(name, "Module '%s' already has a submodule named '%s'"_err_en_US,
         ancestorName, name);
   }

--- a/lib/semantics/resolve-names.h
+++ b/lib/semantics/resolve-names.h
@@ -25,8 +25,10 @@ class CookedSource;
 
 namespace Fortran::semantics {
 
-void ResolveNames(parser::Program &, const parser::CookedSource &,
-    const std::vector<std::string> &);
+class Scope;
+
+void ResolveNames(Scope &rootScope, parser::Program &,
+    const parser::CookedSource &, const std::vector<std::string> &);
 void DumpSymbols(std::ostream &);
 
 }  // namespace Fortran::semantics

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -48,6 +48,18 @@ Scope::size_type Scope::erase(const SourceName &name) {
     return 0;
   }
 }
+Scope *Scope::FindSubmodule(const SourceName &name) const {
+  auto it{submodules_.find(name)};
+  if (it == submodules_.end()) {
+    return nullptr;
+  } else {
+    return it->second;
+  }
+}
+Scope *Scope::AddSubmodule(const SourceName &name, Scope *submodule) {
+  auto pair{submodules_.emplace(name, submodule)};
+  return !pair.second ? pair.first->second : nullptr;
+}
 DerivedTypeSpec &Scope::MakeDerivedTypeSpec(const SourceName &name) {
   derivedTypeSpecs_.emplace_back(name);
   return derivedTypeSpecs_.back();

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -56,9 +56,8 @@ Scope *Scope::FindSubmodule(const SourceName &name) const {
     return it->second;
   }
 }
-Scope *Scope::AddSubmodule(const SourceName &name, Scope *submodule) {
-  auto pair{submodules_.emplace(name, submodule)};
-  return !pair.second ? pair.first->second : nullptr;
+bool Scope::AddSubmodule(const SourceName &name, Scope *submodule) {
+  return submodules_.emplace(name, submodule).second;
 }
 DerivedTypeSpec &Scope::MakeDerivedTypeSpec(const SourceName &name) {
   derivedTypeSpecs_.emplace_back(name);

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -91,7 +91,7 @@ public:
   std::pair<iterator, bool> try_emplace(
       const SourceName &name, Attrs attrs, D &&details) {
     Symbol &symbol{MakeSymbol(name, attrs, std::move(details))};
-    return symbols_.insert(std::make_pair(name, &symbol));
+    return symbols_.emplace(name, &symbol);
   }
 
   /// Make a Symbol but don't add it to the scope.
@@ -103,13 +103,16 @@ public:
   std::list<Scope> &children() { return children_; }
   const std::list<Scope> &children() const { return children_; }
 
+  // For Module scope, maintain a mapping of all submodule scopes with this
+  // module as its ancestor module.
+  Scope *FindSubmodule(const SourceName &) const;
+  Scope *AddSubmodule(const SourceName &, Scope *);
+
   DerivedTypeSpec &MakeDerivedTypeSpec(const SourceName &);
 
   // For modules read from module files, this is the stream of characters
   // that are referenced by SourceName objects.
-  void set_chars(std::string &&chars) {
-    chars_ = std::move(chars);
-  }
+  void set_chars(std::string &&chars) { chars_ = std::move(chars); }
 
 private:
   Scope &parent_;
@@ -117,6 +120,7 @@ private:
   Symbol *const symbol_;
   std::list<Scope> children_;
   mapType symbols_;
+  std::map<SourceName, Scope *> submodules_;
   std::list<DerivedTypeSpec> derivedTypeSpecs_;
   std::string chars_;
 

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -104,9 +104,9 @@ public:
   const std::list<Scope> &children() const { return children_; }
 
   // For Module scope, maintain a mapping of all submodule scopes with this
-  // module as its ancestor module.
+  // module as its ancestor module. AddSubmodule returns false if already there.
   Scope *FindSubmodule(const SourceName &) const;
-  Scope *AddSubmodule(const SourceName &, Scope *);
+  bool AddSubmodule(const SourceName &, Scope *);
 
   DerivedTypeSpec &MakeDerivedTypeSpec(const SourceName &);
 

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -23,6 +23,28 @@ std::ostream &operator<<(std::ostream &os, const parser::CharBlock &name) {
   return os << name.ToString();
 }
 
+const Scope *ModuleDetails::parent() const {
+  return isSubmodule_ ? &scope_->parent() : nullptr;
+}
+const Scope *ModuleDetails::ancestor() const {
+  if (!isSubmodule_) {
+    return nullptr;
+  }
+  for (auto *scope{scope_};;) {
+    auto *parent{&scope->parent()};
+    if (parent->kind() != Scope::Kind::Module) {
+      return scope;
+    }
+    scope = parent;
+  }
+}
+void ModuleDetails::set_scope(const Scope *scope) {
+  CHECK(!scope_);
+  bool scopeIsSubmodule{scope->parent().kind() == Scope::Kind::Module};
+  CHECK(isSubmodule_ == scopeIsSubmodule);
+  scope_ = scope;
+}
+
 void EntityDetails::set_type(const DeclTypeSpec &type) {
   CHECK(!type_);
   type_ = type;
@@ -261,7 +283,17 @@ std::ostream &operator<<(std::ostream &os, const Details &details) {
       common::visitors{
           [&](const UnknownDetails &x) {},
           [&](const MainProgramDetails &x) {},
-          [&](const ModuleDetails &x) {},
+          [&](const ModuleDetails &x) {
+            if (x.isSubmodule()) {
+              auto &ancestor{x.ancestor()->name()};
+              auto &parent{x.parent()->name()};
+              os << " (" << ancestor.ToString();
+              if (parent != ancestor) {
+                os << ':' << parent.ToString();
+              }
+              os << ")";
+            }
+          },
           [&](const SubprogramDetails &x) {
             os << " (";
             int n = 0;

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -105,9 +105,9 @@ const std::string Symbol::GetDetailsName() const {
   return DetailsToString(details_);
 }
 
-void Symbol::set_details(Details &&details) {
+void Symbol::set_details(const Details &details) {
   CHECK(CanReplaceDetails(details));
-  details_.swap(details);
+  details_ = details;
 }
 
 bool Symbol::CanReplaceDetails(const Details &details) const {

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -132,9 +132,7 @@ public:
 
   const ProcInterface &interface() const { return interface_; }
   ProcInterface &interface() { return interface_; }
-  void set_interface(ProcInterface &&interface) {
-    interface_ = std::move(interface);
-  }
+  void set_interface(const ProcInterface &interface) { interface_ = interface; }
   bool HasExplicitInterface() const;
 
 private:
@@ -276,7 +274,7 @@ public:
   const Details &details() const { return details_; }
   // Assign the details of the symbol from one of the variants.
   // Only allowed in certain cases.
-  void set_details(Details &&details);
+  void set_details(const Details &);
 
   // Can the details of this symbol be replaced with the given details?
   bool CanReplaceDetails(const Details &details) const;
@@ -322,12 +320,12 @@ std::ostream &operator<<(std::ostream &, Symbol::Flag);
 template<std::size_t BLOCK_SIZE> class Symbols {
 public:
   Symbol &Make(const Scope &owner, const SourceName &name, const Attrs &attrs,
-      Details &&details) {
+      const Details &details) {
     Symbol &symbol = Get();
     symbol.owner_ = &owner;
     symbol.occurrences_.push_back(name);
     symbol.attrs_ = attrs;
-    symbol.details_ = std::move(details);
+    symbol.details_ = details;
     return symbol;
   }
 

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -29,15 +29,18 @@ namespace Fortran::semantics {
 class Scope;
 class Symbol;
 
+// A module or submodule.
 class ModuleDetails {
 public:
+  ModuleDetails(bool isSubmodule = false) : isSubmodule_{isSubmodule} {}
+  bool isSubmodule() const { return isSubmodule_; }
   const Scope *scope() const { return scope_; }
-  void set_scope(const Scope *scope) {
-    CHECK(!scope_);
-    scope_ = scope;
-  }
+  const Scope *ancestor() const;  // for submodule; nullptr for module
+  const Scope *parent() const;  // for submodule; nullptr for module
+  void set_scope(const Scope *);
 
 private:
+  bool isSubmodule_;
   const Scope *scope_{nullptr};
 };
 

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -269,25 +269,13 @@ std::ostream &operator<<(std::ostream &o, const DeclTypeSpec &x) {
   }
 }
 
-ProcInterface::ProcInterface(const ProcInterface &that)
-  : symbol_{that.symbol_} {
-  if (that.type_) {
-    set_type(*that.type_);
-  }
-}
-ProcInterface &ProcInterface::operator=(ProcInterface &&that) {
-  symbol_ = that.symbol_;
-  type_ = std::move(that.type_);
-  return *this;
-}
-
 void ProcInterface::set_symbol(const Symbol &symbol) {
   CHECK(!type_);
   symbol_ = &symbol;
 }
 void ProcInterface::set_type(const DeclTypeSpec &type) {
   CHECK(!symbol_);
-  type_ = std::make_unique<DeclTypeSpec>(type);
+  type_ = type;
 }
 
 std::ostream &operator<<(std::ostream &o, const ProcDecl &x) {
@@ -295,8 +283,8 @@ std::ostream &operator<<(std::ostream &o, const ProcDecl &x) {
 }
 
 ProcComponentDef::ProcComponentDef(
-    const ProcDecl &decl, Attrs attrs, ProcInterface &&interface)
-  : decl_{decl}, attrs_{attrs}, interface_{std::move(interface)} {
+    const ProcDecl &decl, Attrs attrs, const ProcInterface &interface)
+  : decl_{decl}, attrs_{attrs}, interface_{interface} {
   CHECK(attrs_.test(Attr::POINTER));
   attrs_.CheckValid(
       {Attr::PUBLIC, Attr::PRIVATE, Attr::NOPASS, Attr::POINTER, Attr::PASS});

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -116,8 +116,8 @@ public:
 private:
   enum Category { Explicit, Deferred, Assumed };
   Bound(Category category) : category_{category}, expr_{std::nullopt} {}
-  const Category category_;
-  const std::optional<IntExpr> expr_;
+  Category category_;
+  std::optional<IntExpr> expr_;
   friend std::ostream &operator<<(std::ostream &, const Bound &);
 };
 
@@ -324,8 +324,8 @@ public:
 
 private:
   ShapeSpec(const Bound &lb, const Bound &ub) : lb_{lb}, ub_{ub} {}
-  const Bound lb_;
-  const Bound ub_;
+  Bound lb_;
+  Bound ub_;
   friend std::ostream &operator<<(std::ostream &, const ShapeSpec &);
 };
 
@@ -365,17 +365,14 @@ class Symbol;
 // or neither.
 class ProcInterface {
 public:
-  ProcInterface() = default;
-  ProcInterface(const ProcInterface &);
-  ProcInterface &operator=(ProcInterface &&);
   const Symbol *symbol() const { return symbol_; }
-  const DeclTypeSpec *type() const { return type_.get(); }
+  const DeclTypeSpec *type() const { return type_ ? &*type_ : nullptr; }
   void set_symbol(const Symbol &symbol);
   void set_type(const DeclTypeSpec &type);
 
 private:
   const Symbol *symbol_{nullptr};
-  std::unique_ptr<const DeclTypeSpec> type_;
+  std::optional<DeclTypeSpec> type_;
 };
 
 class ProcDecl {
@@ -393,7 +390,7 @@ private:
 class ProcComponentDef {
 public:
   ProcComponentDef(
-      const ProcDecl &decl, Attrs attrs, ProcInterface &&interface);
+      const ProcDecl &decl, Attrs attrs, const ProcInterface &interface);
 
   const ProcDecl &decl() const { return decl_; }
   const Attrs &attrs() const { return attrs_; }

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -49,6 +49,8 @@ set(ERROR_TESTS
   resolve23.f90
   resolve24.f90
   resolve25.f90
+  resolve26.f90
+  resolve27.f90
 )
 
 # These test files have expected symbols in the source
@@ -66,6 +68,7 @@ set(MODFILE_TESTS
   modfile06.f90
   modfile07.f90
   modfile08.f90
+  modfile09-*.f90
 )
 
 foreach(test ${ERROR_TESTS})

--- a/test/semantics/modfile09-a.f90
+++ b/test/semantics/modfile09-a.f90
@@ -1,0 +1,16 @@
+module m
+  integer :: m1_x
+  interface
+    module subroutine s()
+    end subroutine
+  end interface
+end
+
+!Expect: m.mod
+!module m
+!integer::m1_x
+!interface
+!module subroutine s()
+!end
+!end interface
+!end

--- a/test/semantics/modfile09-b.f90
+++ b/test/semantics/modfile09-b.f90
@@ -1,0 +1,8 @@
+submodule(m) s1
+  integer s1_x
+end
+
+!Expect: m-s1.mod
+!submodule(m) s1
+!integer::s1_x
+!end

--- a/test/semantics/modfile09-c.f90
+++ b/test/semantics/modfile09-c.f90
@@ -1,0 +1,8 @@
+submodule(m:s1) s2
+  integer s2_x
+end
+
+!Expect: m-s2.mod
+!submodule(m:s1) s2
+!integer::s2_x
+!end

--- a/test/semantics/modfile09-d.f90
+++ b/test/semantics/modfile09-d.f90
@@ -1,0 +1,8 @@
+submodule(m:s2) s3
+  integer s3_x
+end
+
+!Expect: m-s3.mod
+!submodule(m:s2) s3
+!integer::s3_x
+!end

--- a/test/semantics/resolve26.f90
+++ b/test/semantics/resolve26.f90
@@ -1,0 +1,24 @@
+module m1
+  interface
+    module subroutine s()
+    end subroutine
+  end interface
+end
+
+module m2
+  interface
+    module subroutine s()
+    end subroutine
+  end interface
+end
+
+submodule(m1) s1
+end
+
+!ERROR: Cannot find module file for submodule 's1' of module 'm2'
+submodule(m2:s1) s2
+end
+
+!ERROR: Cannot find module file for 'm3'
+submodule(m3:s1) s3
+end

--- a/test/semantics/resolve27.f90
+++ b/test/semantics/resolve27.f90
@@ -1,0 +1,21 @@
+module m
+  interface
+    module subroutine s()
+    end subroutine
+  end interface
+end
+
+submodule(m) s1
+end
+
+submodule(m) s2
+end
+
+submodule(m:s1) s3
+  integer x
+end
+
+!ERROR: Module 'm' already has a submodule named 's3'
+submodule(m:s2) s3
+  integer y
+end

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -25,6 +25,7 @@
 #include "../../lib/semantics/dump-parse-tree.h"
 #include "../../lib/semantics/mod-file.h"
 #include "../../lib/semantics/resolve-names.h"
+#include "../../lib/semantics/scope.h"
 #include "../../lib/semantics/unparse-with-symbols.h"
 #include <cerrno>
 #include <cstdio>
@@ -212,7 +213,8 @@ std::string CompileFortran(
     if (driver.moduleDirectory != "."s) {
       directories.insert(directories.begin(), driver.moduleDirectory);
     }
-    Fortran::semantics::ResolveNames(parseTree, parsing.cooked(), directories);
+    Fortran::semantics::ResolveNames(Fortran::semantics::Scope::globalScope,
+        parseTree, parsing.cooked(), directories);
     Fortran::semantics::ModFileWriter writer;
     writer.set_directory(driver.moduleDirectory);
     if (!writer.WriteAll()) {


### PR DESCRIPTION
Symbols for submodules have `ModuleDetails` with `isSubmodule` set.
Scopes for submodules have `Module` kind and have a parent scope that
is also `Module` kind.

Scopes for modules now contain a mapping of submodule name to scope
so that we can find them without having to search the scope tree or
re-read their `.mod` file.

The module file for submodule `s` with ancestor module `m` is named `m-s.mod`.
The tree structure of scopes means module file writing is now recursive.
Similarly, reading the module file for a submodule may require reading
the module files of its parent and ancestor. `ResolveNames` now requires
the parent scope to be passed in -- it is not always the global scope.

`test_modfiles.sh` now handles an argument that is a filename glob so
that the test can involve multiple files. This allows `modfile09` to
test reading of `.mod` files for modules and submodules.

Make module files read-only after writing them.