### PR TITLE
Implement host association and import statements

### DIFF
--- a/lib/common/fortran.h
+++ b/lib/common/fortran.h
@@ -25,5 +25,8 @@ namespace Fortran::common {
 // Fortran has five kinds of intrinsic data, and the derived types.
 ENUM_CLASS(TypeCategory, Integer, Real, Complex, Character, Logical, Derived)
 
+// Kinds of IMPORT statements. Default means IMPORT or IMPORT :: names.
+ENUM_CLASS(ImportKind, Default, Only, None, All)
+
 }  // namespace Fortran::common
 #endif  // FORTRAN_COMMON_FORTRAN_H_

--- a/lib/parser/grammar.h
+++ b/lib/parser/grammar.h
@@ -1293,11 +1293,12 @@ TYPE_PARSER(space >> (construct<LetterSpec>(letter, maybe("-" >> letter)) ||
 //        IMPORT [[::] import-name-list] |
 //        IMPORT , ONLY : import-name-list | IMPORT , NONE | IMPORT , ALL
 TYPE_CONTEXT_PARSER("IMPORT statement"_en_US,
-    construct<ImportStmt>("IMPORT , ONLY :" >> pure(ImportStmt::Kind::Only),
+    construct<ImportStmt>("IMPORT , ONLY :" >> pure(common::ImportKind::Only),
         nonemptyList(name)) ||
         construct<ImportStmt>(
-            "IMPORT , NONE" >> pure(ImportStmt::Kind::None)) ||
-        construct<ImportStmt>("IMPORT , ALL" >> pure(ImportStmt::Kind::All)) ||
+            "IMPORT , NONE" >> pure(common::ImportKind::None)) ||
+        construct<ImportStmt>(
+            "IMPORT , ALL" >> pure(common::ImportKind::All)) ||
         construct<ImportStmt>(
             "IMPORT" >> maybe("::"_tok) >> optionalList(name)))
 

--- a/lib/parser/parse-tree.cc
+++ b/lib/parser/parse-tree.cc
@@ -21,9 +21,10 @@
 namespace Fortran::parser {
 
 // R867
-ImportStmt::ImportStmt(Kind &&k, std::list<Name> &&n)
+ImportStmt::ImportStmt(common::ImportKind &&k, std::list<Name> &&n)
   : kind{k}, names(std::move(n)) {
-  CHECK(kind == Kind::Default || kind == Kind::Only || names.empty());
+  CHECK(kind == common::ImportKind::Default ||
+      kind == common::ImportKind::Only || names.empty());
 }
 
 // R901 designator

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -28,6 +28,7 @@
 #include "format-specification.h"
 #include "message.h"
 #include "provenance.h"
+#include "../common/fortran.h"
 #include "../common/idioms.h"
 #include "../common/indirection.h"
 #include <cinttypes>
@@ -571,11 +572,10 @@ using ObjectName = Name;
 //        IMPORT , ONLY : import-name-list | IMPORT , NONE | IMPORT , ALL
 struct ImportStmt {
   BOILERPLATE(ImportStmt);
-  ENUM_CLASS(Kind, Default, Only, None, All)
-  ImportStmt(Kind &&k) : kind{k} {}
+  ImportStmt(common::ImportKind &&k) : kind{k} {}
   ImportStmt(std::list<Name> &&n) : names(std::move(n)) {}
-  ImportStmt(Kind &&, std::list<Name> &&);
-  Kind kind{Kind::Default};
+  ImportStmt(common::ImportKind &&, std::list<Name> &&);
+  common::ImportKind kind{common::ImportKind::Default};
   std::list<Name> names;
 };
 

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -19,6 +19,7 @@
 #include "characters.h"
 #include "parse-tree-visitor.h"
 #include "parse-tree.h"
+#include "../common/fortran.h"
 #include "../common/idioms.h"
 #include "../common/indirection.h"
 #include <algorithm>
@@ -648,13 +649,13 @@ public:
   void Unparse(const ImportStmt &x) {  // R867
     Word("IMPORT");
     switch (x.kind) {
-    case ImportStmt::Kind::Default: Walk(" :: ", x.names, ", "); break;
-    case ImportStmt::Kind::Only:
+    case common::ImportKind::Default: Walk(" :: ", x.names, ", "); break;
+    case common::ImportKind::Only:
       Put(", "), Word("ONLY: ");
       Walk(x.names, ", ");
       break;
-    case ImportStmt::Kind::None: Word(", NONE"); break;
-    case ImportStmt::Kind::All: Word(", ALL"); break;
+    case common::ImportKind::None: Word(", NONE"); break;
+    case common::ImportKind::All: Word(", ALL"); break;
     default: CRASH_NO_CASE;
     }
   }

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -293,7 +293,7 @@ private:
 class ScopeHandler : public virtual ImplicitRulesVisitor {
 public:
   void set_rootScope(Scope &scope) { PushScope(scope); }
-  Scope &CurrScope() { return *scopes_.top(); }
+  Scope &CurrScope() { return *currScope_; }
   // Return the enclosing scope not corresponding to a derived type:
   Scope &CurrNonTypeScope();
 
@@ -375,8 +375,7 @@ protected:
   std::optional<const DeclTypeSpec> GetImplicitType(Symbol &);
 
 private:
-  // Stack of containing scopes; memory referenced is owned by parent scopes
-  std::stack<Scope *, std::list<Scope *>> scopes_;
+  Scope *currScope_{nullptr};
 };
 
 class ModuleVisitor : public virtual ScopeHandler {
@@ -1154,11 +1153,11 @@ Scope &ScopeHandler::PushScope(Scope::Kind kind, Symbol *symbol) {
   return scope;
 }
 void ScopeHandler::PushScope(Scope &scope) {
-  scopes_.push(&scope);
+  currScope_ = &scope;
   ImplicitRulesVisitor::PushScope();
 }
 void ScopeHandler::PopScope() {
-  scopes_.pop();
+  currScope_ = &currScope_->parent();
   ImplicitRulesVisitor::PopScope();
 }
 

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -1330,7 +1330,7 @@ bool ModuleVisitor::Pre(const parser::Submodule &x) {
   }
   PushScope(*parentScope);  // submodule is hosted in parent
   auto &symbol{BeginModule(name, true, subpPart)};
-  if (!ancestor->AddSubmodule(name, &currScope())) {
+  if (!ancestor->AddSubmodule(name, currScope())) {
     Say(name, "Module '%s' already has a submodule named '%s'"_err_en_US,
         ancestorName, name);
   }
@@ -2151,7 +2151,7 @@ void ResolveNamesVisitor::Post(const parser::CallStmt &) {
 bool ResolveNamesVisitor::Pre(const parser::ImportStmt &x) {
   auto kind{MapImportKind(x.kind)};
   auto &scope{currScope()};
-  // Check C896 and C899
+  // Check C896 and C899: where IMPORT statements are allowed
   switch (scope.kind()) {
   case Scope::Kind::Module:
     if (!scope.symbol()->get<ModuleDetails>().isSubmodule()) {
@@ -2173,7 +2173,7 @@ bool ResolveNamesVisitor::Pre(const parser::ImportStmt &x) {
     break;
   default:;
   }
-  if (auto error{scope.set_importKind(kind)}) {
+  if (auto error{scope.SetImportKind(kind)}) {
     Say(std::move(*error));
   }
   for (auto &name : x.names) {

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -2393,13 +2393,19 @@ void ResolveNamesVisitor::Post(const parser::SpecificationPart &s) {
 
 bool ResolveNamesVisitor::Pre(const parser::MainProgram &x) {
   using stmtType = std::optional<parser::Statement<parser::ProgramStmt>>;
-  if (const stmtType &stmt = std::get<stmtType>(x.t)) {
+  if (auto &stmt{std::get<stmtType>(x.t)}) {
     const parser::Name &name{stmt->statement.v};
     Symbol &symbol{MakeSymbol(name, MainProgramDetails{})};
     PushScope(Scope::Kind::MainProgram, &symbol);
     MakeSymbol(name, MainProgramDetails{});
   } else {
     PushScope(Scope::Kind::MainProgram, nullptr);
+  }
+  if (auto &subpPart{
+          std::get<std::optional<parser::InternalSubprogramPart>>(x.t)}) {
+    subpNamesOnly_ = SubprogramKind::Internal;
+    parser::Walk(*subpPart, *static_cast<ResolveNamesVisitor *>(this));
+    subpNamesOnly_ = std::nullopt;
   }
   return true;
 }

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -66,8 +66,8 @@ Scope *Scope::FindSubmodule(const SourceName &name) const {
     return it->second;
   }
 }
-bool Scope::AddSubmodule(const SourceName &name, Scope *submodule) {
-  return submodules_.emplace(name, submodule).second;
+bool Scope::AddSubmodule(const SourceName &name, Scope &submodule) {
+  return submodules_.emplace(name, &submodule).second;
 }
 DerivedTypeSpec &Scope::MakeDerivedTypeSpec(const SourceName &name) {
   derivedTypeSpecs_.emplace_back(name);
@@ -88,7 +88,7 @@ Scope::ImportKind Scope::importKind() const {
   return ImportKind::Default;
 }
 
-std::optional<parser::MessageFixedText> Scope::set_importKind(ImportKind kind) {
+std::optional<parser::MessageFixedText> Scope::SetImportKind(ImportKind kind) {
   if (!importKind_.has_value()) {
     importKind_ = kind;
     return std::nullopt;
@@ -96,7 +96,7 @@ std::optional<parser::MessageFixedText> Scope::set_importKind(ImportKind kind) {
   std::optional<parser::MessageFixedText> error;
   bool hasNone{kind == ImportKind::None || *importKind_ == ImportKind::None};
   bool hasAll{kind == ImportKind::All || *importKind_ == ImportKind::All};
-  // Check C8100 and C898
+  // Check C8100 and C898: constraints on multiple IMPORT statements
   if (hasNone || hasAll) {
     return hasNone
         ? "IMPORT,NONE must be the only IMPORT statement in a scope"_err_en_US

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -74,7 +74,7 @@ DerivedTypeSpec &Scope::MakeDerivedTypeSpec(const SourceName &name) {
   return derivedTypeSpecs_.back();
 }
 
-Scope::ImportKind Scope::importKind() const {
+Scope::ImportKind Scope::GetImportKind() const {
   if (importKind_) {
     return *importKind_;
   }
@@ -122,7 +122,7 @@ bool Scope::CanImport(const SourceName &name) const {
   if (kind_ == Kind::Global) {
     return false;
   }
-  switch (importKind()) {
+  switch (GetImportKind()) {
   case ImportKind::None: return false;
   case ImportKind::All:
   case ImportKind::Default: return true;

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -17,6 +17,7 @@
 
 #include "attr.h"
 #include "symbol.h"
+#include "../common/fortran.h"
 #include "../common/idioms.h"
 #include "../parser/message.h"
 #include <list>
@@ -37,7 +38,7 @@ public:
   static Scope globalScope;  // contains program-units
 
   ENUM_CLASS(Kind, System, Global, Module, MainProgram, Subprogram, DerivedType)
-  ENUM_CLASS(ImportKind, Default, Only, None, All);
+  using ImportKind = common::ImportKind;
 
   Scope(Scope &parent, Kind kind, Symbol *symbol)
     : parent_{parent}, kind_{kind}, symbol_{symbol} {
@@ -125,7 +126,7 @@ public:
   // that are referenced by SourceName objects.
   void set_chars(std::string &&chars) { chars_ = std::move(chars); }
 
-  ImportKind importKind() const;
+  ImportKind GetImportKind() const;
   // Names appearing in IMPORT statements in this scope
   std::set<SourceName> importNames() const { return importNames_; }
 

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -117,7 +117,7 @@ public:
   // For Module scope, maintain a mapping of all submodule scopes with this
   // module as its ancestor module. AddSubmodule returns false if already there.
   Scope *FindSubmodule(const SourceName &) const;
-  bool AddSubmodule(const SourceName &, Scope *);
+  bool AddSubmodule(const SourceName &, Scope &);
 
   DerivedTypeSpec &MakeDerivedTypeSpec(const SourceName &);
 
@@ -131,7 +131,7 @@ public:
 
   // Set the kind of imports from host into this scope.
   // Return an error message for incompatible kinds.
-  std::optional<parser::MessageFixedText> set_importKind(ImportKind);
+  std::optional<parser::MessageFixedText> SetImportKind(ImportKind);
 
   bool add_importName(const SourceName &);
 

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -372,7 +372,7 @@ std::ostream &operator<<(std::ostream &os, const Symbol &symbol) {
 // Output a unique name for a scope by qualifying it with the names of
 // parent scopes. For scopes without corresponding symbols, use "ANON".
 static void DumpUniqueName(std::ostream &os, const Scope &scope) {
-  if (&scope != &Scope::globalScope) {
+  if (scope.kind() != Scope::Kind::Global) {
     DumpUniqueName(os, scope.parent());
     os << '/';
     if (auto *scopeSymbol{scope.symbol()}) {

--- a/lib/semantics/unparse-with-symbols.cc
+++ b/lib/semantics/unparse-with-symbols.cc
@@ -59,6 +59,8 @@ public:
   void Post(const parser::DerivedTypeSpec &) { PostReference(); }
   bool Pre(const parser::UseStmt &) { return PreReference(); }
   void Post(const parser::UseStmt &) { PostReference(); }
+  bool Pre(const parser::ImportStmt &) { return PreReference(); }
+  void Post(const parser::ImportStmt &) { PostReference(); }
 
 private:
   using symbolMap = std::multimap<const char *, const Symbol *>;

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -60,6 +60,7 @@ set(SYMBOL_TESTS
   symbol01.f90
   symbol02.f90
   symbol03.f90
+  symbol04.f90
 )
 
 # These test files have expected .mod file contents in the source

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -51,11 +51,15 @@ set(ERROR_TESTS
   resolve25.f90
   resolve26.f90
   resolve27.f90
+  resolve28.f90
+  resolve29.f90
 )
 
 # These test files have expected symbols in the source
 set(SYMBOL_TESTS
   symbol01.f90
+  symbol02.f90
+  symbol03.f90
 )
 
 # These test files have expected .mod file contents in the source

--- a/test/semantics/resolve26.f90
+++ b/test/semantics/resolve26.f90
@@ -1,3 +1,17 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
 module m1
   interface
     module subroutine s()

--- a/test/semantics/resolve27.f90
+++ b/test/semantics/resolve27.f90
@@ -1,3 +1,17 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
 module m
   interface
     module subroutine s()

--- a/test/semantics/resolve28.f90
+++ b/test/semantics/resolve28.f90
@@ -1,0 +1,63 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+subroutine s
+  type t
+  end type
+  interface
+    subroutine s1
+      import, none
+      !ERROR: IMPORT,NONE must be the only IMPORT statement in a scope
+      import, all
+    end subroutine
+    subroutine s2
+      import :: t
+      !ERROR: IMPORT,NONE must be the only IMPORT statement in a scope
+      import, none
+    end subroutine
+    subroutine s3
+      import, all
+      !ERROR: IMPORT,ALL must be the only IMPORT statement in a scope
+      import :: t
+    end subroutine
+    subroutine s4
+      import :: t
+      !ERROR: IMPORT,ALL must be the only IMPORT statement in a scope
+      import, all
+    end subroutine
+  end interface
+end
+
+module m
+  !ERROR: IMPORT is not allowed in a module scoping unit
+  import, none
+end
+
+submodule(m) sub1
+  import, all !OK
+end
+
+submodule(m) sub2
+  !ERROR: IMPORT,NONE is not allowed in a submodule scoping unit
+  import, none
+end
+
+function f
+  !ERROR: IMPORT is not allowed in an external subprogram scoping unit
+  import, all
+end
+
+!ERROR: IMPORT is not allowed in a main program scoping unit
+import
+end

--- a/test/semantics/resolve29.f90
+++ b/test/semantics/resolve29.f90
@@ -1,0 +1,57 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+module m
+  type t1
+  end type
+  type t3
+  end type
+  interface
+    subroutine s1(x)
+      !ERROR: 't1' from host is not accessible
+      import :: t1
+      type(t1) :: x
+      integer :: t1
+    end subroutine
+    subroutine s2()
+      !ERROR: 't2' not found in host scope
+      import :: t2
+    end subroutine
+    subroutine s3(x, y)
+      !ERROR: Derived type 't1' not found
+      type(t1) :: x, y
+    end subroutine
+    subroutine s4(x, y)
+      !ERROR: 't3' from host is not accessible
+      import, all
+      type(t1) :: x
+      type(t3) :: y
+      integer :: t3
+    end subroutine
+  end interface
+contains
+  subroutine s5()
+  end
+  subroutine s6()
+    import, only: s5
+    implicit none(external)
+    call s5()
+  end
+  subroutine s7()
+    import, only: t1
+    implicit none(external)
+    !ERROR: 's5' is an external procedure without the EXTERNAL attribute in a scope with IMPLICIT NONE(EXTERNAL)
+    call s5()
+  end
+end module

--- a/test/semantics/symbol02.f90
+++ b/test/semantics/symbol02.f90
@@ -1,0 +1,57 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test host association in module subroutine and internal subroutine.
+
+!DEF: /m Module
+module m
+ !DEF: /m/t PUBLIC DerivedType
+ type :: t
+ end type
+ !DEF: /m/x PUBLIC Entity TYPE(t)
+ !REF: /m/t
+ type(t) :: x
+contains
+ !DEF: /m/s PUBLIC Subprogram
+ subroutine s
+  !DEF: /m/s/y Entity TYPE(t)
+  !REF: /m/t
+  type(t) :: y
+  !REF: /m/s/y
+  !REF: /m/x
+  y = x
+  !REF: /m/s/s
+  call s
+ contains
+  !DEF: /m/s/s2 Subprogram
+  subroutine s2
+   !REF: /m/x
+   !REF: /m/s/y
+   !REF: /m/t
+   !REF: /m/s/s
+   import, only: x, y, t, s
+   !DEF: /m/s/s2/z Entity TYPE(t)
+   !REF: /m/t
+   type(t) :: z
+   !REF: /m/s/s2/z
+   !REF: /m/x
+   z = x
+   !REF: /m/s/s2/z
+   !REF: /m/s/y
+   z = y
+   !REF: /m/s/s
+   call s
+  end subroutine
+ end subroutine
+end module

--- a/test/semantics/symbol03.f90
+++ b/test/semantics/symbol03.f90
@@ -1,0 +1,30 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test host association in internal subroutine of main program.
+
+!DEF: /main MainProgram
+program main
+ !DEF: /main/x Entity INTEGER
+ integer x
+ !REF: /main/s
+ call s
+contains
+ !DEF: /main/s Subprogram
+ subroutine s
+  !DEF: /main/s/y (implicit) ObjectEntity REAL
+  !REF: /main/x
+  y = x
+ end subroutine
+end program

--- a/test/semantics/symbol04.f90
+++ b/test/semantics/symbol04.f90
@@ -1,0 +1,30 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test that derived type component does not hide type in host.
+
+!DEF: /m Module
+module m
+ !DEF: /m/t1 PUBLIC DerivedType
+ type :: t1
+ end type
+ !DEF: /m/t2 PUBLIC DerivedType
+ type :: t2
+  !DEF: /m/t2/t1 ObjectEntity INTEGER
+  integer :: t1
+  !DEF: /m/t2/x ObjectEntity TYPE(t1)
+  !REF: /m/t1
+  type(t1) :: x
+ end type
+end module


### PR DESCRIPTION
Host association is done by search for symbols using `Scope::FindSymbol()`
which looks for the the name in the parent scope if the import rules
permit it.

Import statements are implemented using `importKind_` and `importNames_`
in class `Scope`. Most of the constraints are checked when the
`ImportStmt` is encountered. `CheckImports()` is called at the end of
the `SpecificationPart` to verify the names mentioned in the IMPORT
statement. That has to happen then so that we can detect if an imported
name is hidden by a declaration in the current scope.
