### PR TITLE
Correct the spelling of LOCAL_INIT clauses on DO CONCURRENT statements.

### DIFF
--- a/documentation/f2018-grammar.txt
+++ b/documentation/f2018-grammar.txt
@@ -485,7 +485,7 @@ R1127 concurrent-limit -> scalar-int-expr
 R1128 concurrent-step -> scalar-int-expr
 R1129 concurrent-locality -> [locality-spec]...
 R1130 locality-spec ->
-        LOCAL ( variable-name-list ) | LOCAL INIT ( variable-name-list ) |
+        LOCAL ( variable-name-list ) | LOCAL_INIT ( variable-name-list ) |
         SHARED ( variable-name-list ) | DEFAULT ( NONE )
 R1131 end-do -> end-do-stmt | continue-stmt
 R1132 end-do-stmt -> END DO [do-construct-name]

--- a/lib/parser/grammar.h
+++ b/lib/parser/grammar.h
@@ -2137,12 +2137,12 @@ TYPE_PARSER(construct<ConcurrentControl>(name / "=", scalarIntExpr / ":",
     scalarIntExpr, maybe(":" >> scalarIntExpr)))
 
 // R1130 locality-spec ->
-//         LOCAL ( variable-name-list ) | LOCAL INIT ( variable-name-list ) |
+//         LOCAL ( variable-name-list ) | LOCAL_INIT ( variable-name-list ) |
 //         SHARED ( variable-name-list ) | DEFAULT ( NONE )
 TYPE_PARSER(construct<LocalitySpec>(construct<LocalitySpec::Local>(
                 "LOCAL" >> parenthesized(listOfNames))) ||
     construct<LocalitySpec>(construct<LocalitySpec::LocalInit>(
-        "LOCAL INIT"_sptok >> parenthesized(listOfNames))) ||
+        "LOCAL_INIT"_sptok >> parenthesized(listOfNames))) ||
     construct<LocalitySpec>(construct<LocalitySpec::Shared>(
         "SHARED" >> parenthesized(listOfNames))) ||
     construct<LocalitySpec>(

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -2153,7 +2153,7 @@ struct ConcurrentHeader {
 };
 
 // R1130 locality-spec ->
-//         LOCAL ( variable-name-list ) | LOCAL INIT ( variable-name-list ) |
+//         LOCAL ( variable-name-list ) | LOCAL_INIT ( variable-name-list ) |
 //         SHARED ( variable-name-list ) | DEFAULT ( NONE )
 struct LocalitySpec {
   UNION_CLASS_BOILERPLATE(LocalitySpec);

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -936,7 +936,7 @@ public:
     Word("LOCAL("), Walk(x.v, ", "), Put(')');
   }
   void Unparse(const LocalitySpec::LocalInit &x) {
-    Word("LOCAL INIT("), Walk(x.v, ", "), Put(')');
+    Word("LOCAL_INIT("), Walk(x.v, ", "), Put(')');
   }
   void Unparse(const LocalitySpec::Shared &x) {
     Word("SHARED("), Walk(x.v, ", "), Put(')');


### PR DESCRIPTION
I left out the underscore, and noticed the problem now that DO CONCURRENT tests have been added to the PGI test suites.