### PR TITLE
Simplify representation of intrinsic types

### DIFF
--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -87,10 +87,9 @@ IntrinsicTypeSpec::IntrinsicTypeSpec(TypeCategory category, int kind)
 int IntrinsicTypeSpec::GetDefaultKind(TypeCategory category) {
   switch (category) {
   case TypeCategory::Character: return evaluate::DefaultCharacter::kind;
-  //case TypeCategory::Complex: return evaluate::DefaultComplex::kind;
-  case TypeCategory::Complex: return 4;  // TEMP to work around bug
   case TypeCategory::Integer: return evaluate::DefaultInteger::kind;
   case TypeCategory::Logical: return evaluate::DefaultLogical::kind;
+  case TypeCategory::Complex:
   case TypeCategory::Real: return evaluate::DefaultReal::kind;
   default: CRASH_NO_CASE;
   }

--- a/test/semantics/modfile01.f90
+++ b/test/semantics/modfile01.f90
@@ -27,11 +27,11 @@ end
 
 !Expect: m.mod
 !module m
-!integer::i
-!integer,private::j
+!integer(4)::i
+!integer(4),private::j
 !type::t
-!integer::i
-!integer,private::j
+!integer(4)::i
+!integer(4),private::j
 !end type
 !type,private::u
 !end type

--- a/test/semantics/modfile02.f90
+++ b/test/semantics/modfile02.f90
@@ -28,10 +28,10 @@ end
 !Expect: m.mod
 !module m
 !type,private::t1
-!integer::i
+!integer(4)::i
 !end type
 !type,private::t2
-!integer::i
+!integer(4)::i
 !end type
 !type(t1)::x1
 !type(t2),private::x2

--- a/test/semantics/modfile03.f90
+++ b/test/semantics/modfile03.f90
@@ -35,14 +35,14 @@ end
 
 !Expect: m1.mod
 !module m1
-!integer::x1
-!integer,private::x2
+!integer(4)::x1
+!integer(4),private::x2
 !end
 
 !Expect: m2.mod
 !module m2
 !use m1,only:x1
-!integer::y1
+!integer(4)::y1
 !end
 
 !Expect: m3.mod

--- a/test/semantics/modfile04.f90
+++ b/test/semantics/modfile04.f90
@@ -38,14 +38,14 @@ end
 !module m
 !contains
 !pure subroutine s(x,y) bind(c)
-!logical,intent(in)::x
-!real,intent(inout)::y
+!logical(4),intent(in)::x
+!real(4),intent(inout)::y
 !end
 !function f1() result(x)
-!real::x
+!real(4)::x
 !end
 !function f2(y)
-!real::f2
-!complex::y
+!real(4)::f2
+!complex(4)::y
 !end
 !end

--- a/test/semantics/modfile05.f90
+++ b/test/semantics/modfile05.f90
@@ -29,9 +29,9 @@ end
 
 !Expect: m1.mod
 !module m1
-!real::x
-!integer::y
-!real,volatile::z
+!real(4)::x
+!integer(4)::y
+!real(4),volatile::z
 !end
 
 !Expect: m2.mod

--- a/test/semantics/modfile06.f90
+++ b/test/semantics/modfile06.f90
@@ -28,14 +28,14 @@ end
 !module m
 ! interface
 !  function f(x)
-!   integer::f
-!   real::x
+!   integer(4)::f
+!   real(4)::x
 !  end
 ! end interface
 ! interface
 !  subroutine s(y,z)
-!   logical::y
-!   complex::z
+!   logical(4)::y
+!   complex(4)::z
 !  end
 ! end interface
 !end

--- a/test/semantics/modfile07.f90
+++ b/test/semantics/modfile07.f90
@@ -42,20 +42,20 @@ end
 ! generic::foo=>s1,s2
 ! interface
 !  subroutine s1(x)
-!   real::x
+!   real(4)::x
 !  end
 ! end interface
 ! interface
 !  subroutine s2(x)
-!   complex::x
+!   complex(4)::x
 !  end
 ! end interface
 ! generic::bar=>s1,s2,s3,s4
 !contains
 ! subroutine s3(x)
-!  logical::x
+!  logical(4)::x
 ! end
 ! subroutine s4(x)
-!  integer::x
+!  integer(4)::x
 ! end
 !end

--- a/test/semantics/modfile08.f90
+++ b/test/semantics/modfile08.f90
@@ -35,16 +35,16 @@ end
 
 !Expect: m.mod
 !module m
-!  procedure(real)::a
-!  procedure(logical)::b
-!  procedure(complex)::c
+!  procedure(real(4))::a
+!  procedure(logical(4))::b
+!  procedure(complex(4))::c
 !  procedure()::d
 !  procedure()::e
-!  procedure(real)::f
+!  procedure(real(4))::f
 !  procedure(s)::g
 !  type::t
 !    procedure(),nopass,pointer::e
-!    procedure(real),nopass,pointer::f
+!    procedure(real(4)),nopass,pointer::f
 !    procedure(s),pointer,private::g
 !  end type
 !contains

--- a/test/semantics/modfile09-a.f90
+++ b/test/semantics/modfile09-a.f90
@@ -8,7 +8,7 @@ end
 
 !Expect: m.mod
 !module m
-!integer::m1_x
+!integer(4)::m1_x
 !interface
 !module subroutine s()
 !end

--- a/test/semantics/modfile09-b.f90
+++ b/test/semantics/modfile09-b.f90
@@ -4,5 +4,5 @@ end
 
 !Expect: m-s1.mod
 !submodule(m) s1
-!integer::s1_x
+!integer(4)::s1_x
 !end

--- a/test/semantics/modfile09-c.f90
+++ b/test/semantics/modfile09-c.f90
@@ -4,5 +4,5 @@ end
 
 !Expect: m-s2.mod
 !submodule(m:s1) s2
-!integer::s2_x
+!integer(4)::s2_x
 !end

--- a/test/semantics/modfile09-d.f90
+++ b/test/semantics/modfile09-d.f90
@@ -4,5 +4,5 @@ end
 
 !Expect: m-s3.mod
 !submodule(m:s2) s3
-!integer::s3_x
+!integer(4)::s3_x
 !end

--- a/test/semantics/modfile10.f90
+++ b/test/semantics/modfile10.f90
@@ -38,6 +38,8 @@ module m
     sequence
     integer i
     real x
+    double precision y
+    double complex z
   end type
 contains
   subroutine b()
@@ -58,19 +60,19 @@ end module
 !module m
 !  interface
 !    subroutine a(i,j)
-!      integer::i
-!      integer::j
+!      integer(4)::i
+!      integer(4)::j
 !    end
 !  end interface
 !  type,abstract::t
-!    integer::i
+!    integer(4)::i
 !  contains
 !    procedure(a),deferred,nopass::q
 !    procedure(b),deferred,nopass::p
 !    procedure(b),deferred,nopass::r
 !  end type
 !  type::t2
-!    integer::x
+!    integer(4)::x
 !  contains
 !    final::c
 !    procedure,non_overridable,private::d
@@ -78,8 +80,10 @@ end module
 !  end type
 !  type::t3
 !    sequence
-!    integer::i
-!    real::x
+!    integer(4)::i
+!    real(4)::x
+!    real(8)::y
+!    complex(8)::z
 !  end type
 !contains
 !  subroutine b()

--- a/test/semantics/modfile11.f90
+++ b/test/semantics/modfile11.f90
@@ -28,13 +28,13 @@ end
 !Expect: m.mod
 !module m
 !  type::t1(a,b,c)
-!    integer,kind::a
+!    integer(4),kind::a
 !    integer(8),len::b
 !    integer(8),len::c
-!    integer::d
+!    integer(4)::d
 !  end type
 !  type,extends(t1)::t2(e)
-!    integer,len::e
+!    integer(4),len::e
 !  end type
 !  type,bind(c),extends(t2)::t3
 !  end type

--- a/test/semantics/symbol01.f90
+++ b/test/semantics/symbol01.f90
@@ -20,8 +20,8 @@ module m
  private :: f
 contains
  !DEF: /m/s BIND(C), PUBLIC, PURE Subprogram
- !DEF: /m/s/x INTENT(IN) (implicit) ObjectEntity REAL
- !DEF: /m/s/y INTENT(INOUT) (implicit) ObjectEntity REAL
+ !DEF: /m/s/x INTENT(IN) (implicit) ObjectEntity REAL(4)
+ !DEF: /m/s/y INTENT(INOUT) (implicit) ObjectEntity REAL(4)
  pure subroutine s (x, y) bind(c)
   intent(in) :: x
   intent(inout) :: y
@@ -31,7 +31,7 @@ contains
   end subroutine
  end subroutine
  !DEF: /m/f PRIVATE, PURE, RECURSIVE Subprogram
- !DEF: /m/f/x ALLOCATABLE ObjectEntity REAL
+ !DEF: /m/f/x ALLOCATABLE ObjectEntity REAL(4)
  recursive pure function f() result(x)
   real, allocatable :: x
   !REF: /m/f/x

--- a/test/semantics/symbol03.f90
+++ b/test/semantics/symbol03.f90
@@ -16,14 +16,14 @@
 
 !DEF: /main MainProgram
 program main
- !DEF: /main/x ObjectEntity INTEGER
+ !DEF: /main/x ObjectEntity INTEGER(4)
  integer x
  !REF: /main/s
  call s
 contains
  !DEF: /main/s Subprogram
  subroutine s
-  !DEF: /main/s/y (implicit) ObjectEntity REAL
+  !DEF: /main/s/y (implicit) ObjectEntity REAL(4)
   !REF: /main/x
   y = x
  end subroutine

--- a/test/semantics/symbol04.f90
+++ b/test/semantics/symbol04.f90
@@ -21,7 +21,7 @@ module m
  end type
  !DEF: /m/t2 PUBLIC DerivedType
  type :: t2
-  !DEF: /m/t2/t1 ObjectEntity INTEGER
+  !DEF: /m/t2/t1 ObjectEntity INTEGER(4)
   integer :: t1
   !DEF: /m/t2/x ObjectEntity TYPE(t1)
   !REF: /m/t1

--- a/test/semantics/symbol05.f90
+++ b/test/semantics/symbol05.f90
@@ -16,10 +16,10 @@
 
 !DEF: /s1 Subprogram
 subroutine s1
- !DEF: /s1/x ObjectEntity INTEGER
+ !DEF: /s1/x ObjectEntity INTEGER(4)
  integer x
  block
-  !DEF: /s1/Block1/y ObjectEntity INTEGER
+  !DEF: /s1/Block1/y ObjectEntity INTEGER(4)
   integer y
   !REF: /s1/x
   x = 1
@@ -27,7 +27,7 @@ subroutine s1
   y = 2.0
  end block
  block
-  !DEF: /s1/Block2/y ObjectEntity REAL
+  !DEF: /s1/Block2/y ObjectEntity REAL(4)
   real y
   !REF: /s1/Block2/y
   y = 3.0
@@ -38,9 +38,9 @@ end subroutine
 subroutine s2
  implicit integer(w-x)
  block
-  !DEF: /s2/x (implicit) ObjectEntity INTEGER
+  !DEF: /s2/x (implicit) ObjectEntity INTEGER(4)
   x = 1
-  !DEF: /s2/y (implicit) ObjectEntity REAL
+  !DEF: /s2/y (implicit) ObjectEntity REAL(4)
   y = 2
  end block
 contains
@@ -48,7 +48,7 @@ contains
  subroutine s
   !REF: /s2/x
   x = 1
-  !DEF: /s2/s/w (implicit) ObjectEntity INTEGER
+  !DEF: /s2/s/w (implicit) ObjectEntity INTEGER(4)
   w = 1
  end subroutine
 end subroutine
@@ -58,8 +58,8 @@ subroutine s3
  block
   !DEF: /s3/Block1/t DerivedType
   type :: t
-   !DEF: /s3/i (implicit) ObjectEntity INTEGER
-   !DEF: /s3/Block1/t/x ObjectEntity REAL
+   !DEF: /s3/i (implicit) ObjectEntity INTEGER(4)
+   !DEF: /s3/Block1/t/x ObjectEntity REAL(4)
    real :: x(10) = [(i, i=1,10)]
   end type
  end block
@@ -70,8 +70,8 @@ subroutine s4
  implicit integer(x)
  interface
   !DEF: /s4/s EXTERNAL Subprogram
-  !DEF: /s4/s/x (implicit) ObjectEntity REAL
-  !DEF: /s4/s/y (implicit) ObjectEntity INTEGER
+  !DEF: /s4/s/x (implicit) ObjectEntity REAL(4)
+  !DEF: /s4/s/y (implicit) ObjectEntity INTEGER(4)
   subroutine s (x, y)
    implicit integer(y)
   end subroutine
@@ -81,13 +81,13 @@ end subroutine
 !DEF: /s5 Subprogram
 subroutine s5
  block
-  !DEF: /s5/Block1/x (implicit) ObjectEntity REAL
+  !DEF: /s5/Block1/x (implicit) ObjectEntity REAL(4)
   dimension :: x(2)
   block
-   !DEF: /s5/Block1/Block1/x (implicit) ObjectEntity REAL
+   !DEF: /s5/Block1/Block1/x (implicit) ObjectEntity REAL(4)
    dimension :: x(3)
   end block
  end block
- !DEF: /s5/x (implicit) ObjectEntity REAL
+ !DEF: /s5/x (implicit) ObjectEntity REAL(4)
  x = 1.0
 end subroutine

--- a/test/semantics/test_modfile.sh
+++ b/test/semantics/test_modfile.sh
@@ -61,7 +61,7 @@ for src in "$@"; do
     fi
     sed '/^!mod\$/d' $temp/$mod > $actual
     sed '1,/^!Expect: '"$mod"'/d' $src | sed -e '/^$/,$d' -e 's/^! *//' > $expect
-    if ! diff -U999999 $actual $expect > $diffs; then
+    if ! diff -U999999 $expect $actual > $diffs; then
       echo "Module file $mod differs from expected:"
       sed '1,2d' $diffs
       echo FAIL

--- a/tools/f18/dump.cc
+++ b/tools/f18/dump.cc
@@ -40,7 +40,8 @@ DEFINE_DUMP(parser, Name)
 DEFINE_DUMP(parser, CharBlock)
 DEFINE_DUMP(semantics, Symbol)
 DEFINE_DUMP(semantics, Scope)
-DEFINE_DUMP(semantics, TypeSpec)
+DEFINE_DUMP(semantics, IntrinsicTypeSpec)
+DEFINE_DUMP(semantics, DerivedTypeSpec)
 DEFINE_DUMP(semantics, DeclTypeSpec)
 }  // namespace Fortran
 


### PR DESCRIPTION
Intrinsic types are now just a TypeCategory and a int kind. If no kind
is specified the default is used so that every type has an explicit
kind. This caused changes in the expected results of some of the tests.

Add support for "double precision" and "double complex".

Intrinsic types are now stored as values in DeclTypeSpec so none of the
KindedTypeHelper machinery is needed any more.

Eliminate DerivedTypeDef, DataComponentDef, ProcComponentDef,
TypeBoundProc. The components and bindings of a derived type are now
represented by the corresponding Scope.