### PR TITLE
Format Style Change: Removed namespace comments after closing brace

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,6 +12,7 @@ AlignTrailingComments: false
 ConstructorInitializerIndentWidth: 2
 SpaceAfterTemplateKeyword: false
 SpacesBeforeTrailingComments: 2
+FixNamespaceComments: false
 IncludeCategories:
   - Regex:           '^<'
     Priority:        4

--- a/include/flang/ISO_Fortran_binding.h
+++ b/include/flang/ISO_Fortran_binding.h
@@ -99,7 +99,7 @@ typedef signed char CFI_type_t;
 #define CFI_type_other (-1)  // must be negative
 
 /* Error code macros */
-#define CFI_SUCCESS 0  /* must be zero */
+#define CFI_SUCCESS 0 /* must be zero */
 #define CFI_ERROR_BASE_ADDR_NULL 1
 #define CFI_ERROR_BASE_ADDR_NOT_NULL 2
 #define CFI_INVALID_ELEM_LEN 3
@@ -152,8 +152,8 @@ int CFI_setpointer(
 #ifdef __cplusplus
 }  // extern "C"
 }  // inline namespace Fortran_2018
-}  // namespace ISO
-}  // namespace Fortran
+}
+}
 #endif
 
 #undef CFI_ISO_FORTRAN_BINDING_FLEXIBLE_ARRAY

--- a/lib/common/bit-population-count.h
+++ b/lib/common/bit-population-count.h
@@ -85,5 +85,5 @@ template<typename UINT> inline constexpr bool Parity(UINT x) {
 template<typename UINT> inline constexpr int TrailingZeroCount(UINT x) {
   return BitPopulationCount(x ^ (x - 1)) - !!x;
 }
-}  // namespace Fortran::common
+}
 #endif  // FORTRAN_COMMON_BIT_POPULATION_COUNT_H_

--- a/lib/common/constexpr-bitset.h
+++ b/lib/common/constexpr-bitset.h
@@ -149,5 +149,5 @@ public:
 private:
   Word bits_{0};
 };
-}  // namespace Fortran::common
+}
 #endif  // FORTRAN_COMMON_CONSTEXPR_BITSET_H_

--- a/lib/common/enum-set.h
+++ b/lib/common/enum-set.h
@@ -198,7 +198,7 @@ public:
 private:
   bitsetType bitset_;
 };
-}  // namespace Fortran::common
+}
 
 template<typename ENUM, std::size_t values>
 struct std::hash<Fortran::common::EnumSet<ENUM, values>> {

--- a/lib/common/fortran.h
+++ b/lib/common/fortran.h
@@ -33,6 +33,5 @@ ENUM_CLASS(ImportKind, Default, Only, None, All)
 ENUM_CLASS(TypeParamAttr, Kind, Len)
 
 ENUM_CLASS(RelationalOperator, LT, LE, EQ, NE, GE, GT)
-
-}  // namespace Fortran::common
+}
 #endif  // FORTRAN_COMMON_FORTRAN_H_

--- a/lib/common/idioms.cc
+++ b/lib/common/idioms.cc
@@ -46,4 +46,4 @@ std::string EnumIndexToString(int index, const char *enumNames) {
   }
   return std::string(p, q - p);
 }
-}  // namespace Fortran::common
+}

--- a/lib/common/idioms.h
+++ b/lib/common/idioms.h
@@ -44,7 +44,7 @@ template<typename A>
 struct is_trivially_copy_constructible<list<A>> : false_type {};
 template<typename A>
 struct is_trivially_copy_constructible<optional<list<A>>> : false_type {};
-}  // namespace std
+}
 #endif
 
 // enable "this is a std::string"s with the 's' suffix
@@ -133,6 +133,5 @@ template<typename A> struct ListItemCount {
     return Fortran::common::EnumIndexToString( \
         static_cast<int>(e), #__VA_ARGS__); \
   }
-
-}  // namespace Fortran::common
+}
 #endif  // FORTRAN_COMMON_IDIOMS_H_

--- a/lib/common/indirection.h
+++ b/lib/common/indirection.h
@@ -152,6 +152,5 @@ public:
 private:
   A *p_{nullptr};
 };
-
-}  // namespace Fortran::common
+}
 #endif  // FORTRAN_COMMON_INDIRECTION_H_

--- a/lib/common/interval.h
+++ b/lib/common/interval.h
@@ -107,6 +107,5 @@ private:
   A start_;
   std::size_t size_{0};
 };
-
-}  // namespace Fortran::common
+}
 #endif  // FORTRAN_COMMON_INTERVAL_H_

--- a/lib/common/reference-counted.h
+++ b/lib/common/reference-counted.h
@@ -78,6 +78,5 @@ private:
 
   type *p_{nullptr};
 };
-
-}  // namespace Fortran::common
+}
 #endif  // FORTRAN_COMMON_REFERENCE_COUNTED_H_

--- a/lib/common/template.h
+++ b/lib/common/template.h
@@ -268,6 +268,5 @@ template<typename VISITOR>
 typename VISITOR::Result SearchDynamicTypes(VISITOR &&visitor) {
   return SearchDynamicTypesHelper<0, VISITOR>(std::move(visitor));
 }
-
-}  // namespace Fortran::common
+}
 #endif  // FORTRAN_COMMON_TEMPLATE_H_

--- a/lib/evaluate/call.cc
+++ b/lib/evaluate/call.cc
@@ -42,5 +42,4 @@ std::optional<int> ActualArgument::VectorSize() const {
 }
 
 FOR_EACH_SPECIFIC_TYPE(template struct FunctionRef)
-
-}  // namespace Fortran::evaluate
+}

--- a/lib/evaluate/call.h
+++ b/lib/evaluate/call.h
@@ -47,6 +47,5 @@ struct ActualArgument {
 };
 
 using Arguments = std::vector<ActualArgument>;
-
-}  // namespace Fortran::evaluate
+}
 #endif  // FORTRAN_EVALUATE_CALL_H_

--- a/lib/evaluate/common.cc
+++ b/lib/evaluate/common.cc
@@ -33,5 +33,4 @@ void RealFlagWarnings(
     context.messages.Say("underflow on %s"_en_US, operation);
   }
 }
-
-}  // namespace Fortran::evaluate
+}

