### PR TITLE
Add top-level Semantics class

### DIFF
--- a/lib/semantics/CMakeLists.txt
+++ b/lib/semantics/CMakeLists.txt
@@ -17,10 +17,11 @@ add_library(FortranSemantics
   attr.cc
   expression.cc
   mod-file.cc
-  resolve-names.cc
   resolve-labels.cc
+  resolve-names.cc
   rewrite-parse-tree.cc
   scope.cc
+  semantics.cc
   symbol.cc
   type.cc
   unparse-with-symbols.cc

--- a/lib/semantics/attr.cc
+++ b/lib/semantics/attr.cc
@@ -14,6 +14,7 @@
 
 #include "attr.h"
 #include "../common/idioms.h"
+#include <ostream>
 #include <stddef.h>
 
 namespace Fortran::semantics {

--- a/lib/semantics/attr.h
+++ b/lib/semantics/attr.h
@@ -18,7 +18,6 @@
 #include "../common/enum-set.h"
 #include "../common/idioms.h"
 #include <cinttypes>
-#include <iostream>
 #include <string>
 
 namespace Fortran::semantics {

--- a/lib/semantics/mod-file.h
+++ b/lib/semantics/mod-file.h
@@ -18,8 +18,6 @@
 #include "attr.h"
 #include "resolve-names.h"
 #include "../parser/message.h"
-#include "../parser/provenance.h"
-#include <iosfwd>
 #include <set>
 #include <sstream>
 #include <string>
@@ -41,10 +39,10 @@ public:
   void set_directory(const std::string &dir) { dir_ = dir; }
 
   // Errors encountered during writing. Non-empty if WriteAll returns false.
-  parser::Messages &errors() { return errors_; }
+  parser::Messages &&errors() { return std::move(errors_); }
 
   // Write out all .mod files; if error return false.
-  bool WriteAll();
+  bool WriteAll(const Scope &);
 
 private:
   std::string dir_{"."};
@@ -56,7 +54,6 @@ private:
   // Any errors encountered during writing:
   parser::Messages errors_;
 
-  void WriteChildren(const Scope &);
   void WriteOne(const Scope &);
   void Write(const Symbol &);
   std::string GetAsString(const Symbol &);
@@ -77,7 +74,7 @@ public:
   // Find and read the module file for a module or submodule.
   // If ancestor is specified, look for a submodule of that module.
   // Return the Scope for that module/submodule or nullptr on error.
-  Scope *Read(const SourceName &, Scope *ancestor = nullptr);
+  Scope *Read(Scope &, const SourceName &, Scope *ancestor = nullptr);
   // Errors that occurred when Read returns nullptr.
   parser::Messages &errors() { return errors_; }
 

--- a/lib/semantics/resolve-labels.cc
+++ b/lib/semantics/resolve-labels.cc
@@ -216,6 +216,7 @@ struct UnitAnalysis {
 
 class ParseTreeAnalyzer {
 public:
+  ParseTreeAnalyzer(ParseTreeAnalyzer &&that) = default;
   ParseTreeAnalyzer(parser::Messages &errorHandler)
     : errorHandler_{errorHandler} {}
 

--- a/lib/semantics/resolve-labels.h
+++ b/lib/semantics/resolve-labels.h
@@ -16,18 +16,17 @@
 #define FORTRAN_SEMANTICS_RESOLVE_LABELS_H_
 
 namespace Fortran::parser {
+class Messages;
 struct Program;
-class CookedSource;
 }  // namespace Fortran::parser
 
 namespace Fortran::semantics {
 
 /// \brief Validate the labels in the program
-/// \param ParseTree  the parse tree
-/// \param Source     the cooked source
+/// \param messages   where to emit messages
+/// \param program    the parse tree of the program
 /// \return true, iff the program's labels pass semantics checks
-bool ValidateLabels(
-    const parser::Program &ParseTree, const parser::CookedSource &Source);
-}  // namespace Fortran::semantics
+bool ValidateLabels(parser::Messages &messages, const parser::Program &program);
 
+}  // namespace Fortran::semantics
 #endif  // FORTRAN_SEMANTICS_RESOLVE_LABELS_H_

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -187,7 +187,7 @@ public:
   using Message = parser::Message;
   using MessageFixedText = parser::MessageFixedText;
 
-  const parser::Messages &messages() const { return messages_; }
+  void set_messages(parser::Messages &messages) { messages_ = &messages; }
 
   template<typename T> bool Pre(const parser::Statement<T> &x) {
     currStmtSource_ = &x.source;
@@ -218,14 +218,13 @@ public:
 
 private:
   // Where messages are emitted:
-  parser::Messages messages_;
+  parser::Messages *messages_;
   // Source location of current statement; null if not in a statement
   const SourceName *currStmtSource_{nullptr};
 };
 
 // Visit ImplicitStmt and related parse tree nodes and updates implicit rules.
-class ImplicitRulesVisitor : public DeclTypeSpecVisitor,
-                             public virtual MessageHandler {
+class ImplicitRulesVisitor : public DeclTypeSpecVisitor, public MessageHandler {
 public:
   using DeclTypeSpecVisitor::Post;
   using DeclTypeSpecVisitor::Pre;
@@ -301,12 +300,13 @@ private:
 };
 
 // Manage a stack of Scopes
-class ScopeHandler : public virtual ImplicitRulesVisitor {
+class ScopeHandler : public ImplicitRulesVisitor {
 public:
-  void set_rootScope(Scope &scope) { PushScope(scope); }
   Scope &currScope() { return *currScope_; }
   // The enclosing scope, skipping blocks and derived types.
   Scope &InclusiveScope();
+  // The global scope, containing program units.
+  Scope &GlobalScope();
 
   // Create a new scope and push it on the scope stack.
   void PushScope(Scope::Kind kind, Symbol *symbol);
@@ -646,6 +646,11 @@ public:
   using SubprogramVisitor::Post;
   using SubprogramVisitor::Pre;
 
+  ResolveNamesVisitor(parser::Messages &messages, Scope &rootScope) {
+    set_messages(messages);
+    PushScope(rootScope);
+  }
+
   // Default action for a parse tree node is to visit children.
   template<typename T> bool Pre(const T &) { return true; }
   template<typename T> void Post(const T &) {}
@@ -963,7 +968,7 @@ int DeclTypeSpecVisitor::GetKindParamValue(
 
 MessageHandler::Message &MessageHandler::Say(MessageFixedText &&msg) {
   CHECK(currStmtSource_);
-  return messages_.Say(*currStmtSource_, std::move(msg));
+  return messages_->Say(*currStmtSource_, std::move(msg));
 }
 MessageHandler::Message &MessageHandler::Say(
     const SourceName &name, MessageFixedText &&msg) {
@@ -971,15 +976,15 @@ MessageHandler::Message &MessageHandler::Say(
 }
 MessageHandler::Message &MessageHandler::Say(
     const parser::Name &name, MessageFixedText &&msg) {
-  return messages_.Say(name.source, std::move(msg), name.ToString().c_str());
+  return messages_->Say(name.source, std::move(msg), name.ToString().c_str());
 }
 MessageHandler::Message &MessageHandler::Say(const SourceName &location,
     MessageFixedText &&msg, const std::string &arg1) {
-  return messages_.Say(location, std::move(msg), arg1.c_str());
+  return messages_->Say(location, std::move(msg), arg1.c_str());
 }
 MessageHandler::Message &MessageHandler::Say(const SourceName &location,
     MessageFixedText &&msg, const SourceName &arg1, const SourceName &arg2) {
-  return messages_.Say(location, std::move(msg), arg1.ToString().c_str(),
+  return messages_->Say(location, std::move(msg), arg1.ToString().c_str(),
       arg2.ToString().c_str());
 }
 void MessageHandler::SayAlreadyDeclared(
@@ -992,7 +997,7 @@ void MessageHandler::Say2(const SourceName &name1, MessageFixedText &&msg1,
   Say(name1, std::move(msg1)).Attach(name2, msg2, name2.ToString().c_str());
 }
 void MessageHandler::Annex(parser::Messages &&msgs) {
-  messages_.Annex(std::move(msgs));
+  messages_->Annex(std::move(msgs));
 }
 
 // ImplicitRulesVisitor implementation
@@ -1184,6 +1189,15 @@ Scope &ScopeHandler::InclusiveScope() {
       return *scope;
     }
   }
+  common::die("inclusive scope not found");
+}
+Scope &ScopeHandler::GlobalScope() {
+  for (auto *scope = currScope_; scope; scope = &scope->parent()) {
+    if (scope->kind() == Scope::Kind::Global) {
+      return *scope;
+    }
+  }
+  common::die("global scope not found");
 }
 void ScopeHandler::PushScope(Scope::Kind kind, Symbol *symbol) {
   PushScope(currScope().MakeScope(kind, symbol));
@@ -1411,7 +1425,7 @@ Symbol &ModuleVisitor::BeginModule(const SourceName &name, bool isSubmodule,
 // If an error occurs, report it and return nullptr.
 Scope *ModuleVisitor::FindModule(const SourceName &name, Scope *ancestor) {
   ModFileReader reader{searchDirectories_};
-  auto *scope{reader.Read(name, ancestor)};
+  auto *scope{reader.Read(GlobalScope(), name, ancestor)};
   if (!scope) {
     Annex(std::move(reader.errors()));
     return nullptr;
@@ -2842,20 +2856,14 @@ void ResolveNamesVisitor::Post(const parser::Program &) {
   CHECK(!GetDeclTypeSpec());
 }
 
-void ResolveNames(Scope &rootScope, parser::Program &program,
-    const parser::CookedSource &cookedSource,
+void ResolveNames(parser::Messages &messages, Scope &rootScope,
+    const parser::Program &program,
     const std::vector<std::string> &searchDirectories) {
-  ResolveNamesVisitor visitor;
-  visitor.set_rootScope(rootScope);
+  ResolveNamesVisitor visitor{messages, rootScope};
   for (auto &dir : searchDirectories) {
     visitor.add_searchDirectory(dir);
   }
-  parser::Walk(const_cast<const parser::Program &>(program), visitor);
-  if (!visitor.messages().empty()) {
-    visitor.messages().Emit(std::cerr, cookedSource);
-    return;
-  }
-  RewriteParseTree(program, cookedSource);
+  parser::Walk(program, visitor);
 }
 
 // Map the enum in the parser to the one in GenericSpec
@@ -2939,38 +2947,5 @@ static GenericSpec MapGenericSpec(const parser::GenericSpec &genericSpec) {
       },
       genericSpec.u);
 }
-
-static void PutIndent(std::ostream &os, int indent) {
-  for (int i = 0; i < indent; ++i) {
-    os << "  ";
-  }
-}
-
-static void DumpSymbols(std::ostream &os, const Scope &scope, int indent = 0) {
-  PutIndent(os, indent);
-  os << Scope::EnumToString(scope.kind()) << " scope:";
-  if (const auto *symbol{scope.symbol()}) {
-    os << ' ' << symbol->name().ToString();
-  }
-  os << '\n';
-  ++indent;
-  for (const auto &pair : scope) {
-    const auto &symbol{*pair.second};
-    PutIndent(os, indent);
-    os << symbol << '\n';
-    if (const auto *details{symbol.detailsIf<GenericDetails>()}) {
-      if (const auto &type{details->derivedType()}) {
-        PutIndent(os, indent);
-        os << *type << '\n';
-      }
-    }
-  }
-  for (const auto &child : scope.children()) {
-    DumpSymbols(os, child, indent);
-  }
-  --indent;
-}
-
-void DumpSymbols(std::ostream &os) { DumpSymbols(os, Scope::globalScope); }
 
 }  // namespace Fortran::semantics

--- a/lib/semantics/rewrite-parse-tree.h
+++ b/lib/semantics/rewrite-parse-tree.h
@@ -16,12 +16,15 @@
 #define FORTRAN_SEMANTICS_REWRITE_PARSE_TREE_H_
 
 namespace Fortran::parser {
+class Messages;
 struct Program;
-class CookedSource;
 }  // namespace Fortran::parser
+namespace Fortran::semantics {
+class Scope;
+}  // namespace Fortran::semantics
 
 namespace Fortran::semantics {
-void RewriteParseTree(parser::Program &, const parser::CookedSource &);
+void RewriteParseTree(parser::Messages &, const Scope &, parser::Program &);
 }  // namespace Fortran::semantics
 
 #endif  // FORTRAN_SEMANTICS_REWRITE_PARSE_TREE_H_

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -18,9 +18,6 @@
 
 namespace Fortran::semantics {
 
-Scope Scope::systemScope{Scope::systemScope, Scope::Kind::System, nullptr};
-Scope Scope::globalScope{Scope::systemScope, Scope::Kind::Global, nullptr};
-
 Symbols<1024> Scope::allSymbols;
 
 bool Scope::IsModule() const {

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -33,14 +33,12 @@ class Scope {
   using mapType = std::map<SourceName, Symbol *>;
 
 public:
-  // root of the scope tree; contains intrinsics:
-  static Scope systemScope;
-  static Scope globalScope;  // contains program-units
-
   ENUM_CLASS(
       Kind, System, Global, Module, MainProgram, Subprogram, DerivedType, Block)
   using ImportKind = common::ImportKind;
 
+  // Create the Global scope -- the root of the scope tree
+  Scope() : Scope{*this, Kind::Global, nullptr} {}
   Scope(Scope &parent, Kind kind, Symbol *symbol)
     : parent_{parent}, kind_{kind}, symbol_{symbol} {
     if (symbol) {

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -1,0 +1,99 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "semantics.h"
+#include "mod-file.h"
+#include "resolve-labels.h"
+#include "resolve-names.h"
+#include "rewrite-parse-tree.h"
+#include "scope.h"
+#include "symbol.h"
+
+namespace Fortran::semantics {
+
+static void DoDumpSymbols(std::ostream &, const Scope &, int indent = 0);
+static void PutIndent(std::ostream &, int indent);
+
+Semantics &Semantics::set_searchDirectories(
+    const std::vector<std::string> &directories) {
+  for (auto directory : directories) {
+    directories_.push_back(directory);
+  }
+  return *this;
+}
+
+Semantics &Semantics::set_moduleDirectory(const std::string &directory) {
+  moduleDirectory_ = directory;
+  directories_.insert(directories_.begin(), directory);
+  return *this;
+}
+
+bool Semantics::Perform(parser::Program &program) {
+  ValidateLabels(messages_, program);
+  if (AnyFatalError()) {
+    return false;
+  }
+  ResolveNames(messages_, globalScope_, program, directories_);
+  if (AnyFatalError()) {
+    return false;
+  }
+  RewriteParseTree(messages_, globalScope_, program);
+  if (AnyFatalError()) {
+    return false;
+  }
+  ModFileWriter writer;
+  writer.set_directory(moduleDirectory_);
+  if (!writer.WriteAll(globalScope_)) {
+    messages_.Annex(writer.errors());
+    return false;
+  }
+  return true;
+}
+
+void Semantics::DumpSymbols(std::ostream &os) {
+  DoDumpSymbols(os, globalScope_);
+}
+
+void DoDumpSymbols(std::ostream &os, const Scope &scope, int indent) {
+  PutIndent(os, indent);
+  os << Scope::EnumToString(scope.kind()) << " scope:";
+  if (const auto *symbol{scope.symbol()}) {
+    os << ' ' << symbol->name().ToString();
+  }
+  os << '\n';
+  ++indent;
+  for (const auto &pair : scope) {
+    const auto &symbol{*pair.second};
+    PutIndent(os, indent);
+    os << symbol << '\n';
+    if (const auto *details{symbol.detailsIf<GenericDetails>()}) {
+      if (const auto &type{details->derivedType()}) {
+        PutIndent(os, indent);
+        os << *type << '\n';
+      }
+    }
+  }
+  for (const auto &child : scope.children()) {
+    DoDumpSymbols(os, child, indent);
+  }
+  --indent;
+}
+
+static void PutIndent(std::ostream &os, int indent) {
+  for (int i = 0; i < indent; ++i) {
+    os << "  ";
+  }
+}
+
+}  // namespace Fortran::semantics

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -19,6 +19,7 @@
 #include "../parser/message.h"
 #include <string>
 #include <vector>
+#include <iostream>
 
 namespace Fortran::parser {
   struct Program;
@@ -28,7 +29,6 @@ namespace Fortran::semantics {
 
 class Semantics {
 public:
-  Semantics() { directories_.push_back("."s); }
   const parser::Messages &messages() const { return messages_; }
   Semantics &set_searchDirectories(const std::vector<std::string> &);
   Semantics &set_moduleDirectory(const std::string &);
@@ -38,10 +38,11 @@ public:
 
 private:
   Scope globalScope_;
-  std::vector<std::string> directories_;
+  std::vector<std::string> directories_{"."s};
   std::string moduleDirectory_{"."s};
   parser::Messages messages_;
 };
+
 }  // namespace Fortran::semantics
 
 #endif

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -12,26 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef FORTRAN_SEMANTICS_RESOLVE_NAMES_H_
-#define FORTRAN_SEMANTICS_RESOLVE_NAMES_H_
+#ifndef FORTRAN_SEMANTICS_SEMANTICS_H_
+#define FORTRAN_SEMANTICS_SEMANTICS_H_
 
-#include <iosfwd>
+#include "scope.h"
+#include "../parser/message.h"
 #include <string>
 #include <vector>
 
 namespace Fortran::parser {
-class Messages;
-struct Program;
-}  // namespace Fortran::parser
+  struct Program;
+}
 
 namespace Fortran::semantics {
 
-class Scope;
+class Semantics {
+public:
+  Semantics() { directories_.push_back("."s); }
+  const parser::Messages &messages() const { return messages_; }
+  Semantics &set_searchDirectories(const std::vector<std::string> &);
+  Semantics &set_moduleDirectory(const std::string &);
+  bool AnyFatalError() const { return messages_.AnyFatalError(); }
+  bool Perform(parser::Program &);
+  void DumpSymbols(std::ostream &);
 
-void ResolveNames(parser::Messages &, Scope &, const parser::Program &,
-    const std::vector<std::string> &);
-void DumpSymbols(std::ostream &);
-
+private:
+  Scope globalScope_;
+  std::vector<std::string> directories_;
+  std::string moduleDirectory_{"."s};
+  parser::Messages messages_;
+};
 }  // namespace Fortran::semantics
 
-#endif  // FORTRAN_SEMANTICS_RESOLVE_NAMES_H_
+#endif


### PR DESCRIPTION
Refactor to create the Semantics class that is responsible for holding
state during semantics (the scope tree and messages) and managing the
logic of the various phases of semantic processing. Eliminate static
Scope::globalScope.

The messages generated during semantic processing are accumulated in a
Messages data member of Semantics so that individual phases don't need
to emit them to std::cerr. This is now done by the driver so that it has
control over where they go and eliminates other includes of iostream.
To do this, the messages object is passed in to the various semantics
operations.

Move DumpSymbols into semantics.cc: it doesn't belong in resolve-names.cc
and it depends on the global scope, so it's as good a place as any.
The call to RewriteParseTree is also moved to Semantics.