### PR TITLE
Fix problems with extended derived types

### DIFF
--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -272,8 +272,10 @@ std::vector<const Symbol *> CollectSymbols(const Scope &scope) {
   sorted.reserve(scope.size());
   for (const auto &pair : scope) {
     auto *symbol{pair.second};
-    if (symbols.insert(symbol).second) {
-      sorted.push_back(symbol);
+    if (!symbol->test(Symbol::Flag::ParentComp)) {
+      if (symbols.insert(symbol).second) {
+        sorted.push_back(symbol);
+      }
     }
   }
   std::sort(sorted.begin(), sorted.end(), [](const Symbol *x, const Symbol *y) {

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -272,7 +272,7 @@ public:
   ENUM_CLASS(Flag,
       Function,  // symbol is a function
       Subroutine,  // symbol is a subroutine
-      Implicit,  // symbol is implicity typed
+      Implicit,  // symbol is implicitly typed
       ModFile,  // symbol came from .mod file
       ParentComp  // symbol is the "parent component" of an extended type
   );

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -269,11 +269,18 @@ std::string DetailsToString(const Details &);
 
 class Symbol {
 public:
-  ENUM_CLASS(Flag, Function, Subroutine, Implicit, ModFile);
+  ENUM_CLASS(Flag,
+      Function,  // symbol is a function
+      Subroutine,  // symbol is a subroutine
+      Implicit,  // symbol is implicity typed
+      ModFile,  // symbol came from .mod file
+      ParentComp  // symbol is the "parent component" of an extended type
+  );
   using Flags = common::EnumSet<Flag, Flag_enumSize>;
 
   const Scope &owner() const { return *owner_; }
   const SourceName &name() const { return occurrences_.front(); }
+  const SourceName &lastOccurrence() const { return occurrences_.back(); }
   Attrs &attrs() { return attrs_; }
   const Attrs &attrs() const { return attrs_; }
   Flags &flags() { return flags_; }

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -58,6 +58,7 @@ set(ERROR_TESTS
   resolve31.f90
   resolve32.f90
   resolve33.f90
+  resolve34.f90
 )
 
 # These test files have expected symbols in the source
@@ -67,6 +68,7 @@ set(SYMBOL_TESTS
   symbol03.f90
   symbol04.f90
   symbol05.f90
+  symbol06.f90
 )
 
 # These test files have expected .mod file contents in the source

--- a/test/semantics/resolve34.f90
+++ b/test/semantics/resolve34.f90
@@ -1,0 +1,107 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Extended derived types
+
+module m1
+  type :: t1
+    integer :: x
+    !ERROR: Component 'x' is already declared in this derived type
+    real :: x
+  end type
+end
+
+module m2
+  type :: t1
+    integer :: i
+  end type
+  type, extends(t1) :: t2
+    !ERROR: Component 'i' is already declared in a parent of this derived type
+    integer :: i
+  end type
+end
+
+module m3
+  type :: t1
+  end type
+  type, extends(t1) :: t2
+    integer :: i
+    !ERROR: 't1' is a parent type of this type and so cannot be a component
+    real :: t1
+  end type
+  type, extends(t2) :: t3
+    !ERROR: 't1' is a parent type of this type and so cannot be a component
+    real :: t1
+  end type
+end
+
+module m4
+  type :: t1
+    integer :: t1
+  end type
+  !ERROR: Type cannot be extended as it has a component named 't1'
+  type, extends(t1) :: t2
+  end type
+end
+
+module m5
+  type :: t1
+    integer :: t2
+  end type
+  type, extends(t1) :: t2
+  end type
+  !ERROR: Type cannot be extended as it has a component named 't2'
+  type, extends(t2) :: t3
+  end type
+end
+
+module m6
+  ! t1 can be extended if it is known as anything but t3
+  type :: t1
+    integer :: t3
+  end type
+  type, extends(t1) :: t2
+  end type
+end
+subroutine s6
+  use :: m6, only: t3 => t1
+  !ERROR: Type cannot be extended as it has a component named 't3'
+  type, extends(t3) :: t4
+  end type
+end
+subroutine r6
+  use :: m6, only: t5 => t1
+  type, extends(t5) :: t6
+  end type
+end
+
+module m7
+  type, private :: t1
+    integer :: i1
+  end type
+  type, extends(t1) :: t2
+    integer :: i2
+    integer, private :: i3
+  end type
+end
+subroutine s7
+  use m7
+  type(t2) :: x
+  integer :: j
+  j = x%i2
+  !ERROR: PRIVATE component 'i3' is only accessible within module 'm7'
+  j = x%i3
+  !ERROR: PRIVATE component 't1' is only accessible within module 'm7'
+  j = x%t1%i1
+end

--- a/test/semantics/symbol06.f90
+++ b/test/semantics/symbol06.f90
@@ -1,0 +1,103 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+!DEF: /main MainProgram
+program main
+ !DEF: /main/t1 DerivedType
+ type :: t1
+  !DEF: /main/t1/a1 ObjectEntity INTEGER(4)
+  integer :: a1
+ end type
+ !DEF: /main/t2 DerivedType
+ !REF: /main/t1
+ type, extends(t1) :: t2
+  !DEF: /main/t2/a2 ObjectEntity INTEGER(4)
+  integer :: a2
+ end type
+ !DEF: /main/t3 DerivedType
+ !REF: /main/t2
+ type, extends(t2) :: t3
+  !DEF: /main/t3/a3 ObjectEntity INTEGER(4)
+  integer :: a3
+ end type
+ !DEF: /main/x3 ObjectEntity TYPE(t3)
+ !REF: /main/t3
+ type(t3) :: x3
+ !DEF: /main/i ObjectEntity INTEGER(4)
+ integer i
+ !REF: /main/i
+ !REF: /main/x3
+ !REF: /main/t2/a2
+ i = x3%a2
+ !REF: /main/i
+ !REF: /main/x3
+ !REF: /main/t1/a1
+ i = x3%a1
+ !REF: /main/i
+ !REF: /main/x3
+ !REF: /main/t3/t2
+ !REF: /main/t2/a2
+ i = x3%t2%a2
+ !REF: /main/i
+ !REF: /main/x3
+ !REF: /main/t3/t2
+ !REF: /main/t1/a1
+ i = x3%t2%a1
+ !REF: /main/i
+ !REF: /main/x3
+ !REF: /main/t2/t1
+ !REF: /main/t1/a1
+ i = x3%t1%a1
+ !REF: /main/i
+ !REF: /main/x3
+ !REF: /main/t3/t2
+ !REF: /main/t2/t1
+ !REF: /main/t1/a1
+ i = x3%t2%t1%a1
+end program
+
+!DEF: /m1 Module
+module m1
+ !DEF: /m1/t1 PUBLIC DerivedType
+ type :: t1
+  !DEF: /m1/t1/t1 ObjectEntity INTEGER(4)
+  integer :: t1
+ end type
+end module
+
+!DEF: /s1 Subprogram
+subroutine s1
+ !DEF: /s1/t2 Use
+ !REF: /m1
+ !REF: /m1/t1
+ use :: m1, only: t2 => t1
+ !DEF: /s1/t3 DerivedType
+ !REF: /s1/t2
+ type, extends(t2) :: t3
+ end type
+ !DEF: /s1/x ObjectEntity TYPE(t3)
+ !REF: /s1/t3
+ type(t3) :: x
+ !DEF: /s1/i ObjectEntity INTEGER(4)
+ integer i
+ !REF: /s1/i
+ !REF: /s1/x
+ !REF: /m1/t1/t1
+ i = x%t1
+ !REF: /s1/i
+ !REF: /s1/x
+ !REF: /s1/t3/t2
+ !REF: /m1/t1/t1
+ i = x%t2%t1
+end subroutine


### PR DESCRIPTION
When looking for a component name in a derived type, also look in the
parent type. Before adding a component to a derived type, report an
error if it already has one with that name. Check that components are
accessible when they are accessed.

Add the "parent component" to derived types (i.e. a component with the
same name as the parent type). The symbol is marked with the
`ParentComp` flag so we can avoid writing it to `.mod` files.

Add calls to `add_occurrence()` so that those particular instances of
`parser::Name` get their symbol set.

Change `DeclareObjectEntity` and `DeclareProcEntity` to use `SourceName` as
the name passed in rather than `parser::Name`.

Fix some problems in `unparse-with-symbols.cc` on statements that both
define and reference names.

Fixes #187.