### PR TITLE
Better error recovery and messages for PROCEDURE components (issue#174)

### DIFF
--- a/documentation/ParserCombinators.md
+++ b/documentation/ParserCombinators.md
@@ -96,6 +96,8 @@ They are `constexpr`, so they should be viewed as type-safe macros.
 * `recovery(p, q)` is equivalent to `p || q`, except that error messages
   generated from the first parser are retained, and a flag is set in
   the ParseState to remember that error recovery was necessary.
+* `localRecovery(msg, p, q)` is equivalent to `recovery(withMessage(msg, p), defaulted(cut >> p) >> q)`.  It is useful for targeted error recovery situations
+  within statements.
 
 Note that
 ```
@@ -143,9 +145,12 @@ is built.  All of the following parsers consume characters acquired from
    free form source.
 * `parenthesized(p)` is shorthand for `"(" >> p / ")"`.
 * `bracketed(p)` is shorthand for `"[" >> p / "]"`.
-* `nonEmptyListOf(p)` matches a comma-separated list of one or more
+* `nonEmptyList(p)` matches a comma-separated list of one or more
   instances of p.
-* `optionalListOf(p)` is the same thing, but can be empty, and always succeeds.
+* `nonEmptyList(errorMessage, p)` is equivalent to
+  `withMessage(errorMessage, nonemptyList(p))`, which allows one to supply
+  a meaningful error message in the event of an empty list.
+* `optionalList(p)` is the same thing, but can be empty, and always succeeds.
 
 ### Debugging Parser
 Last, a string literal `"..."_debug` denotes a parser that emits the string to

--- a/lib/parser/basic-parsers.h
+++ b/lib/parser/basic-parsers.h
@@ -379,6 +379,7 @@ inline constexpr auto operator||(const PA &pa, const PB &pb) {
 // If a and b are parsers, then recovery(a,b) returns a parser that succeeds if
 // a does so, or if a fails and b succeeds.  If a succeeds, b is not attempted.
 // All messages from the first parse are retained.
+// The two parsers must return values of the same type.
 template<typename PA, typename PB> class RecoveryParser {
 public:
   using resultType = typename PA::resultType;
@@ -1244,6 +1245,13 @@ template<bool pass> struct FixedParser {
 
 constexpr FixedParser<true> ok;
 constexpr FixedParser<false> cut;
+
+// A variant of recovery() above for convenience.
+template<typename PA, typename PB>
+inline constexpr auto localRecovery(
+    MessageFixedText msg, const PA &pa, const PB &pb) {
+  return recovery(withMessage(msg, pa), pb >> defaulted(cut >> pa));
+}
 
 // nextCh is a parser that succeeds if the parsing state is not
 // at the end of its input, returning the next character location and

--- a/lib/parser/grammar.h
+++ b/lib/parser/grammar.h
@@ -445,7 +445,7 @@ constexpr auto obsoleteExecutionPartConstruct{recovery(ignoredStatementPrefix >>
             "obsolete legacy extension is not supported"_err_en_US),
     construct<ExecutionPartConstruct>(
         statement("REDIMENSION" >> name >>
-            parenthesized(Parser<AllocateShapeSpec>{}) >> ok) >>
+            parenthesized(nonemptyList(Parser<AllocateShapeSpec>{})) >> ok) >>
         construct<ErrorRecovery>()))};
 
 TYPE_PARSER(recovery(

--- a/lib/parser/stmt-parser.h
+++ b/lib/parser/stmt-parser.h
@@ -61,9 +61,14 @@ template<typename PA> inline constexpr auto unambiguousStatement(const PA &p) {
 constexpr auto ignoredStatementPrefix{
     skipStuffBeforeStatement >> maybe(label) >> maybe(name / ":") >> space};
 
-// Error recovery within statements: skip to the end of the line,
+// Error recovery within a statement() call: skip *to* the end of the line,
+// unless at an END or CONTAINS statement.
+constexpr auto inStmtErrorRecovery{!"END"_tok >> !"CONTAINS"_tok >>
+    SkipTo<'\n'>{} >> construct<ErrorRecovery>()};
+
+// Error recovery within statement sequences: skip *past* the end of the line,
 // but not over an END or CONTAINS statement.
-constexpr auto stmtErrorRecovery{!"END"_tok >> !"CONTAINS"_tok >>
+constexpr auto skipStmtErrorRecovery{!"END"_tok >> !"CONTAINS"_tok >>
     SkipPast<'\n'>{} >> construct<ErrorRecovery>()};
 
 // Error recovery across statements: skip the line, unless it looks

--- a/lib/semantics/rewrite-parse-tree.h
+++ b/lib/semantics/rewrite-parse-tree.h
@@ -17,7 +17,7 @@
 
 namespace Fortran::parser {
 struct Program;
-struct CookedSource;
+class CookedSource;
 }  // namespace Fortran::parser
 
 namespace Fortran::semantics {


### PR DESCRIPTION
Also change a `struct` to a `class` to silence a clang (only) warning.