--- a/lib/evaluate/common.h
+++ b/lib/evaluate/common.h
@@ -164,6 +164,5 @@ struct FoldingContext {
 };
 
 void RealFlagWarnings(FoldingContext &, const RealFlags &, const char *op);
-
-}  // namespace Fortran::evaluate
+}
 #endif  // FORTRAN_EVALUATE_COMMON_H_

--- a/lib/evaluate/complex.cc
+++ b/lib/evaluate/complex.cc
@@ -100,4 +100,4 @@ template class Complex<Real<Integer<32>, 24>>;
 template class Complex<Real<Integer<64>, 53>>;
 template class Complex<Real<Integer<80>, 64, false>>;
 template class Complex<Real<Integer<128>, 112>>;
-}  // namespace Fortran::evaluate::value
+}

--- a/lib/evaluate/complex.h
+++ b/lib/evaluate/complex.h
@@ -95,6 +95,5 @@ extern template class Complex<Real<Integer<32>, 24>>;
 extern template class Complex<Real<Integer<64>, 53>>;
 extern template class Complex<Real<Integer<80>, 64, false>>;
 extern template class Complex<Real<Integer<128>, 112>>;
-
-}  // namespace Fortran::evaluate::value
+}
 #endif  // FORTRAN_EVALUATE_COMPLEX_H_

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -588,8 +588,7 @@ FOR_EACH_CHARACTER_KIND(template struct Relational)
 template struct Relational<SomeType>;
 FOR_EACH_INTRINSIC_KIND(template struct ExpressionBase)
 FOR_EACH_CATEGORY_TYPE(template struct ExpressionBase)
-
-}  // namespace Fortran::evaluate
+}
 
 // For reclamation of analyzed expressions to which owning pointers have
 // been embedded in the parse tree.  This destructor appears here, where
@@ -601,4 +600,4 @@ template<> OwningPointer<evaluate::GenericExprWrapper>::~OwningPointer() {
   p_ = nullptr;
 }
 template class OwningPointer<evaluate::GenericExprWrapper>;
-}  // namespace Fortran::common
+}

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -711,6 +711,5 @@ template<> inline bool IsVariable(const Expr<SomeType> &expr) {
 
 FOR_EACH_CATEGORY_TYPE(extern template class Expr)
 FOR_EACH_TYPE_AND_KIND(extern template struct ExpressionBase)
-
-}  // namespace Fortran::evaluate
+}
 #endif  // FORTRAN_EVALUATE_EXPRESSION_H_

--- a/lib/evaluate/int-power.h
+++ b/lib/evaluate/int-power.h
@@ -55,6 +55,5 @@ ValueWithRealFlags<REAL> IntPower(
   }
   return result;
 }
-
-}  // namespace Fortran::evaluate
+}
 #endif  // FORTRAN_EVALUATE_INT_POWER_H_

--- a/lib/evaluate/integer.cc
+++ b/lib/evaluate/integer.cc
@@ -34,5 +34,4 @@ static_assert(Integer<64>::partBits == 32);
 static_assert(std::is_same_v<typename Integer<64>::Part, std::uint32_t>);
 static_assert(Integer<128>::partBits == 32);
 static_assert(std::is_same_v<typename Integer<128>::Part, std::uint32_t>);
-
-}  // namespace Fortran::evaluate::value
+}

--- a/lib/evaluate/integer.h
+++ b/lib/evaluate/integer.h
@@ -1003,5 +1003,5 @@ extern template class Integer<32>;
 extern template class Integer<64>;
 extern template class Integer<80>;
 extern template class Integer<128>;
-}  // namespace Fortran::evaluate::value
+}
 #endif  // FORTRAN_EVALUATE_INTEGER_H_

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -1275,5 +1275,4 @@ std::ostream &IntrinsicProcTable::Implementation::Dump(std::ostream &o) const {
 std::ostream &IntrinsicProcTable::Dump(std::ostream &o) const {
   return impl_->Dump(o);
 }
-
-}  // namespace Fortran::evaluate
+}

--- a/lib/evaluate/intrinsics.h
+++ b/lib/evaluate/intrinsics.h
@@ -68,5 +68,5 @@ public:
 private:
   Implementation *impl_{nullptr};  // owning pointer
 };
-}  // namespace Fortran::evaluate
+}
 #endif  // FORTRAN_EVALUATE_INTRINSICS_H_

--- a/lib/evaluate/leading-zero-bit-count.h
+++ b/lib/evaluate/leading-zero-bit-count.h
@@ -46,7 +46,7 @@ static constexpr std::uint8_t mapping[64]{63, 0, 58, 1, 59, 47, 53, 2, 60, 39,
     48, 27, 54, 33, 42, 3, 61, 51, 37, 40, 49, 18, 28, 20, 55, 30, 34, 11, 43,
     14, 22, 4, 62, 57, 46, 52, 38, 26, 32, 41, 50, 36, 17, 19, 29, 10, 13, 21,
     56, 45, 25, 31, 35, 16, 9, 12, 44, 24, 15, 8, 23, 7, 6, 5};
-}  // namespace
+}
 
 inline constexpr int LeadingZeroBitCount(std::uint64_t x) {
   if (x == 0) {
@@ -89,10 +89,10 @@ static constexpr std::uint8_t eightBitLeadingZeroBitCount[256]{8, 7, 6, 6, 5, 5,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-}  // namespace
+}
 
 inline constexpr int LeadingZeroBitCount(std::uint8_t x) {
   return eightBitLeadingZeroBitCount[x];
 }
-}  // namespace Fortran::evaluate
+}
 #endif  // FORTRAN_EVALUATE_LEADING_ZERO_BIT_COUNT_H_

--- a/lib/evaluate/logical.cc
+++ b/lib/evaluate/logical.cc
@@ -20,5 +20,4 @@ template class Logical<8>;
 template class Logical<16>;
 template class Logical<32>;
 template class Logical<64>;
-
-}  // namespace Fortran::evaluate::value
+}

--- a/lib/evaluate/logical.h
+++ b/lib/evaluate/logical.h
@@ -57,5 +57,5 @@ extern template class Logical<8>;
 extern template class Logical<16>;
 extern template class Logical<32>;
 extern template class Logical<64>;
