### PR TITLE
Roll up work on folding, descriptors, runtime, RESHAPE

### DIFF
--- a/documentation/C++style.md
+++ b/documentation/C++style.md
@@ -102,11 +102,14 @@ you are considering.
 1. Never use run-time type information or `dynamic_cast<>`.
 1. Never declare static data that executes a constructor.
    (This is why `#include <iostream>` is contraindicated.)
-Use `{braced initializers}` in all circumstances where they work, including
+1. Use `{braced initializers}` in all circumstances where they work, including
 default data member initialization.  They inhibit implicit truncation.
 Don't use `= expr` initialization just to effect implicit truncation;
 prefer an explicit `static_cast<>`.
 With C++17, braced initializers work fine with `auto` too.
+Sometimes, however, there are better alternatives to empty braces;
+e.g., prefer `return std::nullopt;` to `return {};` to make it more clear
+that the function's result type is a `std::optional<>`.
 1. Avoid unsigned types apart from `size_t`, which must be used with care.
 When `int` just obviously works, just use `int`.  When you need something
 bigger than `int`, use `std::int64_t` rather than `long` or `long long`.
@@ -133,7 +136,8 @@ explicitly, it should contains either a `default:;` at its end or a
 `default:` label that obviously crashes.
 #### Classes
 1. Define POD structures with `struct`.
-1. Don't use `this->` in (non-static) member functions.
+1. Don't use `this->` in (non-static) member functions, unless forced to
+do so in a template.
 1. Define accessor and mutator member functions (implicitly) inline in the
 class, after constructors and assignments.  Don't needlessly define
 (implicit) inline member functions in classes unless they really solve a

--- a/documentation/C++style.md
+++ b/documentation/C++style.md
@@ -42,7 +42,7 @@ a container).
 letters, internal camelCase capitalization, and a trailing underscore,
 e.g. `DoubleEntryBookkeepingSystem myLedger_;`.  POD structures with
 only public data members shouldn't use trailing underscores, since they
-don't have class functions in which data members need to be distinguishable.
+don't have class functions from which data members need to be distinguishable.
 1. Accessor member functions are named with the non-public data member's name,
 less the trailing underscore.  Mutator member functions are named `set_...`
 and should return `*this`.  Don't define accessors or mutators needlessly.
@@ -98,6 +98,7 @@ the idiom of wrapping them with extra parentheses.
 ### C++ language
 Use *C++17*, unless some compiler to which we must be portable lacks a feature
 you are considering.
+However:
 1. Never throw or catch exceptions.
 1. Never use run-time type information or `dynamic_cast<>`.
 1. Never declare static data that executes a constructor.
@@ -114,13 +115,17 @@ that the function's result type is a `std::optional<>`.
 When `int` just obviously works, just use `int`.  When you need something
 bigger than `int`, use `std::int64_t` rather than `long` or `long long`.
 1. Use namespaces to avoid conflicts with client code.  Use one top-level
-project namespace.  Don't introduce needless nested namespaces within a
+`Fortran` project namespace.  Don't introduce needless nested namespaces within the
 project when names don't conflict or better solutions exist.  Never use
-`using namespace ...;`, especially not `using namespace std;`.  Access
-STL entities with names like `std::unique_ptr<>`, without a leading `::`.
-1. Prefer static functions to functions in anonymous namespaces in source files.
+`using namespace ...;` outside test code; never use `using namespace std;`
+anywhere.  Access STL entities with names like `std::unique_ptr<>`,
+without a leading `::`.
+1. Prefer `static` functions over functions in anonymous namespaces in source files.
 1. Use `auto` judiciously.  When the type of a local variable is known,
 monomorphic, and easy to type, be explicit rather than using `auto`.
+Don't use `auto` functions unless the type of the result of an outlined member
+function definition can be more clear due to its use of types declared in the
+class.
 1. Use move semantics and smart pointers to make dynamic memory ownership
 clear.  Consider reworking any code that uses `malloc()` or a (non-placement)
 `operator new`.
@@ -130,14 +135,16 @@ and `int`).  Use non-`const` pointers for output arguments.  Put output argument
 last (_pace_ the standard C library conventions for `memcpy()` & al.).
 1. Prefer `typename` to `class` in template argument declarations.
 1. Prefer `enum class` to plain `enum` wherever `enum class` will work.
+We have an `ENUM_CLASS` macro that helps capture the names of constants.
 1. Use `constexpr` and `const` generously.
 1. When a `switch()` statement's labels do not cover all possible case values
 explicitly, it should contains either a `default:;` at its end or a
-`default:` label that obviously crashes.
+`default:` label that obviously crashes; we have a `CRASH_NO_CASE` macro
+for such situations.
 #### Classes
 1. Define POD structures with `struct`.
 1. Don't use `this->` in (non-static) member functions, unless forced to
-do so in a template.
+do so in a template member function.
 1. Define accessor and mutator member functions (implicitly) inline in the
 class, after constructors and assignments.  Don't needlessly define
 (implicit) inline member functions in classes unless they really solve a
@@ -149,7 +156,7 @@ and move constructors/assignment is present, don't declare them and they
 will be implicitly deleted.  When neither copy nor move constructors
 or assignments should exist for a class, explicitly `=delete` all of them.
 1. Make single-argument constructors (other than copy and move constructors)
-explicit unless you really want to define an implicit conversion.
+'explicit' unless you really want to define an implicit conversion.
 #### Overall design preferences
 Don't use dynamic solutions to solve problems that can be solved at
 build time; don't solve build time problems by writing programs that

--- a/include/flang/ISO_Fortran_binding.h
+++ b/include/flang/ISO_Fortran_binding.h
@@ -51,7 +51,7 @@ typedef ptrdiff_t CFI_index_t;
     CFI_dim_t dim[rank]; \
   };
 
-typedef unsigned short CFI_attribute_t;
+typedef unsigned char CFI_attribute_t;
 #define CFI_attribute_pointer 1
 #define CFI_attribute_allocatable 2
 #define CFI_attribute_other 0 /* neither pointer nor allocatable */

--- a/include/flang/ISO_Fortran_binding.h
+++ b/include/flang/ISO_Fortran_binding.h
@@ -127,6 +127,7 @@ typedef struct CFI_cdesc_t {
   CFI_rank_t rank; /* [0 .. CFI_MAX_RANK] */
   CFI_type_t type;
   CFI_attribute_t attribute;
+  unsigned char f18Addendum;
   CFI_dim_t dim[CFI_ISO_FORTRAN_BINDING_FLEXIBLE_ARRAY]; /* must appear last */
 } CFI_cdesc_t;
 

--- a/lib/common/fortran.h
+++ b/lib/common/fortran.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_COMMON_FORTRAN_H_
+#define FORTRAN_COMMON_FORTRAN_H_
+
+// Fortran language concepts that are used in many phases are defined
+// once here to avoid redundancy and needless translation.
+
+#include "idioms.h"
+
+namespace Fortran::common {
+
+// Fortran has five kinds of intrinsic data, and the derived types.
+ENUM_CLASS(TypeCategory, Integer, Real, Complex, Character, Logical, Derived)
+
+}  // namespace Fortran::common
+#endif  // FORTRAN_COMMON_FORTRAN_H_

