### PR TITLE
Fix bug in rewriting function reference

### DIFF
--- a/lib/semantics/rewrite-parse-tree.cc
+++ b/lib/semantics/rewrite-parse-tree.cc
@@ -83,7 +83,8 @@ private:
     }
     parser::Name *name{std::get_if<parser::Name>(
         &std::get<parser::ProcedureDesignator>((*funcRef)->v.t).u)};
-    if (!name || !name->symbol || !name->symbol->has<ObjectEntityDetails>()) {
+    if (!name || !name->symbol ||
+        !name->symbol->GetUltimate().has<ObjectEntityDetails>()) {
       return;
     }
     x.u = common::Indirection{(*funcRef)->ConvertToArrayElementRef()};


### PR DESCRIPTION
`a(i)` is parsed as a function reference and needs to be converted to an
array element reference when `a` is an object entity. That determination
was wrong if the symbol for `a` was a symbol representing host-association
or use-association. In that case we need to get to the original symbol
by calling `GetUltimate()` on the symbol.

This was causing symbol09.f90 to get a compilation error because an
array element reference looked like a call to a non-pure function, which
is prohibited inside a DO CONCURRENT.