-}  // namespace Fortran::evaluate::value
+}
 #endif  // FORTRAN_EVALUATE_LOGICAL_H_

--- a/lib/evaluate/real.cc
+++ b/lib/evaluate/real.cc
@@ -486,4 +486,4 @@ template class Real<Integer<32>, 24>;
 template class Real<Integer<64>, 53>;
 template class Real<Integer<80>, 64, false>;
 template class Real<Integer<128>, 112>;
-}  // namespace Fortran::evaluate::value
+}

--- a/lib/evaluate/real.h
+++ b/lib/evaluate/real.h
@@ -339,6 +339,5 @@ extern template class Real<Integer<64>, 53>;
 extern template class Real<Integer<80>, 64, false>;  // 80387 extended precision
 extern template class Real<Integer<128>, 112>;
 // N.B. No "double-double" support.
-
-}  // namespace Fortran::evaluate::value
+}
 #endif  // FORTRAN_EVALUATE_REAL_H_

--- a/lib/evaluate/rounding-bits.h
+++ b/lib/evaluate/rounding-bits.h
@@ -100,5 +100,5 @@ private:
   bool round_{false};  // 0.25 * ulp
   bool sticky_{false};  // true if any lesser-valued bit would be set
 };
-}  // namespace Fortran::evaluate::value
+}
 #endif  // FORTRAN_EVALUATE_ROUNDING_BITS_H_

--- a/lib/evaluate/tools.cc
+++ b/lib/evaluate/tools.cc
@@ -492,5 +492,4 @@ Expr<SomeLogical> BinaryLogicalOperation(
       },
       AsSameKindExprs(std::move(x), std::move(y)));
 }
-
-}  // namespace Fortran::evaluate
+}

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -447,6 +447,5 @@ struct TypeKindVisitor {
   int kind;
   VALUE value;
 };
-
-}  // namespace Fortran::evaluate
+}
 #endif  // FORTRAN_EVALUATE_TOOLS_H_

--- a/lib/evaluate/type.cc
+++ b/lib/evaluate/type.cc
@@ -91,4 +91,4 @@ DynamicType DynamicType::ResultTypeForMultiply(const DynamicType &that) const {
 std::string SomeDerived::Dump() const {
   return "TYPE("s + spec().name().ToString() + ')';
 }
-}  // namespace Fortran::evaluate
+}

--- a/lib/evaluate/type.h
+++ b/lib/evaluate/type.h
@@ -38,7 +38,7 @@
 namespace Fortran::semantics {
 class DerivedTypeSpec;
 class Symbol;
-}  // namespace Fortran::semantics
+}
 
 namespace Fortran::evaluate {
 
@@ -403,6 +403,5 @@ template<typename T> struct Constant {
   std::ostream &Dump(std::ostream &) const;
   Value value;
 };
-
-}  // namespace Fortran::evaluate
+}
 #endif  // FORTRAN_EVALUATE_TYPE_H_

--- a/lib/evaluate/variable.cc
+++ b/lib/evaluate/variable.cc
@@ -502,5 +502,4 @@ std::optional<DynamicType> ProcedureDesignator::GetType() const {
 }
 
 FOR_EACH_CHARACTER_KIND(template class Designator)
-
-}  // namespace Fortran::evaluate
+}

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -380,6 +380,5 @@ private:
   ProcedureDesignator proc_;
   Arguments arguments_;
 };
-
-}  // namespace Fortran::evaluate
+}
 #endif  // FORTRAN_EVALUATE_VARIABLE_H_

--- a/lib/parser/basic-parsers.h
+++ b/lib/parser/basic-parsers.h
@@ -1356,6 +1356,5 @@ private:
 template<typename PA> inline constexpr auto sourced(const PA &parser) {
   return SourcedParser<PA>{parser};
 }
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_BASIC_PARSERS_H_

--- a/lib/parser/char-block.h
+++ b/lib/parser/char-block.h
@@ -128,8 +128,7 @@ inline bool operator>=(const char *left, const CharBlock &right) {
 inline bool operator>(const char *left, const CharBlock &right) {
   return right < left;
 }
-
-}  // namespace Fortran::parser
+}
 
 // Specializations to enable std::unordered_map<CharBlock, ...> &c.
 template<> struct std::hash<Fortran::parser::CharBlock> {

--- a/lib/parser/char-buffer.cc
+++ b/lib/parser/char-buffer.cc
@@ -93,5 +93,4 @@ std::string CharBuffer::MarshalNormalized() const {
   result.shrink_to_fit();
   return result;
 }
-
-}  // namespace Fortran::parser
+}

--- a/lib/parser/char-buffer.h
+++ b/lib/parser/char-buffer.h
@@ -79,6 +79,5 @@ private:
   std::size_t bytes_{0};
   bool lastBlockEmpty_{false};
 };
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_CHAR_BUFFER_H_

--- a/lib/parser/char-set.cc
+++ b/lib/parser/char-set.cc
@@ -27,5 +27,4 @@ std::string SetOfChars::ToString() const {
   }
   return result;
 }
-
-}  // namespace Fortran::parser
+}

--- a/lib/parser/char-set.h
+++ b/lib/parser/char-set.h
@@ -82,6 +82,5 @@ private:
   constexpr SetOfChars(std::uint64_t b) : bits_{b} {}
   std::uint64_t bits_{0};
 };
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_CHAR_SET_H_

--- a/lib/parser/characters.cc
+++ b/lib/parser/characters.cc
@@ -92,4 +92,4 @@ std::string QuoteCharacterLiteral(
   result += '"';
   return result;
 }
-}  // namespace Fortran::parser
+}

--- a/lib/parser/characters.h
+++ b/lib/parser/characters.h
@@ -168,6 +168,5 @@ std::optional<int> UTF8CharacterBytes(const char *);
 std::optional<int> EUC_JPCharacterBytes(const char *);
 std::optional<std::size_t> CountCharacters(
     const char *, std::size_t bytes, std::optional<int> (*)(const char *));
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_CHARACTERS_H_

--- a/lib/parser/debug-parser.cc
+++ b/lib/parser/debug-parser.cc
@@ -31,5 +31,4 @@ std::optional<Success> DebugParser::Parse(ParseState &state) const {
   }
   return {Success{}};
 }
