### PR TITLE
Use fundamental types in overloadings of Unparse.

### DIFF
--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -62,8 +62,11 @@ public:
   // Emit simple types as-is.
   void Unparse(const std::string &x) { Put(x); }
   void Unparse(int x) { Put(std::to_string(x)); }
-  void Unparse(std::uint64_t x) { Put(std::to_string(x)); }
-  void Unparse(std::int64_t x) { Put(std::to_string(x)); }
+  void Unparse(unsigned int x) { Put(std::to_string(x)); }
+  void Unparse(long x) { Put(std::to_string(x)); }
+  void Unparse(unsigned long x) { Put(std::to_string(x)); }
+  void Unparse(long long x) { Put(std::to_string(x)); }
+  void Unparse(unsigned long long x) { Put(std::to_string(x)); }
   void Unparse(char x) { Put(x); }
 
   // Statement labels and ends of lines


### PR DESCRIPTION
Different systems map std::size_t, string::size_type, etc. to different
fundamental types. To ensure they are all covered, make the overloadings
of Unparse for integer types use only fundamental types.

This fixes compilations problems on Darwin and *BSD systems.