### PR TITLE
Resolve g++ 7.2 build problem

### DIFF
--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -539,8 +539,14 @@ Expr<SomeType>::~Expr() {}
 // Rank()
 template<typename A> int ExpressionBase<A>::Rank() const {
   return std::visit(
-      common::visitors{[](const BOZLiteralConstant &) { return 0; },
-          [](const auto &x) { return x.Rank(); }},
+      [](const auto &x) {
+        if constexpr (std::is_same_v<std::decay_t<decltype(x)>,
+                          BOZLiteralConstant>) {
+          return 0;
+        } else {
+          return x.Rank();
+        }
+      },
       derived().u);
 }
 

--- a/lib/evaluate/variable.cc
+++ b/lib/evaluate/variable.cc
@@ -420,13 +420,28 @@ int CoarrayRef::Rank() const {
 }
 int DataRef::Rank() const {
   return std::visit(
-      common::visitors{[](const Symbol *sym) { return sym->Rank(); },
-          [](const auto &x) { return x.Rank(); }},
+      // g++ 7.2 emits bogus warnings here and below when common::visitors{}
+      // is used with a "const auto &" catch-all member, so a constexpr type
+      // test has to be used instead.
+      [](const auto &x) {
+        if constexpr (std::is_same_v<std::decay_t<decltype(x)>,
+                          const Symbol *>) {
+          return x->Rank();
+        } else {
+          return x.Rank();
+        }
+      },
       u);
 }
 int Substring::Rank() const {
-  return std::visit(common::visitors{[](const std::string &) { return 0; },
-                        [](const auto &x) { return x.Rank(); }},
+  return std::visit(
+      [](const auto &x) {
+        if constexpr (std::is_same_v<std::decay_t<decltype(x)>, std::string>) {
+          return 0;
+        } else {
+          return x.Rank();
+        }
+      },
       u_);
 }
 int ComplexPart::Rank() const { return complex_.Rank(); }

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -17,12 +17,12 @@
 
 #include "scope.h"
 #include "../parser/message.h"
+#include <iostream>
 #include <string>
 #include <vector>
-#include <iostream>
 
 namespace Fortran::parser {
-  struct Program;
+struct Program;
 }
 
 namespace Fortran::semantics {


### PR DESCRIPTION
g++ 7.2.0 bungles a `const auto &` catch-all lambda in a `common::visitors{}` list in a couple of cases that I have reworked as `constexpr` type tests instead.  I did not make the changes sensitive to the compiler & version as the new code is readable enough to remain.