-
-}  // namespace Fortran::parser
+}

--- a/lib/parser/debug-parser.h
+++ b/lib/parser/debug-parser.h
@@ -42,6 +42,5 @@ private:
 constexpr DebugParser operator""_debug(const char str[], std::size_t n) {
   return DebugParser{str, n};
 }
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_DEBUG_PARSER_H_

--- a/lib/parser/features.h
+++ b/lib/parser/features.h
@@ -60,6 +60,5 @@ private:
   LanguageFeatures warn_;
   bool warnAll_{false};
 };
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_FEATURES_H_

--- a/lib/parser/format-specification.h
+++ b/lib/parser/format-specification.h
@@ -143,6 +143,5 @@ struct FormatSpecification {
     : items(std::move(is)), unlimitedItems(std::move(us)) {}
   std::list<FormatItem> items, unlimitedItems;
 };
-
-}  // namespace Fortran::format
+}
 #endif  // FORTRAN_PARSER_FORMAT_SPECIFICATION_H_

--- a/lib/parser/grammar.h
+++ b/lib/parser/grammar.h
@@ -3482,5 +3482,5 @@ TYPE_CONTEXT_PARSER("PAUSE statement"_en_US,
 //     is not used because parsing is not sensitive to rank
 //   R1030 default-char-constant-expr -> default-char-expr
 //     is only used via scalar-default-char-constant-expr
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_GRAMMAR_H_

--- a/lib/parser/instrumented-parser.cc
+++ b/lib/parser/instrumented-parser.cc
@@ -80,5 +80,4 @@ void ParsingLog::Dump(std::ostream &o, const CookedSource &cooked) const {
     }
   }
 }
-
-}  // namespace Fortran::parser
+}

--- a/lib/parser/instrumented-parser.h
+++ b/lib/parser/instrumented-parser.h
@@ -83,6 +83,5 @@ inline constexpr auto instrumented(
     const MessageFixedText &tag, const PA &parser) {
   return InstrumentedParser{tag, parser};
 }
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_INSTRUMENTED_PARSER_H_

--- a/lib/parser/message.cc
+++ b/lib/parser/message.cc
@@ -301,5 +301,4 @@ ContextualMessages::SavedState ContextualMessages::SetLocation(
     const CharBlock &at) {
   return SavedState(*this, at);
 }
-
-}  // namespace Fortran::parser
+}

--- a/lib/parser/message.h
+++ b/lib/parser/message.h
@@ -63,7 +63,7 @@ constexpr MessageFixedText operator""_err_en_US(
     const char str[], std::size_t n) {
   return MessageFixedText{str, n, true /* fatal */};
 }
-}  // namespace literals
+}
 
 class MessageFormattedText {
 public:
@@ -274,5 +274,5 @@ private:
   CharBlock at_;
   Messages *messages_{nullptr};
 };
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_MESSAGE_H_

--- a/lib/parser/openmp-grammar.h
+++ b/lib/parser/openmp-grammar.h
@@ -585,6 +585,5 @@ TYPE_PARSER(skipStuffBeforeStatement >> "!$OMP "_sptok >> "END"_tok >>
 
 TYPE_PARSER(construct<OpenMPLoopConstruct>(
     Parser<OmpLoopDirective>{}, Parser<OmpClauseList>{} / endOmpLine))
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_OPENMP_GRAMMAR_H_

--- a/lib/parser/parse-state.h
+++ b/lib/parser/parse-state.h
@@ -239,6 +239,5 @@ private:
   // reflected in the copy and move constructors defined at the top of this
   // class definition!
 };
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_PARSE_STATE_H_

--- a/lib/parser/parse-tree-visitor.h
+++ b/lib/parser/parse-tree-visitor.h
@@ -757,6 +757,5 @@ void Walk(OpenMPDeclareTargetConstruct::WithExtendedList &x, M &mutator) {
     mutator.Post(x);
   }
 }
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_PARSE_TREE_VISITOR_H_

--- a/lib/parser/parse-tree.cc
+++ b/lib/parser/parse-tree.cc
@@ -131,5 +131,4 @@ std::ostream &operator<<(std::ostream &os, const Name &x) {
 std::ostream &operator<<(std::ostream &os, const CharBlock &x) {
   return os << x.ToString();
 }
-
-}  // namespace Fortran::parser
+}

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -60,7 +60,7 @@ CLASS_TRAIT(TupleTrait)
 // here.
 namespace Fortran::semantics {
 class Symbol;
-}  // namespace Fortran::semantics
+}
 
 // Expressions in the parse tree have owning pointers that can be set to
 // type-checked generic expression representations by semantic analysis.
@@ -68,10 +68,10 @@ class Symbol;
 // the bulk of lib/evaluate/*.h headers into the parser proper.
 namespace Fortran::evaluate {
 struct GenericExprWrapper;  // forward definition, wraps Expr<SomeType>
-}  // namespace Fortran::evaluate
+}
 namespace Fortran::common {
 extern template class OwningPointer<evaluate::GenericExprWrapper>;
-}  // namespace Fortran::common
+}
 
 // Most non-template classes in this file use these default definitions
 // for their move constructor and move assignment operator=, and disable
@@ -3699,6 +3699,5 @@ struct OpenMPConstruct {
       common::Indirection<OpenMPCriticalConstruct>, OmpSection>
       u;
 };
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_PARSE_TREE_H_

--- a/lib/parser/parsing.cc
+++ b/lib/parser/parsing.cc
@@ -136,5 +136,4 @@ bool Parsing::ForTesting(std::string path, std::ostream &err) {
   }
   return true;
 }
-
-}  // namespace Fortran::parser
+}

--- a/lib/parser/parsing.h
+++ b/lib/parser/parsing.h
@@ -82,6 +82,5 @@ private:
   std::optional<Program> parseTree_;
   ParsingLog log_;
 };
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_PARSING_H_

--- a/lib/parser/preprocessor.cc
+++ b/lib/parser/preprocessor.cc
@@ -986,5 +986,4 @@ bool Preprocessor::IsIfPredicateTrue(const TokenSequence &expr,
   }
   return result;
 }
-
-}  // namespace Fortran::parser
+}

