### PR TITLE
Removed obsolete comments and conversions

### DIFF
--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -476,10 +476,8 @@ template<int KIND>
 Expr<SubscriptInteger> Expr<Type<TypeCategory::Character, KIND>>::LEN() const {
   return std::visit(
       common::visitors{[](const Constant<Result> &c) {
-                         // std::string::size_type isn't convertible to uint64_t
-                         // on Darwin
-                         return AsExpr(Constant<SubscriptInteger>{
-                             static_cast<std::uint64_t>(c.value.size())});
+                         return AsExpr(
+                             Constant<SubscriptInteger>{c.value.size()});
                        },
           [](const Parentheses<Result> &x) { return x.left().LEN(); },
           [](const Concat<KIND> &c) {

--- a/lib/evaluate/variable.cc
+++ b/lib/evaluate/variable.cc
@@ -117,10 +117,7 @@ Expr<SubscriptInteger> Substring::last() const {
   }
   return std::visit(
       common::visitors{[](const std::string &s) {
-                         // std::string::size_type isn't convertible to uint64_t
-                         // on Darwin
-                         return AsExpr(Constant<SubscriptInteger>{
-                             static_cast<std::uint64_t>(s.size())});
+                         return AsExpr(Constant<SubscriptInteger>{s.size()});
                        },
           [](const DataRef &x) { return x.LEN(); }},
       u_);


### PR DESCRIPTION
The addition of a more robust Integer constructor for POD types has
made some comments and static_cast expressions obsolete.