### PR TITLE
Improve error message for "type already declared"

### DIFF
--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -2287,10 +2287,12 @@ void DeclarationVisitor::SetType(
   if (!prevType) {
     symbol.SetType(type);
   } else if (!symbol.test(Symbol::Flag::Implicit)) {
-    Say(name, "The type of '%s' has already been declared"_err_en_US);
+    Say2(name, "The type of '%s' has already been declared"_err_en_US,
+        symbol.name(), "Declaration of '%s'"_en_US);
   } else if (type != *prevType) {
-    Say(name,
-        "The type of '%s' has already been implicitly declared"_err_en_US);
+    Say2(name,
+        "The type of '%s' has already been implicitly declared"_err_en_US,
+        symbol.name(), "Declaration of '%s'"_en_US);
   } else {
     symbol.set(Symbol::Flag::Implicit, false);
   }


### PR DESCRIPTION
Add reference to the statement where the type was first set. Compiling resolve01.f90 now results in this:
```
test/semantics/resolve01.f90:17:9: error: The type of 'x' has already been declared
  real :: x
          ^
test/semantics/resolve01.f90:15:12: Declaration of 'x'
  integer :: x
             ^
test/semantics/resolve01.f90:22:9: error: The type of 'k' has already been implicitly declared
  real :: k
          ^
test/semantics/resolve01.f90:19:19: Declaration of 'k'
  parameter(i=1,j=2,k=3)
                    ^
```