--- a/lib/evaluate/common.h
+++ b/lib/evaluate/common.h
@@ -82,6 +82,8 @@ template<typename A> struct ValueWithRealFlags {
 
 ENUM_CLASS(Rounding, TiesToEven, ToZero, Down, Up, TiesAwayFromZero)
 
+static constexpr Rounding defaultRounding{Rounding::TiesToEven};
+
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 constexpr bool IsHostLittleEndian{false};
 #elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__

--- a/lib/evaluate/common.h
+++ b/lib/evaluate/common.h
@@ -26,7 +26,7 @@ namespace Fortran::evaluate {
 ENUM_CLASS(Ordering, Less, Equal, Greater)
 ENUM_CLASS(Relation, Less, Equal, Greater, Unordered)
 
-static constexpr Ordering CompareUnsigned(std::uint64_t x, std::uint64_t y) {
+template<typename A> static constexpr Ordering Compare(const A &x, const A &y) {
   if (x < y) {
     return Ordering::Less;
   } else if (x > y) {

--- a/lib/evaluate/complex.h
+++ b/lib/evaluate/complex.h
@@ -29,6 +29,8 @@ public:
   constexpr Complex(const Complex &) = default;
   constexpr Complex(const Part &r, const Part &i) : re_{r}, im_{i} {}
   explicit constexpr Complex(const Part &r) : re_{r} {}
+  constexpr Complex &operator=(const Complex &) = default;
+  constexpr Complex &operator=(Complex &&) = default;
 
   constexpr const Part &REAL() const { return re_; }
   constexpr const Part &AIMAG() const { return im_; }
@@ -40,10 +42,43 @@ public:
         im_.Compare(that.im_) == Relation::Equal;
   }
 
-  ValueWithRealFlags<Complex> Add(const Complex &) const;
-  ValueWithRealFlags<Complex> Subtract(const Complex &) const;
-  ValueWithRealFlags<Complex> Multiply(const Complex &) const;
-  ValueWithRealFlags<Complex> Divide(const Complex &) const;
+  constexpr bool IsZero() const { return re_.IsZero() || im_.IsZero(); }
+
+  constexpr bool IsInfinite() const {
+    return re_.IsInfinite() || im_.IsInfinite();
+  }
+
+  constexpr bool IsNotANumber() const {
+    return re_.IsNotANumber() || im_.IsNotANumber();
+  }
+
+  constexpr bool IsSignalingNaN() const {
+    return re_.IsSignalingNaN() || im_.IsSignalingNaN();
+  }
+
+  template<typename INT>
+  static ValueWithRealFlags<Complex> FromInteger(
+      const INT &n, Rounding rounding = defaultRounding) {
+    ValueWithRealFlags<Complex> result;
+    result.value.re_ =
+        Part::FromInteger(n, rounding).AccumulateFlags(result.flags);
+    return result;
+  }
+
+  ValueWithRealFlags<Complex> Add(
+      const Complex &, Rounding rounding = defaultRounding) const;
+  ValueWithRealFlags<Complex> Subtract(
+      const Complex &, Rounding rounding = defaultRounding) const;
+  ValueWithRealFlags<Complex> Multiply(
+      const Complex &, Rounding rounding = defaultRounding) const;
+  ValueWithRealFlags<Complex> Divide(
+      const Complex &, Rounding rounding = defaultRounding) const;
+
+  constexpr Complex FlushDenormalToZero() const {
+    return {re_.FlushDenormalToZero(), im_.FlushDenormalToZero()};
+  }
+
+  static constexpr Complex NaN() { return {Part::NaN(), Part::NaN()}; }
 
   std::string DumpHexadecimal() const;
   // TODO: (C)ABS once Real::HYPOT is done

--- a/lib/evaluate/complex.h
+++ b/lib/evaluate/complex.h
@@ -78,7 +78,9 @@ public:
     return {re_.FlushDenormalToZero(), im_.FlushDenormalToZero()};
   }
 
-  static constexpr Complex NaN() { return {Part::NaN(), Part::NaN()}; }
+  static constexpr Complex NotANumber() {
+    return {Part::NotANumber(), Part::NotANumber()};
+  }
 
   std::string DumpHexadecimal() const;
   // TODO: (C)ABS once Real::HYPOT is done

--- a/lib/evaluate/expression-forward.h
+++ b/lib/evaluate/expression-forward.h
@@ -25,20 +25,21 @@ namespace Fortran::evaluate {
 
 // An expression of some specific result type.
 template<typename A> class Expr;
-template<int KIND> using IntegerExpr = Expr<Type<Category::Integer, KIND>>;
+template<int KIND> using IntegerExpr = Expr<Type<TypeCategory::Integer, KIND>>;
 using DefaultIntegerExpr = IntegerExpr<DefaultInteger::kind>;
-template<int KIND> using RealExpr = Expr<Type<Category::Real, KIND>>;
-template<int KIND> using ComplexExpr = Expr<Type<Category::Complex, KIND>>;
-template<int KIND> using CharacterExpr = Expr<Type<Category::Character, KIND>>;
-template<int KIND> using LogicalExpr = Expr<Type<Category::Logical, KIND>>;
+template<int KIND> using RealExpr = Expr<Type<TypeCategory::Real, KIND>>;
+template<int KIND> using ComplexExpr = Expr<Type<TypeCategory::Complex, KIND>>;
+template<int KIND>
+using CharacterExpr = Expr<Type<TypeCategory::Character, KIND>>;
+template<int KIND> using LogicalExpr = Expr<Type<TypeCategory::Logical, KIND>>;
 
 // An expression whose result is within one particular type category and
 // of any supported kind.
-using AnyKindIntegerExpr = Expr<AnyKindType<Category::Integer>>;
-using AnyKindRealExpr = Expr<AnyKindType<Category::Real>>;
-using AnyKindComplexExpr = Expr<AnyKindType<Category::Complex>>;
-using AnyKindCharacterExpr = Expr<AnyKindType<Category::Character>>;
-using AnyKindLogicalExpr = Expr<AnyKindType<Category::Logical>>;
+using AnyKindIntegerExpr = Expr<AnyKindType<TypeCategory::Integer>>;
+using AnyKindRealExpr = Expr<AnyKindType<TypeCategory::Real>>;
+using AnyKindComplexExpr = Expr<AnyKindType<TypeCategory::Complex>>;
+using AnyKindCharacterExpr = Expr<AnyKindType<TypeCategory::Character>>;
+using AnyKindLogicalExpr = Expr<AnyKindType<TypeCategory::Logical>>;
 
 // A completely generic expression.
 struct GenericExpr;

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -657,7 +657,24 @@ auto Comparison<A>::FoldScalar(FoldingContext &c,
     case Relation::Unordered: return std::nullopt;
     }
   }
-  // TODO complex and character comparisons
+  if constexpr (A::category == Category::Complex) {
+    bool eqOk{opr == RelationalOperator::LE || opr == RelationalOperator::EQ ||
+        opr == RelationalOperator::GE};
+    return {eqOk == a.Equals(b)};
+  }
+  if constexpr (A::category == Category::Character) {
+    switch (Compare(a, b)) {
+    case Ordering::Less:
+      return {opr == RelationalOperator::LE || opr == RelationalOperator::LE ||
+          opr == RelationalOperator::NE};
+    case Ordering::Equal:
+      return {opr == RelationalOperator::LE || opr == RelationalOperator::EQ ||
+          opr == RelationalOperator::GE};
+    case Ordering::Greater:
+      return {opr == RelationalOperator::NE || opr == RelationalOperator::GE ||
+          opr == RelationalOperator::GT};
+    }
+  }
   return std::nullopt;
 }
 

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -44,12 +44,12 @@ std::ostream &DumpExpr(std::ostream &o, const std::variant<A...> &u) {
   return o;
 }
 
-template<Category CAT>
+template<TypeCategory CAT>
 std::ostream &Expr<AnyKindType<CAT>>::Dump(std::ostream &o) const {
   return DumpExpr(o, u);
 }
 
-template<Category CAT>
+template<TypeCategory CAT>
 std::ostream &CategoryComparison<CAT>::Dump(std::ostream &o) const {
   return DumpExpr(o, u);
 }
@@ -231,7 +231,7 @@ auto Binary<CRTP, RESULT, A, B>::Fold(FoldingContext &context)
 
 template<int KIND>
 auto IntegerExpr<KIND>::ConvertInteger::FoldScalar(FoldingContext &context,
-    const ScalarConstant<Category::Integer> &c) -> std::optional<Scalar> {
+    const ScalarConstant<TypeCategory::Integer> &c) -> std::optional<Scalar> {
   return std::visit(
       [&](auto &x) -> std::optional<Scalar> {
         auto converted{Scalar::ConvertSigned(x)};
@@ -246,7 +246,7 @@ auto IntegerExpr<KIND>::ConvertInteger::FoldScalar(FoldingContext &context,
 
 template<int KIND>
 auto IntegerExpr<KIND>::ConvertReal::FoldScalar(FoldingContext &context,
-    const ScalarConstant<Category::Real> &c) -> std::optional<Scalar> {
+    const ScalarConstant<TypeCategory::Real> &c) -> std::optional<Scalar> {
   return std::visit(
       [&](auto &x) -> std::optional<Scalar> {
         auto converted{x.template ToInteger<Scalar>()};
@@ -402,7 +402,7 @@ static void RealFlagWarnings(
 
 template<int KIND>
 auto RealExpr<KIND>::ConvertInteger::FoldScalar(FoldingContext &context,
-    const ScalarConstant<Category::Integer> &c) -> std::optional<Scalar> {
+    const ScalarConstant<TypeCategory::Integer> &c) -> std::optional<Scalar> {
   return std::visit(
       [&](auto &x) -> std::optional<Scalar> {
         auto converted{Scalar::FromInteger(x)};
@@ -414,7 +414,7 @@ auto RealExpr<KIND>::ConvertInteger::FoldScalar(FoldingContext &context,
 
 template<int KIND>
 auto RealExpr<KIND>::ConvertReal::FoldScalar(FoldingContext &context,
-    const ScalarConstant<Category::Real> &c) -> std::optional<Scalar> {
+    const ScalarConstant<TypeCategory::Real> &c) -> std::optional<Scalar> {
   return std::visit(
       [&](auto &x) -> std::optional<Scalar> {
         auto converted{Scalar::Convert(x)};
@@ -470,7 +470,7 @@ auto RealExpr<KIND>::Power::FoldScalar(FoldingContext &context, const Scalar &a,
 
 template<int KIND>
 auto RealExpr<KIND>::IntPower::FoldScalar(FoldingContext &context,
-    const Scalar &a, const ScalarConstant<Category::Integer> &b)
+    const Scalar &a, const ScalarConstant<TypeCategory::Integer> &b)
     -> std::optional<Scalar> {
   return std::visit(
       [&](const auto &pow) -> std::optional<Scalar> {
@@ -580,7 +580,7 @@ auto ComplexExpr<KIND>::Power::FoldScalar(FoldingContext &context,
 
 template<int KIND>
 auto ComplexExpr<KIND>::IntPower::FoldScalar(FoldingContext &context,
-    const Scalar &a, const ScalarConstant<Category::Integer> &b)
+    const Scalar &a, const ScalarConstant<TypeCategory::Integer> &b)
     -> std::optional<Scalar> {
   return std::visit(
       [&](const auto &pow) -> std::optional<Scalar> {
@@ -672,7 +672,7 @@ template<typename A>
 auto Comparison<A>::FoldScalar(FoldingContext &c,
     const OperandScalarConstant &a, const OperandScalarConstant &b)
     -> std::optional<Scalar> {
-  if constexpr (A::category == Category::Integer) {
+  if constexpr (A::category == TypeCategory::Integer) {
     switch (a.CompareSigned(b)) {
     case Ordering::Less:
       return {opr == RelationalOperator::LE || opr == RelationalOperator::LE ||
@@ -685,7 +685,7 @@ auto Comparison<A>::FoldScalar(FoldingContext &c,
           opr == RelationalOperator::GT};
     }
   }
-  if constexpr (A::category == Category::Real) {
+  if constexpr (A::category == TypeCategory::Real) {
     switch (a.Compare(b)) {
     case Relation::Less:
       return {opr == RelationalOperator::LE || opr == RelationalOperator::LE ||
@@ -699,12 +699,12 @@ auto Comparison<A>::FoldScalar(FoldingContext &c,
     case Relation::Unordered: return std::nullopt;
     }
   }
-  if constexpr (A::category == Category::Complex) {
+  if constexpr (A::category == TypeCategory::Complex) {
     bool eqOk{opr == RelationalOperator::LE || opr == RelationalOperator::EQ ||
         opr == RelationalOperator::GE};
     return {eqOk == a.Equals(b)};
   }
-  if constexpr (A::category == Category::Character) {
+  if constexpr (A::category == TypeCategory::Character) {
     switch (Compare(a, b)) {
     case Ordering::Less:
       return {opr == RelationalOperator::LE || opr == RelationalOperator::LE ||
@@ -781,7 +781,7 @@ std::optional<GenericScalar> GenericExpr::ScalarValue() const {
       u);
 }
 
-template<Category CAT>
+template<TypeCategory CAT>
 auto Expr<AnyKindType<CAT>>::ScalarValue() const -> std::optional<Scalar> {
   return std::visit(
       [](const auto &x) -> std::optional<Scalar> {
@@ -793,7 +793,7 @@ auto Expr<AnyKindType<CAT>>::ScalarValue() const -> std::optional<Scalar> {
       u);
 }
 
-template<Category CAT>
+template<TypeCategory CAT>
 auto Expr<AnyKindType<CAT>>::Fold(FoldingContext &context)
     -> std::optional<Scalar> {
   return std::visit(
@@ -817,47 +817,47 @@ std::optional<GenericScalar> GenericExpr::Fold(FoldingContext &context) {
       u);
 }
 
-template class Expr<AnyKindType<Category::Integer>>;
-template class Expr<AnyKindType<Category::Real>>;
-template class Expr<AnyKindType<Category::Complex>>;
-template class Expr<AnyKindType<Category::Character>>;
-template class Expr<AnyKindType<Category::Logical>>;
+template class Expr<AnyKindType<TypeCategory::Integer>>;
+template class Expr<AnyKindType<TypeCategory::Real>>;
+template class Expr<AnyKindType<TypeCategory::Complex>>;
+template class Expr<AnyKindType<TypeCategory::Character>>;
+template class Expr<AnyKindType<TypeCategory::Logical>>;
 
-template class Expr<Type<Category::Integer, 1>>;
-template class Expr<Type<Category::Integer, 2>>;
-template class Expr<Type<Category::Integer, 4>>;
-template class Expr<Type<Category::Integer, 8>>;
-template class Expr<Type<Category::Integer, 16>>;
-template class Expr<Type<Category::Real, 2>>;
-template class Expr<Type<Category::Real, 4>>;
-template class Expr<Type<Category::Real, 8>>;
-template class Expr<Type<Category::Real, 10>>;
-template class Expr<Type<Category::Real, 16>>;
-template class Expr<Type<Category::Complex, 2>>;
-template class Expr<Type<Category::Complex, 4>>;
-template class Expr<Type<Category::Complex, 8>>;
-template class Expr<Type<Category::Complex, 10>>;
-template class Expr<Type<Category::Complex, 16>>;
-template class Expr<Type<Category::Character, 1>>;
-template class Expr<Type<Category::Logical, 1>>;
-template class Expr<Type<Category::Logical, 2>>;
-template class Expr<Type<Category::Logical, 4>>;
-template class Expr<Type<Category::Logical, 8>>;
+template class Expr<Type<TypeCategory::Integer, 1>>;
+template class Expr<Type<TypeCategory::Integer, 2>>;
+template class Expr<Type<TypeCategory::Integer, 4>>;
+template class Expr<Type<TypeCategory::Integer, 8>>;
+template class Expr<Type<TypeCategory::Integer, 16>>;
+template class Expr<Type<TypeCategory::Real, 2>>;
+template class Expr<Type<TypeCategory::Real, 4>>;
+template class Expr<Type<TypeCategory::Real, 8>>;
+template class Expr<Type<TypeCategory::Real, 10>>;
+template class Expr<Type<TypeCategory::Real, 16>>;
+template class Expr<Type<TypeCategory::Complex, 2>>;
+template class Expr<Type<TypeCategory::Complex, 4>>;
+template class Expr<Type<TypeCategory::Complex, 8>>;
+template class Expr<Type<TypeCategory::Complex, 10>>;
+template class Expr<Type<TypeCategory::Complex, 16>>;
+template class Expr<Type<TypeCategory::Character, 1>>;
+template class Expr<Type<TypeCategory::Logical, 1>>;
+template class Expr<Type<TypeCategory::Logical, 2>>;
+template class Expr<Type<TypeCategory::Logical, 4>>;
+template class Expr<Type<TypeCategory::Logical, 8>>;
 
-template struct Comparison<Type<Category::Integer, 1>>;
-template struct Comparison<Type<Category::Integer, 2>>;
-template struct Comparison<Type<Category::Integer, 4>>;
-template struct Comparison<Type<Category::Integer, 8>>;
-template struct Comparison<Type<Category::Integer, 16>>;
-template struct Comparison<Type<Category::Real, 2>>;
-template struct Comparison<Type<Category::Real, 4>>;
-template struct Comparison<Type<Category::Real, 8>>;
-template struct Comparison<Type<Category::Real, 10>>;
-template struct Comparison<Type<Category::Real, 16>>;
-template struct Comparison<Type<Category::Complex, 2>>;
-template struct Comparison<Type<Category::Complex, 4>>;
-template struct Comparison<Type<Category::Complex, 8>>;
-template struct Comparison<Type<Category::Complex, 10>>;
-template struct Comparison<Type<Category::Complex, 16>>;
-template struct Comparison<Type<Category::Character, 1>>;
+template struct Comparison<Type<TypeCategory::Integer, 1>>;
+template struct Comparison<Type<TypeCategory::Integer, 2>>;
+template struct Comparison<Type<TypeCategory::Integer, 4>>;
+template struct Comparison<Type<TypeCategory::Integer, 8>>;
+template struct Comparison<Type<TypeCategory::Integer, 16>>;
+template struct Comparison<Type<TypeCategory::Real, 2>>;
+template struct Comparison<Type<TypeCategory::Real, 4>>;
+template struct Comparison<Type<TypeCategory::Real, 8>>;
+template struct Comparison<Type<TypeCategory::Real, 10>>;
+template struct Comparison<Type<TypeCategory::Real, 16>>;
+template struct Comparison<Type<TypeCategory::Complex, 2>>;
+template struct Comparison<Type<TypeCategory::Complex, 4>>;
+template struct Comparison<Type<TypeCategory::Complex, 8>>;
+template struct Comparison<Type<TypeCategory::Complex, 10>>;
+template struct Comparison<Type<TypeCategory::Complex, 16>>;
+template struct Comparison<Type<TypeCategory::Character, 1>>;
 }  // namespace Fortran::evaluate

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -215,7 +215,7 @@ auto Unary<CRTP, RESULT, A>::Fold(FoldingContext &context)
   if (std::optional<OperandScalarConstant> c{operand_->Fold(context)}) {
     return static_cast<CRTP *>(this)->FoldScalar(context, *c);
   }
-  return {};
+  return std::nullopt;
 }
 
 template<typename CRTP, typename RESULT, typename A, typename B>
@@ -226,7 +226,7 @@ auto Binary<CRTP, RESULT, A, B>::Fold(FoldingContext &context)
   if (lc.has_value() && rc.has_value()) {
     return static_cast<CRTP *>(this)->FoldScalar(context, *lc, *rc);
   }
-  return {};
+  return std::nullopt;
 }
 
 template<int KIND>
@@ -237,7 +237,7 @@ auto IntegerExpr<KIND>::ConvertInteger::FoldScalar(FoldingContext &context,
         auto converted{Scalar::ConvertSigned(x)};
         if (converted.overflow) {
           context.messages.Say("integer conversion overflowed"_en_US);
-          return {};
+          return std::nullopt;
         }
         return {std::move(converted.value)};
       },
@@ -252,12 +252,12 @@ auto IntegerExpr<KIND>::ConvertReal::FoldScalar(FoldingContext &context,
         auto converted{x.template ToInteger<Scalar>()};
         if (converted.flags.test(RealFlag::Overflow)) {
           context.messages.Say("real->integer conversion overflowed"_en_US);
-          return {};
+          return std::nullopt;
         }
         if (converted.flags.test(RealFlag::InvalidArgument)) {
           context.messages.Say(
               "real->integer conversion: invalid argument"_en_US);
-          return {};
+          return std::nullopt;
         }
         return {std::move(converted.value)};
       },
@@ -270,7 +270,7 @@ auto IntegerExpr<KIND>::Negate::FoldScalar(
   auto negated{c.Negate()};
   if (negated.overflow) {
     context.messages.Say("integer negation overflowed"_en_US);
-    return {};
+    return std::nullopt;
   }
   return {std::move(negated.value)};
 }
@@ -281,7 +281,7 @@ auto IntegerExpr<KIND>::Add::FoldScalar(FoldingContext &context,
   auto sum{a.AddSigned(b)};
   if (sum.overflow) {
     context.messages.Say("integer addition overflowed"_en_US);
-    return {};
+    return std::nullopt;
   }
   return {std::move(sum.value)};
 }
@@ -292,7 +292,7 @@ auto IntegerExpr<KIND>::Subtract::FoldScalar(FoldingContext &context,
   auto diff{a.SubtractSigned(b)};
   if (diff.overflow) {
     context.messages.Say("integer subtraction overflowed"_en_US);
-    return {};
+    return std::nullopt;
   }
   return {std::move(diff.value)};
 }
@@ -303,7 +303,7 @@ auto IntegerExpr<KIND>::Multiply::FoldScalar(FoldingContext &context,
   auto product{a.MultiplySigned(b)};
   if (product.SignedMultiplicationOverflowed()) {
     context.messages.Say("integer multiplication overflowed"_en_US);
-    return {};
+    return std::nullopt;
   }
   return {std::move(product.lower)};
 }
@@ -314,11 +314,11 @@ auto IntegerExpr<KIND>::Divide::FoldScalar(FoldingContext &context,
   auto qr{a.DivideSigned(b)};
   if (qr.divisionByZero) {
     context.messages.Say("integer division by zero"_en_US);
-    return {};
+    return std::nullopt;
   }
   if (qr.overflow) {
     context.messages.Say("integer division overflowed"_en_US);
-    return {};
+    return std::nullopt;
   }
   return {std::move(qr.quotient)};
 }
@@ -329,15 +329,15 @@ auto IntegerExpr<KIND>::Power::FoldScalar(FoldingContext &context,
   typename Scalar::PowerWithErrors power{a.Power(b)};
   if (power.divisionByZero) {
     context.messages.Say("zero to negative power"_en_US);
-    return {};
+    return std::nullopt;
   }
   if (power.overflow) {
     context.messages.Say("integer power overflowed"_en_US);
-    return {};
+    return std::nullopt;
   }
   if (power.zeroToZero) {
     context.messages.Say("integer 0**0"_en_US);
-    return {};
+    return std::nullopt;
   }
   return {std::move(power.power)};
 }
@@ -375,7 +375,7 @@ auto IntegerExpr<KIND>::Fold(FoldingContext &context) -> std::optional<Scalar> {
             return c;
           }
         }
-        return {};
+        return std::nullopt;
       },
       u_);
 }
@@ -465,7 +465,7 @@ auto RealExpr<KIND>::Divide::FoldScalar(FoldingContext &context,
 template<int KIND>
 auto RealExpr<KIND>::Power::FoldScalar(FoldingContext &context, const Scalar &a,
     const Scalar &b) -> std::optional<Scalar> {
-  return {};  // TODO
+  return std::nullopt;  // TODO
 }
 
 template<int KIND>
@@ -522,28 +522,108 @@ auto RealExpr<KIND>::Fold(FoldingContext &context) -> std::optional<Scalar> {
         if constexpr (evaluate::FoldableTrait<Ty>) {
           auto c{x.Fold(context)};
           if (c.has_value()) {
-            if (context.flushDenormalsToZero && c->IsDenormal()) {
-              u_ = Scalar{};
-            } else {
-              u_ = *c;
+            if (context.flushDenormalsToZero) {
+              *c = c->FlushDenormalToZero();
             }
+            u_ = *c;
             return c;
           }
         }
-        return {};
+        return std::nullopt;
       },
       u_);
 }
 
 template<int KIND>
+auto ComplexExpr<KIND>::Negate::FoldScalar(
+    FoldingContext &context, const Scalar &c) -> std::optional<Scalar> {
+  return {c.Negate()};
+}
+
+template<int KIND>
+auto ComplexExpr<KIND>::Add::FoldScalar(FoldingContext &context,
+    const Scalar &a, const Scalar &b) -> std::optional<Scalar> {
+  auto sum{a.Add(b, context.rounding)};
+  RealFlagWarnings(context, sum.flags, "complex addition");
+  return {std::move(sum.value)};
+}
+
+template<int KIND>
+auto ComplexExpr<KIND>::Subtract::FoldScalar(FoldingContext &context,
+    const Scalar &a, const Scalar &b) -> std::optional<Scalar> {
+  auto difference{a.Subtract(b, context.rounding)};
+  RealFlagWarnings(context, difference.flags, "complex subtraction");
+  return {std::move(difference.value)};
+}
+
+template<int KIND>
+auto ComplexExpr<KIND>::Multiply::FoldScalar(FoldingContext &context,
+    const Scalar &a, const Scalar &b) -> std::optional<Scalar> {
+  auto product{a.Multiply(b, context.rounding)};
+  RealFlagWarnings(context, product.flags, "complex multiplication");
+  return {std::move(product.value)};
+}
+
+template<int KIND>
+auto ComplexExpr<KIND>::Divide::FoldScalar(FoldingContext &context,
+    const Scalar &a, const Scalar &b) -> std::optional<Scalar> {
+  auto quotient{a.Divide(b, context.rounding)};
+  RealFlagWarnings(context, quotient.flags, "complex  division");
+  return {std::move(quotient.value)};
+}
+
+template<int KIND>
+auto ComplexExpr<KIND>::Power::FoldScalar(FoldingContext &context,
+    const Scalar &a, const Scalar &b) -> std::optional<Scalar> {
+  return std::nullopt;  // TODO
+}
+
+template<int KIND>
+auto ComplexExpr<KIND>::IntPower::FoldScalar(FoldingContext &context,
+    const Scalar &a, const ScalarConstant<Category::Integer> &b)
+    -> std::optional<Scalar> {
+  return std::visit(
+      [&](const auto &pow) -> std::optional<Scalar> {
+        auto power{evaluate::IntPower(a, pow)};
+        RealFlagWarnings(context, power.flags, "raising to integer power");
+        return {std::move(power.value)};
+      },
+      b.u);
+}
+
+template<int KIND>
+auto ComplexExpr<KIND>::CMPLX::FoldScalar(FoldingContext &context,
+    const PartScalar &a, const PartScalar &b) -> std::optional<Scalar> {
+  return {Scalar{a, b}};
+}
+
+template<int KIND>
 auto ComplexExpr<KIND>::Fold(FoldingContext &context) -> std::optional<Scalar> {
-  return {};  // TODO
+  return std::visit(
+      [&](auto &x) -> std::optional<Scalar> {
+        using Ty = typename std::decay<decltype(x)>::type;
+        if constexpr (std::is_same_v<Ty, Scalar>) {
+          return {x};
+        }
+        if constexpr (evaluate::FoldableTrait<Ty>) {
+          auto c{x.Fold(context)};
+          if (c.has_value()) {
+            if (context.flushDenormalsToZero) {
+              *c = c->FlushDenormalToZero();
+            }
+            u_ = *c;
+            return c;
+          }
+        }
+        return std::nullopt;
+      },
+      u_);
 }
 
 template<int KIND>
 auto CharacterExpr<KIND>::Fold(FoldingContext &context)
     -> std::optional<Scalar> {
-  return {};  // TODO
+  return std::nullopt;  // TODO
 }
 
 template<typename A>
@@ -574,11 +654,11 @@ auto Comparison<A>::FoldScalar(FoldingContext &c,
     case Relation::Greater:
       return {opr == RelationalOperator::NE || opr == RelationalOperator::GE ||
           opr == RelationalOperator::GT};
-    case Relation::Unordered: return {};
+    case Relation::Unordered: return std::nullopt;
     }
   }
   // TODO complex and character comparisons
-  return {};
+  return std::nullopt;
 }
 
 template<int KIND>
@@ -626,7 +706,7 @@ auto LogicalExpr<KIND>::Fold(FoldingContext &context) -> std::optional<Scalar> {
             return c;
           }
         }
-        return {};
+        return std::nullopt;
       },
       u_);
 }
@@ -637,7 +717,7 @@ std::optional<GenericScalar> GenericExpr::ScalarValue() const {
         if (auto c{x.ScalarValue()}) {
           return {GenericScalar{std::move(*c)}};
         }
-        return {};
+        return std::nullopt;
       },
       u);
 }
@@ -649,9 +729,7 @@ auto Expr<AnyKindType<CAT>>::ScalarValue() const -> std::optional<Scalar> {
         if (auto c{x.ScalarValue()}) {
           return {Scalar{std::move(*c)}};
         }
-        std::optional<Scalar> avoidBogusGCCWarning;  // ... with return {};
-        return avoidBogusGCCWarning;
-        ;
+        return std::nullopt;
       },
       u);
 }
@@ -664,9 +742,7 @@ auto Expr<AnyKindType<CAT>>::Fold(FoldingContext &context)
         if (auto c{x.Fold(context)}) {
           return {Scalar{std::move(*c)}};
         }
-        std::optional<Scalar> avoidBogusGCCWarning;  // ... with return {};
-        return avoidBogusGCCWarning;
-        ;
+        return std::nullopt;
       },
       u);
 }
@@ -677,7 +753,7 @@ std::optional<GenericScalar> GenericExpr::Fold(FoldingContext &context) {
         if (auto c{x.Fold(context)}) {
           return {GenericScalar{std::move(*c)}};
         }
-        return {};
+        return std::nullopt;
       },
       u);
 }

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -37,6 +37,7 @@ CLASS_TRAIT(FoldableTrait);
 struct FoldingContext {
   parser::ContextualMessages &messages;
   Rounding rounding{Rounding::TiesToEven};
+  bool flushDenormalsToZero{false};
 };
 
 // Helper base classes for packaging subexpressions.

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -100,24 +100,25 @@ private:
 
 // Per-category expressions
 
-template<int KIND> class Expr<Type<Category::Integer, KIND>> {
+template<int KIND> class Expr<Type<TypeCategory::Integer, KIND>> {
 public:
-  using Result = Type<Category::Integer, KIND>;
+  using Result = Type<TypeCategory::Integer, KIND>;
   using Scalar = typename Result::Value;
   using FoldableTrait = std::true_type;
 
   struct ConvertInteger
-    : public Unary<ConvertInteger, Result, AnyKindType<Category::Integer>> {
-    using Unary<ConvertInteger, Result, AnyKindType<Category::Integer>>::Unary;
+    : public Unary<ConvertInteger, Result, AnyKindType<TypeCategory::Integer>> {
+    using Unary<ConvertInteger, Result,
+        AnyKindType<TypeCategory::Integer>>::Unary;
     static std::optional<Scalar> FoldScalar(
-        FoldingContext &, const ScalarConstant<Category::Integer> &);
+        FoldingContext &, const ScalarConstant<TypeCategory::Integer> &);
   };
 
   struct ConvertReal
-    : public Unary<ConvertReal, Result, AnyKindType<Category::Real>> {
-    using Unary<ConvertReal, Result, AnyKindType<Category::Real>>::Unary;
+    : public Unary<ConvertReal, Result, AnyKindType<TypeCategory::Real>> {
+    using Unary<ConvertReal, Result, AnyKindType<TypeCategory::Real>>::Unary;
     static std::optional<Scalar> FoldScalar(
-        FoldingContext &, const ScalarConstant<Category::Real> &);
+        FoldingContext &, const ScalarConstant<TypeCategory::Real> &);
   };
 
   template<typename CRTP> using Un = Unary<CRTP, Result>;
@@ -203,9 +204,9 @@ private:
       u_;
 };
 
-template<int KIND> class Expr<Type<Category::Real, KIND>> {
+template<int KIND> class Expr<Type<TypeCategory::Real, KIND>> {
 public:
-  using Result = Type<Category::Real, KIND>;
+  using Result = Type<TypeCategory::Real, KIND>;
   using Scalar = typename Result::Value;
   using FoldableTrait = std::true_type;
 
@@ -213,16 +214,17 @@ public:
   // and part access operations (resp.).  Conversions between kinds of
   // Complex are done via decomposition to Real and reconstruction.
   struct ConvertInteger
-    : public Unary<ConvertInteger, Result, AnyKindType<Category::Integer>> {
-    using Unary<ConvertInteger, Result, AnyKindType<Category::Integer>>::Unary;
+    : public Unary<ConvertInteger, Result, AnyKindType<TypeCategory::Integer>> {
+    using Unary<ConvertInteger, Result,
+        AnyKindType<TypeCategory::Integer>>::Unary;
     static std::optional<Scalar> FoldScalar(
-        FoldingContext &, const ScalarConstant<Category::Integer> &);
+        FoldingContext &, const ScalarConstant<TypeCategory::Integer> &);
   };
   struct ConvertReal
-    : public Unary<ConvertReal, Result, AnyKindType<Category::Real>> {
-    using Unary<ConvertReal, Result, AnyKindType<Category::Real>>::Unary;
+    : public Unary<ConvertReal, Result, AnyKindType<TypeCategory::Real>> {
+    using Unary<ConvertReal, Result, AnyKindType<TypeCategory::Real>>::Unary;
     static std::optional<Scalar> FoldScalar(
-        FoldingContext &, const ScalarConstant<Category::Real> &);
+        FoldingContext &, const ScalarConstant<TypeCategory::Real> &);
   };
   template<typename CRTP> using Un = Unary<CRTP, Result>;
   template<typename CRTP> using Bin = Binary<CRTP, Result>;
@@ -261,12 +263,12 @@ public:
     static std::optional<Scalar> FoldScalar(
         FoldingContext &, const Scalar &, const Scalar &);
   };
-  struct IntPower
-    : public Binary<IntPower, Result, Result, AnyKindType<Category::Integer>> {
+  struct IntPower : public Binary<IntPower, Result, Result,
+                        AnyKindType<TypeCategory::Integer>> {
     using Binary<IntPower, Result, Result,
-        AnyKindType<Category::Integer>>::Binary;
+        AnyKindType<TypeCategory::Integer>>::Binary;
     static std::optional<Scalar> FoldScalar(FoldingContext &, const Scalar &,
-        const ScalarConstant<Category::Integer> &);
+        const ScalarConstant<TypeCategory::Integer> &);
   };
   struct Max : public Bin<Max> {
     using Bin<Max>::Bin;
@@ -278,7 +280,7 @@ public:
     static std::optional<Scalar> FoldScalar(
         FoldingContext &, const Scalar &, const Scalar &);
   };
-  using Cplx = Type<Category::Complex, KIND>;
+  using Cplx = Type<TypeCategory::Complex, KIND>;
   using CplxScalar = typename Cplx::Value;
   template<typename CRTP> using CplxUn = Unary<CRTP, Result, Cplx>;
   struct RealPart : public CplxUn<RealPart> {
@@ -321,9 +323,9 @@ private:
       u_;
 };
 
-template<int KIND> class Expr<Type<Category::Complex, KIND>> {
+template<int KIND> class Expr<Type<TypeCategory::Complex, KIND>> {
 public:
-  using Result = Type<Category::Complex, KIND>;
+  using Result = Type<TypeCategory::Complex, KIND>;
   using Scalar = typename Result::Value;
   using FoldableTrait = std::true_type;
   template<typename CRTP> using Un = Unary<CRTP, Result>;
@@ -363,14 +365,14 @@ public:
     static std::optional<Scalar> FoldScalar(
         FoldingContext &, const Scalar &, const Scalar &);
   };
-  struct IntPower
-    : public Binary<IntPower, Result, Result, AnyKindType<Category::Integer>> {
+  struct IntPower : public Binary<IntPower, Result, Result,
+                        AnyKindType<TypeCategory::Integer>> {
     using Binary<IntPower, Result, Result,
-        AnyKindType<Category::Integer>>::Binary;
+        AnyKindType<TypeCategory::Integer>>::Binary;
     static std::optional<Scalar> FoldScalar(FoldingContext &, const Scalar &,
-        const ScalarConstant<Category::Integer> &);
+        const ScalarConstant<TypeCategory::Integer> &);
   };
-  using Part = Type<Category::Real, KIND>;
+  using Part = Type<TypeCategory::Real, KIND>;
   using PartScalar = typename Part::Value;
   struct CMPLX : public Binary<CMPLX, Result, Part> {
     using Binary<CMPLX, Result, Part>::Binary;
@@ -397,9 +399,9 @@ private:
       u_;
 };
 
-template<int KIND> class Expr<Type<Category::Character, KIND>> {
+template<int KIND> class Expr<Type<TypeCategory::Character, KIND>> {
 public:
-  using Result = Type<Category::Character, KIND>;
+  using Result = Type<TypeCategory::Character, KIND>;
   using Scalar = typename Result::Value;
   using FoldableTrait = std::true_type;
   template<typename CRTP> using Bin = Binary<CRTP, Result>;
@@ -447,8 +449,8 @@ ENUM_CLASS(RelationalOperator, LT, LE, EQ, NE, GE, GT)
 
 template<typename A>
 struct Comparison
-  : public Binary<Comparison<A>, Type<Category::Logical, 1>, A> {
-  using Base = Binary<Comparison, Type<Category::Logical, 1>, A>;
+  : public Binary<Comparison<A>, Type<TypeCategory::Logical, 1>, A> {
+  using Base = Binary<Comparison, Type<TypeCategory::Logical, 1>, A>;
   using typename Base::Scalar;
   using OperandScalarConstant = typename Base::LeftScalar;
   CLASS_BOILERPLATE(Comparison)
@@ -461,27 +463,27 @@ struct Comparison
   RelationalOperator opr;
 };
 
-extern template struct Comparison<Type<Category::Integer, 1>>;
-extern template struct Comparison<Type<Category::Integer, 2>>;
-extern template struct Comparison<Type<Category::Integer, 4>>;
-extern template struct Comparison<Type<Category::Integer, 8>>;
-extern template struct Comparison<Type<Category::Integer, 16>>;
-extern template struct Comparison<Type<Category::Real, 2>>;
-extern template struct Comparison<Type<Category::Real, 4>>;
-extern template struct Comparison<Type<Category::Real, 8>>;
-extern template struct Comparison<Type<Category::Real, 10>>;
-extern template struct Comparison<Type<Category::Real, 16>>;
-extern template struct Comparison<Type<Category::Complex, 2>>;
-extern template struct Comparison<Type<Category::Complex, 4>>;
-extern template struct Comparison<Type<Category::Complex, 8>>;
-extern template struct Comparison<Type<Category::Complex, 10>>;
-extern template struct Comparison<Type<Category::Complex, 16>>;
-extern template struct Comparison<Type<Category::Character, 1>>;
+extern template struct Comparison<Type<TypeCategory::Integer, 1>>;
+extern template struct Comparison<Type<TypeCategory::Integer, 2>>;
+extern template struct Comparison<Type<TypeCategory::Integer, 4>>;
+extern template struct Comparison<Type<TypeCategory::Integer, 8>>;
+extern template struct Comparison<Type<TypeCategory::Integer, 16>>;
+extern template struct Comparison<Type<TypeCategory::Real, 2>>;
+extern template struct Comparison<Type<TypeCategory::Real, 4>>;
+extern template struct Comparison<Type<TypeCategory::Real, 8>>;
+extern template struct Comparison<Type<TypeCategory::Real, 10>>;
+extern template struct Comparison<Type<TypeCategory::Real, 16>>;
+extern template struct Comparison<Type<TypeCategory::Complex, 2>>;
+extern template struct Comparison<Type<TypeCategory::Complex, 4>>;
+extern template struct Comparison<Type<TypeCategory::Complex, 8>>;
+extern template struct Comparison<Type<TypeCategory::Complex, 10>>;
+extern template struct Comparison<Type<TypeCategory::Complex, 16>>;
+extern template struct Comparison<Type<TypeCategory::Character, 1>>;
 
 // Dynamically polymorphic comparisons whose operands are expressions of
 // the same supported kind of a particular type category.
-template<Category CAT> struct CategoryComparison {
-  using Scalar = typename Type<Category::Logical, 1>::Value;
+template<TypeCategory CAT> struct CategoryComparison {
+  using Scalar = typename Type<TypeCategory::Logical, 1>::Value;
   CLASS_BOILERPLATE(CategoryComparison)
   template<int KIND> using KindComparison = Comparison<Type<CAT, KIND>>;
   template<int KIND> CategoryComparison(const KindComparison<KIND> &x) : u{x} {}
@@ -491,9 +493,9 @@ template<Category CAT> struct CategoryComparison {
   typename KindsVariant<CAT, KindComparison>::type u;
 };
 
-template<int KIND> class Expr<Type<Category::Logical, KIND>> {
+template<int KIND> class Expr<Type<TypeCategory::Logical, KIND>> {
 public:
-  using Result = Type<Category::Logical, KIND>;
+  using Result = Type<TypeCategory::Logical, KIND>;
   using Scalar = typename Result::Value;
   using FoldableTrait = std::true_type;
   struct Not : Unary<Not, Result> {
@@ -525,9 +527,9 @@ public:
   CLASS_BOILERPLATE(Expr)
   Expr(const Scalar &x) : u_{x} {}
   Expr(bool x) : u_{Scalar{x}} {}
-  template<Category CAT, int K>
+  template<TypeCategory CAT, int K>
   Expr(const Comparison<Type<CAT, K>> &x) : u_{CategoryComparison<CAT>{x}} {}
-  template<Category CAT, int K>
+  template<TypeCategory CAT, int K>
   Expr(Comparison<Type<CAT, K>> &&x)
     : u_{CategoryComparison<CAT>{std::move(x)}} {}
   template<typename A> Expr(const A &x) : u_(x) {}
@@ -543,36 +545,37 @@ public:
 private:
   std::variant<Scalar, CopyableIndirection<DataRef>,
       CopyableIndirection<FunctionRef>, Not, And, Or, Eqv, Neqv,
-      CategoryComparison<Category::Integer>, CategoryComparison<Category::Real>,
-      CategoryComparison<Category::Complex>,
-      CategoryComparison<Category::Character>>
+      CategoryComparison<TypeCategory::Integer>,
+      CategoryComparison<TypeCategory::Real>,
+      CategoryComparison<TypeCategory::Complex>,
+      CategoryComparison<TypeCategory::Character>>
       u_;
 };
 
-extern template class Expr<Type<Category::Integer, 1>>;
-extern template class Expr<Type<Category::Integer, 2>>;
-extern template class Expr<Type<Category::Integer, 4>>;
-extern template class Expr<Type<Category::Integer, 8>>;
-extern template class Expr<Type<Category::Integer, 16>>;
-extern template class Expr<Type<Category::Real, 2>>;
-extern template class Expr<Type<Category::Real, 4>>;
-extern template class Expr<Type<Category::Real, 8>>;
-extern template class Expr<Type<Category::Real, 10>>;
-extern template class Expr<Type<Category::Real, 16>>;
-extern template class Expr<Type<Category::Complex, 2>>;
-extern template class Expr<Type<Category::Complex, 4>>;
-extern template class Expr<Type<Category::Complex, 8>>;
-extern template class Expr<Type<Category::Complex, 10>>;
-extern template class Expr<Type<Category::Complex, 16>>;
-extern template class Expr<Type<Category::Character, 1>>;
-extern template class Expr<Type<Category::Logical, 1>>;
-extern template class Expr<Type<Category::Logical, 2>>;
-extern template class Expr<Type<Category::Logical, 4>>;
-extern template class Expr<Type<Category::Logical, 8>>;
+extern template class Expr<Type<TypeCategory::Integer, 1>>;
+extern template class Expr<Type<TypeCategory::Integer, 2>>;
+extern template class Expr<Type<TypeCategory::Integer, 4>>;
+extern template class Expr<Type<TypeCategory::Integer, 8>>;
+extern template class Expr<Type<TypeCategory::Integer, 16>>;
+extern template class Expr<Type<TypeCategory::Real, 2>>;
+extern template class Expr<Type<TypeCategory::Real, 4>>;
+extern template class Expr<Type<TypeCategory::Real, 8>>;
+extern template class Expr<Type<TypeCategory::Real, 10>>;
+extern template class Expr<Type<TypeCategory::Real, 16>>;
+extern template class Expr<Type<TypeCategory::Complex, 2>>;
+extern template class Expr<Type<TypeCategory::Complex, 4>>;
+extern template class Expr<Type<TypeCategory::Complex, 8>>;
+extern template class Expr<Type<TypeCategory::Complex, 10>>;
+extern template class Expr<Type<TypeCategory::Complex, 16>>;
+extern template class Expr<Type<TypeCategory::Character, 1>>;
+extern template class Expr<Type<TypeCategory::Logical, 1>>;
+extern template class Expr<Type<TypeCategory::Logical, 2>>;
+extern template class Expr<Type<TypeCategory::Logical, 4>>;
+extern template class Expr<Type<TypeCategory::Logical, 8>>;
 
 // Dynamically polymorphic expressions that can hold any supported kind
 // of a specific intrinsic type category.
-template<Category CAT> class Expr<AnyKindType<CAT>> {
+template<TypeCategory CAT> class Expr<AnyKindType<CAT>> {
 public:
   using Result = AnyKindType<CAT>;
   using Scalar = typename Result::Value;
@@ -586,11 +589,11 @@ public:
   typename KindsVariant<CAT, KindExpr>::type u;
 };
 
-extern template class Expr<AnyKindType<Category::Integer>>;
-extern template class Expr<AnyKindType<Category::Real>>;
-extern template class Expr<AnyKindType<Category::Complex>>;
-extern template class Expr<AnyKindType<Category::Character>>;
-extern template class Expr<AnyKindType<Category::Logical>>;
+extern template class Expr<AnyKindType<TypeCategory::Integer>>;
+extern template class Expr<AnyKindType<TypeCategory::Real>>;
+extern template class Expr<AnyKindType<TypeCategory::Complex>>;
+extern template class Expr<AnyKindType<TypeCategory::Character>>;
+extern template class Expr<AnyKindType<TypeCategory::Logical>>;
 
 // A completely generic expression, polymorphic across the intrinsic type
 // categories and each of their kinds.
@@ -598,9 +601,9 @@ struct GenericExpr {
   using Scalar = GenericScalar;
   using FoldableTrait = std::true_type;
   CLASS_BOILERPLATE(GenericExpr)
-  template<Category CAT, int KIND>
+  template<TypeCategory CAT, int KIND>
   GenericExpr(const Expr<Type<CAT, KIND>> &x) : u{Expr<AnyKindType<CAT>>{x}} {}
-  template<Category CAT, int KIND>
+  template<TypeCategory CAT, int KIND>
   GenericExpr(Expr<Type<CAT, KIND>> &&x)
     : u{Expr<AnyKindType<CAT>>{std::move(x)}} {}
   template<typename A> GenericExpr(const A &x) : u{x} {}

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -405,12 +405,18 @@ public:
   template<typename CRTP> using Bin = Binary<CRTP, Result>;
   struct Concat : public Bin<Concat> {
     using Bin<Concat>::Bin;
+    static std::optional<Scalar> FoldScalar(
+        FoldingContext &, const Scalar &, const Scalar &);
   };
   struct Max : public Bin<Max> {
     using Bin<Max>::Bin;
+    static std::optional<Scalar> FoldScalar(
+        FoldingContext &, const Scalar &, const Scalar &);
   };
   struct Min : public Bin<Min> {
     using Bin<Min>::Bin;
+    static std::optional<Scalar> FoldScalar(
+        FoldingContext &, const Scalar &, const Scalar &);
   };
 
   CLASS_BOILERPLATE(Expr)

--- a/lib/evaluate/int-power.h
+++ b/lib/evaluate/int-power.h
@@ -28,7 +28,7 @@ ValueWithRealFlags<REAL> IntPower(
   ValueWithRealFlags<REAL> result;
   result.value = one;
   if (base.IsNotANumber()) {
-    result.value = REAL::NaN();
+    result.value = REAL::NotANumber();
     if (base.IsSignalingNaN()) {
       result.flags.set(RealFlag::InvalidArgument);
     }

--- a/lib/evaluate/int-power.h
+++ b/lib/evaluate/int-power.h
@@ -1,0 +1,60 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_EVALUATE_INT_POWER_H_
+#define FORTRAN_EVALUATE_INT_POWER_H_
+
+// Computes an integer power of a real or complex value.
+
+#include "common.h"
+
+namespace Fortran::evaluate {
+
+template<typename REAL, typename INT>
+ValueWithRealFlags<REAL> IntPower(const REAL &base, const INT &power,
+    Rounding rounding = Rounding::TiesToEven) {
+  REAL one{REAL::FromInteger(INT{1}).value};
+  ValueWithRealFlags<REAL> result;
+  result.value = one;
+  if (base.IsNotANumber()) {
+    result.value = REAL::NaN();
+    if (base.IsSignalingNaN()) {
+      result.flags.set(RealFlag::InvalidArgument);
+    }
+  } else if (power.IsZero()) {
+    if (base.IsZero() || base.IsInfinite()) {
+      result.flags.set(RealFlag::InvalidArgument);
+    }
+  } else {
+    bool negativePower{power.IsNegative()};
+    INT absPower{power.ABS().value};
+    REAL shifted{base};
+    int nbits{INT::bits - absPower.LEADZ()};
+    for (int j{0}; j + 1 < nbits; ++j) {
+      if (absPower.BTEST(j)) {
+        result.value =
+            result.value.Multiply(shifted).AccumulateFlags(result.flags);
+      }
+      shifted = shifted.Add(shifted).AccumulateFlags(result.flags);
+    }
+    result.value = result.value.Multiply(shifted).AccumulateFlags(result.flags);
+    if (negativePower) {
+      result.value = one.Divide(result.value).AccumulateFlags(result.flags);
+    }
+  }
+  return result;
+}
+
+}  // namespace Fortran::evaluate
+#endif  // FORTRAN_EVALUATE_INT_POWER_H_

--- a/lib/evaluate/int-power.h
+++ b/lib/evaluate/int-power.h
@@ -22,8 +22,8 @@
 namespace Fortran::evaluate {
 
 template<typename REAL, typename INT>
-ValueWithRealFlags<REAL> IntPower(const REAL &base, const INT &power,
-    Rounding rounding = Rounding::TiesToEven) {
+ValueWithRealFlags<REAL> IntPower(
+    const REAL &base, const INT &power, Rounding rounding = defaultRounding) {
   REAL one{REAL::FromInteger(INT{1}).value};
   ValueWithRealFlags<REAL> result;
   result.value = one;

--- a/lib/evaluate/integer.h
+++ b/lib/evaluate/integer.h
@@ -431,7 +431,7 @@ public:
 
   constexpr std::int64_t ToInt64() const {
     std::int64_t signExtended = ToUInt64();
-    if (bits < 64) {
+    if constexpr (bits < 64) {
       signExtended |= -(signExtended >> (bits - 1)) << bits;
     }
     return signExtended;

--- a/lib/evaluate/integer.h
+++ b/lib/evaluate/integer.h
@@ -102,7 +102,7 @@ public:
 
   struct PowerWithErrors {
     Integer power;
-    bool divisionByZero, overflow, zeroToZero;
+    bool divisionByZero{false}, overflow{false}, zeroToZero{false};
   };
 
   // Constructors and value-generating static functions

--- a/lib/evaluate/real.cc
+++ b/lib/evaluate/real.cc
@@ -60,7 +60,7 @@ ValueWithRealFlags<Real<W, P, IM>> Real<W, P, IM>::Add(
     const Real &y, Rounding rounding) const {
   ValueWithRealFlags<Real> result;
   if (IsNotANumber() || y.IsNotANumber()) {
-    result.value.word_ = NaNWord();  // NaN + x -> NaN
+    result.value = NaN();  // NaN + x -> NaN
     if (IsSignalingNaN() || y.IsSignalingNaN()) {
       result.flags.set(RealFlag::InvalidArgument);
     }
@@ -73,7 +73,7 @@ ValueWithRealFlags<Real<W, P, IM>> Real<W, P, IM>::Add(
       if (isNegative == yIsNegative) {
         result.value = *this;  // +/-Inf + +/-Inf -> +/-Inf
       } else {
-        result.value.word_ = NaNWord();  // +/-Inf + -/+Inf -> NaN
+        result.value = NaN();  // +/-Inf + -/+Inf -> NaN
         result.flags.set(RealFlag::InvalidArgument);
       }
     } else {
@@ -140,7 +140,7 @@ ValueWithRealFlags<Real<W, P, IM>> Real<W, P, IM>::Multiply(
     const Real &y, Rounding rounding) const {
   ValueWithRealFlags<Real> result;
   if (IsNotANumber() || y.IsNotANumber()) {
-    result.value.word_ = NaNWord();  // NaN * x -> NaN
+    result.value = NaN();  // NaN * x -> NaN
     if (IsSignalingNaN() || y.IsSignalingNaN()) {
       result.flags.set(RealFlag::InvalidArgument);
     }
@@ -148,10 +148,10 @@ ValueWithRealFlags<Real<W, P, IM>> Real<W, P, IM>::Multiply(
     bool isNegative{IsNegative() != y.IsNegative()};
     if (IsInfinite() || y.IsInfinite()) {
       if (IsZero() || y.IsZero()) {
-        result.value.word_ = NaNWord();  // 0 * Inf -> NaN
+        result.value = NaN();  // 0 * Inf -> NaN
         result.flags.set(RealFlag::InvalidArgument);
       } else {
-        result.value.word_ = InfinityWord(isNegative);
+        result.value = Infinity(isNegative);
       }
     } else {
       auto product{GetFraction().MultiplyUnsigned(y.GetFraction())};
@@ -200,7 +200,7 @@ ValueWithRealFlags<Real<W, P, IM>> Real<W, P, IM>::Divide(
     const Real &y, Rounding rounding) const {
   ValueWithRealFlags<Real> result;
   if (IsNotANumber() || y.IsNotANumber()) {
-    result.value.word_ = NaNWord();  // NaN / x -> NaN, x / NaN -> NaN
+    result.value = NaN();  // NaN / x -> NaN, x / NaN -> NaN
     if (IsSignalingNaN() || y.IsSignalingNaN()) {
       result.flags.set(RealFlag::InvalidArgument);
     }
@@ -208,17 +208,17 @@ ValueWithRealFlags<Real<W, P, IM>> Real<W, P, IM>::Divide(
     bool isNegative{IsNegative() != y.IsNegative()};
     if (IsInfinite()) {
       if (y.IsInfinite()) {
-        result.value.word_ = NaNWord();  // Inf/Inf -> NaN
+        result.value = NaN();  // Inf/Inf -> NaN
         result.flags.set(RealFlag::InvalidArgument);
       } else {  // Inf/x -> Inf,  Inf/0 -> Inf
-        result.value.word_ = InfinityWord(isNegative);
+        result.value = Infinity(isNegative);
       }
     } else if (y.IsZero()) {
       if (IsZero()) {  // 0/0 -> NaN
-        result.value.word_ = NaNWord();
+        result.value = NaN();
         result.flags.set(RealFlag::InvalidArgument);
       } else {  // x/0 -> Inf, Inf/0 -> Inf
-        result.value.word_ = InfinityWord(isNegative);
+        result.value = Infinity(isNegative);
         result.flags.set(RealFlag::DivideByZero);
       }
     } else if (IsZero() || y.IsInfinite()) {  // 0/x, x/Inf -> 0

--- a/lib/evaluate/real.cc
+++ b/lib/evaluate/real.cc
@@ -43,7 +43,7 @@ Relation Real<W, P, IM>::Compare(const Real &y) const {
       }
     } else {
       // same sign
-      Ordering order{CompareUnsigned(Exponent(), y.Exponent())};
+      Ordering order{evaluate::Compare(Exponent(), y.Exponent())};
       if (order == Ordering::Equal) {
         order = GetSignificand().CompareUnsigned(y.GetSignificand());
       }

--- a/lib/evaluate/real.cc
+++ b/lib/evaluate/real.cc
@@ -60,7 +60,7 @@ ValueWithRealFlags<Real<W, P, IM>> Real<W, P, IM>::Add(
     const Real &y, Rounding rounding) const {
   ValueWithRealFlags<Real> result;
   if (IsNotANumber() || y.IsNotANumber()) {
-    result.value = NaN();  // NaN + x -> NaN
+    result.value = NotANumber();  // NaN + x -> NaN
     if (IsSignalingNaN() || y.IsSignalingNaN()) {
       result.flags.set(RealFlag::InvalidArgument);
     }
@@ -73,7 +73,7 @@ ValueWithRealFlags<Real<W, P, IM>> Real<W, P, IM>::Add(
       if (isNegative == yIsNegative) {
         result.value = *this;  // +/-Inf + +/-Inf -> +/-Inf
       } else {
-        result.value = NaN();  // +/-Inf + -/+Inf -> NaN
+        result.value = NotANumber();  // +/-Inf + -/+Inf -> NaN
         result.flags.set(RealFlag::InvalidArgument);
       }
     } else {
@@ -140,7 +140,7 @@ ValueWithRealFlags<Real<W, P, IM>> Real<W, P, IM>::Multiply(
     const Real &y, Rounding rounding) const {
   ValueWithRealFlags<Real> result;
   if (IsNotANumber() || y.IsNotANumber()) {
-    result.value = NaN();  // NaN * x -> NaN
+    result.value = NotANumber();  // NaN * x -> NaN
     if (IsSignalingNaN() || y.IsSignalingNaN()) {
       result.flags.set(RealFlag::InvalidArgument);
     }
@@ -148,7 +148,7 @@ ValueWithRealFlags<Real<W, P, IM>> Real<W, P, IM>::Multiply(
     bool isNegative{IsNegative() != y.IsNegative()};
     if (IsInfinite() || y.IsInfinite()) {
       if (IsZero() || y.IsZero()) {
-        result.value = NaN();  // 0 * Inf -> NaN
+        result.value = NotANumber();  // 0 * Inf -> NaN
         result.flags.set(RealFlag::InvalidArgument);
       } else {
         result.value = Infinity(isNegative);
@@ -200,7 +200,7 @@ ValueWithRealFlags<Real<W, P, IM>> Real<W, P, IM>::Divide(
     const Real &y, Rounding rounding) const {
   ValueWithRealFlags<Real> result;
   if (IsNotANumber() || y.IsNotANumber()) {
-    result.value = NaN();  // NaN / x -> NaN, x / NaN -> NaN
+    result.value = NotANumber();  // NaN / x -> NaN, x / NaN -> NaN
     if (IsSignalingNaN() || y.IsSignalingNaN()) {
       result.flags.set(RealFlag::InvalidArgument);
     }
@@ -208,14 +208,14 @@ ValueWithRealFlags<Real<W, P, IM>> Real<W, P, IM>::Divide(
     bool isNegative{IsNegative() != y.IsNegative()};
     if (IsInfinite()) {
       if (y.IsInfinite()) {
-        result.value = NaN();  // Inf/Inf -> NaN
+        result.value = NotANumber();  // Inf/Inf -> NaN
         result.flags.set(RealFlag::InvalidArgument);
       } else {  // Inf/x -> Inf,  Inf/0 -> Inf
         result.value = Infinity(isNegative);
       }
     } else if (y.IsZero()) {
       if (IsZero()) {  // 0/0 -> NaN
-        result.value = NaN();
+        result.value = NotANumber();
         result.flags.set(RealFlag::InvalidArgument);
       } else {  // x/0 -> Inf, Inf/0 -> Inf
         result.value = Infinity(isNegative);

--- a/lib/evaluate/real.h
+++ b/lib/evaluate/real.h
@@ -124,8 +124,8 @@ public:
     return *this;
   }
 
-  // TODO: Configurable NaN representations
-  static constexpr Real NaN() {
+  // TODO: Configurable NotANumber representations
+  static constexpr Real NotANumber() {
     return {Word{maxExponent}
                 .SHIFTL(significandBits)
                 .IBSET(significandBits - 1)
@@ -310,7 +310,7 @@ private:
   }
 
   // Normalizes and marshals the fields of a floating-point number in place.
-  // The value is not a NaN, and a zero fraction means a zero value (i.e.,
+  // The value is a number, and a zero fraction means a zero value (i.e.,
   // a maximal exponent and zero fraction doesn't signify infinity, although
   // this member function will detect overflow and encode infinities).
   RealFlags Normalize(bool negative, std::uint64_t exponent,

--- a/lib/evaluate/real.h
+++ b/lib/evaluate/real.h
@@ -117,6 +117,23 @@ public:
     return epsilon;
   }
 
+  // TODO: Configurable NaN representations
+  static constexpr Real NaN() {
+    return {Word{maxExponent}
+                .SHIFTL(significandBits)
+                .IBSET(significandBits - 1)
+                .IBSET(significandBits - 2)};
+  }
+
+  static constexpr Real Infinity(bool negative) {
+    Word infinity{maxExponent};
+    infinity = infinity.SHIFTL(significandBits);
+    if (negative) {
+      infinity = infinity.IBSET(infinity.bits - 1);
+    }
+    return {infinity};
+  }
+
   template<typename INT>
   static ValueWithRealFlags<Real> FromInteger(
       const INT &n, Rounding rounding = Rounding::TiesToEven) {
@@ -283,23 +300,6 @@ private:
     top = doubled.value;
     msb = doubled.carry;
     return greaterOrEqual;
-  }
-
-  // TODO: Configurable NaN representations
-  static constexpr Word NaNWord() {
-    return Word{maxExponent}
-        .SHIFTL(significandBits)
-        .IBSET(significandBits - 1)
-        .IBSET(significandBits - 2);
-  }
-
-  static constexpr Word InfinityWord(bool negative) {
-    Word infinity{maxExponent};
-    infinity = infinity.SHIFTL(significandBits);
-    if (negative) {
-      infinity = infinity.IBSET(infinity.bits - 1);
-    }
-    return infinity;
   }
 
   // Normalizes and marshals the fields of a floating-point number in place.

--- a/lib/evaluate/real.h
+++ b/lib/evaluate/real.h
@@ -52,7 +52,6 @@ public:
   constexpr Real &operator=(const Real &) = default;
   constexpr Real &operator=(Real &&) = default;
 
-  // TODO: facility to flush denormal results to zero
   // TODO AINT/ANINT, CEILING, FLOOR, DIM, MAX, MIN, DPROD, FRACTION
   // HUGE, INT/NINT, MAXEXPONENT, MINEXPONENT, NEAREST, OUT_OF_RANGE,
   // PRECISION, HUGE, TINY, RRSPACING/SPACING, SCALE, SET_EXPONENT, SIGN

--- a/lib/evaluate/variable.cc
+++ b/lib/evaluate/variable.cc
@@ -41,21 +41,21 @@ std::optional<SubscriptIntegerExpr> Triplet::lower() const {
   if (lower_) {
     return {**lower_};
   }
-  return {};
+  return std::nullopt;
 }
 
 std::optional<SubscriptIntegerExpr> Triplet::upper() const {
   if (upper_) {
     return {**upper_};
   }
-  return {};
+  return std::nullopt;
 }
 
 std::optional<SubscriptIntegerExpr> Triplet::stride() const {
   if (stride_) {
     return {**stride_};
   }
-  return {};
+  return std::nullopt;
 }
 
 CoarrayRef::CoarrayRef(std::vector<const Symbol *> &&c,

--- a/lib/parser/basic-parsers.h
+++ b/lib/parser/basic-parsers.h
@@ -56,7 +56,7 @@ public:
   constexpr explicit FailParser(MessageFixedText t) : text_{t} {}
   std::optional<A> Parse(ParseState &state) const {
     state.Say(text_);
-    return {};
+    return std::nullopt;
   }
 
 private:
@@ -123,7 +123,7 @@ public:
     ParseState forked{state};
     forked.set_deferMessages(true);
     if (parser_.Parse(forked)) {
-      return {};
+      return std::nullopt;
     }
     return {Success{}};
   }
@@ -149,7 +149,7 @@ public:
     if (parser_.Parse(forked).has_value()) {
       return {Success{}};
     }
-    return {};
+    return std::nullopt;
   }
 
 private:
@@ -491,7 +491,7 @@ public:
       }
       return {std::move(result)};
     }
-    return {};
+    return std::nullopt;
   }
 
 private:
@@ -626,7 +626,7 @@ public:
     if (std::optional<paType> ax{parser_.Parse(state)}) {
       return {function_(std::move(*ax))};
     }
-    return {};
+    return std::nullopt;
   }
 
 private:
@@ -653,7 +653,7 @@ public:
     if (std::optional<paType> ax{parser_.Parse(state)}) {
       return {functor_(std::move(*ax))};
     }
-    return {};
+    return std::nullopt;
   }
 
 private:
@@ -709,7 +709,7 @@ public:
         return {function_(std::move(*ax), std::move(*bx))};
       }
     }
-    return {};
+    return std::nullopt;
   }
 
 private:
@@ -741,7 +741,7 @@ public:
         return {function_(std::move(*ax), std::move(*bx))};
       }
     }
-    return {};
+    return std::nullopt;
   }
 
 private:
@@ -773,7 +773,7 @@ public:
         return result;
       }
     }
-    return {};
+    return std::nullopt;
   }
 
 private:
@@ -807,7 +807,7 @@ public:
         }
       }
     }
-    return {};
+    return std::nullopt;
   }
 
 private:
@@ -845,7 +845,7 @@ public:
         }
       }
     }
-    return {};
+    return std::nullopt;
   }
 
 private:
@@ -886,7 +886,7 @@ public:
         }
       }
     }
-    return {};
+    return std::nullopt;
   }
 
 private:
@@ -929,7 +929,7 @@ public:
         }
       }
     }
-    return {};
+    return std::nullopt;
   }
 
 private:
@@ -971,7 +971,7 @@ template<class T, typename PA> struct Construct01 {
     if (std::optional<Success>{parser_.Parse(state)}) {
       return {T{}};
     }
-    return {};
+    return std::nullopt;
   }
 
 private:
@@ -987,7 +987,7 @@ public:
     if (auto ax{parser_.Parse(state)}) {
       return {T(std::move(*ax))};
     }
-    return {};
+    return std::nullopt;
   }
 
 private:
@@ -1023,7 +1023,7 @@ public:
         return {T{std::move(*ax), std::move(*bx)}};
       }
     }
-    return {};
+    return std::nullopt;
   }
 
 private:
@@ -1050,7 +1050,7 @@ public:
         }
       }
     }
-    return {};
+    return std::nullopt;
   }
 
 private:
@@ -1083,7 +1083,7 @@ public:
         }
       }
     }
-    return {};
+    return std::nullopt;
   }
 
 private:
@@ -1121,7 +1121,7 @@ public:
         }
       }
     }
-    return {};
+    return std::nullopt;
   }
 
 private:
@@ -1163,7 +1163,7 @@ public:
         }
       }
     }
-    return {};
+    return std::nullopt;
   }
 
 private:
@@ -1238,7 +1238,7 @@ template<bool pass> struct FixedParser {
     if (pass) {
       return {Success{}};
     }
-    return {};
+    return std::nullopt;
   }
 };
 
@@ -1256,7 +1256,7 @@ constexpr struct NextCh {
       return result;
     }
     state.Say("end of file"_err_en_US);
-    return {};
+    return std::nullopt;
   }
 } nextCh;
 
@@ -1271,7 +1271,7 @@ public:
   std::optional<resultType> Parse(ParseState &state) const {
     if (UserState * ustate{state.userState()}) {
       if (!ustate->features().IsEnabled(LF)) {
-        return {};
+        return std::nullopt;
       }
     }
     auto at{state.GetLocation()};
@@ -1303,7 +1303,7 @@ public:
   std::optional<resultType> Parse(ParseState &state) const {
     if (UserState * ustate{state.userState()}) {
       if (!ustate->features().IsEnabled(LF)) {
-        return {};
+        return std::nullopt;
       }
     }
     auto at{state.GetLocation()};

--- a/lib/parser/basic-parsers.h
+++ b/lib/parser/basic-parsers.h
@@ -327,7 +327,7 @@ template<typename... Ps> inline constexpr auto first(const Ps &... ps) {
   return AlternativesParser<Ps...>{ps...};
 }
 
-#if !__GNUC__ || __clang__
+#if !__GNUC__ || __clang__ || ((100 * __GNUC__ + __GNUC__MINOR__) >= 802)
 // Implement operator|| with first(), unless compiling with g++,
 // which can segfault at compile time and needs to continue to use
 // the original implementation of operator|| as of gcc-8.1.0.
@@ -335,7 +335,7 @@ template<typename PA, typename PB>
 inline constexpr auto operator||(const PA &pa, const PB &pb) {
   return first(pa, pb);
 }
-#else  // g++ only: original implementation
+#else  // g++ <= 8.1.0 only: original implementation
 // If a and b are parsers, then a || b returns a parser that succeeds if
 // a does so, or if a fails and b succeeds.  The result types of the parsers
 // must be the same type.  If a succeeds, b is not attempted.

--- a/lib/parser/characters.cc
+++ b/lib/parser/characters.cc
@@ -36,7 +36,7 @@ std::optional<int> UTF8CharacterBytes(const char *p) {
       return {2};
     }
   }
-  return {};
+  return std::nullopt;
 }
 
 std::optional<int> EUC_JPCharacterBytes(const char *p) {
@@ -64,7 +64,7 @@ std::optional<int> EUC_JPCharacterBytes(const char *p) {
       return {3};
     }
   }
-  return {};
+  return std::nullopt;
 }
 
 std::optional<std::size_t> CountCharacters(
@@ -75,7 +75,7 @@ std::optional<std::size_t> CountCharacters(
     ++chars;
     std::optional<int> cb{cbf(p)};
     if (!cb.has_value()) {
-      return {};
+      return std::nullopt;
     }
     p += *cb;
   }

--- a/lib/parser/characters.h
+++ b/lib/parser/characters.h
@@ -113,7 +113,7 @@ inline constexpr std::optional<char> BackslashEscapeValue(char ch) {
   case '"':
   case '\'':
   case '\\': return {ch};
-  default: return {};
+  default: return std::nullopt;
   }
 }
 
@@ -129,7 +129,7 @@ inline constexpr std::optional<char> BackslashEscapeChar(char ch) {
   case '"':
   case '\'':
   case '\\': return {ch};
-  default: return {};
+  default: return std::nullopt;
   }
 }
 

--- a/lib/parser/instrumented-parser.h
+++ b/lib/parser/instrumented-parser.h
@@ -61,7 +61,7 @@ public:
       if (ParsingLog * log{ustate->log()}) {
         const char *at{state.GetLocation()};
         if (log->Fails(at, tag_, state)) {
-          return {};
+          return std::nullopt;
         }
         Messages messages{std::move(state.messages())};
         std::optional<resultType> result{parser_.Parse(state)};

--- a/lib/parser/parse-state.h
+++ b/lib/parser/parse-state.h
@@ -197,14 +197,14 @@ public:
 
   std::optional<const char *> GetNextChar() {
     if (p_ >= limit_) {
-      return {};
+      return std::nullopt;
     }
     return {UncheckedAdvance()};
   }
 
   std::optional<const char *> PeekAtNextChar() const {
     if (p_ >= limit_) {
-      return {};
+      return std::nullopt;
     }
     return {p_};
   }

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -119,8 +119,7 @@ struct GenericExpr;
     WRAPPER_CLASS_BOILERPLATE(classname, type); \
   }
 
-namespace Fortran {
-namespace parser {
+namespace Fortran::parser {
 
 // These are the unavoidable recursively-defined productions of Fortran.
 // Some references to the representations of their parses require
@@ -3701,6 +3700,5 @@ struct OpenMPConstruct {
       u;
 };
 
-}  // namespace parser
-}  // namespace Fortran
+}  // namespace Fortran::parser
 #endif  // FORTRAN_PARSER_PARSE_TREE_H_

--- a/lib/parser/preprocessor.cc
+++ b/lib/parser/preprocessor.cc
@@ -236,7 +236,7 @@ std::optional<TokenSequence> Preprocessor::MacroReplacement(
     }
   }
   if (j == tokens) {
-    return {};  // input contains nothing that would be replaced
+    return std::nullopt;  // input contains nothing that would be replaced
   }
   TokenSequence result{input, 0, j};
   for (; j < tokens; ++j) {

--- a/lib/parser/prescan.cc
+++ b/lib/parser/prescan.cc
@@ -602,14 +602,14 @@ std::optional<std::size_t> Prescanner::IsIncludeLine(const char *start) const {
   const char *p{SkipWhiteSpace(start)};
   for (char ch : "include"s) {
     if (ToLowerCaseLetter(*p++) != ch) {
-      return {};
+      return std::nullopt;
     }
   }
   p = SkipWhiteSpace(p);
   if (*p == '"' || *p == '\'') {
     return {p - start};
   }
-  return {};
+  return std::nullopt;
 }
 
 void Prescanner::FortranInclude(const char *firstQuote) {
@@ -856,7 +856,7 @@ Prescanner::IsFixedFormCompilerDirectiveLine(const char *start) const {
   const char *p{start};
   char col1{*p++};
   if (!IsFixedFormCommentChar(col1)) {
-    return {};
+    return std::nullopt;
   }
   char sentinel[5], *sp{sentinel};
   int column{2};
@@ -877,11 +877,11 @@ Prescanner::IsFixedFormCompilerDirectiveLine(const char *start) const {
       ++p;
     } else {
       // This is a Continuation line, not an initial directive line.
-      return {};
+      return std::nullopt;
     }
   }
   if (sp == sentinel) {
-    return {};
+    return std::nullopt;
   }
   *sp = '\0';
   if (const char *ss{IsCompilerDirectiveSentinel(sentinel)}) {
@@ -889,7 +889,7 @@ Prescanner::IsFixedFormCompilerDirectiveLine(const char *start) const {
     return {LineClassification{
         LineClassification::Kind::CompilerDirective, payloadOffset, ss}};
   }
-  return {};
+  return std::nullopt;
 }
 
 std::optional<Prescanner::LineClassification>
@@ -897,7 +897,7 @@ Prescanner::IsFreeFormCompilerDirectiveLine(const char *start) const {
   char sentinel[8];
   const char *p{SkipWhiteSpace(start)};
   if (*p++ != '!') {
-    return {};
+    return std::nullopt;
   }
   for (std::size_t j{0}; j + 1 < sizeof sentinel; ++p, ++j) {
     if (*p == '\n') {
@@ -921,7 +921,7 @@ Prescanner::IsFreeFormCompilerDirectiveLine(const char *start) const {
     }
     sentinel[j] = ToLowerCaseLetter(*p);
   }
-  return {};
+  return std::nullopt;
 }
 
 Prescanner &Prescanner::AddCompilerDirectiveSentinel(const std::string &dir) {

--- a/lib/parser/user-state.cc
+++ b/lib/parser/user-state.cc
@@ -56,7 +56,7 @@ EndDoStmtForCapturedLabelDoStmt::Parse(ParseState &state) {
       }
     }
   }
-  return {};
+  return std::nullopt;
 }
 
 std::optional<Success> EnterNonlabelDoConstruct::Parse(ParseState &state) {
@@ -81,7 +81,7 @@ std::optional<Name> OldStructureComponentName::Parse(ParseState &state) {
       }
     }
   }
-  return {};
+  return std::nullopt;
 }
 
 std::optional<DataComponentDefStmt> StructureComponents::Parse(

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -32,7 +32,7 @@ std::optional<evaluate::GenericExpr> AnalyzeHelper(
   if (result.has_value()) {
     if (result->Rank() > 1) {
       ea.context().messages.Say("must be scalar"_err_en_US);
-      return {};
+      return std::nullopt;
     }
   }
   return result;
@@ -46,7 +46,7 @@ std::optional<evaluate::GenericExpr> AnalyzeHelper(
     result->Fold(ea.context());
     if (!result->ScalarValue().has_value()) {
       ea.context().messages.Say("must be constant"_err_en_US);
-      return {};
+      return std::nullopt;
     }
   }
   return result;
@@ -59,7 +59,7 @@ std::optional<evaluate::GenericExpr> AnalyzeHelper(
   if (result.has_value() &&
       !std::holds_alternative<evaluate::AnyKindIntegerExpr>(result->u)) {
     ea.context().messages.Say("must be integer"_err_en_US);
-    return {};
+    return std::nullopt;
   }
   return result;
 }
@@ -68,7 +68,7 @@ template<>
 std::optional<evaluate::GenericExpr> AnalyzeHelper(
     ExpressionAnalyzer &ea, const parser::Name &n) {
   // TODO
-  return {};
+  return std::nullopt;
 }
 
 ExpressionAnalyzer::KindParam ExpressionAnalyzer::Analyze(
@@ -118,7 +118,7 @@ std::optional<evaluate::GenericExpr> AnalyzeHelper(
     ea.context().messages.Say(parser::MessageFormattedText{
         "unimplemented INTEGER kind (%ju)"_err_en_US,
         static_cast<std::uintmax_t>(kind)});
-    return {};
+    return std::nullopt;
   }
 }
 

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -14,5 +14,7 @@
 
 add_library(FortranRuntime
   ISO_Fortran_binding.cc
+  derived-type.cc
   descriptor.cc
+  type-code.cc
 )

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -16,5 +16,10 @@ add_library(FortranRuntime
   ISO_Fortran_binding.cc
   derived-type.cc
   descriptor.cc
+  transformational.cc
   type-code.cc
+)
+
+target_link_libraries(FortranRuntime
+  FortranEvaluate
 )

--- a/runtime/ISO_Fortran_binding.cc
+++ b/runtime/ISO_Fortran_binding.cc
@@ -181,7 +181,7 @@ int CFI_establish(CFI_cdesc_t *descriptor, void *base_addr,
 }
 
 int CFI_is_contiguous(const CFI_cdesc_t *descriptor) {
-  std::size_t bytes{descriptor->elem_len};
+  CFI_index_t bytes = descriptor->elem_len;
   for (int j{0}; j < descriptor->rank; ++j) {
     if (bytes != descriptor->dim[j].sm) {
       return 0;

--- a/runtime/ISO_Fortran_binding.cc
+++ b/runtime/ISO_Fortran_binding.cc
@@ -144,9 +144,6 @@ int CFI_establish(CFI_cdesc_t *descriptor, void *base_addr,
   if ((attribute & ~(CFI_attribute_pointer | CFI_attribute_allocatable)) != 0) {
     return CFI_INVALID_ATTRIBUTE;
   }
-  if ((attribute & CFI_attribute_allocatable) != 0 && base_addr != nullptr) {
-    return CFI_ERROR_BASE_ADDR_NOT_NULL;
-  }
   if (rank > CFI_MAX_RANK) {
     return CFI_INVALID_RANK;
   }
@@ -166,7 +163,9 @@ int CFI_establish(CFI_cdesc_t *descriptor, void *base_addr,
   descriptor->elem_len = elem_len;
   descriptor->version = CFI_VERSION;
   descriptor->rank = rank;
+  descriptor->type = type;
   descriptor->attribute = attribute;
+  descriptor->f18Addendum = 0;
   std::size_t byteSize{elem_len};
   for (std::size_t j{0}; j < rank; ++j) {
     descriptor->dim[j].lower_bound = 1;

--- a/runtime/derived-type.cc
+++ b/runtime/derived-type.cc
@@ -1,0 +1,50 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "derived-type.h"
+#include "descriptor.h"
+#include <cstring>
+
+namespace Fortran::runtime {
+
+TypeParameterValue TypeParameter::GetValue(const Descriptor &descriptor) const {
+  if (which_ < 0) {
+    return value_;
+  } else {
+    return descriptor.Addendum()->LenParameterValue(which_);
+  }
+}
+
+bool DerivedType::IsNontrivialAnalysis() const {
+  if (kindParameters_ > 0 || lenParameters_ > 0 || typeBoundProcedures_ > 0 ||
+      definedAssignments_ > 0) {
+    return true;
+  }
+  for (int j{0}; j < components_; ++j) {
+    if (component_[j].IsDescriptor()) {
+      return true;
+    }
+    if (const Descriptor * staticDescriptor{component_[j].staticDescriptor()}) {
+      if (const DescriptorAddendum * addendum{staticDescriptor->Addendum()}) {
+        if (const DerivedType * dt{addendum->derivedType()}) {
+          if (dt->IsNontrivial()) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+}  // namespace Fortran::runtime

--- a/runtime/derived-type.cc
+++ b/runtime/derived-type.cc
@@ -55,11 +55,13 @@ void DerivedType::Initialize(char *instance) const {
       f(instance);
     }
   }
+#if 0  // TODO
   for (std::size_t j{0}; j < components_; ++j) {
     if (const Descriptor * descriptor{component_[j].GetDescriptor(instance)}) {
-      // TODO
+      // invoke initialization TBP
     }
   }
+#endif
 }
 
 void DerivedType::Destroy(char *instance, bool finalize) const {

--- a/runtime/derived-type.cc
+++ b/runtime/derived-type.cc
@@ -31,7 +31,7 @@ bool DerivedType::IsNontrivialAnalysis() const {
       definedAssignments_ > 0) {
     return true;
   }
-  for (int j{0}; j < components_; ++j) {
+  for (std::size_t j{0}; j < components_; ++j) {
     if (component_[j].IsDescriptor()) {
       return true;
     }

--- a/runtime/derived-type.cc
+++ b/runtime/derived-type.cc
@@ -27,8 +27,7 @@ TypeParameterValue TypeParameter::GetValue(const Descriptor &descriptor) const {
 }
 
 bool DerivedType::IsNontrivialAnalysis() const {
-  if (kindParameters_ > 0 || lenParameters_ > 0 || typeBoundProcedures_ > 0 ||
-      definedAssignments_ > 0) {
+  if (kindParameters_ > 0 || lenParameters_ > 0 || typeBoundProcedures_ > 0) {
     return true;
   }
   for (std::size_t j{0}; j < components_; ++j) {

--- a/runtime/derived-type.h
+++ b/runtime/derived-type.h
@@ -77,6 +77,14 @@ public:
     return reinterpret_cast<const A *>(dtInstance + offset_);
   }
 
+  Descriptor *GetDescriptor(char *dtInstance) const {
+    if (IsDescriptor()) {
+      return Locate<Descriptor>(dtInstance);
+    } else {
+      return nullptr;
+    }
+  }
+
   const Descriptor *GetDescriptor(const char *dtInstance) const {
     if (staticDescriptor_ != nullptr) {
       return staticDescriptor_;
@@ -144,14 +152,8 @@ public:
 
   std::size_t components() const { return components_; }
 
-  // TBP 0 is the initializer: SUBROUTINE INIT(INSTANCE)
-  static constexpr int initializerTBP{0};
-
-  // TBP 1 is the sourced allocation copier: SUBROUTINE COPYINIT(TO, FROM)
-  static constexpr int copierTBP{1};
-
-  // TBP 2 is the FINAL subroutine.
-  static constexpr int finalTBP{2};
+  // The first few type-bound procedure indices are special.
+  enum SpecialTBP { InitializerTBP, CopierTBP, FinalTBP };
 
   std::size_t typeBoundProcedures() const { return typeBoundProcedures_; }
   const TypeBoundProcedure &typeBoundProcedure(int n) const {
@@ -175,6 +177,9 @@ public:
   bool IsNontrivial() const { return (flags_ & NONTRIVIAL) != 0; }
 
   bool IsSameType(const DerivedType &) const;
+
+  void Initialize(char *instance) const;
+  void Destroy(char *instance, bool finalize = true) const;
 
 private:
   enum Flag { SEQUENCE = 1, BIND_C = 2, NONTRIVIAL = 4 };

--- a/runtime/derived-type.h
+++ b/runtime/derived-type.h
@@ -122,8 +122,9 @@ struct DefinedAssignment {
 // the execution of FINAL subroutines.
 class DerivedType {
 public:
-  DerivedType(const char *n, int kps, int lps, const TypeParameter *tp, int cs,
-      const Component *ca, int tbps, const TypeBoundProcedure *tbp, int das,
+  DerivedType(const char *n, std::size_t kps, std::size_t lps,
+      const TypeParameter *tp, std::size_t cs, const Component *ca,
+      std::size_t tbps, const TypeBoundProcedure *tbp, std::size_t das,
       const DefinedAssignment *da, std::size_t sz)
     : name_{n}, kindParameters_{kps}, lenParameters_{lps}, typeParameter_{tp},
       components_{cs}, component_{ca}, typeBoundProcedures_{tbps},
@@ -135,13 +136,13 @@ public:
   }
 
   const char *name() const { return name_; }
-  int kindParameters() const { return kindParameters_; }
-  int lenParameters() const { return lenParameters_; }
+  std::size_t kindParameters() const { return kindParameters_; }
+  std::size_t lenParameters() const { return lenParameters_; }
 
   // KIND type parameters come first.
   const TypeParameter &typeParameter(int n) const { return typeParameter_[n]; }
 
-  int components() const { return components_; }
+  std::size_t components() const { return components_; }
 
   // TBP 0 is the initializer: SUBROUTINE INIT(INSTANCE)
   static constexpr int initializerTBP{0};
@@ -152,7 +153,7 @@ public:
   // TBP 2 is the FINAL subroutine.
   static constexpr int finalTBP{2};
 
-  int typeBoundProcedures() const { return typeBoundProcedures_; }
+  std::size_t typeBoundProcedures() const { return typeBoundProcedures_; }
   const TypeBoundProcedure &typeBoundProcedure(int n) const {
     return typeBoundProcedure_[n];
   }
@@ -184,14 +185,14 @@ private:
   bool IsNontrivialAnalysis() const;
 
   const char *name_{""};  // NUL-terminated constant text
-  int kindParameters_{0};
-  int lenParameters_{0};
+  std::size_t kindParameters_{0};
+  std::size_t lenParameters_{0};
   const TypeParameter *typeParameter_{nullptr};  // array
-  int components_{0};  // *not* including type parameters
+  std::size_t components_{0};  // *not* including type parameters
   const Component *component_{nullptr};  // array
-  int typeBoundProcedures_{0};
+  std::size_t typeBoundProcedures_{0};
   const TypeBoundProcedure *typeBoundProcedure_{nullptr};  // array
-  int definedAssignments_{0};
+  std::size_t definedAssignments_{0};
   const DefinedAssignment *definedAssignment_{nullptr};  // array
   std::uint64_t flags_{0};
   std::size_t bytes_{0};

--- a/runtime/derived-type.h
+++ b/runtime/derived-type.h
@@ -117,12 +117,6 @@ struct TypeBoundProcedure {
   ExecutableCode code;
 };
 
-struct DefinedAssignment {
-  int destinationRank, sourceRank;
-  bool isElemental;
-  ExecutableCode code;
-};
-
 // Represents a specialization of a derived type; i.e., any KIND type
 // parameters have values set at compilation time.
 // Extended derived types have the EXTENDS flag set and place their base
@@ -132,12 +126,10 @@ class DerivedType {
 public:
   DerivedType(const char *n, std::size_t kps, std::size_t lps,
       const TypeParameter *tp, std::size_t cs, const Component *ca,
-      std::size_t tbps, const TypeBoundProcedure *tbp, std::size_t das,
-      const DefinedAssignment *da, std::size_t sz)
+      std::size_t tbps, const TypeBoundProcedure *tbp, std::size_t sz)
     : name_{n}, kindParameters_{kps}, lenParameters_{lps}, typeParameter_{tp},
       components_{cs}, component_{ca}, typeBoundProcedures_{tbps},
-      typeBoundProcedure_{tbp}, definedAssignments_{das},
-      definedAssignment_{da}, bytes_{sz} {
+      typeBoundProcedure_{tbp}, bytes_{sz} {
     if (IsNontrivialAnalysis()) {
       flags_ |= NONTRIVIAL;
     }
@@ -197,8 +189,6 @@ private:
   const Component *component_{nullptr};  // array
   std::size_t typeBoundProcedures_{0};
   const TypeBoundProcedure *typeBoundProcedure_{nullptr};  // array
-  std::size_t definedAssignments_{0};
-  const DefinedAssignment *definedAssignment_{nullptr};  // array
   std::uint64_t flags_{0};
   std::size_t bytes_{0};
 };

--- a/runtime/derived-type.h
+++ b/runtime/derived-type.h
@@ -1,0 +1,200 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_RUNTIME_DERIVED_TYPE_H_
+#define FORTRAN_RUNTIME_DERIVED_TYPE_H_
+
+#include "type-code.h"
+#include "../include/flang/ISO_Fortran_binding.h"
+#include <cinttypes>
+#include <cstddef>
+
+namespace Fortran::runtime {
+
+class Descriptor;
+
+// Static type information about derived type specializations,
+// suitable for residence in read-only storage.
+
+using TypeParameterValue = ISO::CFI_index_t;
+
+class TypeParameter {
+public:
+  const char *name() const { return name_; }
+  const TypeCode typeCode() const { return typeCode_; }
+
+  bool IsLenTypeParameter() const { return which_ < 0; }
+
+  // Returns the static value of a KIND type parameter, or the default
+  // value of a LEN type parameter.
+  TypeParameterValue StaticValue() const { return value_; }
+
+  // Returns the static value of a KIND type parameter, or an
+  // instantiated value of LEN type parameter.
+  TypeParameterValue GetValue(const Descriptor &) const;
+
+private:
+  const char *name_;
+  TypeCode typeCode_;  // INTEGER, but not necessarily default kind
+  int which_{-1};  // index into DescriptorAddendum LEN type parameter values
+  TypeParameterValue value_;  // default in the case of LEN type parameter
+};
+
+// Components that have any need for a descriptor will either reference
+// a static descriptor that applies to all instances, or will *be* a
+// descriptor.  Be advised: the base addresses in static descriptors
+// are null.  Most runtime interfaces separate the data address from that
+// of the descriptor, and ignore the encapsulated base address in the
+// descriptor.  Some interfaces, e.g. calls to interoperable procedures,
+// cannot pass a separate data address, and any static descriptor being used
+// in that kind of situation must be copied and customized.
+// Static descriptors are flagged in their attributes.
+class Component {
+public:
+  const char *name() const { return name_; }
+  TypeCode typeCode() const { return typeCode_; }
+  const Descriptor *staticDescriptor() const { return staticDescriptor_; }
+
+  bool IsParent() const { return (flags_ & PARENT) != 0; }
+  bool IsPrivate() const { return (flags_ & PRIVATE) != 0; }
+  bool IsDescriptor() const { return (flags_ & IS_DESCRIPTOR) != 0; }
+
+  template<typename A> A *Locate(char *dtInstance) const {
+    return reinterpret_cast<A *>(dtInstance + offset_);
+  }
+  template<typename A> const A *Locate(const char *dtInstance) const {
+    return reinterpret_cast<const A *>(dtInstance + offset_);
+  }
+
+  const Descriptor *GetDescriptor(const char *dtInstance) const {
+    if (staticDescriptor_ != nullptr) {
+      return staticDescriptor_;
+    } else if (IsDescriptor()) {
+      return Locate<const Descriptor>(dtInstance);
+    } else {
+      return nullptr;
+    }
+  }
+
+private:
+  enum Flag { PARENT = 1, PRIVATE = 2, IS_DESCRIPTOR = 4 };
+  const char *name_{nullptr};
+  std::uint32_t flags_{0};
+  TypeCode typeCode_{CFI_type_other};
+  const Descriptor *staticDescriptor_{nullptr};
+  std::size_t offset_{0};  // byte offset in derived type instance
+};
+
+struct ExecutableCode {
+  ExecutableCode() {}
+  ExecutableCode(const ExecutableCode &) = default;
+  ExecutableCode &operator=(const ExecutableCode &) = default;
+  std::intptr_t host{0};
+  std::intptr_t device{0};
+};
+
+struct TypeBoundProcedure {
+  const char *name;
+  ExecutableCode code;
+};
+
+struct DefinedAssignment {
+  int destinationRank, sourceRank;
+  bool isElemental;
+  ExecutableCode code;
+};
+
+// Represents a specialization of a derived type; i.e., any KIND type
+// parameters have values set at compilation time.
+// Extended derived types have the EXTENDS flag set and place their base
+// component first in the component descriptions, which is significant for
+// the execution of FINAL subroutines.
+class DerivedType {
+public:
+  DerivedType(const char *n, int kps, int lps, const TypeParameter *tp, int cs,
+      const Component *ca, int tbps, const TypeBoundProcedure *tbp, int das,
+      const DefinedAssignment *da, std::size_t sz)
+    : name_{n}, kindParameters_{kps}, lenParameters_{lps}, typeParameter_{tp},
+      components_{cs}, component_{ca}, typeBoundProcedures_{tbps},
+      typeBoundProcedure_{tbp}, definedAssignments_{das},
+      definedAssignment_{da}, bytes_{sz} {
+    if (IsNontrivialAnalysis()) {
+      flags_ |= NONTRIVIAL;
+    }
+  }
+
+  const char *name() const { return name_; }
+  int kindParameters() const { return kindParameters_; }
+  int lenParameters() const { return lenParameters_; }
+
+  // KIND type parameters come first.
+  const TypeParameter &typeParameter(int n) const { return typeParameter_[n]; }
+
+  int components() const { return components_; }
+
+  // TBP 0 is the initializer: SUBROUTINE INIT(INSTANCE)
+  static constexpr int initializerTBP{0};
+
+  // TBP 1 is the sourced allocation copier: SUBROUTINE COPYINIT(TO, FROM)
+  static constexpr int copierTBP{1};
+
+  // TBP 2 is the FINAL subroutine.
+  static constexpr int finalTBP{2};
+
+  int typeBoundProcedures() const { return typeBoundProcedures_; }
+  const TypeBoundProcedure &typeBoundProcedure(int n) const {
+    return typeBoundProcedure_[n];
+  }
+
+  DerivedType &set_sequence() {
+    flags_ |= SEQUENCE;
+    return *this;
+  }
+  DerivedType &set_bind_c() {
+    flags_ |= BIND_C;
+    return *this;
+  }
+
+  std::size_t SizeInBytes() const { return bytes_; }
+  bool Extends() const { return components_ > 0 && component_[0].IsParent(); }
+  bool AnyPrivate() const;
+  bool IsSequence() const { return (flags_ & SEQUENCE) != 0; }
+  bool IsBindC() const { return (flags_ & BIND_C) != 0; }
+  bool IsNontrivial() const { return (flags_ & NONTRIVIAL) != 0; }
+
+  bool IsSameType(const DerivedType &) const;
+
+private:
+  enum Flag { SEQUENCE = 1, BIND_C = 2, NONTRIVIAL = 4 };
+
+  // True when any descriptor of data of this derived type will require
+  // an addendum pointing to a DerivedType, possibly with values of
+  // LEN type parameters.  Conservative.
+  bool IsNontrivialAnalysis() const;
+
+  const char *name_{""};  // NUL-terminated constant text
+  int kindParameters_{0};
+  int lenParameters_{0};
+  const TypeParameter *typeParameter_{nullptr};  // array
+  int components_{0};  // *not* including type parameters
+  const Component *component_{nullptr};  // array
+  int typeBoundProcedures_{0};
+  const TypeBoundProcedure *typeBoundProcedure_{nullptr};  // array
+  int definedAssignments_{0};
+  const DefinedAssignment *definedAssignment_{nullptr};  // array
+  std::uint64_t flags_{0};
+  std::size_t bytes_{0};
+};
+}  // namespace Fortran::runtime
+#endif  // FORTRAN_RUNTIME_DERIVED_TYPE_H_

--- a/runtime/descriptor.cc
+++ b/runtime/descriptor.cc
@@ -26,14 +26,14 @@ int Descriptor::Establish(TypeCode t, std::size_t elementBytes, void *p,
       &raw_, p, CFI_attribute_other, t.raw(), elementBytes, rank, extent);
 }
 
-int Descriptor::Establish(TypeCode::Form f, int kind, void *p, int rank,
-    const SubscriptValue *extent) {
+int Descriptor::Establish(
+    TypeCategory c, int kind, void *p, int rank, const SubscriptValue *extent) {
   std::size_t elementBytes = kind;
-  if (f == TypeCode::Form::Complex) {
+  if (c == TypeCategory::Complex) {
     elementBytes *= 2;
   }
   return ISO::CFI_establish(&raw_, p, CFI_attribute_other,
-      TypeCode(f, kind).raw(), elementBytes, rank, extent);
+      TypeCode(c, kind).raw(), elementBytes, rank, extent);
 }
 
 int Descriptor::Establish(
@@ -53,11 +53,11 @@ Descriptor *Descriptor::Create(TypeCode t, std::size_t elementBytes, void *p,
   return result;
 }
 
-Descriptor *Descriptor::Create(TypeCode::Form f, int kind, void *p, int rank,
-    const SubscriptValue *extent) {
+Descriptor *Descriptor::Create(
+    TypeCategory c, int kind, void *p, int rank, const SubscriptValue *extent) {
   std::size_t bytes{SizeInBytes(rank)};
   Descriptor *result{reinterpret_cast<Descriptor *>(new char[bytes])};
-  result->Establish(f, kind, p, rank, extent);
+  result->Establish(c, kind, p, rank, extent);
   result->Attributes() |= CREATED;
   return result;
 }

--- a/runtime/descriptor.cc
+++ b/runtime/descriptor.cc
@@ -15,36 +15,173 @@
 // TODO: Not complete; exists to check compilability of descriptor.h
 
 #include "descriptor.h"
+#include <cstdlib>
 
 namespace Fortran::runtime {
 
-Descriptor::Descriptor(const DerivedTypeSpecialization &dts, int rank) {
-  raw_.base_addr = nullptr;
-  raw_.elem_len = dts.SizeInBytes();
-  raw_.version = CFI_VERSION;
-  raw_.rank = rank;
-  raw_.type = CFI_type_struct;
-  raw_.attribute = ADDENDUM;
-  Addendum()->set_derivedTypeSpecialization(&dts);
+TypeCode::TypeCode(TypeCode::Form f, int kind) {
+  switch (f) {
+  case Form::Integer:
+    switch (kind) {
+    case 1: raw_ = CFI_type_int8_t; break;
+    case 2: raw_ = CFI_type_int16_t; break;
+    case 4: raw_ = CFI_type_int32_t; break;
+    case 8: raw_ = CFI_type_int64_t; break;
+    case 16: raw_ = CFI_type_int128_t; break;
+    }
+    break;
+  case Form::Real:
+    switch (kind) {
+    case 4: raw_ = CFI_type_float; break;
+    case 8: raw_ = CFI_type_double; break;
+    case 10:
+    case 16: raw_ = CFI_type_long_double; break;
+    }
+    break;
+  case Form::Complex:
+    switch (kind) {
+    case 4: raw_ = CFI_type_float_Complex; break;
+    case 8: raw_ = CFI_type_double_Complex; break;
+    case 10:
+    case 16: raw_ = CFI_type_long_double_Complex; break;
+    }
+    break;
+  case Form::Character:
+    if (kind == 1) {
+      raw_ = CFI_type_cptr;
+    }
+    break;
+  case Form::Logical:
+    switch (kind) {
+    case 1: raw_ = CFI_type_Bool; break;
+    case 2: raw_ = CFI_type_int16_t; break;
+    case 4: raw_ = CFI_type_int32_t; break;
+    case 8: raw_ = CFI_type_int64_t; break;
+    }
+    break;
+  case Form::Derived: raw_ = CFI_type_struct; break;
+  }
 }
 
-std::size_t Descriptor::SizeInBytes() const {
+std::size_t DescriptorAddendum::SizeInBytes() const {
+  return SizeInBytes(derivedTypeSpecialization_->derivedType().lenParameters());
+}
+
+void DescriptorView::SetDerivedTypeSpecialization(
+    const DerivedTypeSpecialization &dts) {
+  raw_.attribute |= ADDENDUM;
+  Addendum()->set_derivedTypeSpecialization(dts);
+}
+
+void DescriptorView::SetLenParameterValue(int which, TypeParameterValue x) {
+  raw_.attribute |= ADDENDUM;
+  Addendum()->SetLenParameterValue(which, x);
+}
+
+std::size_t DescriptorView::SizeInBytes() const {
   const DescriptorAddendum *addendum{Addendum()};
-  return sizeof *this + raw_.rank * sizeof(Dimension) +
-      (addendum ? addendum->SizeOfAddendumInBytes() : 0);
+  return sizeof *this - sizeof(Dimension) + raw_.rank * sizeof(Dimension) +
+      (addendum ? addendum->SizeInBytes() : 0);
 }
 
-std::int64_t TypeParameter::KindParameterValue(
+int DescriptorView::Establish(TypeCode t, std::size_t elementBytes, void *p,
+    int rank, const SubscriptValue *extent) {
+  return CFI_establish(
+      &raw_, p, CFI_attribute_other, t.raw(), elementBytes, rank, extent);
+}
+
+int DescriptorView::Establish(TypeCode::Form f, int kind, void *p, int rank,
+    const SubscriptValue *extent) {
+  std::size_t elementBytes = kind;
+  if (f == TypeCode::Form::Complex) {
+    elementBytes *= 2;
+  }
+  return ISO::CFI_establish(&raw_, p, CFI_attribute_other,
+      TypeCode(f, kind).raw(), elementBytes, rank, extent);
+}
+
+int DescriptorView::Establish(const DerivedTypeSpecialization &dts, void *p,
+    int rank, const SubscriptValue *extent) {
+  int result{ISO::CFI_establish(
+      &raw_, p, ADDENDUM, CFI_type_struct, dts.SizeInBytes(), rank, extent)};
+  if (result == CFI_SUCCESS) {
+    Addendum()->set_derivedTypeSpecialization(dts);
+  }
+  return result;
+}
+
+TypeParameterValue TypeParameter::KindParameterValue(
     const DerivedTypeSpecialization &specialization) const {
   return specialization.KindParameterValue(which_);
 }
 
-std::int64_t TypeParameter::Value(const Descriptor &descriptor) const {
+TypeParameterValue TypeParameter::Value(
+    const DescriptorView &descriptor) const {
   const DescriptorAddendum &addendum{*descriptor.Addendum()};
   if (isLenTypeParameter_) {
     return addendum.LenParameterValue(which_);
   } else {
     return KindParameterValue(*addendum.derivedTypeSpecialization());
   }
+}
+
+bool DerivedType::IsNonTrivial() const {
+  if (kindParameters_ > 0 || lenParameters_ > 0 || typeBoundProcedures_ > 0 ||
+      definedAssignments_ > 0 || finalSubroutine_.host != 0) {
+    return true;
+  }
+  for (int j{0}; j < components_; ++j) {
+    if (component_[j].IsDescriptor()) {
+      return true;
+    }
+    if (const DescriptorView *
+        staticDescriptor{component_[j].staticDescriptor()}) {
+      if (const DescriptorAddendum * addendum{staticDescriptor->Addendum()}) {
+        if (const DerivedTypeSpecialization *
+            dts{addendum->derivedTypeSpecialization()}) {
+          if (dts->derivedType().IsNonTrivial()) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
+Object::~Object() {
+  if (p_ != nullptr) {
+    // TODO final procedure calls and component destruction
+    delete reinterpret_cast<char *>(p_);
+    p_ = nullptr;
+  }
+}
+
+bool Object::Create(
+    TypeCode::Form f, int kind, int rank, const SubscriptValue *extent) {
+  if (f == TypeCode::Form::Character || f == TypeCode::Form::Derived) {
+    // TODO support these...
+    return false;
+  }
+  std::size_t descriptorBytes{DescriptorView::SizeInBytes(rank)};
+  std::size_t elementBytes = kind;
+  if (f == TypeCode::Form::Complex) {
+    elementBytes *= 2;
+  }
+  std::size_t elements{1};
+  for (int j{0}; j < rank; ++j) {
+    if (extent[j] < 0) {
+      return false;
+    }
+    elements *= static_cast<std::size_t>(extent[j]);
+  }
+  std::size_t totalBytes{descriptorBytes + elements * elementBytes};
+  char *p{reinterpret_cast<char *>(std::malloc(totalBytes))};
+  if (p == nullptr) {
+    return false;
+  }
+  p_ = reinterpret_cast<DescriptorView *>(p);
+  p_->Establish(f, kind, p + descriptorBytes, rank, extent);
+  return true;
 }
 }  // namespace Fortran::runtime

--- a/runtime/descriptor.cc
+++ b/runtime/descriptor.cc
@@ -31,8 +31,10 @@ void Descriptor::Establish(TypeCode t, std::size_t elementBytes, void *p,
   CHECK(ISO::CFI_establish(&raw_, p, attribute, t.raw(), elementBytes, rank,
             extent) == CFI_SUCCESS);
   raw_.f18Addendum = addendum;
-  if (addendum) {
-    new (Addendum()) DescriptorAddendum{};
+  DescriptorAddendum *a{Addendum()};
+  CHECK(addendum == (a != nullptr));
+  if (a) {
+    new (a) DescriptorAddendum{};
   }
 }
 
@@ -46,8 +48,10 @@ void Descriptor::Establish(TypeCategory c, int kind, void *p, int rank,
   CHECK(ISO::CFI_establish(&raw_, p, attribute, TypeCode(c, kind).raw(),
             elementBytes, rank, extent) == CFI_SUCCESS);
   raw_.f18Addendum = addendum;
-  if (addendum) {
-    new (Addendum()) DescriptorAddendum{};
+  DescriptorAddendum *a{Addendum()};
+  CHECK(addendum == (a != nullptr));
+  if (a) {
+    new (a) DescriptorAddendum{};
   }
 }
 
@@ -56,7 +60,9 @@ void Descriptor::Establish(const DerivedType &dt, void *p, int rank,
   CHECK(ISO::CFI_establish(&raw_, p, attribute, CFI_type_struct,
             dt.SizeInBytes(), rank, extent) == CFI_SUCCESS);
   raw_.f18Addendum = true;
-  new (Addendum()) DescriptorAddendum{&dt};
+  DescriptorAddendum *a{Addendum()};
+  CHECK(a != nullptr);
+  new (a) DescriptorAddendum{&dt};
 }
 
 std::unique_ptr<Descriptor> Descriptor::Create(TypeCode t,

--- a/runtime/descriptor.h
+++ b/runtime/descriptor.h
@@ -108,15 +108,15 @@ public:
 
   int Establish(TypeCode t, std::size_t elementBytes, void *p = nullptr,
       int rank = maxRank, const SubscriptValue *extent = nullptr);
-  int Establish(TypeCode::Form f, int kind, void *p = nullptr,
-      int rank = maxRank, const SubscriptValue *extent = nullptr);
+  int Establish(TypeCategory, int kind, void *p = nullptr, int rank = maxRank,
+      const SubscriptValue *extent = nullptr);
   int Establish(const DerivedType &dt, void *p = nullptr, int rank = maxRank,
       const SubscriptValue *extent = nullptr);
 
   static Descriptor *Create(TypeCode t, std::size_t elementBytes,
       void *p = nullptr, int rank = maxRank,
       const SubscriptValue *extent = nullptr);
-  static Descriptor *Create(TypeCode::Form f, int kind, void *p = nullptr,
+  static Descriptor *Create(TypeCategory, int kind, void *p = nullptr,
       int rank = maxRank, const SubscriptValue *extent = nullptr);
   static Descriptor *Create(const DerivedType &dt, void *p = nullptr,
       int rank = maxRank, const SubscriptValue *extent = nullptr);

--- a/runtime/descriptor.h
+++ b/runtime/descriptor.h
@@ -264,7 +264,7 @@ private:
 };
 static_assert(sizeof(DescriptorView) == sizeof(ISO::CFI_cdesc_t));
 
-// Static type information is suitable for loading in a read-only section.
+// Static type information is suitable for residence in a read-only section.
 // Information about intrinsic types is inferable from raw CFI_type_t
 // type codes (packaged as TypeCode above).
 // Information about derived types and their KIND parameter specializations
@@ -464,6 +464,11 @@ struct ProcedurePointer {
 };
 
 // TODO: coarray hooks
+
+
+// TODO: Change mind on this class template.  Restore DescriptorView -> Descriptor,
+// its constructors, and add a factory static member function and a destructor
+// that cleans up a non-pointer.
 
 template<int MAX_RANK = CFI_MAX_RANK,
     bool NONTRIVIAL_DERIVED_TYPE_ALLOWED = false, int MAX_LEN_PARMS = 0>

--- a/runtime/descriptor.h
+++ b/runtime/descriptor.h
@@ -24,71 +24,22 @@
 // User C code is welcome to depend on that ISO_Fortran_binding.h file,
 // but should never reference this internal header.
 
+#include "derived-type.h"
+#include "type-code.h"
 #include "../include/flang/ISO_Fortran_binding.h"
+#include <cassert>
 #include <cinttypes>
 #include <cstddef>
+#include <cstring>
 
 namespace Fortran::runtime {
 
-class DerivedTypeSpecialization;
-
-using TypeParameterValue = ISO::CFI_index_t;
 using SubscriptValue = ISO::CFI_index_t;
+
+static constexpr int maxRank{CFI_MAX_RANK};
 
 // A C++ view of the sole interoperable standard descriptor (ISO_cdesc_t)
 // and its type and per-dimension information.
-
-class TypeCode {
-public:
-  enum class Form { Integer, Real, Complex, Character, Logical, Derived };
-
-  TypeCode() {}
-  explicit TypeCode(ISO::CFI_type_t t) : raw_{t} {}
-  TypeCode(Form, int);
-
-  int raw() const { return raw_; }
-
-  constexpr bool IsValid() const {
-    return raw_ >= CFI_type_signed_char && raw_ <= CFI_type_struct;
-  }
-  constexpr bool IsInteger() const {
-    return raw_ >= CFI_type_signed_char && raw_ <= CFI_type_ptrdiff_t;
-  }
-  constexpr bool IsReal() const {
-    return raw_ >= CFI_type_float && raw_ <= CFI_type_long_double;
-  }
-  constexpr bool IsComplex() const {
-    return raw_ >= CFI_type_float_Complex &&
-        raw_ <= CFI_type_long_double_Complex;
-  }
-  constexpr bool IsCharacter() const { return raw_ == CFI_type_cptr; }
-  constexpr bool IsLogical() const { return raw_ == CFI_type_Bool; }
-  constexpr bool IsDerived() const { return raw_ == CFI_type_struct; }
-
-  constexpr bool IsIntrinsic() const { return IsValid() && !IsDerived(); }
-
-  constexpr Form GetForm() const {
-    if (IsInteger()) {
-      return Form::Integer;
-    }
-    if (IsReal()) {
-      return Form::Real;
-    }
-    if (IsComplex()) {
-      return Form::Complex;
-    }
-    if (IsCharacter()) {
-      return Form::Character;
-    }
-    if (IsLogical()) {
-      return Form::Logical;
-    }
-    return Form::Derived;
-  }
-
-private:
-  ISO::CFI_type_t raw_{CFI_type_other};
-};
 
 class Dimension {
 public:
@@ -100,29 +51,22 @@ public:
 private:
   ISO::CFI_dim_t raw_;
 };
-static_assert(sizeof(Dimension) == sizeof(ISO::CFI_dim_t));
 
 // The storage for this object follows the last used dim[] entry in a
-// Descriptor (CFI_cdesc_t) generic descriptor; this is why that class
-// cannot be defined as a derivation or encapsulation of the standard
-// argument descriptor.  Space matters here, since dynamic descriptors
-// can serve as components of derived type instances.  The presence of
-// this structure is implied by (CFI_cdesc_t.attribute & ADDENDUM) != 0,
-// and the number of elements in the len_[] array is determined by
-// DerivedType::lenParameters().
+// Descriptor (CFI_cdesc_t) generic descriptor.  Space matters here, since
+// descriptors serve as POINTER and ALLOCATABLE components of derived type
+// instances.  The presence of this structure is implied by the flag
+// (CFI_cdesc_t.attribute & ADDENDUM) != 0, and the number of elements in
+// the len_[] array is determined by DerivedType::lenParameters().
 class DescriptorAddendum {
 public:
-  explicit DescriptorAddendum(const DerivedTypeSpecialization &dts)
-    : derivedTypeSpecialization_{&dts} {}
+  explicit DescriptorAddendum(const DerivedType &dt) : derivedType_{&dt} {}
 
-  DescriptorAddendum &set_derivedTypeSpecialization(
-      const DerivedTypeSpecialization &dts) {
-    derivedTypeSpecialization_ = &dts;
+  const DerivedType *derivedType() const { return derivedType_; }
+
+  DescriptorAddendum &set_derivedType(const DerivedType &dt) {
+    derivedType_ = &dt;
     return *this;
-  }
-
-  const DerivedTypeSpecialization *derivedTypeSpecialization() const {
-    return derivedTypeSpecialization_;
   }
 
   TypeParameterValue LenParameterValue(int which) const { return len_[which]; }
@@ -137,7 +81,7 @@ public:
   }
 
 private:
-  const DerivedTypeSpecialization *derivedTypeSpecialization_{nullptr};
+  const DerivedType *derivedType_{nullptr};
   TypeParameterValue len_[1];  // must be the last component
   // The LEN type parameter values can also include captured values of
   // specification expressions that were used for bounds and for LEN type
@@ -148,21 +92,37 @@ private:
 // A C++ view of a standard descriptor object.
 class Descriptor {
 public:
-  Descriptor(TypeCode t, std::size_t elementBytes, void *p = nullptr,
-      int rank = CFI_MAX_RANK, const SubscriptValue *extent = nullptr);
-  Descriptor(TypeCode::Form f, int kind, void *p = nullptr,
-      int rank = CFI_MAX_RANK, const SubscriptValue *extent = nullptr);
-  Descriptor(const DerivedTypeSpecialization &dts, void *p = nullptr,
-      int rank = CFI_MAX_RANK, const SubscriptValue *extent = nullptr);
+  // Be advised: this class type is not suitable for use when allocating
+  // a descriptor -- it is a dynamic view of the common descriptor format.
+  // If used in a simple declaration of a local variable or dynamic allocation,
+  // the size is going to be wrong, since the true size of a descriptor
+  // depends on the number of its dimensions and the presence of an addendum
+  // with derived type information.  Use the class template StaticDescriptor
+  // (below) to declare a descriptor with type and rank that are known at
+  // compilation time.  Use the Create() static member functions to
+  // dynamically allocate a descriptor when the type or rank are not known
+  // at compilation time.
+  Descriptor() = delete;
+
+  ~Descriptor();
+
+  int Establish(TypeCode t, std::size_t elementBytes, void *p = nullptr,
+      int rank = maxRank, const SubscriptValue *extent = nullptr);
+  int Establish(TypeCode::Form f, int kind, void *p = nullptr,
+      int rank = maxRank, const SubscriptValue *extent = nullptr);
+  int Establish(const DerivedType &dt, void *p = nullptr, int rank = maxRank,
+      const SubscriptValue *extent = nullptr);
 
   static Descriptor *Create(TypeCode t, std::size_t elementBytes,
-      void *p = nullptr, int rank = CFI_MAX_RANK,
+      void *p = nullptr, int rank = maxRank,
       const SubscriptValue *extent = nullptr);
   static Descriptor *Create(TypeCode::Form f, int kind, void *p = nullptr,
-      int rank = CFI_MAX_RANK, const SubscriptValue *extent = nullptr);
-  static Descriptor *Create(const DerivedTypeSpecialization &dts,
-      void *p = nullptr, int rank = CFI_MAX_RANK,
-      const SubscriptValue *extent = nullptr);
+      int rank = maxRank, const SubscriptValue *extent = nullptr);
+  static Descriptor *Create(const DerivedType &dt, void *p = nullptr,
+      int rank = maxRank, const SubscriptValue *extent = nullptr);
+
+  // Descriptor instances allocated via Create() above must be deallocated
+  // by calling Destroy() so that operator delete[] is invoked.
   void Destroy();
 
   ISO::CFI_cdesc_t &raw() { return raw_; }
@@ -176,26 +136,24 @@ public:
     return *this;
   }
 
-  bool IsPointer() const {
-    return (raw_.attribute & CFI_attribute_pointer) != 0;
-  }
+  bool IsPointer() const { return (Attributes() & CFI_attribute_pointer) != 0; }
   bool IsAllocatable() const {
-    return (raw_.attribute & CFI_attribute_allocatable) != 0;
+    return (Attributes() & CFI_attribute_allocatable) != 0;
   }
   bool IsImplicitlyAllocated() const {
-    return (raw_.attribute & IMPLICITLY_ALLOCATED) != 0;
+    return (Attributes() & IMPLICITLY_ALLOCATED) != 0;
   }
   bool IsDescriptorStatic() const {
-    return (raw_.attribute & STATIC_DESCRIPTOR) != 0;
+    return (Attributes() & STATIC_DESCRIPTOR) != 0;
   }
   bool IsTarget() const {
-    return (raw_.attribute & (CFI_attribute_pointer | TARGET)) != 0;
+    return (Attributes() & (CFI_attribute_pointer | TARGET)) != 0;
   }
-  bool IsContiguous() const { return (raw_.attribute & CONTIGUOUS) != 0; }
+  bool IsContiguous() const { return (Attributes() & CONTIGUOUS) != 0; }
   bool IsColumnContiguous() const {
-    return (raw_.attribute & COLUMN_CONTIGUOUS) != 0;
+    return (Attributes() & COLUMN_CONTIGUOUS) != 0;
   }
-  bool IsTemporary() const { return (raw_.attribute & TEMPORARY) != 0; }
+  bool IsTemporary() const { return (Attributes() & TEMPORARY) != 0; }
 
   Dimension &GetDimension(int dim) {
     return *reinterpret_cast<Dimension *>(&raw_.dim[dim]);
@@ -211,14 +169,14 @@ public:
   }
 
   DescriptorAddendum *Addendum() {
-    if ((raw_.attribute & ADDENDUM) != 0) {
+    if ((Attributes() & ADDENDUM) != 0) {
       return reinterpret_cast<DescriptorAddendum *>(&GetDimension(rank()));
     } else {
       return nullptr;
     }
   }
   const DescriptorAddendum *Addendum() const {
-    if ((raw_.attribute & ADDENDUM) != 0) {
+    if ((Attributes() & ADDENDUM) != 0) {
       return reinterpret_cast<const DescriptorAddendum *>(
           &GetDimension(rank()));
     } else {
@@ -226,7 +184,7 @@ public:
     }
   }
 
-  void SetDerivedTypeSpecialization(const DerivedTypeSpecialization &);
+  void SetDerivedType(const DerivedType &);
 
   void SetLenParameterValue(int, TypeParameterValue);
 
@@ -243,7 +201,7 @@ public:
 
   void Check() const;
 
-  // TODO: creation of sections
+  // TODO: creation of array sections
 
   template<typename A> A &Element(std::size_t offset = 0) const {
     auto p = reinterpret_cast<char *>(raw_.base_addr);
@@ -253,254 +211,69 @@ public:
 private:
   // These values must coexist with the ISO_Fortran_binding.h definitions
   // for CFI_attribute_... values and fit in the "attribute" field of
-  // CFI_cdesc_t.
+  // CFI_cdesc_t, which is 16 bits wide.
   enum AdditionalAttributes {
     // non-pointer nonallocatable derived type component implemented as
     // an implicit allocatable due to dependence on LEN type parameters
-    IMPLICITLY_ALLOCATED = 0x100,  // bounds depend on LEN type parameter
-    ADDENDUM = 0x200,  // last dim[] entry is followed by DescriptorAddendum
-    STATIC_DESCRIPTOR = 0x400,  // base_addr is null, get base address elsewhere
-    TARGET = 0x800,  // TARGET attribute; also implied by CFI_attribute_pointer
-    CONTIGUOUS = 0x1000,
-    COLUMN_CONTIGUOUS = 0x2000,  // first dimension is contiguous
-    TEMPORARY = 0x4000,  // compiler temp, do not finalize
+    IMPLICITLY_ALLOCATED = 0x8,  // bounds depend on LEN type parameter
+    ADDENDUM = 0x10,  // last dim[] entry is followed by DescriptorAddendum
+    STATIC_DESCRIPTOR = 0x20,  // base_addr is null, get base address elsewhere
+    TARGET = 0x40,  // TARGET attribute; also implied by CFI_attribute_pointer
+    CONTIGUOUS = 0x80,
+    COLUMN_CONTIGUOUS = 0x100,  // first dimension is contiguous
+    TEMPORARY = 0x200,  // compiler temp, do not finalize
+    CREATED = 0x400,  // was allocated by Descriptor::Create()
   };
+
+  ISO::CFI_attribute_t &Attributes() { return raw_.attribute; }
+  const ISO::CFI_attribute_t &Attributes() const { return raw_.attribute; }
 
   ISO::CFI_cdesc_t raw_;
 };
 static_assert(sizeof(Descriptor) == sizeof(ISO::CFI_cdesc_t));
 
-// Static type information is suitable for residence in a read-only section.
-// Information about intrinsic types is inferable from raw CFI_type_t
-// type codes (packaged as TypeCode above).
-// Information about derived types and their KIND parameter specializations
-// appears in the compiled program units that define or specialize the types.
-
-class TypeParameter {
-public:
-  const char *name() const { return name_; }
-  const TypeCode typeCode() const { return typeCode_; }
-  bool isLenTypeParameter() const { return isLenTypeParameter_; }
-  int which() const { return which_; }
-  TypeParameterValue defaultValue() const { return defaultValue_; }
-
-  TypeParameterValue KindParameterValue(
-      const DerivedTypeSpecialization &) const;
-  TypeParameterValue Value(const Descriptor &) const;
-
-private:
-  const char *name_;
-  TypeCode typeCode_;  // INTEGER, but not necessarily default kind
-  bool isLenTypeParameter_;  // whether value is in dynamic descriptor
-  int which_;  // index of this parameter in kind/len array
-  TypeParameterValue defaultValue_;
-};
-
-// Components that have any need for a descriptor will either reference
-// a static descriptor that applies to all instances, or will *be* a
-// descriptor.  Be advised: the base addresses in static descriptors
-// are null.  Most runtime interfaces separate the data address from that
-// of the descriptor, and ignore the encapsulated base address in the
-// descriptor.  Some interfaces, e.g. calls to interoperable procedures,
-// cannot pass a separate data address, and any static descriptor being used
-// in that kind of situation must be copied and customized.
-// Static descriptors are flagged in their attributes.
-class Component {
-public:
-  const char *name() const { return name_; }
-  TypeCode typeCode() const { return typeCode_; }
-  const Descriptor *staticDescriptor() const { return staticDescriptor_; }
-  bool IsParent() const { return (flags_ & PARENT) != 0; }
-  bool IsPrivate() const { return (flags_ & PRIVATE) != 0; }
-  bool IsDescriptor() const { return (flags_ & IS_DESCRIPTOR) != 0; }
-
-private:
-  enum Flag { PARENT = 1, PRIVATE = 2, IS_DESCRIPTOR = 4 };
-  const char *name_{nullptr};
-  std::uint32_t flags_{0};
-  TypeCode typeCode_{CFI_type_other};
-  const Descriptor *staticDescriptor_{nullptr};
-};
-
-struct ExecutableCode {
-  ExecutableCode() {}
-  ExecutableCode(const ExecutableCode &) = default;
-  ExecutableCode &operator=(const ExecutableCode &) = default;
-  std::intptr_t host{0};
-  std::intptr_t device{0};
-};
-
-struct TypeBoundProcedure {
-  const char *name;
-  ExecutableCode code;
-};
-
-struct DefinedAssignment {
-  int destinationRank, sourceRank;
-  bool isElemental;
-  ExecutableCode code;
-};
-
-// This static description of a derived type is not specialized by
-// the values of kind type parameters.  All specializations share
-// this information.
-// Extended derived types have the EXTENDS flag set and place their base
-// component first in the component descriptions, which is significant for
-// the execution of FINAL subroutines.
-class DerivedType {
-public:
-  DerivedType(const char *n, int kps, int lps, const TypeParameter *tp, int cs,
-      const Component *ca, int tbps, const TypeBoundProcedure *tbp, int das,
-      const DefinedAssignment *da)
-    : name_{n}, kindParameters_{kps}, lenParameters_{lps}, components_{cs},
-      typeParameter_{tp}, typeBoundProcedures_{tbps}, typeBoundProcedure_{tbp},
-      definedAssignments_{das}, definedAssignment_{da} {
-    if (IsNontrivialAnalysis()) {
-      flags_ |= NONTRIVIAL;
-    }
-  }
-
-  const char *name() const { return name_; }
-  int kindParameters() const { return kindParameters_; }
-  int lenParameters() const { return lenParameters_; }
-  const TypeParameter &typeParameter(int n) const { return typeParameter_[n]; }
-  int components() const { return components_; }
-  int typeBoundProcedures() const { return typeBoundProcedures_; }
-  const TypeBoundProcedure &typeBoundProcedure(int n) const {
-    return typeBoundProcedure_[n];
-  }
-
-  DerivedType &set_sequence() {
-    flags_ |= SEQUENCE;
-    return *this;
-  }
-  DerivedType &set_bind_c() {
-    flags_ |= BIND_C;
-    return *this;
-  }
-  DerivedType &set_finalSubroutine(const ExecutableCode &c) {
-    finalSubroutine_ = c;
-    return *this;
-  }
-
-  bool Extends() const { return components_ > 0 && component_[0].IsParent(); }
-  bool AnyPrivate() const;
-  bool IsSequence() const { return (flags_ & SEQUENCE) != 0; }
-  bool IsBindC() const { return (flags_ & BIND_C) != 0; }
-  bool IsNontrivial() const { return (flags_ & NONTRIVIAL) != 0; }
-
-  // TODO: assignment
-  // TODO: finalization
-
-private:
-  enum Flag { SEQUENCE = 1, BIND_C = 2, NONTRIVIAL = 4 };
-
-  // True when any descriptor of data of this derived type will require
-  // an addendum pointing to a DerivedTypeSpecialization &/or values of
-  // length type parameters.  Conservative.
-  bool IsNontrivialAnalysis() const;
-
-  const char *name_{""};  // NUL-terminated constant text
-  int kindParameters_{0};
-  int lenParameters_{0};
-  int components_{0};  // *not* including type parameters
-  const TypeParameter *typeParameter_{nullptr};  // array
-  const Component *component_{nullptr};  // array
-  int typeBoundProcedures_{0};
-  const TypeBoundProcedure *typeBoundProcedure_{
-      nullptr};  // array of overridable TBP bindings
-  ExecutableCode finalSubroutine_;  // can be null
-  int definedAssignments_{0};
-  const DefinedAssignment *definedAssignment_{nullptr};  // array
-  std::uint64_t flags_{0};
-};
-
-class ComponentSpecialization {
-public:
-  template<typename A> A *Locate(char *instance) const {
-    return reinterpret_cast<A *>(instance + offset_);
-  }
-  template<typename A> const A *Locate(const char *instance) const {
-    return reinterpret_cast<const A *>(instance + offset_);
-  }
-  const Descriptor *GetDescriptor(
-      const Component &c, const char *instance) const {
-    if (const Descriptor * staticDescriptor{c.staticDescriptor()}) {
-      return staticDescriptor;
-    } else if (c.IsDescriptor()) {
-      return Locate<const Descriptor>(instance);
-    } else {
-      return nullptr;
-    }
-  }
-
-private:
-  std::size_t offset_{0};  // relative to start of derived type instance
-};
-
-// This static representation of a derived type specialization includes
-// the values of all its KIND type parameters, and reflects those values
-// in the values of array bounds and static derived type descriptors that
-// appear in the static descriptors of the components.
-class DerivedTypeSpecialization {
-public:
-  DerivedTypeSpecialization(const DerivedType &dt, std::size_t n,
-      const char *init, const TypeParameterValue *kp,
-      const ComponentSpecialization *cs)
-    : derivedType_{dt}, bytes_{n}, initializer_{init}, kindParameterValue_{kp},
-      componentSpecialization_{cs} {}
-
-  const DerivedType &derivedType() const { return derivedType_; }
-
-  std::size_t SizeInBytes() const { return bytes_; }
-  TypeParameterValue KindParameterValue(int n) const {
-    return kindParameterValue_[n];
-  }
-  const ComponentSpecialization &GetComponent(int n) const {
-    return componentSpecialization_[n];
-  }
-  bool IsSameType(const DerivedTypeSpecialization &) const;
-
-  // TODO: initialization
-  // TODO: sourced allocation initialization
-
-private:
-  const DerivedType &derivedType_;
-  std::size_t bytes_;  // allocation size of one scalar instance, w/ alignment
-  const char *initializer_;  // can be null; includes base components
-  const TypeParameterValue *kindParameterValue_;  // array
-  const ComponentSpecialization *componentSpecialization_;  // array
-};
-
-// Procedure pointers have static links for host association.
-// TODO: define the target data structure of that static link
-struct ProcedurePointer {
-  ExecutableCode entryAddresses;
-  void *staticLink;
-};
-
-template<int MAX_RANK = CFI_MAX_RANK,
-    bool NONTRIVIAL_DERIVED_TYPE_ALLOWED = false, int MAX_LEN_PARMS = 0>
+// Properly configured instances of StaticDescriptor will occupy the
+// exact amount of storage required for the descriptor based on its
+// number of dimensions and whether it requires an addendum.  To build
+// such a static descriptor, declare an instance of StaticDescriptor<>,
+// extract a reference to the Descriptor via the descriptor() accessor,
+// and then built a Descriptor therein via descriptor.Establish().
+// e.g.:
+//   StaticDescriptor<R,NT,LP> statDesc;
+//   Descriptor &descriptor{statDesc.descriptor()};
+//   descriptor.Establish( ... );
+template<int MAX_RANK = maxRank, bool NONTRIVIAL_DERIVED_TYPE_ALLOWED = false,
+    int MAX_LEN_PARMS = 0>
 class alignas(Descriptor) StaticDescriptor {
 public:
   static constexpr int maxRank{MAX_RANK};
   static constexpr int maxLengthTypeParameters{MAX_LEN_PARMS};
   static constexpr bool hasAddendum{
       NONTRIVIAL_DERIVED_TYPE_ALLOWED || MAX_LEN_PARMS > 0};
-
-  Descriptor &descriptor() { return *reinterpret_cast<Descriptor *>(this); }
-  const Descriptor &descriptor() const {
-    return *reinterpret_cast<const Descriptor *>(this);
-  }
-
-  // Usage with placement new:
-  //   StaticDescriptor<R,NT,LP> staticDescriptor;
-  //   new(staticDescriptor.storage()) Descriptor{ .... }
-  char *storage() const { return storage_; }
-
-private:
   static constexpr std::size_t byteSize{
       Descriptor::SizeInBytes(maxRank, hasAddendum, maxLengthTypeParameters)};
+
+  Descriptor &descriptor() { return *reinterpret_cast<Descriptor *>(storage_); }
+  const Descriptor &descriptor() const {
+    return *reinterpret_cast<const Descriptor *>(storage_);
+  }
+
+  void Check() {
+    assert(descriptor().SizeInBytes() <= byteSize);
+    assert(descriptor().rank() <= maxRank);
+    if (DescriptorAddendum * addendum{descriptor().Addendum()}) {
+      if (const DerivedType * dt{addendum->derivedType()}) {
+        assert(dt->lenParameters() <= maxLengthTypeParameters);
+      } else {
+        assert(maxLengthTypeParameters == 0);
+      }
+    } else {
+      assert(!hasAddendum);
+      assert(maxLengthTypeParameters == 0);
+    }
+  }
+
+private:
   char storage_[byteSize];
 };
 }  // namespace Fortran::runtime

--- a/runtime/transformational.cc
+++ b/runtime/transformational.cc
@@ -1,0 +1,150 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "descriptor.h"
+#include "../lib/common/idioms.h"
+#include "../lib/evaluate/integer.h"
+#include <algorithm>
+#include <bitset>
+#include <cinttypes>
+#include <cstdlib>
+
+namespace Fortran::runtime {
+
+template<int BITS> inline std::int64_t LoadInt64(const char *p) {
+  using Int = const evaluate::value::Integer<BITS>;
+  Int *ip{reinterpret_cast<Int *>(p)};
+  return ip->ToInt64();
+}
+
+static inline std::int64_t GetInt64(const char *p, std::size_t bytes) {
+  switch (bytes) {
+  case 1: return LoadInt64<8>(p);
+  case 2: return LoadInt64<16>(p);
+  case 4: return LoadInt64<32>(p);
+  case 8: return LoadInt64<64>(p);
+  default: CRASH_NO_CASE;
+  }
+}
+
+// F2018 16.9.163
+Descriptor *RESHAPE(const Descriptor &source, const Descriptor &shape,
+    const Descriptor *pad, const Descriptor *order) {
+  // Compute and check the rank of the result.
+  CHECK(shape.rank() == 1);
+  CHECK(shape.type().IsInteger());
+  SubscriptValue resultRank{shape.GetDimension(0).Extent()};
+  CHECK(resultRank >= 0 && resultRank <= static_cast<SubscriptValue>(maxRank));
+
+  // Extract and check the shape of the result; compute its element count.
+  SubscriptValue resultExtent[maxRank];
+  std::size_t shapeElementBytes{shape.ElementBytes()};
+  std::size_t resultElements{1};
+  SubscriptValue shapeSubscript{shape.GetDimension(0).LowerBound()};
+  for (SubscriptValue j{0}; j < resultRank; ++j, ++shapeSubscript) {
+    resultExtent[j] =
+        GetInt64(shape.Element<char>(&shapeSubscript), shapeElementBytes);
+    CHECK(resultExtent[j] >= 0);
+    resultElements *= resultExtent[j];
+  }
+
+  // Check that there are sufficient elements in the SOURCE=, or that
+  // the optional PAD= argument is present and nonempty.
+  std::size_t sourceElements{source.Elements()};
+  std::size_t padElements{pad ? pad->Elements() : 0};
+  if (resultElements < sourceElements) {
+    CHECK(padElements > 0);
+    CHECK(pad->ElementBytes() == source.ElementBytes());
+  }
+
+  // Extract and check the optional ORDER= argument, which must be a
+  // permutation of [1..resultRank].
+  int dimOrder[maxRank];
+  if (order != nullptr) {
+    CHECK(order->rank() == 1);
+    CHECK(order->type().IsInteger());
+    CHECK(order->GetDimension(0).Extent() == resultRank);
+    std::bitset<maxRank> values;
+    SubscriptValue orderSubscript{order->GetDimension(0).LowerBound()};
+    for (SubscriptValue j{0}; j < resultRank; ++j, ++orderSubscript) {
+      auto k{GetInt64(order->Element<char>(orderSubscript), shapeElementBytes)};
+      CHECK(k >= 1 && k <= resultRank && !values.test(k - 1));
+      values.set(k - 1);
+      dimOrder[k - 1] = j;
+    }
+  } else {
+    for (int j{0}; j < resultRank; ++j) {
+      dimOrder[j] = j;
+    }
+  }
+
+  // Allocate the result's data storage.
+  std::size_t elementBytes{source.ElementBytes()};
+  std::size_t resultBytes{resultElements * elementBytes};
+  void *data{std::malloc(resultBytes)};
+  CHECK(resultBytes == 0 || data != nullptr);
+
+  // Create and populate the result's descriptor.
+  const DescriptorAddendum *sourceAddendum{source.Addendum()};
+  const DerivedType *sourceDerivedType{
+      sourceAddendum ? sourceAddendum->derivedType() : nullptr};
+  Descriptor *result{nullptr};
+  if (sourceDerivedType != nullptr) {
+    result =
+        Descriptor::Create(*sourceDerivedType, data, resultRank, resultExtent);
+  } else {
+    result = Descriptor::Create(
+        source.type(), elementBytes, data, resultRank, resultExtent);
+  }
+  DescriptorAddendum *resultAddendum{result->Addendum()};
+  CHECK(resultAddendum != nullptr);
+  resultAddendum->flags() |= DescriptorAddendum::DoNotFinalize;
+  resultAddendum->flags() |= DescriptorAddendum::AllContiguous;
+  if (sourceDerivedType != nullptr) {
+    std::size_t lenParameters{sourceDerivedType->lenParameters()};
+    for (std::size_t j{0}; j < lenParameters; ++j) {
+      resultAddendum->SetLenParameterValue(
+          j, sourceAddendum->LenParameterValue(j));
+    }
+  }
+
+  // Populate the result's elements.
+  SubscriptValue resultSubscript[maxRank];
+  result->GetLowerBounds(resultSubscript);
+  SubscriptValue sourceSubscript[maxRank];
+  source.GetLowerBounds(sourceSubscript);
+  std::size_t resultElement{0};
+  std::size_t elementsFromSource{std::min(resultElements, sourceElements)};
+  for (; resultElement < elementsFromSource; ++resultElement) {
+    std::memcpy(result->Element<void>(resultSubscript),
+        source.Element<const void>(sourceSubscript), elementBytes);
+    source.IncrementSubscripts(sourceSubscript);
+    result->IncrementSubscripts(resultSubscript, dimOrder);
+  }
+  if (resultElement < resultElements) {
+    // Remaining elements come from the optional PAD= argument.
+    SubscriptValue padSubscript[maxRank];
+    pad->GetLowerBounds(padSubscript);
+    for (; resultElement < resultElements; ++resultElement) {
+      std::memcpy(result->Element<void>(resultSubscript),
+          pad->Element<const void>(padSubscript), elementBytes);
+      pad->IncrementSubscripts(padSubscript);
+      result->IncrementSubscripts(resultSubscript, dimOrder);
+    }
+  }
+
+  return result;
+}
+
+}  // namespace Fortran::runtime

--- a/runtime/transformational.h
+++ b/runtime/transformational.h
@@ -16,11 +16,13 @@
 #define FORTRAN_RUNTIME_TRANSFORMATIONAL_H_
 
 #include "descriptor.h"
+#include <memory>
 
 namespace Fortran::runtime {
 
-Descriptor *RESHAPE(const Descriptor &source, const Descriptor &shape,
-    const Descriptor *pad = nullptr, const Descriptor *order = nullptr);
+std::unique_ptr<Descriptor> RESHAPE(const Descriptor &source,
+    const Descriptor &shape, const Descriptor *pad = nullptr,
+    const Descriptor *order = nullptr);
 
 }  // namespace Fortran::runtime
 #endif  // FORTRAN_RUNTIME_TRANSFORMATIONAL_H_

--- a/runtime/transformational.h
+++ b/runtime/transformational.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_RUNTIME_TRANSFORMATIONAL_H_
+#define FORTRAN_RUNTIME_TRANSFORMATIONAL_H_
+
+#include "descriptor.h"
+
+namespace Fortran::runtime {
+
+Descriptor *RESHAPE(const Descriptor &source, const Descriptor &shape,
+    const Descriptor *pad = nullptr, const Descriptor *order = nullptr);
+
+}  // namespace Fortran::runtime
+#endif  // FORTRAN_RUNTIME_TRANSFORMATIONAL_H_

--- a/runtime/type-code.cc
+++ b/runtime/type-code.cc
@@ -1,0 +1,63 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "type-code.h"
+
+namespace Fortran::runtime {
+
+TypeCode::TypeCode(TypeCode::Form f, int kind) {
+  switch (f) {
+  case Form::Integer:
+    switch (kind) {
+    case 1: raw_ = CFI_type_int8_t; break;
+    case 2: raw_ = CFI_type_int16_t; break;
+    case 4: raw_ = CFI_type_int32_t; break;
+    case 8: raw_ = CFI_type_int64_t; break;
+    case 16: raw_ = CFI_type_int128_t; break;
+    }
+    break;
+  case Form::Real:
+    switch (kind) {
+    case 4: raw_ = CFI_type_float; break;
+    case 8: raw_ = CFI_type_double; break;
+    case 10:
+    case 16: raw_ = CFI_type_long_double; break;
+    }
+    break;
+  case Form::Complex:
+    switch (kind) {
+    case 4: raw_ = CFI_type_float_Complex; break;
+    case 8: raw_ = CFI_type_double_Complex; break;
+    case 10:
+    case 16: raw_ = CFI_type_long_double_Complex; break;
+    }
+    break;
+  case Form::Character:
+    if (kind == 1) {
+      raw_ = CFI_type_cptr;
+    }
+    break;
+  case Form::Logical:
+    switch (kind) {
+    case 1: raw_ = CFI_type_Bool; break;
+    case 2: raw_ = CFI_type_int16_t; break;
+    case 4: raw_ = CFI_type_int32_t; break;
+    case 8: raw_ = CFI_type_int64_t; break;
+    }
+    break;
+  case Form::Derived: raw_ = CFI_type_struct; break;
+  }
+}
+
+}  // namespace Fortran::runtime

--- a/runtime/type-code.cc
+++ b/runtime/type-code.cc
@@ -16,9 +16,9 @@
 
 namespace Fortran::runtime {
 
-TypeCode::TypeCode(TypeCode::Form f, int kind) {
+TypeCode::TypeCode(TypeCategory f, int kind) {
   switch (f) {
-  case Form::Integer:
+  case TypeCategory::Integer:
     switch (kind) {
     case 1: raw_ = CFI_type_int8_t; break;
     case 2: raw_ = CFI_type_int16_t; break;
@@ -27,7 +27,7 @@ TypeCode::TypeCode(TypeCode::Form f, int kind) {
     case 16: raw_ = CFI_type_int128_t; break;
     }
     break;
-  case Form::Real:
+  case TypeCategory::Real:
     switch (kind) {
     case 4: raw_ = CFI_type_float; break;
     case 8: raw_ = CFI_type_double; break;
@@ -35,7 +35,7 @@ TypeCode::TypeCode(TypeCode::Form f, int kind) {
     case 16: raw_ = CFI_type_long_double; break;
     }
     break;
-  case Form::Complex:
+  case TypeCategory::Complex:
     switch (kind) {
     case 4: raw_ = CFI_type_float_Complex; break;
     case 8: raw_ = CFI_type_double_Complex; break;
@@ -43,12 +43,12 @@ TypeCode::TypeCode(TypeCode::Form f, int kind) {
     case 16: raw_ = CFI_type_long_double_Complex; break;
     }
     break;
-  case Form::Character:
+  case TypeCategory::Character:
     if (kind == 1) {
       raw_ = CFI_type_cptr;
     }
     break;
-  case Form::Logical:
+  case TypeCategory::Logical:
     switch (kind) {
     case 1: raw_ = CFI_type_Bool; break;
     case 2: raw_ = CFI_type_int16_t; break;
@@ -56,7 +56,7 @@ TypeCode::TypeCode(TypeCode::Form f, int kind) {
     case 8: raw_ = CFI_type_int64_t; break;
     }
     break;
-  case Form::Derived: raw_ = CFI_type_struct; break;
+  case TypeCategory::Derived: raw_ = CFI_type_struct; break;
   }
 }
 

--- a/runtime/type-code.cc
+++ b/runtime/type-code.cc
@@ -59,5 +59,4 @@ TypeCode::TypeCode(TypeCategory f, int kind) {
   case TypeCategory::Derived: raw_ = CFI_type_struct; break;
   }
 }
-
 }  // namespace Fortran::runtime

--- a/runtime/type-code.h
+++ b/runtime/type-code.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_RUNTIME_TYPE_CODE_H_
+#define FORTRAN_RUNTIME_TYPE_CODE_H_
+
+#include "../include/flang/ISO_Fortran_binding.h"
+
+namespace Fortran::runtime {
+
+class TypeCode {
+public:
+  enum class Form { Integer, Real, Complex, Character, Logical, Derived };
+
+  TypeCode() {}
+  explicit TypeCode(ISO::CFI_type_t t) : raw_{t} {}
+  TypeCode(Form, int);
+
+  int raw() const { return raw_; }
+
+  constexpr bool IsValid() const {
+    return raw_ >= CFI_type_signed_char && raw_ <= CFI_type_struct;
+  }
+  constexpr bool IsInteger() const {
+    return raw_ >= CFI_type_signed_char && raw_ <= CFI_type_ptrdiff_t;
+  }
+  constexpr bool IsReal() const {
+    return raw_ >= CFI_type_float && raw_ <= CFI_type_long_double;
+  }
+  constexpr bool IsComplex() const {
+    return raw_ >= CFI_type_float_Complex &&
+        raw_ <= CFI_type_long_double_Complex;
+  }
+  constexpr bool IsCharacter() const { return raw_ == CFI_type_cptr; }
+  constexpr bool IsLogical() const { return raw_ == CFI_type_Bool; }
+  constexpr bool IsDerived() const { return raw_ == CFI_type_struct; }
+
+  constexpr bool IsIntrinsic() const { return IsValid() && !IsDerived(); }
+
+  constexpr Form GetForm() const {
+    if (IsInteger()) {
+      return Form::Integer;
+    }
+    if (IsReal()) {
+      return Form::Real;
+    }
+    if (IsComplex()) {
+      return Form::Complex;
+    }
+    if (IsCharacter()) {
+      return Form::Character;
+    }
+    if (IsLogical()) {
+      return Form::Logical;
+    }
+    return Form::Derived;
+  }
+
+private:
+  ISO::CFI_type_t raw_{CFI_type_other};
+};
+}  // namespace Fortran::runtime
+#endif  // FORTRAN_RUNTIME_TYPE_CODE_H_

--- a/runtime/type-code.h
+++ b/runtime/type-code.h
@@ -16,16 +16,17 @@
 #define FORTRAN_RUNTIME_TYPE_CODE_H_
 
 #include "../include/flang/ISO_Fortran_binding.h"
+#include "../lib/common/fortran.h"
 
 namespace Fortran::runtime {
 
+using common::TypeCategory;
+
 class TypeCode {
 public:
-  enum class Form { Integer, Real, Complex, Character, Logical, Derived };
-
   TypeCode() {}
   explicit TypeCode(ISO::CFI_type_t t) : raw_{t} {}
-  TypeCode(Form, int);
+  TypeCode(TypeCategory, int);
 
   int raw() const { return raw_; }
 
@@ -48,23 +49,23 @@ public:
 
   constexpr bool IsIntrinsic() const { return IsValid() && !IsDerived(); }
 
-  constexpr Form GetForm() const {
+  constexpr TypeCategory Categorize() const {
     if (IsInteger()) {
-      return Form::Integer;
+      return TypeCategory::Integer;
     }
     if (IsReal()) {
-      return Form::Real;
+      return TypeCategory::Real;
     }
     if (IsComplex()) {
-      return Form::Complex;
+      return TypeCategory::Complex;
     }
     if (IsCharacter()) {
-      return Form::Character;
+      return TypeCategory::Character;
     }
     if (IsLogical()) {
-      return Form::Logical;
+      return TypeCategory::Logical;
     }
-    return Form::Derived;
+    return TypeCategory::Derived;
   }
 
 private:

--- a/test/evaluate/CMakeLists.txt
+++ b/test/evaluate/CMakeLists.txt
@@ -73,9 +73,20 @@ target_link_libraries(expression-test
   FortranParser
 )
 
+add_executable(reshape-test
+  reshape.cc
+)
+
+target_link_libraries(reshape-test
+  FortranEvaluate
+  FortranEvaluateTesting
+  FortranRuntime
+)
+
 add_test(NAME Expression COMMAND expression-test)
 add_test(NAME Leadz COMMAND leading-zero-bit-count-test)
 add_test(NAME PopPar COMMAND bit-population-count-test)
 add_test(NAME Integer COMMAND integer-test)
 add_test(NAME Logical COMMAND logical-test)
 add_test(NAME Real COMMAND real-test)
+add_test(NAME RESHAPE COMMAND reshape-test)

--- a/test/evaluate/expression.cc
+++ b/test/evaluate/expression.cc
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "../../lib/evaluate/expression.h"
-#include "../../lib/parser/message.h"
 #include "testing.h"
+#include "../../lib/parser/message.h"
 #include <cstdio>
 #include <cstdlib>
 #include <sstream>
@@ -32,14 +32,16 @@ int main() {
   TEST(DefaultIntegerExpr::Result::Dump() == "Integer(4)");
   MATCH("666", Dump(DefaultIntegerExpr{666}));
   MATCH("(-1)", Dump(-DefaultIntegerExpr{1}));
-  auto ex1{DefaultIntegerExpr{2} + DefaultIntegerExpr{3} * -DefaultIntegerExpr{4}};
+  auto ex1{
+      DefaultIntegerExpr{2} + DefaultIntegerExpr{3} * -DefaultIntegerExpr{4}};
   MATCH("(2+(3*(-4)))", Dump(ex1));
   Fortran::parser::CharBlock src;
   Fortran::parser::ContextualMessages messages{src, nullptr};
   FoldingContext context{messages};
   ex1.Fold(context);
   MATCH("-10", Dump(ex1));
-  MATCH("(Integer(4)::6.LE.7)", Dump(DefaultIntegerExpr{6} <= DefaultIntegerExpr{7}));
+  MATCH("(Integer(4)::6.LE.7)",
+      Dump(DefaultIntegerExpr{6} <= DefaultIntegerExpr{7}));
   DefaultIntegerExpr a{1};
   DefaultIntegerExpr b{2};
   MATCH("(1/2)", Dump(a / b));

--- a/test/evaluate/logical.cc
+++ b/test/evaluate/logical.cc
@@ -18,8 +18,8 @@
 
 template<int KIND> void testKind() {
   using Type =
-      Fortran::evaluate::Type<Fortran::evaluate::Category::Logical, KIND>;
-  TEST(Type::category == Fortran::evaluate::Category::Logical);
+      Fortran::evaluate::Type<Fortran::common::TypeCategory::Logical, KIND>;
+  TEST(Type::category == Fortran::common::TypeCategory::Logical);
   TEST(Type::kind == KIND);
   TEST(!Type::hasLen);
   using Value = typename Type::Value;

--- a/test/evaluate/real.cc
+++ b/test/evaluate/real.cc
@@ -19,37 +19,30 @@
 #include <cstdlib>
 
 using namespace Fortran::evaluate;
+using namespace Fortran::common;
 
-using Real2 = typename Type<Category::Real, 2>::Value;
-using Real4 = typename Type<Category::Real, 4>::Value;
-using Real8 = typename Type<Category::Real, 8>::Value;
-using Real10 = typename Type<Category::Real, 10>::Value;
-using Real16 = typename Type<Category::Real, 16>::Value;
-using Integer4 = typename Type<Category::Integer, 4>::Value;
-using Integer8 = typename Type<Category::Integer, 8>::Value;
+using Real2 = typename Type<TypeCategory::Real, 2>::Value;
+using Real4 = typename Type<TypeCategory::Real, 4>::Value;
+using Real8 = typename Type<TypeCategory::Real, 8>::Value;
+using Real10 = typename Type<TypeCategory::Real, 10>::Value;
+using Real16 = typename Type<TypeCategory::Real, 16>::Value;
+using Integer4 = typename Type<TypeCategory::Integer, 4>::Value;
+using Integer8 = typename Type<TypeCategory::Integer, 8>::Value;
 
 void dumpTest() {
   struct {
     std::uint64_t raw;
     const char *expected;
-  } table[] = {
-    { 0x7f876543, "NaN 0x7f876543" },
-    { 0x7f800000, "Inf" },
-    { 0xff800000, "-Inf" },
-    { 0x00000000, "0.0" },
-    { 0x80000000, "-0.0" },
-    { 0x3f800000, "0x1.0p0" },
-    { 0xbf800000, "-0x1.0p0" },
-    { 0x40000000, "0x1.0p1" },
-    { 0x3f000000, "0x1.0p-1" },
-    { 0x7f7fffff, "0x1.fffffep127" },
-    { 0x00800000, "0x1.0p-126" },
-    { 0x00400000, "0x0.8p-127" },
-    { 0x00000001, "0x0.000002p-127" },
-    { 0, nullptr }
-  };
+  } table[] = {{0x7f876543, "NaN 0x7f876543"}, {0x7f800000, "Inf"},
+      {0xff800000, "-Inf"}, {0x00000000, "0.0"}, {0x80000000, "-0.0"},
+      {0x3f800000, "0x1.0p0"}, {0xbf800000, "-0x1.0p0"},
+      {0x40000000, "0x1.0p1"}, {0x3f000000, "0x1.0p-1"},
+      {0x7f7fffff, "0x1.fffffep127"}, {0x00800000, "0x1.0p-126"},
+      {0x00400000, "0x0.8p-127"}, {0x00000001, "0x0.000002p-127"},
+      {0, nullptr}};
   for (int j{0}; table[j].expected != nullptr; ++j) {
-    TEST(Real4{Integer4{table[j].raw}}.DumpHexadecimal() == table[j].expected)("%d", j);
+    TEST(Real4{Integer4{table[j].raw}}.DumpHexadecimal() == table[j].expected)
+    ("%d", j);
   }
 }
 

--- a/test/evaluate/real.cc
+++ b/test/evaluate/real.cc
@@ -33,13 +33,22 @@ void dumpTest() {
   struct {
     std::uint64_t raw;
     const char *expected;
-  } table[] = {{0x7f876543, "NaN 0x7f876543"}, {0x7f800000, "Inf"},
-      {0xff800000, "-Inf"}, {0x00000000, "0.0"}, {0x80000000, "-0.0"},
-      {0x3f800000, "0x1.0p0"}, {0xbf800000, "-0x1.0p0"},
-      {0x40000000, "0x1.0p1"}, {0x3f000000, "0x1.0p-1"},
-      {0x7f7fffff, "0x1.fffffep127"}, {0x00800000, "0x1.0p-126"},
-      {0x00400000, "0x0.8p-127"}, {0x00000001, "0x0.000002p-127"},
-      {0, nullptr}};
+  } table[] = {
+      {0x7f876543, "NaN 0x7f876543"},
+      {0x7f800000, "Inf"},
+      {0xff800000, "-Inf"},
+      {0x00000000, "0.0"},
+      {0x80000000, "-0.0"},
+      {0x3f800000, "0x1.0p0"},
+      {0xbf800000, "-0x1.0p0"},
+      {0x40000000, "0x1.0p1"},
+      {0x3f000000, "0x1.0p-1"},
+      {0x7f7fffff, "0x1.fffffep127"},
+      {0x00800000, "0x1.0p-126"},
+      {0x00400000, "0x0.8p-127"},
+      {0x00000001, "0x0.000002p-127"},
+      {0, nullptr},
+  };
   for (int j{0}; table[j].expected != nullptr; ++j) {
     TEST(Real4{Integer4{table[j].raw}}.DumpHexadecimal() == table[j].expected)
     ("%d", j);

--- a/test/evaluate/reshape.cc
+++ b/test/evaluate/reshape.cc
@@ -1,0 +1,84 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "testing.h"
+#include "../../runtime/descriptor.h"
+#include "../../runtime/transformational.h"
+#include <cinttypes>
+
+using namespace Fortran::common;
+using namespace Fortran::runtime;
+
+int main() {
+  std::size_t dataElements{24};
+  std::int32_t *data{new std::int32_t[dataElements]};
+  for (std::size_t j{0}; j < dataElements; ++j) {
+    data[j] = j;
+  }
+
+  static const SubscriptValue sourceExtent[]{2, 3, 4};
+  Descriptor *source{Descriptor::Create(TypeCategory::Integer, sizeof data[0],
+      reinterpret_cast<void *>(data), 3, sourceExtent,
+      CFI_attribute_allocatable)};
+  source->Check();
+  MATCH(3, source->rank());
+  MATCH(2, source->GetDimension(0).Extent());
+  MATCH(3, source->GetDimension(1).Extent());
+  MATCH(4, source->GetDimension(2).Extent());
+
+  static const std::int16_t shapeData[]{8, 4};
+  static const SubscriptValue shapeExtent{2};
+  Descriptor *shape{Descriptor::Create(TypeCategory::Integer,
+      static_cast<int>(sizeof shapeData[0]),
+      const_cast<void *>(reinterpret_cast<const void *>(shapeData)), 1,
+      &shapeExtent)};
+  shape->Check();
+  MATCH(1, shape->rank());
+  MATCH(2, shape->GetDimension(0).Extent());
+
+  StaticDescriptor<3> padDescriptor;
+  static const std::int32_t padData[]{24, 25, 26, 27, 28, 29, 30, 31};
+  static const SubscriptValue padExtent[]{2, 2, 3};
+  padDescriptor.descriptor().Establish(TypeCategory::Integer,
+      static_cast<int>(sizeof padData[0]),
+      const_cast<void *>(reinterpret_cast<const void *>(padData)), 3,
+      padExtent);
+  padDescriptor.Check();
+
+  Descriptor *result{RESHAPE(*source, *shape, &padDescriptor.descriptor())};
+
+  TEST(result != nullptr);
+  result->Check();
+  MATCH(sizeof(std::int32_t), result->ElementBytes());
+  MATCH(2, result->rank());
+  TEST(result->type().IsInteger());
+  for (std::int32_t j{0}; j < 32; ++j) {
+    MATCH(j, *result->Element<std::int32_t>(j * sizeof(std::int32_t)));
+  }
+  for (std::int32_t j{0}; j < 32; ++j) {
+    SubscriptValue ss[2]{1 + (j % 8), 1 + (j / 8)};
+    MATCH(j, *result->Element<std::int32_t>(ss));
+  }
+
+  // TODO: test ORDER=
+
+  // Plug leaks; should run cleanly beneath valgrind
+  free(result->raw().base_addr);
+  result->Destroy();
+  shape->Destroy();
+  source->Destroy();
+  delete[] data;
+
+  return testing::Complete();
+}

--- a/test/evaluate/reshape.cc
+++ b/test/evaluate/reshape.cc
@@ -21,44 +21,56 @@ using namespace Fortran::common;
 using namespace Fortran::runtime;
 
 int main() {
-  std::size_t dataElements{24};
-  std::int32_t *data{new std::int32_t[dataElements]};
-  for (std::size_t j{0}; j < dataElements; ++j) {
-    data[j] = j;
-  }
-
+  static const SubscriptValue ones[]{1, 1, 1};
   static const SubscriptValue sourceExtent[]{2, 3, 4};
-  Descriptor *source{Descriptor::Create(TypeCategory::Integer, sizeof data[0],
-      reinterpret_cast<void *>(data), 3, sourceExtent,
-      CFI_attribute_allocatable)};
+  std::unique_ptr<Descriptor> source{
+      Descriptor::Create(TypeCategory::Integer, sizeof(std::int32_t), nullptr,
+          3, sourceExtent, CFI_attribute_allocatable)};
   source->Check();
   MATCH(3, source->rank());
+  MATCH(sizeof(std::int32_t), source->ElementBytes());
+  TEST(source->IsAllocatable());
+  TEST(!source->IsPointer());
+  TEST(source->Allocate(ones, sourceExtent, sizeof(std::int32_t)) ==
+      CFI_SUCCESS);
+  TEST(source->IsAllocated());
   MATCH(2, source->GetDimension(0).Extent());
   MATCH(3, source->GetDimension(1).Extent());
   MATCH(4, source->GetDimension(2).Extent());
+  MATCH(24, source->Elements());
+  for (std::size_t j{0}; j < 24; ++j) {
+    *source->Element<std::int32_t>(j * sizeof(std::int32_t)) = j;
+  }
 
   static const std::int16_t shapeData[]{8, 4};
   static const SubscriptValue shapeExtent{2};
-  Descriptor *shape{Descriptor::Create(TypeCategory::Integer,
+  std::unique_ptr<Descriptor> shape{Descriptor::Create(TypeCategory::Integer,
       static_cast<int>(sizeof shapeData[0]),
       const_cast<void *>(reinterpret_cast<const void *>(shapeData)), 1,
-      &shapeExtent)};
+      &shapeExtent, CFI_attribute_pointer)};
   shape->Check();
   MATCH(1, shape->rank());
   MATCH(2, shape->GetDimension(0).Extent());
+  TEST(shape->IsPointer());
+  TEST(!shape->IsAllocatable());
 
   StaticDescriptor<3> padDescriptor;
+  Descriptor &pad{padDescriptor.descriptor()};
   static const std::int32_t padData[]{24, 25, 26, 27, 28, 29, 30, 31};
   static const SubscriptValue padExtent[]{2, 2, 3};
-  padDescriptor.descriptor().Establish(TypeCategory::Integer,
-      static_cast<int>(sizeof padData[0]),
-      const_cast<void *>(reinterpret_cast<const void *>(padData)), 3,
-      padExtent);
+  pad.Establish(TypeCategory::Integer, static_cast<int>(sizeof padData[0]),
+      const_cast<void *>(reinterpret_cast<const void *>(padData)), 3, padExtent,
+      CFI_attribute_pointer);
   padDescriptor.Check();
+  pad.Check();
+  MATCH(3, pad.rank());
+  MATCH(2, pad.GetDimension(0).Extent());
+  MATCH(2, pad.GetDimension(1).Extent());
+  MATCH(3, pad.GetDimension(2).Extent());
 
-  Descriptor *result{RESHAPE(*source, *shape, &padDescriptor.descriptor())};
+  std::unique_ptr<Descriptor> result{RESHAPE(*source, *shape, &pad)};
 
-  TEST(result != nullptr);
+  TEST(result.get() != nullptr);
   result->Check();
   MATCH(sizeof(std::int32_t), result->ElementBytes());
   MATCH(2, result->rank());
@@ -72,13 +84,6 @@ int main() {
   }
 
   // TODO: test ORDER=
-
-  // Plug leaks; should run cleanly beneath valgrind
-  free(result->raw().base_addr);
-  result->Destroy();
-  shape->Destroy();
-  source->Destroy();
-  delete[] data;
 
   return testing::Complete();
 }


### PR DESCRIPTION
Some disconnected changes here related to evaluation and execution.  The C++ interface to the ISO standard descriptor is now is much better shape, and can serve to implement a working RESHAPE intrinsic.  More to come, but it was past time to checkpoint and merge this work area.

As a readability improvement (I think), I've replaced many instances of `return {};` with `return std::nullopt;` in contexts where the function's type is an instantiation of `std::optional<>`.

Also, a GNU C++ compiler bug workaround in `lib/parser/basic-parsers.h` is no longer needed with GNU 8.2.0, and the conditional compilation tests were adjusted accordingly.