### PR TITLE
Expression analysis and message clean-up

### DIFF
--- a/lib/evaluate/CMakeLists.txt
+++ b/lib/evaluate/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 add_library(FortranEvaluate
+  common.cc
   complex.cc
   expression.cc
   integer.cc

--- a/lib/evaluate/CMakeLists.txt
+++ b/lib/evaluate/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(FortranEvaluate
   integer.cc
   logical.cc
   real.cc
+  type.cc
   variable.cc
 )
 

--- a/lib/evaluate/common.cc
+++ b/lib/evaluate/common.cc
@@ -1,0 +1,37 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common.h"
+
+using namespace Fortran::parser::literals;
+
+namespace Fortran::evaluate {
+
+void RealFlagWarnings(
+    FoldingContext &context, const RealFlags &flags, const char *operation) {
+  if (flags.test(RealFlag::Overflow)) {
+    context.messages.Say("overflow on %s"_en_US, operation);
+  }
+  if (flags.test(RealFlag::DivideByZero)) {
+    context.messages.Say("division by zero on %s"_en_US, operation);
+  }
+  if (flags.test(RealFlag::InvalidArgument)) {
+    context.messages.Say("invalid argument on %s"_en_US, operation);
+  }
+  if (flags.test(RealFlag::Underflow)) {
+    context.messages.Say("underflow on %s"_en_US, operation);
+  }
+}
+
+}  // namespace Fortran::evaluate

--- a/lib/evaluate/common.h
+++ b/lib/evaluate/common.h
@@ -132,10 +132,19 @@ template<typename A> using CopyableIndirection = common::Indirection<A, true>;
 // FoldableTrait set.
 CLASS_TRAIT(FoldableTrait);
 struct FoldingContext {
+  explicit FoldingContext(parser::ContextualMessages &m,
+      Rounding round = defaultRounding, bool flush = false)
+    : messages{m}, rounding{round}, flushDenormalsToZero{flush} {}
+  FoldingContext(parser::ContextualMessages &m, const FoldingContext &c)
+    : messages{m}, rounding{c.rounding}, flushDenormalsToZero{
+                                             c.flushDenormalsToZero} {}
+
   parser::ContextualMessages &messages;
   Rounding rounding{defaultRounding};
   bool flushDenormalsToZero{false};
 };
+
+void RealFlagWarnings(FoldingContext &, const RealFlags &, const char *op);
 
 }  // namespace Fortran::evaluate
 #endif  // FORTRAN_EVALUATE_COMMON_H_

--- a/lib/evaluate/common.h
+++ b/lib/evaluate/common.h
@@ -18,6 +18,7 @@
 #include "../common/enum-set.h"
 #include "../common/idioms.h"
 #include "../common/indirection.h"