--- a/lib/parser/preprocessor.h
+++ b/lib/parser/preprocessor.h
@@ -97,6 +97,5 @@ private:
   std::unordered_map<CharBlock, Definition> definitions_;
   std::stack<CanDeadElseAppear> ifStack_;
 };
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_PREPROCESSOR_H_

--- a/lib/parser/prescan.cc
+++ b/lib/parser/prescan.cc
@@ -973,5 +973,4 @@ void Prescanner::SourceFormChange(std::string &&dir) {
     inFixedForm_ = true;
   }
 }
-
-}  // namespace Fortran::parser
+}

--- a/lib/parser/prescan.h
+++ b/lib/parser/prescan.h
@@ -211,6 +211,5 @@ private:
   std::bitset<prime2> compilerDirectiveBloomFilter_;  // 128 bytes
   std::unordered_set<std::string> compilerDirectiveSentinels_;
 };
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_PRESCAN_H_

--- a/lib/parser/provenance.cc
+++ b/lib/parser/provenance.cc
@@ -388,5 +388,4 @@ std::ostream &CookedSource::Dump(std::ostream &o) const {
   provenanceMap_.Dump(o);
   return o;
 }
-
-}  // namespace Fortran::parser
+}

--- a/lib/parser/provenance.h
+++ b/lib/parser/provenance.h
@@ -232,6 +232,5 @@ private:
   std::string data_;  // all of it, prescanned and preprocessed
   OffsetToProvenanceMappings provenanceMap_;
 };
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_PROVENANCE_H_

--- a/lib/parser/source.cc
+++ b/lib/parser/source.cc
@@ -249,5 +249,4 @@ std::pair<int, int> SourceFile::FindOffsetLineAndColumn(std::size_t at) const {
   return {
       static_cast<int>(low + 1), static_cast<int>(at - lineStart_[low] + 1)};
 }
-
-}  // namespace Fortran::parser
+}

--- a/lib/parser/source.h
+++ b/lib/parser/source.h
@@ -59,6 +59,5 @@ private:
   std::vector<std::size_t> lineStart_;
   std::string normalized_;
 };
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_SOURCE_H_

--- a/lib/parser/stmt-parser.h
+++ b/lib/parser/stmt-parser.h
@@ -94,6 +94,5 @@ constexpr auto progUnitEndStmtErrorRecovery{
     (many(!"END"_tok >> SkipPast<'\n'>{}) >>
         ("END"_tok >> SkipTo<'\n'>{} || consumedAllInput)) >>
     missingOptionalName};
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_STMT_PARSER_H_

--- a/lib/parser/token-parsers.h
+++ b/lib/parser/token-parsers.h
@@ -719,6 +719,5 @@ TYPE_PARSER(space >> "."_ch >>
     construct<DefinedOpName>(
         sourced(some(definedOpNameChar) >> construct<Name>())) /
         "."_ch)
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_TOKEN_PARSERS_H_

--- a/lib/parser/token-sequence.cc
+++ b/lib/parser/token-sequence.cc
@@ -258,4 +258,4 @@ ProvenanceRange TokenSequence::GetIntervalProvenanceRange(
 ProvenanceRange TokenSequence::GetProvenanceRange() const {
   return GetIntervalProvenanceRange(0, start_.size());
 }
-}  // namespace Fortran::parser
+}

--- a/lib/parser/token-sequence.h
+++ b/lib/parser/token-sequence.h
@@ -121,6 +121,5 @@ private:
   std::vector<char> char_;
   OffsetToProvenanceMappings provenances_;
 };
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_TOKEN_SEQUENCE_H_

--- a/lib/parser/type-parsers.h
+++ b/lib/parser/type-parsers.h
@@ -145,6 +145,5 @@ constexpr Parser<CompilerDirective> compilerDirective;
 constexpr Parser<OpenMPConstruct> openmpConstruct;
 constexpr Parser<OpenMPDeclarativeConstruct> openmpDeclarativeConstruct;
 constexpr Parser<OpenMPEndLoopDirective> openmpEndLoopDirective;
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_TYPE_PARSERS_H_

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -2519,5 +2519,4 @@ void Unparse(std::ostream &out, const Program &program, Encoding encoding,
   Walk(program, visitor);
   visitor.Done();
 }
-
-}  // namespace Fortran::parser
+}

--- a/lib/parser/unparse.h
+++ b/lib/parser/unparse.h
@@ -32,7 +32,6 @@ using preStatementType =
 void Unparse(std::ostream &out, const Program &program,
     Encoding encoding = Encoding::UTF8, bool capitalizeKeywords = true,
     bool backslashEscapes = true, preStatementType *preStatement = nullptr);
-
-}  // namespace Fortran::parser
+}
 
 #endif

--- a/lib/parser/user-state.cc
+++ b/lib/parser/user-state.cc
@@ -96,5 +96,4 @@ std::optional<DataComponentDefStmt> StructureComponents::Parse(
   }
   return defs;
 }
-
-}  // namespace Fortran::parser
+}

--- a/lib/parser/user-state.h
+++ b/lib/parser/user-state.h
@@ -145,6 +145,5 @@ struct StructureComponents {
   using resultType = DataComponentDefStmt;
   static std::optional<DataComponentDefStmt> Parse(ParseState &);
 };
-
-}  // namespace Fortran::parser
+}
 #endif  // FORTRAN_PARSER_USER_STATE_H_

--- a/lib/semantics/attr.cc
+++ b/lib/semantics/attr.cc
@@ -54,5 +54,4 @@ std::ostream &operator<<(std::ostream &o, const Attrs &attrs) {
   }
   return o;
 }
-
-}  // namespace Fortran::semantics
+}

--- a/lib/semantics/attr.h
+++ b/lib/semantics/attr.h
@@ -50,6 +50,5 @@ std::string AttrToString(Attr attr);
 
 std::ostream &operator<<(std::ostream &o, Attr attr);
 std::ostream &operator<<(std::ostream &o, const Attrs &attrs);
-
-}  // namespace Fortran::semantics
+}
 #endif  // FORTRAN_SEMANTICS_ATTR_H_

--- a/lib/semantics/canonicalize-do.cc
+++ b/lib/semantics/canonicalize-do.cc
@@ -90,5 +90,4 @@ void CanonicalizeDo(Program &program) {
   CanonicalizationOfDoLoops canonicalizationOfDoLoops;
   Walk(program, canonicalizationOfDoLoops);
 }
