### PR TITLE
Restore buildability with clang

### DIFF
--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -22,6 +22,8 @@
 
 namespace Fortran::semantics {
 
+IntExpr::~IntExpr() {}
+
 std::ostream &operator<<(std::ostream &o, const IntExpr &x) {
   return x.Output(o);
 }

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -64,6 +64,7 @@ public:
     return IntExpr();  // TODO
   }
   IntExpr() {}
+  virtual ~IntExpr();
   virtual std::ostream &Output(std::ostream &o) const { return o << "IntExpr"; }
 };
 


### PR DESCRIPTION
Add virtual IntExpr::~IntExpr to silence a Clang warning about non-virtual dtor in a class with virtual functions that cropped up after some merges today.