### PR TITLE
issue#159 - better error messages in face of garbled source that resembles Hollerith

### DIFF
--- a/documentation/preprocessing.md
+++ b/documentation/preprocessing.md
@@ -33,7 +33,7 @@ Behavior common to (nearly) all compilers:
 * A `#define` directive intermixed with continuation lines can't
   define a macro that's invoked earlier in the same continued statement.
 
-Behavior that is not consistent to all extant compilers but which
+Behavior that is not consistent over all extant compilers but which
 probably should be uncontroversial:
 -----------------------------------
 * Invoked macro names can straddle a Fortran line continuation.

--- a/lib/parser/message.cc
+++ b/lib/parser/message.cc
@@ -89,11 +89,12 @@ std::string MessageExpectedText::ToString() const {
       u_);
 }
 
-void MessageExpectedText::Incorporate(const MessageExpectedText &that) {
-  std::visit(common::visitors{[&](SetOfChars &s1, const SetOfChars &s2) {
-                                s1 = s1.Union(s2);
-                              },
-                 [](const auto &, const auto &) {}},
+bool MessageExpectedText::Merge(const MessageExpectedText &that) {
+  return std::visit(common::visitors{[](SetOfChars &s1, const SetOfChars &s2) {
+                                       s1 = s1.Union(s2);
+                                       return true;
+                                     },
+                        [](const auto &, const auto &) { return false; }},
       u_, that.u_);
 }
 
@@ -189,13 +190,16 @@ void Message::Emit(
   }
 }
 
-void Message::Incorporate(Message &that) {
-  std::visit(common::visitors{[&](MessageExpectedText &e1,
-                                  const MessageExpectedText &e2) {
-                                e1.Incorporate(e2);
-                              },
-                 [](const auto &, const auto &) {}},
-      text_, that.text_);
+bool Message::Merge(const Message &that) {
+  return AtSameLocation(that) &&
+      (!that.attachment_.get() ||
+          attachment_.get() == that.attachment_.get()) &&
+      std::visit(common::visitors{[](MessageExpectedText &e1,
+                                      const MessageExpectedText &e2) {
+                                    return e1.Merge(e2);
+                                  },
+                     [](const auto &, const auto &) { return false; }},
+          text_, that.text_);
 }
 
 void Message::Attach(Message *m) {
@@ -218,11 +222,31 @@ bool Message::AtSameLocation(const Message &that) const {
       location_, that.location_);
 }
 
-void Messages::Incorporate(Messages &that) {
+bool Messages::Merge(const Message &msg) {
+  if (msg.IsMergeable()) {
+    for (auto &m : messages_) {
+      if (m.Merge(msg)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+void Messages::Merge(Messages &&that) {
   if (messages_.empty()) {
     *this = std::move(that);
-  } else if (!that.messages_.empty()) {
-    last_->Incorporate(*that.last_);
+  } else {
+    while (!that.messages_.empty()) {
+      if (Merge(that.messages_.front())) {
+        that.messages_.pop_front();
+      } else {
+        messages_.splice_after(
+            last_, that.messages_, that.messages_.before_begin());
+        ++last_;
+      }
+    }
+    that.ResetLastPointer();
   }
 }
 

--- a/lib/parser/parse-state.h
+++ b/lib/parser/parse-state.h
@@ -48,7 +48,7 @@ public:
       anyConformanceViolation_{that.anyConformanceViolation_},
       deferMessages_{that.deferMessages_},
       anyDeferredMessages_{that.anyDeferredMessages_},
-      tokensMatched_{that.tokensMatched_} {}
+      anyTokenMatched_{that.anyTokenMatched_} {}
   ParseState(ParseState &&that)
     : p_{that.p_}, limit_{that.limit_}, messages_{std::move(that.messages_)},
       context_{std::move(that.context_)}, userState_{that.userState_},
@@ -57,7 +57,7 @@ public:
       anyConformanceViolation_{that.anyConformanceViolation_},
       deferMessages_{that.deferMessages_},
       anyDeferredMessages_{that.anyDeferredMessages_},
-      tokensMatched_{that.tokensMatched_} {}
+      anyTokenMatched_{that.anyTokenMatched_} {}
   ParseState &operator=(const ParseState &that) {
     p_ = that.p_, limit_ = that.limit_, context_ = that.context_;
     userState_ = that.userState_, inFixedForm_ = that.inFixedForm_;
@@ -66,7 +66,7 @@ public:
     anyConformanceViolation_ = that.anyConformanceViolation_;
     deferMessages_ = that.deferMessages_;
     anyDeferredMessages_ = that.anyDeferredMessages_;
-    tokensMatched_ = that.tokensMatched_;
+    anyTokenMatched_ = that.anyTokenMatched_;
     return *this;
   }
   ParseState &operator=(ParseState &&that) {
@@ -78,7 +78,7 @@ public:
     anyConformanceViolation_ = that.anyConformanceViolation_;
     deferMessages_ = that.deferMessages_;
     anyDeferredMessages_ = that.anyDeferredMessages_;
-    tokensMatched_ = that.tokensMatched_;
+    anyTokenMatched_ = that.anyTokenMatched_;
     return *this;
   }
 
@@ -124,13 +124,9 @@ public:
     return *this;
   }
 
-  std::size_t tokensMatched() const { return tokensMatched_; }
-  ParseState &set_tokensMatched(std::size_t n) {
-    tokensMatched_ = n;
-    return *this;
-  }
-  ParseState &TokenMatched() {
-    ++tokensMatched_;
+  bool anyTokenMatched() const { return anyTokenMatched_; }
+  ParseState &set_anyTokenMatched(bool yes = true) {
+    anyTokenMatched_ = yes;
     return *this;
   }
 
@@ -218,20 +214,19 @@ public:
     return remain;
   }
 
-  void CombineFailedParses(ParseState &prev, std::size_t origTokensMatched) {
-    if (prev.tokensMatched_ > origTokensMatched) {
-      if (tokensMatched_ > origTokensMatched) {
-        if (prev.p_ == p_) {
-          prev.messages_.Incorporate(messages_);
-          prev.anyDeferredMessages_ |= anyDeferredMessages_;
-        }
-        if (prev.p_ >= p_) {
-          *this = std::move(prev);
-        }
-      } else {
-        *this = std::move(prev);
+  void CombineFailedParses(ParseState &&prev) {
+    if (prev.anyTokenMatched_) {
+      if (!anyTokenMatched_ || prev.p_ > p_) {
+        anyTokenMatched_ = true;
+        p_ = prev.p_;
+        messages_ = std::move(prev.messages_);
+      } else if (prev.p_ == p_) {
+        messages_.Merge(std::move(prev.messages_));
       }
     }
+    anyDeferredMessages_ |= prev.anyDeferredMessages_;
+    anyConformanceViolation_ |= prev.anyConformanceViolation_;
+    anyErrorRecovery_ |= prev.anyErrorRecovery_;
   }
 
 private:
@@ -250,7 +245,7 @@ private:
   bool anyConformanceViolation_{false};
   bool deferMessages_{false};
   bool anyDeferredMessages_{false};
-  std::size_t tokensMatched_{0};
+  bool anyTokenMatched_{false};
   // NOTE: Any additions or modifications to these data members must also be
   // reflected in the copy and move constructors defined at the top of this
   // class definition!

--- a/lib/parser/prescan.h
+++ b/lib/parser/prescan.h
@@ -144,7 +144,7 @@ private:
   bool NextToken(TokenSequence &);
   bool ExponentAndKind(TokenSequence &);
   void QuotedCharacterLiteral(TokenSequence &);
-  void Hollerith(TokenSequence &, int);
+  void Hollerith(TokenSequence &, int count, const char *start);
   bool PadOutCharacterLiteral(TokenSequence &);
   bool SkipCommentLine();
   bool IsFixedFormCommentLine(const char *) const;

--- a/lib/parser/token-parsers.h
+++ b/lib/parser/token-parsers.h
@@ -47,6 +47,7 @@ public:
     if (std::optional<const char *> at{state.PeekAtNextChar()}) {
       if (set_.Has(**at)) {
         state.UncheckedAdvance();
+        state.set_anyTokenMatched();
         return at;
       }
     }
@@ -160,7 +161,7 @@ public:
         return {};
       }
     }
-    state.TokenMatched();
+    state.set_anyTokenMatched();
     if (IsLegalInIdentifier(p[-1])) {
       return spaceCheck.Parse(state);
     } else {


### PR DESCRIPTION
Make a prescanner tokenization message re: Hollerith truncation into a warning, so parser can get a
shot at it.

Merge messages from failed parsing alternatives more informatively (retain more alternatives).