### PR TITLE
Address differences between std::size_t and std::uint64_t on non-Linux systems

### DIFF
--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -191,9 +191,9 @@ public:
         encoding_ == Encoding::EUC_JP ? EUC_JPCharacterBytes
                                       : UTF8CharacterBytes)};
     if (chars.has_value()) {
-      Unparse(*chars);
+      Unparse(static_cast<std::uint64_t>(*chars));
     } else {
-      Unparse(x.v.size());
+      Unparse(static_cast<std::uint64_t>(x.v.size()));
     }
     Put('H');
   }


### PR DESCRIPTION
Added some static_cast<std::uint64_t> expressions to address differences
between std::size_t and std::uint64_t on Darwin and *BSD systems.  This
commit resolves issue #158 and partially resolves issue #202.