-
-}  // namespace Fortran::parser
+}

--- a/lib/semantics/canonicalize-do.h
+++ b/lib/semantics/canonicalize-do.h
@@ -20,6 +20,6 @@
 namespace Fortran::parser {
 struct Program;
 void CanonicalizeDo(Program &program);
-}  // namespace Fortran::parser
+}
 
 #endif  // FORTRAN_SEMANTICS_CANONICALIZE_DO_H_

--- a/lib/semantics/check-do-concurrent.cc
+++ b/lib/semantics/check-do-concurrent.cc
@@ -508,5 +508,4 @@ void CheckDoConcurrentConstraints(
   FindDoConcurrentLoops findDoConcurrentLoops{messages};
   Walk(program, findDoConcurrentLoops);
 }
-
-}  // namespace Fortran::semantics
+}

--- a/lib/semantics/check-do-concurrent.h
+++ b/lib/semantics/check-do-concurrent.h
@@ -18,11 +18,11 @@
 namespace Fortran::parser {
 class Messages;
 struct Program;
-}  // namespace Fortran::parser
+}
 
 namespace Fortran::semantics {
 
-void CheckDoConcurrentConstraints(parser::Messages &messages, const parser::Program &program);
-
-}  // namespace Fortran::semantics
+void CheckDoConcurrentConstraints(
+    parser::Messages &messages, const parser::Program &program);
+}
 #endif  // FORTRAN_SEMANTICS_CHECK_DO_CONCURRENT_H_

--- a/lib/semantics/default-kinds.cc
+++ b/lib/semantics/default-kinds.cc
@@ -75,4 +75,4 @@ int IntrinsicTypeDefaultKinds::GetDefaultKind(TypeCategory category) const {
   default: CRASH_NO_CASE; return 0;
   }
 }
-}  // namespace Fortran::semantics
+}

--- a/lib/semantics/default-kinds.h
+++ b/lib/semantics/default-kinds.h
@@ -55,6 +55,5 @@ private:
   int defaultCharacterKind_{1};
   int defaultLogicalKind_{defaultIntegerKind_};
 };
-
-}  // namespace Fortran::semantics
+}
 #endif  // FORTRAN_DEFAULT_KINDS_H_

--- a/lib/semantics/dump-parse-tree.h
+++ b/lib/semantics/dump-parse-tree.h
@@ -828,5 +828,5 @@ template<typename T> void DumpTree(std::ostream &out, const T &x) {
   ParseTreeDumper dumper{out};
   parser::Walk(x, dumper);
 }
-}  // namespace Fortran::semantics
+}
 #endif  // FORTRAN_SEMANTICS_DUMP_PARSE_TREE_H_

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1186,8 +1186,7 @@ void ExprAnalyzer::CheckUnsubscriptedComponent(const Component &component) {
     }
   }
 }
-
-}  // namespace Fortran::evaluate
+}
 
 namespace Fortran::semantics {
 
@@ -1225,4 +1224,4 @@ void AnalyzeExpressions(parser::Program &program, SemanticsContext &context) {
   Mutator mutator{context};
   parser::Walk(program, mutator);
 }
-}  // namespace Fortran::semantics
+}

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -34,6 +34,5 @@ std::optional<evaluate::Expr<evaluate::SomeType>> AnalyzeExpr(
 // Semantic analysis of all expressions in a parse tree, which is
 // decorated with typed representations for top-level expressions.
 void AnalyzeExpressions(parser::Program &, SemanticsContext &);
-
-}  // namespace Fortran::semantics
+}
 #endif  // FORTRAN_SEMANTICS_EXPRESSION_H_

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -54,9 +54,7 @@ static bool FileContentsMatch(
 static std::string GetHeader(const std::string &);
 static std::size_t GetFileSize(const std::string &);
 
-void ModFileWriter::WriteAll() {
-  WriteAll(context_.globalScope());
-}
+void ModFileWriter::WriteAll() { WriteAll(context_.globalScope()); }
 
 void ModFileWriter::WriteAll(const Scope &scope) {
   for (const auto &child : scope.children()) {
@@ -78,11 +76,12 @@ void ModFileWriter::WriteOne(const Scope &scope) {
 void ModFileWriter::Write(const Symbol &symbol) {
   auto *ancestor{symbol.get<ModuleDetails>().ancestor()};
   auto ancestorName{ancestor ? ancestor->name().ToString() : ""s};
-  auto path{ModFilePath(context_.moduleDirectory(), symbol.name(), ancestorName)};
+  auto path{
+      ModFilePath(context_.moduleDirectory(), symbol.name(), ancestorName)};
   PutSymbols(*symbol.scope());
   if (!WriteFile(path, GetAsString(symbol))) {
-    context_.Say(symbol.name(), "Error writing %s: %s"_err_en_US,
-        path.c_str(), std::strerror(errno));
+    context_.Say(symbol.name(), "Error writing %s: %s"_err_en_US, path.c_str(),
+        std::strerror(errno));
   }
 }
 
@@ -496,9 +495,8 @@ Scope *ModFileReader::Read(const SourceName &name, Scope *ancestor) {
   auto &parseTree{parsing.parseTree()};
   if (!parsing.messages().empty() || !parsing.consumedWholeFile() ||
       !parseTree.has_value()) {
-    context_.Say(name,
-        "Module file for '%s' is corrupt: %s"_err_en_US, name.ToString().data(),
-        path->data());
+    context_.Say(name, "Module file for '%s' is corrupt: %s"_err_en_US,
+        name.ToString().data(), path->data());
     return nullptr;
   }
   Scope *parentScope;  // the scope this module/submodule goes into
@@ -577,5 +575,4 @@ static std::string ModFilePath(const std::string &dir, const SourceName &name,
   PutLower(path, name.ToString()) << extension;
   return path.str();
 }
-
-}  // namespace Fortran::semantics
+}

--- a/lib/semantics/mod-file.h
+++ b/lib/semantics/mod-file.h
@@ -75,7 +75,6 @@ private:
   std::optional<std::string> FindModFile(
       const SourceName &, const std::string &);
 };
-
-}  // namespace Fortran::semantics
+}
 
 #endif

