### PR TITLE
Make conversions between C++ integral types and Integer fully generic.

### DIFF
--- a/lib/evaluate/integer.h
+++ b/lib/evaluate/integer.h
@@ -29,6 +29,7 @@
 #include <cinttypes>
 #include <climits>
 #include <cstddef>
+#include <cstdint>
 #include <string>
 #include <type_traits>
 
@@ -60,6 +61,10 @@ public:
   static constexpr int partBits{PARTBITS};
   using Part = PART;
   using BigPart = BIGPART;
+  static_assert(std::is_integral_v<Part>);
+  static_assert(std::is_unsigned_v<Part>);
+  static_assert(std::is_integral_v<BigPart>);
+  static_assert(std::is_unsigned_v<BigPart>);
   static_assert(CHAR_BIT * sizeof(BigPart) >= 2 * partBits);
   static constexpr bool littleEndian{IS_LITTLE_ENDIAN};
 
@@ -108,43 +113,64 @@ public:
   // Constructors and value-generating static functions
   constexpr Integer() { Clear(); }  // default constructor: zero
   constexpr Integer(const Integer &) = default;
-  constexpr Integer(std::uint64_t n) {
-    for (int j{0}; j + 1 < parts; ++j) {
-      SetLEPart(j, n);
-      if constexpr (partBits < 64) {
-        n >>= partBits;
+
+  // C++'s integral types can all be converted to Integer
+  // with silent truncation.
+  template<typename INT> constexpr Integer(INT n) {
+    static_assert(std::is_integral_v<INT>);
+    constexpr int nBits = CHAR_BIT * sizeof n;
+    if constexpr (nBits < partBits) {
+      if constexpr (std::is_unsigned_v<INT>) {
+        // Zero-extend an unsigned smaller value.
+        SetLEPart(0, n);
+        for (int j{1}; j < parts; ++j) {
+          SetLEPart(j, 0);
+        }
       } else {
-        n = 0;
+        // n has a signed type smaller than the usable
+        // bits in a Part.
+        // Avoid conversions that change both size and sign.
+        using SignedPart = std::make_signed_t<Part>;
+        Part p = static_cast<SignedPart>(n);
+        SetLEPart(0, p);
+        if constexpr (parts > 1) {
+          Part signExtension = static_cast<SignedPart>(-(n < 0));
+          for (int j{1}; j < parts; ++j) {
+            SetLEPart(j, signExtension);
+          }
+        }
+      }
+    } else {
+      // n has some integral type no smaller than the usable
+      // bits in a Part.
+      // Ensure that all shifts are smaller than a whole word.
+      if constexpr (std::is_unsigned_v<INT>) {
+        for (int j{0}; j < parts; ++j) {
+          SetLEPart(j, static_cast<Part>(n));
+          if constexpr (nBits > partBits) {
+            n >>= partBits;
+          } else {
+            n = 0;
+          }
+        }
+      } else {
+        INT signExtension{-(n < 0)};
+        if constexpr (nBits > partBits) {
+          signExtension <<= partBits;
+          for (int j{0}; j < parts; ++j) {
+            SetLEPart(j, static_cast<Part>(n));
+            n >>= partBits;
+            n |= signExtension;
+          }
+        } else {
+          static_assert(nBits == partBits);
+          SetLEPart(0, static_cast<Part>(n));
+          for (int j{1}; j < parts; ++j) {
+            SetLEPart(j, static_cast<Part>(signExtension));
+          }
+        }
       }
     }
-    SetLEPart(parts - 1, n);
-  }
-  constexpr Integer(std::int64_t n) {
-    std::int64_t signExtension{-(n < 0)};
-    signExtension <<= partBits;
-    for (int j{0}; j + 1 < parts; ++j) {
-      SetLEPart(j, n);
-      if constexpr (partBits < 64) {
-        n = (n >> partBits) | signExtension;
-      } else {
-        n = signExtension;
-      }
-    }
-    SetLEPart(parts - 1, n);
-  }
-  constexpr Integer(int ni) {
-    std::int64_t n{ni};
-    std::int64_t signExtension{-(n < 0)};
-    signExtension <<= partBits;
-    for (int j{0}; j + 1 < parts; ++j) {
-      SetLEPart(j, n);
-      if constexpr (partBits < 64) {
-        n = (n >> partBits) | signExtension;
-      } else {
-        n = signExtension;
-      }
-    }
-    SetLEPart(parts - 1, n);
   }
 
   constexpr Integer &operator=(const Integer &) = default;


### PR DESCRIPTION
Intended to fix lingering and future portability problems by accepting all integer types in the constructor for the class template Integer.