+#include "../parser/message.h"
 #include <cinttypes>
 
 namespace Fortran::evaluate {
@@ -126,6 +127,15 @@ using HostUnsignedInt =
 
 // Force availability of copy construction and assignment
 template<typename A> using CopyableIndirection = common::Indirection<A, true>;
+
+// Classes that support a Fold(FoldingContext &) member function have the
+// FoldableTrait set.
+CLASS_TRAIT(FoldableTrait);
+struct FoldingContext {
+  parser::ContextualMessages &messages;
+  Rounding rounding{defaultRounding};
+  bool flushDenormalsToZero{false};
+};
 
 }  // namespace Fortran::evaluate
 #endif  // FORTRAN_EVALUATE_COMMON_H_

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -383,20 +383,16 @@ auto IntegerExpr<KIND>::Fold(FoldingContext &context) -> std::optional<Scalar> {
 static void RealFlagWarnings(
     FoldingContext &context, const RealFlags &flags, const char *operation) {
   if (flags.test(RealFlag::Overflow)) {
-    context.messages.Say(
-        parser::MessageFormattedText("overflow on %s"_en_US, operation));
+    context.messages.Say("overflow on %s"_en_US, operation);
   }
   if (flags.test(RealFlag::DivideByZero)) {
-    context.messages.Say(parser::MessageFormattedText(
-        "division by zero on %s"_en_US, operation));
+    context.messages.Say("division by zero on %s"_en_US, operation);
   }
   if (flags.test(RealFlag::InvalidArgument)) {
-    context.messages.Say(parser::MessageFormattedText(
-        "invalid argument on %s"_en_US, operation));
+    context.messages.Say("invalid argument on %s"_en_US, operation);
   }
   if (flags.test(RealFlag::Underflow)) {
-    context.messages.Say(
-        parser::MessageFormattedText("underflow on %s"_en_US, operation));
+    context.messages.Say("underflow on %s"_en_US, operation);
   }
 }
 

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -33,13 +33,6 @@
 
 namespace Fortran::evaluate {
 
-CLASS_TRAIT(FoldableTrait);
-struct FoldingContext {
-  parser::ContextualMessages &messages;
-  Rounding rounding{defaultRounding};
-  bool flushDenormalsToZero{false};
-};
-
 // Helper base classes for packaging subexpressions.
 template<typename CRTP, typename RESULT, typename A = RESULT> class Unary {
 protected:
@@ -175,11 +168,15 @@ public:
   Expr(std::int64_t n) : u_{Scalar{n}} {}
   Expr(std::uint64_t n) : u_{Scalar{n}} {}
   Expr(int n) : u_{Scalar{n}} {}
+  Expr(const AnyKindIntegerExpr &x) : u_{ConvertInteger{x}} {}
+  Expr(AnyKindIntegerExpr &&x) : u_{ConvertInteger{std::move(x)}} {}
   template<int K>
   Expr(const IntegerExpr<K> &x) : u_{ConvertInteger{AnyKindIntegerExpr{x}}} {}
   template<int K>
   Expr(IntegerExpr<K> &&x)
     : u_{ConvertInteger{AnyKindIntegerExpr{std::move(x)}}} {}
+  Expr(const AnyKindRealExpr &x) : u_{ConvertReal{x}} {}
+  Expr(AnyKindRealExpr &&x) : u_{ConvertReal{std::move(x)}} {}
   template<int K>
   Expr(const RealExpr<K> &x) : u_{ConvertReal{AnyKindRealExpr{x}}} {}
   template<int K>
@@ -296,11 +293,15 @@ public:
 
   CLASS_BOILERPLATE(Expr)
   Expr(const Scalar &x) : u_{x} {}
+  Expr(const AnyKindIntegerExpr &x) : u_{ConvertInteger{x}} {}
+  Expr(AnyKindIntegerExpr &&x) : u_{ConvertInteger{std::move(x)}} {}
   template<int K>
   Expr(const IntegerExpr<K> &x) : u_{ConvertInteger{AnyKindIntegerExpr{x}}} {}
   template<int K>
   Expr(IntegerExpr<K> &&x)
     : u_{ConvertInteger{AnyKindIntegerExpr{std::move(x)}}} {}
+  Expr(const AnyKindRealExpr &x) : u_{ConvertReal{x}} {}
+  Expr(AnyKindRealExpr &&x) : u_{ConvertReal{std::move(x)}} {}
   template<int K>
   Expr(const RealExpr<K> &x) : u_{ConvertReal{AnyKindRealExpr{x}}} {}
   template<int K>

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -596,6 +596,12 @@ extern template class Expr<AnyKindType<TypeCategory::Complex>>;
 extern template class Expr<AnyKindType<TypeCategory::Character>>;
 extern template class Expr<AnyKindType<TypeCategory::Logical>>;
 
+// BOZ literal constants need to be wide enough to hold an integer or real
+// value of any supported kind.  They also need to be distinguishable from
+// other integer constants, since they are permitted to be used in only a
+// few situations.
+using BOZLiteralConstant = value::Integer<128>;
+
 // A completely generic expression, polymorphic across the intrinsic type
 // categories and each of their kinds.
 struct GenericExpr {
@@ -615,7 +621,7 @@ struct GenericExpr {
   std::optional<Scalar> Fold(FoldingContext &);
   int Rank() const { return 1; }  // TODO
   std::variant<AnyKindIntegerExpr, AnyKindRealExpr, AnyKindComplexExpr,
-      AnyKindCharacterExpr, AnyKindLogicalExpr>
+      AnyKindCharacterExpr, AnyKindLogicalExpr, BOZLiteralConstant>
       u;
 };
 

--- a/lib/evaluate/integer.h
+++ b/lib/evaluate/integer.h
@@ -205,7 +205,7 @@ public:
     // assumptions, so here you go, future programmer in some postapocalyptic
     // hellscape, and best of luck with the inexorable killer robots.
     for (; std::uint64_t digit = *p; ++p) {
-      if (digit >= '0' && digit < '0' + base) {
+      if (digit >= '0' && digit <= '9' && digit < '0' + base) {
         digit -= '0';
       } else if (base > 10 && digit >= 'A' && digit < 'A' + base - 10) {
         digit -= 'A' - 10;

--- a/lib/evaluate/real.h
+++ b/lib/evaluate/real.h
@@ -260,6 +260,8 @@ public:
     return word_.IBITS(significandBits, exponentBits).ToUInt64();
   }
 
+  static ValueWithRealFlags<Real> Read(
+      const char *&, Rounding rounding = defaultRounding);
   std::string DumpHexadecimal() const;
 
 private:

--- a/lib/evaluate/type.cc
+++ b/lib/evaluate/type.cc
@@ -1,0 +1,41 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "type.h"
+#include "../common/idioms.h"
+#include <cinttypes>
+#include <optional>
+#include <variant>
+
+namespace Fortran::evaluate {
+
+std::optional<std::int64_t> GenericScalar::ToInt64() const {
+  if (const auto *j{std::get_if<ScalarConstant<TypeCategory::Integer>>(&u)}) {
+    return std::visit(
+        [](const auto &k) { return std::optional<std::int64_t>{k.ToInt64()}; },
+        j->u);
+  }
+  return std::nullopt;
+}
+
+std::optional<std::string> GenericScalar::ToString() const {
+  if (const auto *c{std::get_if<ScalarConstant<TypeCategory::Character>>(&u)}) {
+    if (const std::string * s{std::get_if<std::string>(&c->u)}) {
+      return std::optional<std::string>{*s};
+    }
+  }
+  return std::nullopt;
+}
+
+}  // namespace Fortran::evaluate

--- a/lib/evaluate/type.h
+++ b/lib/evaluate/type.h
@@ -26,6 +26,8 @@
 #include "real.h"
 #include "../common/fortran.h"
 #include "../common/idioms.h"
+#include <cinttypes>
+#include <optional>
 #include <string>
 #include <variant>
 
@@ -180,6 +182,10 @@ struct GenericScalar {
   template<typename A>
   GenericScalar(std::enable_if_t<!std::is_reference_v<A>, A> &&x)
     : u{std::move(x)} {}
+
+  std::optional<std::int64_t> ToInt64() const;
+  std::optional<std::string> ToString() const;
+
   std::variant<ScalarConstant<TypeCategory::Integer>,
       ScalarConstant<TypeCategory::Real>, ScalarConstant<TypeCategory::Complex>,
       ScalarConstant<TypeCategory::Character>,

--- a/lib/evaluate/variable.cc
+++ b/lib/evaluate/variable.cc
@@ -168,7 +168,8 @@ std::optional<std::string> Substring::Fold(FoldingContext &context) {
       std::int64_t len = str->size();
       if (ubi > len) {
         context.messages.Say(
-            "upper bound on substring (%jd) is greater than character length (%jd)"_en_US);
+            "upper bound on substring (%jd) is greater than character length (%jd)"_en_US,
+            static_cast<std::intmax_t>(ubi), static_cast<std::intmax_t>(len));
         ubi = len;
         last_ = SubscriptIntegerExpr{ubi};
       }

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -164,6 +164,7 @@ private:
 // variants of sections instead.
 class Substring {
 public:
+  using FoldableTrait = std::true_type;
   CLASS_BOILERPLATE(Substring)
   Substring(DataRef &&, std::optional<SubscriptIntegerExpr> &&,
       std::optional<SubscriptIntegerExpr> &&);
@@ -173,6 +174,7 @@ public:
   SubscriptIntegerExpr first() const;
   SubscriptIntegerExpr last() const;
   SubscriptIntegerExpr LEN() const;
+  std::optional<std::string> Fold(FoldingContext &);
 
 private:
   std::variant<DataRef, std::string> u_;

--- a/lib/parser/basic-parsers.h
+++ b/lib/parser/basic-parsers.h
@@ -201,12 +201,12 @@ public:
     std::optional<resultType> result{parser_.Parse(state)};
     bool emitMessage{false};
     if (result.has_value()) {
-      messages.Annex(state.messages());
+      messages.Annex(std::move(state.messages()));
       if (backtrack.anyTokenMatched()) {
         state.set_anyTokenMatched();
       }
     } else if (state.anyTokenMatched()) {
-      messages.Annex(state.messages());
+      messages.Annex(std::move(state.messages()));
       backtrack.set_anyTokenMatched();
       if (state.anyDeferredMessages()) {
         backtrack.set_anyDeferredMessages(true);
@@ -407,7 +407,7 @@ public:
       state.messages().Restore(std::move(messages));
       return ax;
     }
-    messages.Annex(state.messages());
+    messages.Annex(std::move(state.messages()));
     bool hadDeferredMessages{state.anyDeferredMessages()};
     bool anyTokenMatched{state.anyTokenMatched()};
     state = std::move(backtrack);

--- a/lib/parser/debug-parser.cc
+++ b/lib/parser/debug-parser.cc
@@ -23,8 +23,8 @@ std::optional<Success> DebugParser::Parse(ParseState &state) const {
   if (auto ustate{state.userState()}) {
     if (auto out{ustate->debugOutput()}) {
       std::string note{str_, length_};
-      Message message{state.GetLocation(),
-          MessageFormattedText{"parser debug: %s"_en_US, note.data()}};
+      Message message{
+          state.GetLocation(), "parser debug: %s"_en_US, note.data()};
       message.SetContext(state.context().get());
       message.Emit(*out, ustate->cooked(), true);
     }

--- a/lib/parser/message.cc
+++ b/lib/parser/message.cc
@@ -253,7 +253,7 @@ void Messages::Merge(Messages &&that) {
 void Messages::Copy(const Messages &that) {
   for (const Message &m : that.messages_) {
     Message copy{m};
-    Put(std::move(copy));
+    Say(std::move(copy));
   }
 }
 
@@ -273,6 +273,12 @@ void Messages::Emit(
       [](const Message *x, const Message *y) { return x->SortBefore(*y); });
   for (const Message *msg : sorted) {
     msg->Emit(o, cooked, echoSourceLines);
+  }
+}
+
+void Messages::AttachTo(Message &msg) {
+  for (const Message &m : messages_) {
+    msg.Attach(m);
   }
 }
 

--- a/lib/parser/message.h
+++ b/lib/parser/message.h
@@ -241,6 +241,12 @@ private:
 class ContextualMessages {
 public:
   ContextualMessages(CharBlock at, Messages *m) : at_{at}, messages_{m} {}
+  ContextualMessages(CharBlock at, const ContextualMessages &context)
+    : at_{at}, messages_{context.messages_} {}
+
+  CharBlock at() const { return at_; }
+  Messages *messages() const { return messages_; }
+
   template<typename... A> void Say(A &&... args) {
     if (messages_ != nullptr) {
       messages_->Say(at_, std::forward<A>(args)...);

--- a/lib/parser/parse-state.h
+++ b/lib/parser/parse-state.h
@@ -143,30 +143,19 @@ public:
     context_ = context_->attachment();
   }
 
-  void Say(const MessageFixedText &t) { Say(p_, t); }
-  void Say(MessageFormattedText &&t) { Say(p_, std::move(t)); }
-  void Say(const MessageExpectedText &t) { Say(p_, t); }
-
-  void Say(CharBlock range, const MessageFixedText &t) {
+  template<typename... A> void Say(CharBlock range, A &&... args) {
     if (deferMessages_) {
       anyDeferredMessages_ = true;
     } else {
-      messages_.Say(range, t).SetContext(context_.get());
+      messages_.Say(range, std::forward<A>(args)...).SetContext(context_.get());
     }
   }
-  void Say(CharBlock range, MessageFormattedText &&t) {
-    if (deferMessages_) {
-      anyDeferredMessages_ = true;
-    } else {
-      messages_.Say(range, std::move(t)).SetContext(context_.get());
-    }
+  template<typename... A> void Say(const MessageFixedText &text, A &&... args) {
+    Say(p_, text, std::forward<A>(args)...);
   }
-  void Say(CharBlock range, const MessageExpectedText &t) {
-    if (deferMessages_) {
-      anyDeferredMessages_ = true;
-    } else {
-      messages_.Say(range, t).SetContext(context_.get());
-    }
+  template<typename... A>
+  void Say(const MessageExpectedText &text, A &&... args) {
+    Say(p_, text, std::forward<A>(args)...);
   }
 
   void Nonstandard(LanguageFeature lf, const MessageFixedText &msg) {

--- a/lib/parser/parse-tree-visitor.h
+++ b/lib/parser/parse-tree-visitor.h
@@ -33,17 +33,20 @@
 
 namespace Fortran::parser {
 
-// Default case for visitation of non-class data members and strings
+// Default case for visitation of non-class data members, strings, and
+// any other non-decomposable values.
 template<typename A, typename V>
-std::enable_if_t<!std::is_class_v<A> || std::is_same_v<std::string, A>> Walk(
-    const A &x, V &visitor) {
+std::enable_if_t<!std::is_class_v<A> || std::is_same_v<std::string, A> ||
+    std::is_same_v<CharBlock, A>>
+Walk(const A &x, V &visitor) {
   if (visitor.Pre(x)) {
     visitor.Post(x);
   }
 }
 template<typename A, typename M>
-std::enable_if_t<!std::is_class_v<A> || std::is_same_v<std::string, A>> Walk(
-    A &x, M &mutator) {
+std::enable_if_t<!std::is_class_v<A> || std::is_same_v<std::string, A> ||
+    std::is_same_v<CharBlock, A>>
+Walk(A &x, M &mutator) {
   if (mutator.Pre(x)) {
     mutator.Post(x);
   }

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -820,7 +820,9 @@ struct LogicalLiteralConstant {
 // R766 octal-constant -> O ' digit [digit]... ' | O " digit [digit]... "
 // R767 hex-constant ->
 //        Z ' hex-digit [hex-digit]... ' | Z " hex-digit [hex-digit]... "
-WRAPPER_CLASS(BOZLiteralConstant, std::uint64_t);
+// The constant must be large enough to hold any real or integer scalar
+// of any supported kind (F'2018 7.7).
+WRAPPER_CLASS(BOZLiteralConstant, std::string);
 
 // R605 literal-constant ->
 //        int-literal-constant | real-literal-constant |

--- a/lib/parser/parsing.cc
+++ b/lib/parser/parsing.cc
@@ -43,13 +43,12 @@ void Parsing::Prescan(const std::string &path, Options options) {
   }
   if (sourceFile == nullptr) {
     ProvenanceRange range{allSources.AddCompilerInsertion(path)};
-    MessageFormattedText msg("%s"_err_en_US, fileError.str().data());
-    messages_.Put(Message{range, std::move(msg)});
+    messages_.Say(range, "%s"_err_en_US, fileError.str().data());
     return;
   }
   if (sourceFile->bytes() == 0) {
     ProvenanceRange range{allSources.AddCompilerInsertion(path)};
-    messages_.Put(Message{range, "file is empty"_err_en_US});
+    messages_.Say(range, "file is empty"_err_en_US);
     return;
   }
 
@@ -112,7 +111,7 @@ void Parsing::Parse(std::ostream *out) {
   CHECK(
       !parseState.anyErrorRecovery() || parseState.messages().AnyFatalError());
   consumedWholeFile_ = parseState.IsAtEnd();
-  messages_.Annex(parseState.messages());
+  messages_.Annex(std::move(parseState.messages()));
   finalRestingPlace_ = parseState.GetLocation();
 }
 

--- a/lib/parser/prescan.h
+++ b/lib/parser/prescan.h
@@ -70,9 +70,12 @@ public:
   TokenSequence TokenizePreprocessorDirective();
   Provenance GetCurrentProvenance() const { return GetProvenance(at_); }
 
-  void Say(Message &&);
-  void Say(MessageFixedText, ProvenanceRange);
-  void Say(MessageFormattedText &&, ProvenanceRange);
+  template<typename... A> Message &Say(A... a) {
+    Message &m{messages_.Say(std::forward<A>(a)...)};
+    std::optional<ProvenanceRange> range{m.GetProvenanceRange(cooked_)};
+    CHECK(!range.has_value() || cooked_.IsValid(*range));
+    return m;
+  }
 
 private:
   struct LineClassification {

--- a/lib/parser/token-parsers.h
+++ b/lib/parser/token-parsers.h
@@ -353,7 +353,7 @@ struct BOZLiteral {
       if (!IsHexadecimalDigit(**at)) {
         return std::nullopt;
       }
-      content += **at;
+      content += ToLowerCaseLetter(**at);
     }
 
     if (!base) {

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -356,16 +356,7 @@ public:
     Outdent(), Word("END ENUM");
   }
   void Unparse(const BOZLiteralConstant &x) {  // R764 - R767
-    Put("Z'");
-    bool any{false};
-    for (int j{60}; j >= 0; j -= 4) {
-      int d = (x.v >> j) & 0xf;
-      if (d != 0 || any || j == 0) {
-        Put(d > 9 ? 'a' + d - 10 : '0' + d);
-        any = true;
-      }
-    }
-    Put('\'');
+    Put(x.v);
   }
   void Unparse(const AcValue::Triplet &x) {  // R773
     Walk(std::get<0>(x.t)), Put(':'), Walk(std::get<1>(x.t));

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -32,6 +32,8 @@ public:
 
   evaluate::FoldingContext &context() { return context_; }
   KindParam defaultIntegerKind() const { return defaultIntegerKind_; }
+  KindParam defaultRealKind() const { return defaultRealKind_; }
+  KindParam defaultLogicalKind() const { return defaultLogicalKind_; }
 
   // Performs semantic checking on an expression.  If successful,
   // returns its typed expression representation.
@@ -42,6 +44,8 @@ public:
 private:
   evaluate::FoldingContext context_;
   KindParam defaultIntegerKind_{4};
+  KindParam defaultRealKind_{defaultIntegerKind_};
+  KindParam defaultLogicalKind_{defaultIntegerKind_};
 };
 }  // namespace Fortran::semantics
 #endif  // FORTRAN_SEMANTICS_EXPRESSION_H_

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -26,7 +26,6 @@ namespace Fortran::semantics {
 class ExpressionAnalyzer {
 public:
   using KindParam = std::int64_t;
-  using Result = std::optional<evaluate::GenericExpr>;
 
   ExpressionAnalyzer(evaluate::FoldingContext &c, KindParam dIK)
     : context_{c}, defaultIntegerKind_{dIK} {}
@@ -36,7 +35,7 @@ public:
 
   // Performs semantic checking on an expression.  If successful,
   // returns its typed expression representation.
-  Result Analyze(const parser::Expr &);
+  std::optional<evaluate::GenericExpr> Analyze(const parser::Expr &);
   KindParam Analyze(const std::optional<parser::KindParam> &,
       KindParam defaultKind, KindParam kanjiKind = -1 /* not allowed here */);
 

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -26,6 +26,8 @@ namespace Fortran::semantics {
 class ExpressionAnalyzer {
 public:
   using KindParam = std::int64_t;
+  using Result = std::optional<evaluate::GenericExpr>;
+
   ExpressionAnalyzer(evaluate::FoldingContext &c, KindParam dIK)
     : context_{c}, defaultIntegerKind_{dIK} {}
 
@@ -34,7 +36,7 @@ public:
 
   // Performs semantic checking on an expression.  If successful,
   // returns its typed expression representation.
-  std::optional<evaluate::GenericExpr> Analyze(const parser::Expr &);
+  Result Analyze(const parser::Expr &);
   KindParam Analyze(const std::optional<parser::KindParam> &,
       KindParam defaultKind, KindParam kanjiKind = -1 /* not allowed here */);
 

--- a/lib/semantics/mod-file.h
+++ b/lib/semantics/mod-file.h
@@ -41,9 +41,7 @@ public:
   void set_directory(const std::string &dir) { dir_ = dir; }
 
   // Errors encountered during writing. Non-empty if WriteAll returns false.
-  const std::vector<parser::MessageFormattedText> &errors() const {
-    return errors_;
-  }
+  parser::Messages &errors() { return errors_; }
 
   // Write out all .mod files; if error return false.
   bool WriteAll();
@@ -59,7 +57,7 @@ private:
   std::stringstream decls_;
   std::stringstream contains_;
   // Any errors encountered during writing:
-  std::vector<parser::MessageFormattedText> errors_;
+  parser::Messages errors_;
 
   void WriteChildren(const Scope &);
   void WriteOne(const Scope &);
@@ -86,11 +84,11 @@ public:
   // Return the Scope for that module/submodule or nullptr on error.
   Scope *Read(const SourceName &, Scope *ancestor = nullptr);
   // Errors that occurred when Read returns nullptr.
-  std::vector<parser::Message> &errors() { return errors_; }
+  parser::Messages &errors() { return errors_; }
 
 private:
   std::vector<std::string> directories_;
-  std::vector<parser::Message> errors_;
+  parser::Messages errors_;
 
   std::optional<std::string> FindModFile(
       const SourceName &, const std::string &);

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -217,11 +217,8 @@ std::string CompileFortran(
         parseTree, parsing.cooked(), directories);
     Fortran::semantics::ModFileWriter writer;
     writer.set_directory(driver.moduleDirectory);
-    if (!writer.WriteAll()) {
-      for (const auto &message : writer.errors()) {
-        std::cerr << message.string() << '\n';
-      }
-    }
+    writer.WriteAll();
+    writer.errors().Emit(std::cerr, parsing.cooked());
     if (driver.dumpSymbols) {
       Fortran::semantics::DumpSymbols(std::cout);
     }


### PR DESCRIPTION
Continuation of work with expression analysis, plus a big diversion to improve the message APIs so that it's possible to invoke `Say` on a message text with automatic formatting without having to explicitly construct a `MessageFormattedText`.  Requesting review now to make sure that the message API changes are fine and that the changes made to messaging in name resolution and module file I/O are acceptable (I converted a vector of formatted messages into a instance of the `Messages` class).