--- a/lib/semantics/resolve-labels.cc
+++ b/lib/semantics/resolve-labels.cc
@@ -1129,5 +1129,4 @@ bool ValidateLabels(
     parser::Messages &errorHandler, const parser::Program &program) {
   return CheckConstraints(LabelAnalysis(errorHandler, program));
 }
-
-}  // namespace Fortran::semantics
+}

--- a/lib/semantics/resolve-labels.h
+++ b/lib/semantics/resolve-labels.h
@@ -18,7 +18,7 @@
 namespace Fortran::parser {
 class Messages;
 struct Program;
-}  // namespace Fortran::parser
+}
 
 namespace Fortran::semantics {
 
@@ -27,6 +27,5 @@ namespace Fortran::semantics {
 /// \param program    the parse tree of the program
 /// \return true, iff the program's labels pass semantics checks
 bool ValidateLabels(parser::Messages &messages, const parser::Program &program);
-
-}  // namespace Fortran::semantics
+}
 #endif  // FORTRAN_SEMANTICS_RESOLVE_LABELS_H_

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -3307,5 +3307,4 @@ static GenericSpec MapGenericSpec(const parser::GenericSpec &genericSpec) {
       },
       genericSpec.u);
 }
-
-}  // namespace Fortran::semantics
+}

--- a/lib/semantics/resolve-names.h
+++ b/lib/semantics/resolve-names.h
@@ -21,7 +21,7 @@
 
 namespace Fortran::parser {
 struct Program;
-}  // namespace Fortran::parser
+}
 
 namespace Fortran::semantics {
 
@@ -29,7 +29,6 @@ class SemanticsContext;
 
 void ResolveNames(SemanticsContext &, const parser::Program &);
 void DumpSymbols(std::ostream &);
-
-}  // namespace Fortran::semantics
+}
 
 #endif  // FORTRAN_SEMANTICS_RESOLVE_NAMES_H_

--- a/lib/semantics/rewrite-parse-tree.cc
+++ b/lib/semantics/rewrite-parse-tree.cc
@@ -158,5 +158,4 @@ void RewriteParseTree(SemanticsContext &context, parser::Program &program) {
   RewriteMutator mutator{context.messages(), symbols};
   parser::Walk(program, mutator);
 }
-
-}  // namespace Fortran::semantics
+}

--- a/lib/semantics/rewrite-parse-tree.h
+++ b/lib/semantics/rewrite-parse-tree.h
@@ -18,13 +18,13 @@
 namespace Fortran::parser {
 class Messages;
 struct Program;
-}  // namespace Fortran::parser
+}
 namespace Fortran::semantics {
 class SemanticsContext;
-}  // namespace Fortran::semantics
+}
 
 namespace Fortran::semantics {
 void RewriteParseTree(SemanticsContext &, parser::Program &);
-}  // namespace Fortran::semantics
+}
 
 #endif  // FORTRAN_SEMANTICS_REWRITE_PARSE_TREE_H_

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -146,5 +146,4 @@ std::ostream &operator<<(std::ostream &os, const Scope &scope) {
   }
   return os;
 }
-
-}  // namespace Fortran::semantics
+}

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -157,6 +157,5 @@ private:
 
   friend std::ostream &operator<<(std::ostream &, const Scope &);
 };
-
-}  // namespace Fortran::semantics
+}
 #endif  // FORTRAN_SEMANTICS_SCOPE_H_

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -108,5 +108,4 @@ static void PutIndent(std::ostream &os, int indent) {
     os << "  ";
   }
 }
-
-}  // namespace Fortran::semantics
+}

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -16,8 +16,8 @@
 #define FORTRAN_SEMANTICS_SEMANTICS_H_
 
 #include "expression.h"
-#include "../evaluate/common.h"
 #include "scope.h"
+#include "../evaluate/common.h"
 #include "../evaluate/intrinsics.h"
 #include "../parser/message.h"
 #include <iosfwd>
@@ -27,7 +27,7 @@
 namespace Fortran::parser {
 struct Program;
 class CookedSource;
-}  // namespace Fortran::parser
+}
 
 namespace Fortran::semantics {
 
@@ -49,7 +49,7 @@ public:
   const evaluate::IntrinsicProcTable &intrinsics() const { return intrinsics_; }
   Scope &globalScope() { return globalScope_; }
   parser::Messages &messages() { return messages_; }
-  evaluate::FoldingContext& foldingContext() { return foldingContext_; }
+  evaluate::FoldingContext &foldingContext() { return foldingContext_; }
 
   SemanticsContext &set_searchDirectories(const std::vector<std::string> &x) {
     searchDirectories_ = x;
@@ -102,7 +102,6 @@ private:
   parser::Program &program_;
   const parser::CookedSource &cooked_;
 };
-
-}  // namespace Fortran::semantics
+}
 
 #endif

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -485,5 +485,4 @@ std::ostream &DumpForUnparse(
   }
   return os;
 }
-
-}  // namespace Fortran::semantics
+}

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -421,6 +421,5 @@ private:
     return result;
   }
 };
-
-}  // namespace Fortran::semantics
+}
 #endif  // FORTRAN_SEMANTICS_SYMBOL_H_

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -179,5 +179,4 @@ std::ostream &operator<<(std::ostream &o, const GenericSpec &x) {
   default: CRASH_NO_CASE;
   }
 }
-
-}  // namespace Fortran::semantics
+}

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -269,7 +269,6 @@ private:
   const Symbol *symbol_{nullptr};
   std::optional<DeclTypeSpec> type_;
 };
-
-}  // namespace Fortran::semantics
+}
 
 #endif  // FORTRAN_SEMANTICS_TYPE_H_

--- a/lib/semantics/unparse-with-symbols.cc
+++ b/lib/semantics/unparse-with-symbols.cc
@@ -45,7 +45,7 @@ public:
 
 private:
   const SourceName *currStmt_{nullptr};  // current statement we are processing
-  std::multimap<const char *, const Symbol*> symbols_;  // location to symbol
+  std::multimap<const char *, const Symbol *> symbols_;  // location to symbol
   std::set<const Symbol *> symbolsDefined_;  // symbols that have been processed
   void Indent(std::ostream &, int) const;
 };
