### PR TITLE
Add support for BLOCK construct

### DIFF
--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -37,8 +37,10 @@ class MessageHandler;
 
 static GenericSpec MapGenericSpec(const parser::GenericSpec &);
 
-// ImplicitRules maps initial character of identifier to the DeclTypeSpec*
-// representing the implicit type; nullptr if none.
+// ImplicitRules maps initial character of identifier to the DeclTypeSpec
+// representing the implicit type; std::nullopt if none.
+// It also records the presence of IMPLICIT NONE statements.
+// When inheritFromParent is set, defaults come from the parent rules.
 class ImplicitRules {
 public:
   ImplicitRules(MessageHandler &messages)

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -49,6 +49,9 @@ Scope::size_type Scope::erase(const SourceName &name) {
   }
 }
 Symbol *Scope::FindSymbol(const SourceName &name) {
+  if (kind() == Kind::DerivedType) {
+    return parent_.FindSymbol(name);
+  }
   const auto it{find(name)};
   if (it != end()) {
     return it->second;

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -96,7 +96,6 @@ std::optional<parser::MessageFixedText> Scope::SetImportKind(ImportKind kind) {
     importKind_ = kind;
     return std::nullopt;
   }
-  std::optional<parser::MessageFixedText> error;
   bool hasNone{kind == ImportKind::None || *importKind_ == ImportKind::None};
   bool hasAll{kind == ImportKind::All || *importKind_ == ImportKind::All};
   // Check C8100 and C898: constraints on multiple IMPORT statements

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -37,7 +37,8 @@ public:
   static Scope systemScope;
   static Scope globalScope;  // contains program-units
 
-  ENUM_CLASS(Kind, System, Global, Module, MainProgram, Subprogram, DerivedType)
+  ENUM_CLASS(
+      Kind, System, Global, Module, MainProgram, Subprogram, DerivedType, Block)
   using ImportKind = common::ImportKind;
 
   Scope(Scope &parent, Kind kind, Symbol *symbol)

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -370,7 +370,8 @@ std::ostream &operator<<(std::ostream &os, const Symbol &symbol) {
 }
 
 // Output a unique name for a scope by qualifying it with the names of
-// parent scopes. For scopes without corresponding symbols, use "ANON".
+// parent scopes. For scopes without corresponding symbols, use the kind
+// with an index (e.g. Block1, Block2, etc.).
 static void DumpUniqueName(std::ostream &os, const Scope &scope) {
   if (scope.kind() != Scope::Kind::Global) {
     DumpUniqueName(os, scope.parent());
@@ -378,7 +379,16 @@ static void DumpUniqueName(std::ostream &os, const Scope &scope) {
     if (auto *scopeSymbol{scope.symbol()}) {
       os << scopeSymbol->name().ToString();
     } else {
-      os << "ANON";
+      int index{1};
+      for (auto &child : scope.parent().children()) {
+        if (child == scope) {
+          break;
+        }
+        if (child.kind() == scope.kind()) {
+          ++index;
+        }
+      }
+      os << Scope::EnumToString(scope.kind()) << index;
     }
   }
 }

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -24,6 +24,7 @@ set(ERROR_TESTS
   implicit05.f90
   implicit06.f90
   implicit07.f90
+  implicit08.f90
   resolve01.f90
   resolve02.f90
   resolve03.f90
@@ -53,6 +54,7 @@ set(ERROR_TESTS
   resolve27.f90
   resolve28.f90
   resolve29.f90
+  resolve30.f90
 )
 
 # These test files have expected symbols in the source
@@ -61,6 +63,7 @@ set(SYMBOL_TESTS
   symbol02.f90
   symbol03.f90
   symbol04.f90
+  symbol05.f90
 )
 
 # These test files have expected .mod file contents in the source

--- a/test/semantics/implicit07.f90
+++ b/test/semantics/implicit07.f90
@@ -17,4 +17,8 @@ external x
 call x
 !ERROR: 'y' is an external procedure without the EXTERNAL attribute in a scope with IMPLICIT NONE(EXTERNAL)
 call y
+block
+  !ERROR: 'z' is an external procedure without the EXTERNAL attribute in a scope with IMPLICIT NONE(EXTERNAL)
+  call z
+end block
 end

--- a/test/semantics/implicit08.f90
+++ b/test/semantics/implicit08.f90
@@ -12,26 +12,9 @@
 ! See the License for the specific language governing permissions and
 ! limitations under the License.
 
-!ERROR: No explicit type declared for 'f'
-function f()
-  implicit none
-end
-
-!ERROR: No explicit type declared for 'y'
-subroutine s(x, y)
-  implicit none
-  integer :: x
-end
-
-subroutine s2
-  implicit none
+subroutine s1
   block
-    !ERROR: No explicit type declared for 'i'
-    i = 1
+    !ERROR: IMPLICIT statement is not allowed in BLOCK construct
+    implicit logical(a)
   end block
-contains
-  subroutine s3
-    !ERROR: No explicit type declared for 'j'
-    j = 2
-  end subroutine
 end subroutine

--- a/test/semantics/resolve30.f90
+++ b/test/semantics/resolve30.f90
@@ -12,26 +12,30 @@
 ! See the License for the specific language governing permissions and
 ! limitations under the License.
 
-!ERROR: No explicit type declared for 'f'
-function f()
-  implicit none
-end
-
-!ERROR: No explicit type declared for 'y'
-subroutine s(x, y)
-  implicit none
-  integer :: x
+subroutine s1
+  integer x
+  block
+    import, none
+    !ERROR: 'x' from host scoping unit is not accessible due to IMPORT
+    x = 1
+  end block
 end
 
 subroutine s2
-  implicit none
   block
-    !ERROR: No explicit type declared for 'i'
-    i = 1
+    import, none
+    !ERROR: 'y' from host scoping unit is not accessible due to IMPORT
+    y = 1
   end block
-contains
-  subroutine s3
-    !ERROR: No explicit type declared for 'j'
-    j = 2
-  end subroutine
+end
+
+subroutine s3
+  integer j
+  block
+    import, only: j
+    type t
+      !ERROR: 'i' from host scoping unit is not accessible due to IMPORT
+      real :: x(10) = [(i, i=1,10)]
+    end type
+  end block
 end subroutine

--- a/test/semantics/symbol05.f90
+++ b/test/semantics/symbol05.f90
@@ -1,0 +1,93 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Explicit and implicit entities in blocks
+
+!DEF: /s1 Subprogram
+subroutine s1
+ !DEF: /s1/x Entity INTEGER
+ integer x
+ block
+  !DEF: /s1/Block1/y Entity INTEGER
+  integer y
+  !REF: /s1/x
+  x = 1
+  !REF: /s1/Block1/y
+  y = 2.0
+ end block
+ block
+  !DEF: /s1/Block2/y Entity REAL
+  real y
+  !REF: /s1/Block2/y
+  y = 3.0
+ end block
+end subroutine
+
+!DEF: /s2 Subprogram
+subroutine s2
+ implicit integer(w-x)
+ block
+  !DEF: /s2/x (implicit) ObjectEntity INTEGER
+  x = 1
+  !DEF: /s2/y (implicit) ObjectEntity REAL
+  y = 2
+ end block
+contains
+ !DEF: /s2/s Subprogram
+ subroutine s
+  !REF: /s2/x
+  x = 1
+  !DEF: /s2/s/w (implicit) ObjectEntity INTEGER
+  w = 1
+ end subroutine
+end subroutine
+
+!DEF: /s3 Subprogram
+subroutine s3
+ block
+  !DEF: /s3/Block1/t DerivedType
+  type :: t
+   !DEF: /s3/i (implicit) ObjectEntity INTEGER
+   !DEF: /s3/Block1/t/x ObjectEntity REAL
+   real :: x(10) = [(i, i=1,10)]
+  end type
+ end block
+end subroutine
+
+!DEF: /s4 Subprogram
+subroutine s4
+ implicit integer(x)
+ interface
+  !DEF: /s4/s EXTERNAL Subprogram
+  !DEF: /s4/s/x (implicit) ObjectEntity REAL
+  !DEF: /s4/s/y (implicit) ObjectEntity INTEGER
+  subroutine s (x, y)
+   implicit integer(y)
+  end subroutine
+ end interface
+end subroutine
+
+!DEF: /s5 Subprogram
+subroutine s5
+ block
+  !DEF: /s5/Block1/x (implicit) ObjectEntity REAL
+  dimension :: x(2)
+  block
+   !DEF: /s5/Block1/Block1/x (implicit) ObjectEntity REAL
+   dimension :: x(3)
+  end block
+ end block
+ !DEF: /s5/x (implicit) ObjectEntity REAL
+ x = 1.0
+end subroutine


### PR DESCRIPTION
A `BLOCK` statement opens a new scope. It is different from other scopes
in that implicitly typed entities are defined in the enclosing non-block
scope, not immediately in the block. This means that `IMPORT` statements
can cause them to be hidden.

Check that blocks can't have `IMPLICIT` statements in them. It is simpler
for the parser not to deal with the different between a
specification-part and a block-specification-part.

Change `ImplicitRules` to have a parent that is consulted when there isn't
an answer in the current one. For an interface body that does not happen
but for all other nested scopes it does. This parent link eliminates the
need for the `implicitRules_` stack. Make `isImplicitNoneType_` and
`isImplicitNoneExternal_` optional: not set means look in parent.
Fixes #71.

Remove `CurrNonTypeScope()` and put the logic in `Symbol::FindSymbol`.