@@ -89,5 +89,4 @@ void UnparseWithSymbols(std::ostream &out, const parser::Program &program,
       }};
   parser::Unparse(out, program, encoding, false, true, &preStatement);
 }
-
-}  // namespace Fortran::semantics
+}

--- a/lib/semantics/unparse-with-symbols.h
+++ b/lib/semantics/unparse-with-symbols.h
@@ -20,11 +20,11 @@
 
 namespace Fortran::parser {
 struct Program;
-}  // namespace Fortran::parser
+}
 
 namespace Fortran::semantics {
 void UnparseWithSymbols(std::ostream &, const parser::Program &,
     parser::Encoding encoding = parser::Encoding::UTF8);
-}  // namespace Fortran::semantics
+}
 
 #endif  // FORTRAN_SEMANTICS_UNPARSE_WITH_SYMBOLS_H_

--- a/runtime/ISO_Fortran_binding.cc
+++ b/runtime/ISO_Fortran_binding.cc
@@ -207,4 +207,4 @@ int CFI_setpointer(CFI_cdesc_t *result, const CFI_cdesc_t *source,
   return CFI_INVALID_DESCRIPTOR;  // TODO
 }
 }  // extern "C"
-}  // namespace Fortran::ISO
+}

--- a/runtime/derived-type.cc
+++ b/runtime/derived-type.cc
@@ -80,4 +80,4 @@ void DerivedType::Destroy(char *instance, bool finalize) const {
     }
   }
 }
-}  // namespace Fortran::runtime
+}

--- a/runtime/derived-type.h
+++ b/runtime/derived-type.h
@@ -192,5 +192,5 @@ private:
   std::uint64_t flags_{0};
   std::size_t bytes_{0};
 };
-}  // namespace Fortran::runtime
+}
 #endif  // FORTRAN_RUNTIME_DERIVED_TYPE_H_

--- a/runtime/descriptor.cc
+++ b/runtime/descriptor.cc
@@ -180,4 +180,4 @@ std::ostream &DescriptorAddendum::Dump(std::ostream &o) const {
   // TODO: LEN parameter values
   return o;
 }
-}  // namespace Fortran::runtime
+}

--- a/runtime/descriptor.h
+++ b/runtime/descriptor.h
@@ -329,5 +329,5 @@ public:
 private:
   char storage_[byteSize];
 };
-}  // namespace Fortran::runtime
+}
 #endif  // FORTRAN_RUNTIME_DESCRIPTOR_H_

--- a/runtime/transformational.cc
+++ b/runtime/transformational.cc
@@ -148,5 +148,4 @@ std::unique_ptr<Descriptor> RESHAPE(const Descriptor &source,
 
   return result;
 }
-
-}  // namespace Fortran::runtime
+}

--- a/runtime/transformational.h
+++ b/runtime/transformational.h
@@ -23,6 +23,5 @@ namespace Fortran::runtime {
 std::unique_ptr<Descriptor> RESHAPE(const Descriptor &source,
     const Descriptor &shape, const Descriptor *pad = nullptr,
     const Descriptor *order = nullptr);
-
-}  // namespace Fortran::runtime
+}
 #endif  // FORTRAN_RUNTIME_TRANSFORMATIONAL_H_

--- a/runtime/type-code.cc
+++ b/runtime/type-code.cc
@@ -59,4 +59,4 @@ TypeCode::TypeCode(TypeCategory f, int kind) {
   case TypeCategory::Derived: raw_ = CFI_type_struct; break;
   }
 }
-}  // namespace Fortran::runtime
+}

--- a/runtime/type-code.h
+++ b/runtime/type-code.h
@@ -71,5 +71,5 @@ public:
 private:
   ISO::CFI_type_t raw_{CFI_type_other};
 };
-}  // namespace Fortran::runtime
+}
 #endif  // FORTRAN_RUNTIME_TYPE_CODE_H_

--- a/test/evaluate/intrinsics.cc
+++ b/test/evaluate/intrinsics.cc
@@ -206,7 +206,7 @@ void TestIntrinsics() {
   TestCall{table, "abs"}.Push(Const(Scalar<Log4>{})).DoCall();
   // TODO: test other intrinsics
 }
-}  // namespace Fortran::evaluate
+}
 
 int main() {
   Fortran::evaluate::TestIntrinsics();

--- a/test/evaluate/testing.cc
+++ b/test/evaluate/testing.cc
@@ -23,7 +23,7 @@ namespace testing {
 namespace {
 int passes{0};
 int failures{0};
-}  // namespace
+}
 
 static void BitBucket(const char *, ...) {}
 
@@ -133,4 +133,4 @@ int Complete() {
     return EXIT_FAILURE;
   }
 }
-}  // namespace testing
+}

--- a/test/evaluate/testing.h
+++ b/test/evaluate/testing.h
@@ -44,5 +44,5 @@ FailureDetailPrinter Match(const char *file, int line, const char *want,
 FailureDetailPrinter Compare(const char *file, int line, const char *xs,
     const char *rel, const char *ys, unsigned long long x,
     unsigned long long y);
-}  // namespace testing
+}
 #endif  // FORTRAN_EVALUATE_TESTING_H_

--- a/tools/f18/dump.cc
+++ b/tools/f18/dump.cc
@@ -43,6 +43,6 @@ DEFINE_DUMP(semantics, Scope)
 DEFINE_DUMP(semantics, IntrinsicTypeSpec)
 DEFINE_DUMP(semantics, DerivedTypeSpec)
 DEFINE_DUMP(semantics, DeclTypeSpec)
-}  // namespace Fortran
+}
 
 #endif


### PR DESCRIPTION
Changed all  ` }  // namespace xx` to `}` 

**What was done:**
- Removed all such comments from all .cc and .h files with` sed -i 's/}  \/\/ namespace.*$/` command
- Modified  .clang-format so that clang-format will not add automatically a comment after the closing brace of each namespace. 
- Ran clang-format 6.0.1 with updated .clang-format to validate the change. A few blank lines and spaces unrelated to the change have been removed by clang-format. Note that clang-format was only run on .cc and .h files that had been modified by the sed command.

**Change verification**
- Source to source compare to verify no other change occurred while running sed
- namespace comment were not re-added by clang-format run
- Rebuilt F18 on linux86-64 after the change was successful