### PR TITLE
Roll up a bunch of changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@ Release
 MinSizeRel
 build
 tags
+TAGS
 *.o
+.nfs*
 *~
 *#
 CMakeCache.txt

--- a/documentation/C++style.md
+++ b/documentation/C++style.md
@@ -190,6 +190,7 @@ the definition of an external destructor.
 optional deep copy semantics; reassignable.
 Often better than a reference (due to ownership) or `std::unique_ptr<>`
 (due to non-nullability and copyability).
+Can be wrapped in `std::optional<>` when nullability is required.
 * `CountedReference<>`: A nullable pointer with shared ownership via
 reference counting, null by default, shallowly copyable, reassignable.
 Safe to use *only* when the data are private to just one
@@ -199,19 +200,15 @@ of that standard feature is prohibitive.
 
 A feature matrix:
 
-| pointer | nullable | default null | owning | reassignable | copyable |
-| ------- | -------- | ------------ | ------ | ------------ | -------- |
-| `*p` | yes | no | no | yes | shallowly |
-| `&r` | no | n/a | no | no | shallowly |
-| `unique_ptr<>` | yes | yes | yes | yes | no |
-| `shared_ptr<>` | yes | yes | yes | yes | shallowly |
-| `OwningPointer<>` | yes | yes | yes | yes | no |
-| `Indirection<>` | no | n/a | yes | yes | optionally deeply |
-| `CountedReference<>` | yes | yes | yes | yes | shallowly |
-
-Note that `std::optional<Indirection<>>` checks all the boxes, if you
-need a nullable `Indirection<>`.
-
+| pointer | nullable | default null | owning | reassignable | copyable | undefined type ok? |
+| ------- | -------- | ------------ | ------ | ------------ | -------- | ------------------ |
+| `*p` | yes | no | no | yes | shallowly | yes |
+| `&r` | no | n/a | no | no | shallowly | no |
+| `unique_ptr<>` | yes | yes | yes | yes | no | no |
+| `shared_ptr<>` | yes | yes | yes | yes | shallowly | no |
+| `OwningPointer<>` | yes | yes | yes | yes | no | yes |
+| `Indirection<>` | no | n/a | yes | yes | optionally deeply | no |
+| `CountedReference<>` | yes | yes | yes | yes | shallowly | no |
 
 ### Overall design preferences
 Don't use dynamic solutions to solve problems that can be solved at

--- a/documentation/C++style.md
+++ b/documentation/C++style.md
@@ -196,6 +196,23 @@ Safe to use *only* when the data are private to just one
 thread of execution.
 Used sparingly in place of `std::shared_ptr<>` only when the overhead
 of that standard feature is prohibitive.
+
+A feature matrix:
+
+| pointer | nullable | default null | owning | reassignable | copyable |
+| ------- | -------- | ------------ | ------ | ------------ | -------- |
+| `*p` | yes | no | no | yes | shallowly |
+| `&r` | no | n/a | no | no | shallowly |
+| `unique_ptr<>` | yes | yes | yes | yes | no |
+| `shared_ptr<>` | yes | yes | yes | yes | shallowly |
+| `OwningPointer<>` | yes | yes | yes | yes | no |
+| `Indirection<>` | no | n/a | yes | yes | optionally deeply |
+| `CountedReference<>` | yes | yes | yes | yes | shallowly |
+
+Note that `std::optional<Indirection<>>` checks all the boxes, if you
+need a nullable `Indirection<>`.
+
+
 ### Overall design preferences
 Don't use dynamic solutions to solve problems that can be solved at
 build time; don't solve build time problems by writing programs that

--- a/documentation/C++style.md
+++ b/documentation/C++style.md
@@ -164,34 +164,37 @@ There are many -- perhaps too many -- means of indirect addressing
 data in this project.
 Some of these are standard C++ language and library features,
 while others are local inventions in `lib/common`:
-* Bare pointers (`Foo *p`): nullable, non-owning, undefined when
-uninitialized, shallowly copyable, and almost never the right abstraction
-to use in this project.
-* References (`Foo &r`, `const Foo &r`): non-nullable, not owning, and
-shallowly copied.
+* Bare pointers (`Foo *p`): these are obviously nullable, non-owning,
+undefined when uninitialized, shallowly copyable, reassignable, and almost
+never the right abstraction to use in this project.
+* References (`Foo &r`, `const Foo &r`): non-nullable, not owning,
+shallowly copyable, and not reassignable.
 References are great for invisible indirection to objects whose lifetimes are
 broader than that of the reference.
+(Sometimes when a class data member should be a reference, but we also need
+reassignability, it will be declared as a pointer, and its accessor
+will be defined to return a reference.)
 * Rvalue references (`Foo &&r`): These are non-nullable references
 *with* ownership, and they are ubiquitously used for formal arguments
 wherever appropriate.
-* `std::unique_ptr<>`: A nullable pointer with ownership, null by default.
-Not copyable.
+* `std::unique_ptr<>`: A nullable pointer with ownership, null by default,
+not copyable, reassignable.
 * `std::shared_ptr<>`: A nullable pointer with shared ownership via reference
-counting, null by default.  Slow.
+counting, null by default, shallowly copyable, reassignable, and slow.
 * `OwningPointer<>`: A nullable pointer with ownership, better suited
 for use with forward-defined types than `std::unique_ptr<>` is.
-Null by default.
+Null by default, not copyable, reassignable.
 Does not have means for allocating data, and inconveniently requires
 the definition of an external destructor.
 * `Indirection<>`: A non-nullable pointer with ownership and
-optional deep copy semantics.
+optional deep copy semantics; reassignable.
 Often better than a reference (due to ownership) or `std::unique_ptr<>`
 (due to non-nullability and copyability).
 * `CountedReference<>`: A nullable pointer with shared ownership via
-reference counting.
-Safe only when the data are private to one
+reference counting, null by default, shallowly copyable, reassignable.
+Safe to use *only* when the data are private to just one
 thread of execution.
-Used sparely in place of `std::shared_ptr<>` only when the overhead
+Used sparingly in place of `std::shared_ptr<>` only when the overhead
 of that standard feature is prohibitive.
 ### Overall design preferences
 Don't use dynamic solutions to solve problems that can be solved at

--- a/lib/evaluate/CMakeLists.txt
+++ b/lib/evaluate/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(FortranEvaluate
   intrinsics.cc
   logical.cc
   real.cc
+  static-data.cc
   tools.cc
   type.cc
   variable.cc

--- a/lib/evaluate/call.cc
+++ b/lib/evaluate/call.cc
@@ -23,14 +23,14 @@ std::optional<DynamicType> ActualArgument::GetType() const {
 
 int ActualArgument::Rank() const { return value->Rank(); }
 
-std::ostream &ActualArgument::Dump(std::ostream &o) const {
+std::ostream &ActualArgument::AsFortran(std::ostream &o) const {
   if (keyword.has_value()) {
     o << keyword->ToString() << '=';
   }
   if (isAlternateReturn) {
     o << '*';
   }
-  return value->Dump(o);
+  return value->AsFortran(o);
 }
 
 std::optional<int> ActualArgument::VectorSize() const {
@@ -41,11 +41,15 @@ std::optional<int> ActualArgument::VectorSize() const {
   return std::nullopt;
 }
 
-std::ostream &ProcedureRef::Dump(std::ostream &o) const {
-  proc_.Dump(o);
+std::ostream &SpecificIntrinsic::AsFortran(std::ostream &o) const {
+  return o << name;
+}
+
+std::ostream &ProcedureRef::AsFortran(std::ostream &o) const {
+  proc_.AsFortran(o);
   char separator{'('};
   for (const auto &arg : arguments_) {
-    arg->Dump(o << separator);
+    arg->AsFortran(o << separator);
     separator = ',';
   }
   if (separator == '(') {

--- a/lib/evaluate/call.h
+++ b/lib/evaluate/call.h
@@ -41,7 +41,6 @@ struct ActualArgument {
   std::optional<int> VectorSize() const;
 
   std::optional<parser::CharBlock> keyword;
-  bool isAssumedRank{false};  // TODO: make into a function of the value
   bool isAlternateReturn{false};  // when true, "value" is a label number
 
   // TODO: Mark legacy %VAL and %REF arguments

--- a/lib/evaluate/call.h
+++ b/lib/evaluate/call.h
@@ -37,7 +37,7 @@ struct ActualArgument {
 
   std::optional<DynamicType> GetType() const;
   int Rank() const;
-  std::ostream &Dump(std::ostream &) const;
+  std::ostream &AsFortran(std::ostream &) const;
   std::optional<int> VectorSize() const;
 
   std::optional<parser::CharBlock> keyword;
@@ -64,7 +64,7 @@ struct SpecificIntrinsic {
   SpecificIntrinsic(IntrinsicProcedure n, std::optional<DynamicType> &&dt,
       int r, semantics::Attrs a)
     : name{n}, type{std::move(dt)}, rank{r}, attrs{a} {}
-  std::ostream &Dump(std::ostream &) const;
+  std::ostream &AsFortran(std::ostream &) const;
 
   IntrinsicProcedure name;
   bool isRestrictedSpecific{false};  // if true, can only call it
@@ -82,7 +82,7 @@ struct ProcedureDesignator {
   bool IsElemental() const;
   Expr<SubscriptInteger> LEN() const;
   const semantics::Symbol *GetSymbol() const;
-  std::ostream &Dump(std::ostream &) const;
+  std::ostream &AsFortran(std::ostream &) const;
 
   // TODO: When calling X%F, pass X as PASS argument unless NOPASS
   std::variant<SpecificIntrinsic, const semantics::Symbol *> u;

--- a/lib/evaluate/common.h
+++ b/lib/evaluate/common.h
@@ -186,6 +186,7 @@ struct FoldingContext {
   parser::ContextualMessages messages;
   Rounding rounding{defaultRounding};
   bool flushDenormalsToZero{false};
+  bool bigEndian{false};
 };
 
 void RealFlagWarnings(FoldingContext &, const RealFlags &, const char *op);

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -132,7 +132,7 @@ std::ostream &Emit(std::ostream &o, const ArrayConstructorValues<T> &values) {
 
 template<typename T>
 std::ostream &ArrayConstructor<T>::Dump(std::ostream &o) const {
-  o << '[' << Result::Dump() << "::";
+  o << '[' << result.Dump() << "::";
   Emit(o, *this);
   return o << ']';
 }
@@ -148,6 +148,11 @@ std::ostream &ExpressionBase<RESULT>::Dump(std::ostream &o) const {
   return o;
 }
 
+template<typename T> Expr<SubscriptInteger> ArrayConstructor<T>::LEN() const {
+  // TODO pmk: extract from type spec
+  return AsExpr(Constant<SubscriptInteger>{0});  // TODO placeholder
+}
+
 template<int KIND>
 Expr<SubscriptInteger> Expr<Type<TypeCategory::Character, KIND>>::LEN() const {
   return std::visit(
@@ -155,6 +160,7 @@ Expr<SubscriptInteger> Expr<Type<TypeCategory::Character, KIND>>::LEN() const {
                          return AsExpr(
                              Constant<SubscriptInteger>{c.value.size()});
                        },
+          [](const ArrayConstructor<Result> &a) { return a.LEN(); },
           [](const Parentheses<Result> &x) { return x.left().LEN(); },
           [](const Concat<KIND> &c) {
             return c.left().LEN() + c.right().LEN();
@@ -169,6 +175,11 @@ Expr<SubscriptInteger> Expr<Type<TypeCategory::Character, KIND>>::LEN() const {
 }
 
 Expr<SomeType>::~Expr() {}
+
+template<typename T> DynamicType ArrayConstructor<T>::GetType() const {
+  // TODO: pmk: parameterized derived types, CHARACTER length
+  return *result.GetType();
+}
 
 template<typename A>
 std::optional<DynamicType> ExpressionBase<A>::GetType() const {

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -58,11 +58,6 @@ template<typename A> std::ostream &Relational<A>::Infix(std::ostream &o) const {
   return o << '.' << EnumToString(opr) << '.';
 }
 
-template<int KIND>
-std::ostream &LiteralSubstring<KIND>::Prefix(std::ostream &o) const {
-  return o << KIND << '_' << parser::QuoteCharacterLiteral(string) << '(';
-}
-
 std::ostream &Relational<SomeType>::Dump(std::ostream &o) const {
   std::visit([&](const auto &rel) { rel.Dump(o); }, u);
   return o;
@@ -153,12 +148,6 @@ template<typename T> Expr<SubscriptInteger> ArrayConstructor<T>::LEN() const {
   return AsExpr(Constant<SubscriptInteger>{0});  // TODO placeholder
 }
 
-template<int KIND> Expr<SubscriptInteger> LiteralSubstring<KIND>::LEN() const {
-  auto lower{this->left()};
-  auto upper{this->right()};
-  return std::move(upper) - std::move(lower) + Expr<SubscriptInteger>{1};
-}
-
 template<int KIND>
 Expr<SubscriptInteger> Expr<Type<TypeCategory::Character, KIND>>::LEN() const {
   return std::visit(
@@ -166,7 +155,6 @@ Expr<SubscriptInteger> Expr<Type<TypeCategory::Character, KIND>>::LEN() const {
                          return AsExpr(
                              Constant<SubscriptInteger>{c.value.size()});
                        },
-          [](const LiteralSubstring<KIND> &ls) { return ls.LEN(); },
           [](const ArrayConstructor<Result> &a) { return a.LEN(); },
           [](const Parentheses<Result> &x) { return x.left().LEN(); },
           [](const Concat<KIND> &c) {

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -110,11 +110,6 @@ std::ostream &ExpressionBase<RESULT>::Dump(std::ostream &o) const {
   return o;
 }
 
-std::ostream &Expr<SomeDerived>::Dump(std::ostream &o) const {
-  std::visit([&](const auto &x) { x.Dump(o); }, u);
-  return o;
-}
-
 template<int KIND>
 Expr<SubscriptInteger> Expr<Type<TypeCategory::Character, KIND>>::LEN() const {
   return std::visit(
@@ -154,10 +149,6 @@ std::optional<DynamicType> ExpressionBase<A>::GetType() const {
   }
 }
 
-std::optional<DynamicType> Expr<SomeDerived>::GetType() const {
-  return std::visit([](const auto &x) { return x.GetType(); }, u);
-}
-
 template<typename A> int ExpressionBase<A>::Rank() const {
   return std::visit(
       [](const auto &x) {
@@ -171,10 +162,6 @@ template<typename A> int ExpressionBase<A>::Rank() const {
       derived().u);
 }
 
-int Expr<SomeDerived>::Rank() const {
-  return std::visit([](const auto &x) { return x.Rank(); }, u);
-}
-
 // Template instantiations to resolve the "extern template" declarations
 // that appear in expression.h.
 
@@ -184,8 +171,7 @@ FOR_EACH_INTEGER_KIND(template struct Relational)
 FOR_EACH_REAL_KIND(template struct Relational)
 FOR_EACH_CHARACTER_KIND(template struct Relational)
 template struct Relational<SomeType>;
-FOR_EACH_INTRINSIC_KIND(template struct ExpressionBase)
-FOR_EACH_CATEGORY_TYPE(template struct ExpressionBase)
+FOR_EACH_TYPE_AND_KIND(template class ExpressionBase)
 }
 
 // For reclamation of analyzed expressions to which owning pointers have

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -357,27 +357,6 @@ struct Concat
   static std::ostream &Infix(std::ostream &o) { return o << "//"; }
 };
 
-// TODO: Once the symbol table supports compiler temporaries,
-// just put the literal string into one and use a regular Substring.
-template<int KIND>
-struct LiteralSubstring : public Operation<LiteralSubstring<KIND>,
-                              Type<TypeCategory::Character, KIND>,
-                              SubscriptInteger, SubscriptInteger> {
-  using Result = Type<TypeCategory::Character, KIND>;
-  using Operand = SubscriptInteger;
-  using String = Scalar<Result>;
-  using Base = Operation<LiteralSubstring, Result, Operand, Operand>;
-  LiteralSubstring(
-      const String &s, const Expr<Operand> &lower, const Expr<Operand> &upper)
-    : string{s}, Base{lower, upper} {}
-  LiteralSubstring(String &&s, Expr<Operand> &&lower, Expr<Operand> &&upper)
-    : Base{std::move(lower), std::move(upper)}, string{std::move(s)} {}
-
-  std::ostream &Prefix(std::ostream &) const;
-  Expr<SubscriptInteger> LEN() const;
-  String string;
-};
-
 ENUM_CLASS(LogicalOperator, And, Or, Eqv, Neqv)
 
 template<int KIND>
@@ -531,9 +510,8 @@ public:
 
   Expr<SubscriptInteger> LEN() const;
 
-  std::variant<Constant<Result>, LiteralSubstring<KIND>,
-      ArrayConstructor<Result>, Designator<Result>, FunctionRef<Result>,
-      Parentheses<Result>, Concat<KIND>, Extremum<Result>>
+  std::variant<Constant<Result>, ArrayConstructor<Result>, Designator<Result>,
+      FunctionRef<Result>, Parentheses<Result>, Concat<KIND>, Extremum<Result>>
       u;
 };
 

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -86,7 +86,7 @@ public:
 
   std::optional<DynamicType> GetType() const;
   int Rank() const;
-  std::ostream &Dump(std::ostream &) const;
+  std::ostream &AsFortran(std::ostream &) const;
   static Derived Rewrite(FoldingContext &, Derived &&);
 };
 
@@ -184,10 +184,10 @@ public:
     }
   }
 
-  std::ostream &Dump(std::ostream &) const;
+  std::ostream &AsFortran(std::ostream &) const;
 
 protected:
-  // Overridable functions for Dump()
+  // Overridable functions for AsFortran()
   static std::ostream &Prefix(std::ostream &o) { return o << '('; }
   static std::ostream &Infix(std::ostream &o) { return o << ','; }
   static std::ostream &Suffix(std::ostream &o) { return o << ')'; }
@@ -214,7 +214,7 @@ struct Convert : public Operation<Convert<TO, FROMCAT>, TO, SomeKind<FROMCAT>> {
   using Operand = SomeKind<FROMCAT>;
   using Base = Operation<Convert, Result, Operand>;
   using Base::Base;
-  std::ostream &Dump(std::ostream &) const;
+  std::ostream &AsFortran(std::ostream &) const;
 };
 
 template<typename A>
@@ -416,7 +416,7 @@ struct ArrayConstructor : public ArrayConstructorValues<RESULT> {
   DynamicType GetType() const;
   static constexpr int Rank() { return 1; }
   Expr<SubscriptInteger> LEN() const;
-  std::ostream &Dump(std::ostream &) const;
+  std::ostream &AsFortran(std::ostream &) const;
 
   Result result;
   std::vector<Expr<SubscriptInteger>> typeParameterValues;
@@ -557,7 +557,7 @@ public:
   int Rank() const {
     return std::visit([](const auto &x) { return x.Rank(); }, u);
   }
-  std::ostream &Dump(std::ostream &o) const;
+  std::ostream &AsFortran(std::ostream &o) const;
   common::MapTemplate<Relational, DirectlyComparableTypes> u;
 };
 

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -357,6 +357,8 @@ struct Concat
   static std::ostream &Infix(std::ostream &o) { return o << "//"; }
 };
 
+// TODO: Once the symbol table supports compiler temporaries,
+// just put the literal string into one and use a regular Substring.
 template<int KIND>
 struct LiteralSubstring : public Operation<LiteralSubstring<KIND>,
                               Type<TypeCategory::Character, KIND>,
@@ -401,14 +403,14 @@ struct LogicalOperation
 
 template<typename RESULT> struct ArrayConstructorValues;
 
-template<typename ITEM, typename OPERAND> struct ImpliedDo {
-  using Item = ITEM;
-  using Result = typename Item::Result;
+template<typename VALUES, typename OPERAND> struct ImpliedDo {
+  using Values = VALUES;
   using Operand = OPERAND;
+  using Result = ResultType<Values>;
   static_assert(Operand::category == TypeCategory::Integer);
   parser::CharBlock controlVariableName;
   CopyableIndirection<Expr<Operand>> lower, upper, stride;
-  CopyableIndirection<Item> values;
+  CopyableIndirection<Values> values;
 };
 
 template<typename RESULT> struct ArrayConstructorValue {
@@ -432,11 +434,13 @@ template<typename RESULT>
 struct ArrayConstructor : public ArrayConstructorValues<RESULT> {
   using Result = RESULT;
   using ArrayConstructorValues<Result>::ArrayConstructorValues;
-  Result result;
   DynamicType GetType() const;
   static constexpr int Rank() { return 1; }
   Expr<SubscriptInteger> LEN() const;
   std::ostream &Dump(std::ostream &) const;
+
+  Result result;
+  std::vector<Expr<SubscriptInteger>> typeParameterValues;
 };
 
 // Per-category expression representations

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -357,6 +357,25 @@ struct Concat
   static std::ostream &Infix(std::ostream &o) { return o << "//"; }
 };
 
+template<int KIND>
+struct LiteralSubstring : public Operation<LiteralSubstring<KIND>,
+                              Type<TypeCategory::Character, KIND>,
+                              SubscriptInteger, SubscriptInteger> {
+  using Result = Type<TypeCategory::Character, KIND>;
+  using Operand = SubscriptInteger;
+  using String = Scalar<Result>;
+  using Base = Operation<LiteralSubstring, Result, Operand, Operand>;
+  LiteralSubstring(
+      const String &s, const Expr<Operand> &lower, const Expr<Operand> &upper)
+    : string{s}, Base{lower, upper} {}
+  LiteralSubstring(String &&s, Expr<Operand> &&lower, Expr<Operand> &&upper)
+    : Base{std::move(lower), std::move(upper)}, string{std::move(s)} {}
+
+  std::ostream &Prefix(std::ostream &) const;
+  Expr<SubscriptInteger> LEN() const;
+  String string;
+};
+
 ENUM_CLASS(LogicalOperator, And, Or, Eqv, Neqv)
 
 template<int KIND>
@@ -508,8 +527,9 @@ public:
 
   Expr<SubscriptInteger> LEN() const;
 
-  std::variant<Constant<Result>, ArrayConstructor<Result>, Designator<Result>,
-      FunctionRef<Result>, Parentheses<Result>, Concat<KIND>, Extremum<Result>>
+  std::variant<Constant<Result>, LiteralSubstring<KIND>,
+      ArrayConstructor<Result>, Designator<Result>, FunctionRef<Result>,
+      Parentheses<Result>, Concat<KIND>, Extremum<Result>>
       u;
 };
 
@@ -551,9 +571,7 @@ template<> class Relational<SomeType> {
 public:
   using Result = LogicalResult;
   EVALUATE_UNION_CLASS_BOILERPLATE(Relational)
-  static constexpr std::optional<DynamicType> GetType() {
-    return Result::GetType();
-  }
+  static constexpr DynamicType GetType() { return Result::GetType(); }
   int Rank() const {
     return std::visit([](const auto &x) { return x.Rank(); }, u);
   }

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -422,7 +422,7 @@ Expr<Type<TypeCategory::Logical, KIND>> FoldOperation(
 // end per-operation folding functions
 
 template<typename T>
-Expr<T> FoldHelper<T>::FoldExpr(FoldingContext &context, Expr<T> &&expr) {
+Expr<T> ExpressionBase<T>::Rewrite(FoldingContext &context, Expr<T> &&expr) {
   return std::visit(
       [&](auto &&x) -> Expr<T> {
         if constexpr (T::isSpecificIntrinsicType) {
@@ -439,7 +439,7 @@ Expr<T> FoldHelper<T>::FoldExpr(FoldingContext &context, Expr<T> &&expr) {
       std::move(expr.u));
 }
 
-FOR_EACH_TYPE_AND_KIND(template struct FoldHelper)
+FOR_EACH_TYPE_AND_KIND(template class ExpressionBase)
 
 template<typename T>
 std::optional<Constant<T>>

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -34,25 +34,17 @@ Expr<ResultType<A>> FoldOperation(FoldingContext &, A &&x) {
 }
 
 // Designators
-// At the moment, only substrings fold.
-// TODO: Parameters, KIND type parameters
+// At the moment, only empty substrings fold.
+// TODO: Parameters, KIND type parameters, substrings of parameters
 template<int KIND>
 Expr<Type<TypeCategory::Character, KIND>> FoldOperation(FoldingContext &context,
     Designator<Type<TypeCategory::Character, KIND>> &&designator) {
   using CHAR = Type<TypeCategory::Character, KIND>;
   if (auto *substring{std::get_if<Substring>(&designator.u)}) {
-    if (auto folded{substring->Fold(context)}) {
-      if (auto *string{std::get_if<Scalar<CHAR>>(&*folded)}) {
-        return Expr<CHAR>{Constant<CHAR>{std::move(*string)}};
-      }
-      // A zero-length substring of an arbitrary data reference can
-      // be folded, but the C++ string type of the empty value will be
-      // std::string and that may not be right for multi-byte CHARACTER
-      // kinds.
-      if (auto length{ToInt64(Fold(context, substring->LEN()))}) {
-        if (*length == 0) {
-          return Expr<CHAR>{Constant<CHAR>{Scalar<CHAR>{}}};
-        }
+    substring->Fold(context);
+    if (auto length{ToInt64(Fold(context, substring->LEN()))}) {
+      if (*length == 0) {
+        return Expr<CHAR>{Constant<CHAR>{Scalar<CHAR>{}}};
       }
     }
   }
@@ -353,22 +345,56 @@ Expr<T> FoldOperation(FoldingContext &context, Extremum<T> &&x) {
 template<int KIND>
 Expr<Type<TypeCategory::Complex, KIND>> FoldOperation(
     FoldingContext &context, ComplexConstructor<KIND> &&x) {
-  using COMPLEX = Type<TypeCategory::Complex, KIND>;
+  using Result = Type<TypeCategory::Complex, KIND>;
   if (auto folded{FoldOperands(context, x.left(), x.right())}) {
-    return Expr<COMPLEX>{
-        Constant<COMPLEX>{Scalar<COMPLEX>{folded->first, folded->second}}};
+    return Expr<Result>{
+        Constant<Result>{Scalar<Result>{folded->first, folded->second}}};
   }
-  return Expr<COMPLEX>{std::move(x)};
+  return Expr<Result>{std::move(x)};
+}
+
+template<int KIND>
+Expr<Type<TypeCategory::Character, KIND>> FoldOperation(
+    FoldingContext &context, LiteralSubstring<KIND> &&x) {
+  using Result = Type<TypeCategory::Character, KIND>;
+  x.left() = Fold(context, std::move(x.left()));
+  x.right() = Fold(context, std::move(x.right()));
+  auto lower{ToInt64(x.left())};
+  auto upper{ToInt64(x.left())};
+  if (lower.has_value() && *lower < 1) {
+    context.messages.Say("lower bound (%jd) on literal substring "
+                         "is less than one"_en_US,
+        static_cast<std::intmax_t>(*lower));
+    lower = 1;
+  }
+  if (upper.has_value()) {
+    if (*upper < 1 || (lower.has_value() && *upper < *lower)) {
+      return Expr<Result>{Constant<Result>(Scalar<Result>{})};
+    }
+    std::int64_t len = x.string.size();
+    if (*upper > len) {
+      context.messages.Say("upper bound (%jd) on substring "
+                           "is greater than character length (%jd)"_en_US,
+          static_cast<std::intmax_t>(*upper), static_cast<std::intmax_t>(len));
+      upper = len;
+    }
+    if (lower.has_value()) {
+      Scalar<Result> substring{
+          x.string.substr(*lower - 1, *upper - *lower + 1)};
+      return Expr<Result>{Constant<Result>{substring}};
+    }
+  }
+  return Expr<Result>{std::move(x)};
 }
 
 template<int KIND>
 Expr<Type<TypeCategory::Character, KIND>> FoldOperation(
     FoldingContext &context, Concat<KIND> &&x) {
-  using CHAR = Type<TypeCategory::Character, KIND>;
+  using Result = Type<TypeCategory::Character, KIND>;
   if (auto folded{FoldOperands(context, x.left(), x.right())}) {
-    return Expr<CHAR>{Constant<CHAR>{folded->first + folded->second}};
+    return Expr<Result>{Constant<Result>{folded->first + folded->second}};
   }
-  return Expr<CHAR>{std::move(x)};
+  return Expr<Result>{std::move(x)};
 }
 
 template<typename T>

--- a/lib/evaluate/fold.h
+++ b/lib/evaluate/fold.h
@@ -29,14 +29,9 @@ using namespace Fortran::parser::literals;
 // Fold() rewrites an expression and returns it.  When the rewritten expression
 // is a constant, GetScalarConstantValue() below will be able to extract it.
 // Note the rvalue reference argument: the rewrites are performed in place
-// for efficiency.  The implementation is wrapped in a helper template class so
-// that all the per-type template instantiations can be made once in fold.cc.
-template<typename T> struct FoldHelper {
-  static Expr<T> FoldExpr(FoldingContext &, Expr<T> &&);
-};
-
+// for efficiency.
 template<typename T> Expr<T> Fold(FoldingContext &context, Expr<T> &&expr) {
-  return FoldHelper<T>::FoldExpr(context, std::move(expr));
+  return Expr<T>::Rewrite(context, std::move(expr));
 }
 
 template<typename T>
@@ -48,8 +43,6 @@ std::optional<Expr<T>> Fold(
     return std::nullopt;
   }
 }
-
-FOR_EACH_TYPE_AND_KIND(extern template struct FoldHelper)
 
 // GetScalarConstantValue() extracts the constant value of an expression,
 // when it has one, even if it is parenthesized or optional.

--- a/lib/evaluate/integer.h
+++ b/lib/evaluate/integer.h
@@ -87,6 +87,7 @@ private:
   static constexpr Part topPartMask{static_cast<Part>(~0) >> extraTopPartBits};
 
 public:
+  // Some types used for member function results
   struct ValueWithOverflow {
     Integer value;
     bool overflow;
@@ -994,7 +995,7 @@ private:
     }
   }
 
-  Part part_[parts];
+  Part part_[parts]{};
 };
 
 extern template class Integer<8>;

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -867,7 +867,7 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
       return std::nullopt;
     } else if (!d.typePattern.categorySet.test(type->category)) {
       messages.Say("actual argument for '%s=' has bad type '%s'"_err_en_US,
-          d.keyword, type->Dump().data());
+          d.keyword, type->AsFortran().data());
       return std::nullopt;  // argument has invalid type category
     }
     bool argOk{false};
@@ -920,7 +920,7 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
     if (!argOk) {
       messages.Say(
           "actual argument for '%s=' has bad type or kind '%s'"_err_en_US,
-          d.keyword, type->Dump().data());
+          d.keyword, type->AsFortran().data());
       return std::nullopt;
     }
   }
@@ -1268,10 +1268,6 @@ std::optional<SpecificCall> IntrinsicProcTable::Probe(
     parser::ContextualMessages *messages) const {
   CHECK(impl_ != nullptr || !"IntrinsicProcTable: not configured");
   return impl_->Probe(call, arguments, messages);
-}
-
-std::ostream &SpecificIntrinsic::Dump(std::ostream &o) const {
-  return o << name;
 }
 
 std::ostream &TypePattern::Dump(std::ostream &o) const {

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -933,9 +933,9 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
   for (std::size_t j{0}; j < dummies; ++j) {
     const IntrinsicDummyArgument &d{dummy[std::min(j, dummyArgPatterns - 1)]};
     if (const ActualArgument * arg{actualForDummy[j]}) {
-      if (arg->isAssumedRank && d.rank != Rank::anyOrAssumedRank) {
-        messages.Say(
-            "assumed-rank array cannot be used for '%s=' argument"_err_en_US,
+      if (IsAssumedRank(*arg->value) && d.rank != Rank::anyOrAssumedRank) {
+        messages.Say("assumed-rank array cannot be forwarded to "
+                     "'%s=' argument"_err_en_US,
             d.keyword);
         return std::nullopt;
       }

--- a/lib/evaluate/real.cc
+++ b/lib/evaluate/real.cc
@@ -383,7 +383,6 @@ template<typename W, int P, bool IM>
 ValueWithRealFlags<Real<W, P, IM>> Real<W, P, IM>::Read(
     const char *&p, Rounding rounding) {
   ValueWithRealFlags<Real> result;
-  Real ten{FromInteger(Integer<8>{10}).value};
   while (*p == ' ') {
     ++p;
   }

--- a/lib/evaluate/real.h
+++ b/lib/evaluate/real.h
@@ -20,6 +20,7 @@
 #include "rounding-bits.h"
 #include <cinttypes>
 #include <limits>
+#include <ostream>
 #include <string>
 
 // Some environments, viz. clang on Darwin, allow the macro HUGE
@@ -48,6 +49,17 @@ public:
   static constexpr std::uint64_t maxExponent{(1 << exponentBits) - 1};
   static constexpr std::uint64_t exponentBias{maxExponent / 2};
 
+  // Decimal precision
+  // log(2)/log(10) = 0.30102999... in any base; avoid floating constexpr
+  static constexpr int decimalDigits{(precision * 30103) / 100000};
+
+  // Associates a decimal exponent with an integral value for formmatting.
+  struct ScaledDecimal {
+    bool negative{false};
+    Word integer;
+    int decimalExponent{0};  // Exxx
+  };
+
   template<typename W, int P, bool I> friend class Real;
 
   constexpr Real() {}  // +0.0
@@ -56,7 +68,7 @@ public:
   constexpr Real &operator=(const Real &) = default;
   constexpr Real &operator=(Real &&) = default;
 
-  // TODO AINT/ANINT, CEILING, FLOOR, DIM, MAX, MIN, DPROD, FRACTION
+  // TODO ANINT, CEILING, FLOOR, DIM, MAX, MIN, DPROD, FRACTION
   // HUGE, INT/NINT, MAXEXPONENT, MINEXPONENT, NEAREST, OUT_OF_RANGE,
   // PRECISION, HUGE, TINY, RRSPACING/SPACING, SCALE, SET_EXPONENT, SIGN
 
@@ -174,20 +186,44 @@ public:
     return result;
   }
 
+  // Truncation to integer in same real format.
+  constexpr ValueWithRealFlags<Real> AINT() const {
+    ValueWithRealFlags<Real> result{*this};
+    if (IsNotANumber()) {
+      result.flags.set(RealFlag::InvalidArgument);
+      result.value = NotANumber();
+    } else if (IsInfinite()) {
+      result.flags.set(RealFlag::Overflow);
+    } else {
+      std::uint64_t exponent{Exponent()};
+      if (exponent < exponentBias) {  // |x| < 1.0
+        result.value.Normalize(IsNegative(), 0, Fraction{});  // +/-0.0
+      } else {
+        constexpr std::uint64_t noClipExponent{exponentBias + precision - 1};
+        if (int clip = noClipExponent - exponent; clip > 0) {
+          result.value.word_ = result.value.word_.IAND(Word::MASKR(clip).NOT());
+        }
+      }
+    }
+    return result;
+  }
+
   template<typename INT> constexpr ValueWithRealFlags<INT> ToInteger() const {
+    ValueWithRealFlags<INT> result;
+    if (IsNotANumber()) {
+      result.flags.set(RealFlag::InvalidArgument);
+      result.value = result.value.HUGE();
+      return result;
+    }
     bool isNegative{IsNegative()};
     std::uint64_t exponent{Exponent()};
     Fraction fraction{GetFraction()};
-    ValueWithRealFlags<INT> result;
-    if (exponent == maxExponent && !fraction.IsZero()) {  // NaN
-      result.flags.set(RealFlag::InvalidArgument);
-      result.value = result.value.HUGE();
-    } else if (exponent >= maxExponent ||  // +/-Inf
+    if (exponent >= maxExponent ||  // +/-Inf
         exponent >= exponentBias + result.value.bits) {  // too big
       if (isNegative) {
-        result.value = result.value.MASKL(1);
+        result.value = result.value.MASKL(1);  // most negative integer value
       } else {
-        result.value = result.value.HUGE();
+        result.value = result.value.HUGE();  // most positive integer value
       }
       result.flags.set(RealFlag::Overflow);
     } else if (exponent < exponentBias) {  // |x| < 1.0 -> 0
@@ -258,8 +294,12 @@ public:
     return result;
   }
 
+  // Represents the number as "J*(10**K)" where J and K are integers.
+  ValueWithRealFlags<ScaledDecimal> AsScaledDecimal() const;
+
   constexpr Word RawBits() const { return word_; }
 
+  // Extracts "raw" biased exponent field.
   constexpr std::uint64_t Exponent() const {
     return word_.IBITS(significandBits, exponentBits).ToUInt64();
   }
@@ -267,6 +307,10 @@ public:
   static ValueWithRealFlags<Real> Read(
       const char *&, Rounding rounding = defaultRounding);
   std::string DumpHexadecimal() const;
+
+  // Emits a character representation for an equivalent Fortran constant
+  // or parenthesized constant expression that produces this value.
+  std::ostream &AsFortran(std::ostream &, int kind) const;
 
 private:
   using Fraction = Integer<precision>;  // all bits made explicit

--- a/lib/evaluate/static-data.cc
+++ b/lib/evaluate/static-data.cc
@@ -1,0 +1,30 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "static-data.h"
+
+namespace Fortran::evaluate {
+std::ostream &StaticDataObject::Dump(std::ostream &o) const {
+  o << "static data ";
+  char sep{'{'};
+  for (std::uint8_t byte : data_) {
+    o << sep << "0x" << std::hex << byte;
+    sep = ',';
+  }
+  if (sep == '{') {
+    o << '{';
+  }
+  return o << '}';
+}
+}

--- a/lib/evaluate/static-data.cc
+++ b/lib/evaluate/static-data.cc
@@ -27,4 +27,41 @@ std::ostream &StaticDataObject::Dump(std::ostream &o) const {
   }
   return o << '}';
 }
+
+StaticDataObject &StaticDataObject::Push(const std::string &string) {
+  for (auto ch : string) {
+    data_.push_back(static_cast<std::uint8_t>(ch));
+  }
+  return *this;
+}
+
+StaticDataObject &StaticDataObject::Push(const std::u16string &string) {
+  // TODO here and below: big-endian targets
+  for (auto ch : string) {
+    data_.push_back(static_cast<std::uint8_t>(ch));
+    data_.push_back(static_cast<std::uint8_t>(ch >> 8));
+  }
+  return *this;
+}
+
+StaticDataObject &StaticDataObject::Push(const std::u32string &string) {
+  for (auto ch : string) {
+    data_.push_back(static_cast<std::uint8_t>(ch));
+    data_.push_back(static_cast<std::uint8_t>(ch >> 8));
+    data_.push_back(static_cast<std::uint8_t>(ch >> 16));
+    data_.push_back(static_cast<std::uint8_t>(ch >> 24));
+  }
+  return *this;
+}
+
+std::optional<std::string> StaticDataObject::AsString() const {
+  if (itemBytes_ <= 1) {
+    std::string result;
+    for (std::uint8_t byte : data_) {
+      result += static_cast<char>(byte);
+    }
+    return {std::move(result)};
+  }
+  return std::nullopt;
+}
 }

--- a/lib/evaluate/static-data.cc
+++ b/lib/evaluate/static-data.cc
@@ -13,22 +13,23 @@
 // limitations under the License.
 
 #include "static-data.h"
+#include "../parser/characters.h"
 
 namespace Fortran::evaluate {
 
 bool StaticDataObject::bigEndian{false};
 
-std::ostream &StaticDataObject::Dump(std::ostream &o) const {
-  o << "static data ";
-  char sep{'{'};
-  for (std::uint8_t byte : data_) {
-    o << sep << "0x" << std::hex << byte;
-    sep = ',';
+std::ostream &StaticDataObject::AsFortran(std::ostream &o) const {
+  if (auto string{AsString()}) {
+    o << parser::QuoteCharacterLiteral(*string);
+  } else if (auto string{AsU16String()}) {
+    o << "2_" << parser::QuoteCharacterLiteral(*string);
+  } else if (auto string{AsU32String()}) {
+    o << "4_" << parser::QuoteCharacterLiteral(*string);
+  } else {
+    CRASH_NO_CASE;
   }
-  if (sep == '{') {
-    o << '{';
-  }
-  return o << '}';
+  return o;
 }
 
 StaticDataObject &StaticDataObject::Push(const std::string &string) {

--- a/lib/evaluate/static-data.h
+++ b/lib/evaluate/static-data.h
@@ -68,7 +68,7 @@ public:
   std::optional<std::string> AsString() const;
   std::optional<std::u16string> AsU16String() const;
   std::optional<std::u32string> AsU32String() const;
-  std::ostream &Dump(std::ostream &) const;
+  std::ostream &AsFortran(std::ostream &) const;
 
   static bool bigEndian;
 

--- a/lib/evaluate/static-data.h
+++ b/lib/evaluate/static-data.h
@@ -66,7 +66,11 @@ public:
   StaticDataObject &Push(const std::u16string &);
   StaticDataObject &Push(const std::u32string &);
   std::optional<std::string> AsString() const;
+  std::optional<std::u16string> AsU16String() const;
+  std::optional<std::u32string> AsU32String() const;
   std::ostream &Dump(std::ostream &) const;
+
+  static bool bigEndian;
 
 private:
   StaticDataObject() {}

--- a/lib/evaluate/static-data.h
+++ b/lib/evaluate/static-data.h
@@ -1,0 +1,66 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_EVALUATE_STATIC_DATA_H_
+#define FORTRAN_EVALUATE_STATIC_DATA_H_
+
+// Represents constant static data objects
+
+#include "type.h"
+#include "../common/idioms.h"
+#include <cinttypes>
+#include <memory>
+#include <ostream>
+#include <vector>
+
+namespace Fortran::evaluate {
+
+class StaticDataObject {
+public:
+  using Pointer = std::shared_ptr<StaticDataObject>;
+
+  StaticDataObject(const StaticDataObject &) = delete;
+  StaticDataObject(StaticDataObject &&) = delete;
+  StaticDataObject &operator=(const StaticDataObject &) = delete;
+  StaticDataObject &operator=(StaticDataObject &&) = delete;
+
+  static Pointer Create() { return Pointer{new StaticDataObject}; }
+
+  const std::string &name() const { return name_; }
+  StaticDataObject &set_name(std::string n) {
+    name_ = n;
+    return *this;
+  }
+
+  int alignment() const { return alignment_; }
+  StaticDataObject &set_alignment(int a) {
+    CHECK(a >= 0);
+    alignment_ = a;
+    return *this;
+  }
+
+  const std::vector<std::uint8_t> &data() const { return data_; }
+  std::vector<std::uint8_t> &data() { return data_; }
+
+  std::ostream &Dump(std::ostream &) const;
+
+private:
+  StaticDataObject() {}
+
+  std::string name_;
+  int alignment_{0};
+  std::vector<std::uint8_t> data_;
+};
+}
+#endif  // FORTRAN_EVALUATE_STATIC_DATA_H_

--- a/lib/evaluate/static-data.h
+++ b/lib/evaluate/static-data.h
@@ -21,7 +21,9 @@
 #include "../common/idioms.h"
 #include <cinttypes>
 #include <memory>
+#include <optional>
 #include <ostream>
+#include <string>
 #include <vector>
 
 namespace Fortran::evaluate {
@@ -50,16 +52,28 @@ public:
     return *this;
   }
 
+  int itemBytes() const { return itemBytes_; }
+  StaticDataObject &set_itemBytes(int b) {
+    CHECK(b >= 1);
+    itemBytes_ = b;
+    return *this;
+  }
+
   const std::vector<std::uint8_t> &data() const { return data_; }
   std::vector<std::uint8_t> &data() { return data_; }
 
+  StaticDataObject &Push(const std::string &);
+  StaticDataObject &Push(const std::u16string &);
+  StaticDataObject &Push(const std::u32string &);
+  std::optional<std::string> AsString() const;
   std::ostream &Dump(std::ostream &) const;
 
 private:
   StaticDataObject() {}
 
   std::string name_;
-  int alignment_{0};
+  int alignment_{1};
+  int itemBytes_{1};
   std::vector<std::uint8_t> data_;
 };
 }

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -58,7 +58,7 @@ template<typename A> bool IsVariable(const A &) { return false; }
 template<typename A> bool IsVariable(const Designator<A> &designator) {
   if constexpr (common::HasMember<Substring, decltype(Designator<A>::u)>) {
     if (const auto *substring{std::get_if<Substring>(&designator.u)}) {
-      return substring->GetSymbol(false) != nullptr;
+      return substring->GetLastSymbol() != nullptr;
     }
   }
   return true;

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -134,14 +134,19 @@ template<typename A> Expr<ResultType<A>> AsExpr(A &&x) {
   return Expr<ResultType<A>>{std::move(x)};
 }
 
-template<TypeCategory CAT>
-Expr<SomeKind<CAT>> AsCategoryExpr(Expr<SomeKind<CAT>> &&x) {
+template<typename T> Expr<T> AsExpr(Expr<T> &&x) {
+  static_assert(T::isSpecificIntrinsicType);
   return std::move(x);
 }
 
 template<typename A>
 Expr<SomeKind<ResultType<A>::category>> AsCategoryExpr(A &&x) {
   return Expr<SomeKind<ResultType<A>::category>>{AsExpr(std::move(x))};
+}
+
+template<TypeCategory CATEGORY>
+Expr<SomeKind<CATEGORY>> AsCategoryExpr(Expr<SomeKind<CATEGORY>> &&x) {
+  return std::move(x);
 }
 
 template<typename A> Expr<SomeType> AsGenericExpr(A &&x) {

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -127,8 +127,6 @@ std::optional<std::int64_t> ToInt64(const std::optional<A> &x) {
   }
 }
 
-// TODO: GetSymbol and Rank and GetType here, too
-
 // Generalizing packagers: these take operations and expressions of more
 // specific types and wrap them in Expr<> containers of more abstract types.
 

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -84,6 +84,23 @@ template<typename A> bool IsConstant(const Expr<A> &expr) {
   return std::visit([](const auto &x) { return IsConstant(x); }, expr.u);
 }
 
+// Predicate: true when an expression is assumed-rank
+template<typename A> bool IsAssumedRank(const A &) { return false; }
+template<typename A> bool IsAssumedRank(const Designator<A> &designator) {
+  if (const auto *symbolPtr{
+          std::get_if<const semantics::Symbol *>(&designator.u)}) {
+    if (const auto *details{
+            (*symbolPtr)
+                ->template detailsIf<semantics::ObjectEntityDetails>()}) {
+      return details->IsAssumedRank();
+    }
+  }
+  return false;
+}
+template<typename A> bool IsAssumedRank(const Expr<A> &expr) {
+  return std::visit([](const auto &x) { return IsAssumedRank(x); }, expr.u);
+}
+
 // When an expression is a constant integer, extract its value.
 template<typename A> std::optional<std::int64_t> ToInt64(const A &) {
   return std::nullopt;

--- a/lib/evaluate/type.cc
+++ b/lib/evaluate/type.cc
@@ -47,7 +47,7 @@ std::optional<DynamicType> GetSymbolType(const semantics::Symbol &symbol) {
   return std::nullopt;
 }
 
-std::string DynamicType::Dump() const {
+std::string DynamicType::AsFortran() const {
   if (category == TypeCategory::Derived) {
     // TODO: derived type parameters
     return "TYPE("s + derived->name().ToString() + ')';
@@ -99,7 +99,7 @@ DynamicType DynamicType::ResultTypeForMultiply(const DynamicType &that) const {
   return *this;
 }
 
-std::string SomeDerived::Dump() const {
+std::string SomeDerived::AsFortran() const {
   return "TYPE("s + spec().name().ToString() + ')';
 }
 }

--- a/lib/evaluate/type.cc
+++ b/lib/evaluate/type.cc
@@ -46,6 +46,16 @@ std::optional<DynamicType> GetSymbolType(const semantics::Symbol &symbol) {
   return std::nullopt;
 }
 
+std::string DynamicType::Dump() const {
+  if (category == TypeCategory::Derived) {
+    // TODO: derived type parameters
+    return "TYPE("s + derived->name().ToString() + ')';
+  } else {
+    // TODO: CHARACTER length
+    return EnumToString(category) + '(' + std::to_string(kind) + ')';
+  }
+}
+
 DynamicType DynamicType::ResultTypeForMultiply(const DynamicType &that) const {
   switch (category) {
   case TypeCategory::Integer:

--- a/lib/evaluate/type.cc
+++ b/lib/evaluate/type.cc
@@ -34,7 +34,8 @@ std::optional<DynamicType> GetSymbolType(const semantics::Symbol &symbol) {
         if (IsValidKindOfIntrinsicType(category, kind)) {
           return std::make_optional(DynamicType{category, kind});
         }
-      } break;
+        break;
+      }
       case semantics::DeclTypeSpec::Category::TypeDerived:
       case semantics::DeclTypeSpec::Category::ClassDerived:
         return std::make_optional(DynamicType{

--- a/lib/evaluate/type.h
+++ b/lib/evaluate/type.h
@@ -49,7 +49,7 @@ struct DynamicType {
     return category == that.category && kind == that.kind &&
         derived == that.derived;
   }
-  std::string Dump() const;
+  std::string AsFortran() const;
   DynamicType ResultTypeForMultiply(const DynamicType &) const;
 
   TypeCategory category;
@@ -74,7 +74,7 @@ template<TypeCategory CATEGORY, int KIND> struct TypeBase {
   static constexpr DynamicType GetType() { return {dynamicType}; }
   static constexpr TypeCategory category{CATEGORY};
   static constexpr int kind{KIND};
-  static std::string Dump() { return dynamicType.Dump(); }
+  static std::string AsFortran() { return dynamicType.AsFortran(); }
 };
 
 template<int KIND>
@@ -249,7 +249,7 @@ public:
 
   DynamicType GetType() const { return DynamicType{category, 0, spec_}; }
   const semantics::DerivedTypeSpec &spec() const { return *spec_; }
-  std::string Dump() const;
+  std::string AsFortran() const;
 
 private:
   const semantics::DerivedTypeSpec *spec_;
@@ -335,7 +335,7 @@ template<typename T> struct Constant {
 
   constexpr DynamicType GetType() const { return Result::GetType(); }
   int Rank() const { return 0; }
-  std::ostream &Dump(std::ostream &) const;
+  std::ostream &AsFortran(std::ostream &) const;
 
   Value value;
 };

--- a/lib/evaluate/type.h
+++ b/lib/evaluate/type.h
@@ -49,15 +49,14 @@ struct DynamicType {
     return category == that.category && kind == that.kind &&
         derived == that.derived;
   }
-  std::string Dump() const {
-    return EnumToString(category) + '(' + std::to_string(kind) + ')';
-  }
-
+  std::string Dump() const;
   DynamicType ResultTypeForMultiply(const DynamicType &) const;
 
   TypeCategory category;
   int kind{0};
   const semantics::DerivedTypeSpec *derived{nullptr};
+  // TODO pmk: descriptor for character length
+  // TODO pmk: derived type kind parameters and descriptor for lengths
 };
 
 std::optional<DynamicType> GetSymbolType(const semantics::Symbol &);

--- a/lib/evaluate/type.h
+++ b/lib/evaluate/type.h
@@ -68,6 +68,7 @@ template<TypeCategory CATEGORY, int KIND = 0> class Type;
 template<TypeCategory CATEGORY, int KIND> struct TypeBase {
   // Only types that represent a known kind of one of the five intrinsic
   // data types will have set this flag to true.
+  // TODO pmk: convert to type predicate expression
   static constexpr bool isSpecificIntrinsicType{true};
   static constexpr DynamicType dynamicType{CATEGORY, KIND};
   static constexpr DynamicType GetType() { return {dynamicType}; }
@@ -181,8 +182,7 @@ static constexpr bool IsValidKindOfIntrinsicType(
   case TypeCategory::Real:
   case TypeCategory::Complex:
     return kind == 2 || kind == 4 || kind == 8 || kind == 10 || kind == 16;
-  case TypeCategory::Character:
-    return kind == 1;  // TODO: || kind == 2 || kind == 4;
+  case TypeCategory::Character: return kind == 1 || kind == 2 || kind == 4;
   case TypeCategory::Logical:
     return kind == 1 || kind == 2 || kind == 4 || kind == 8;
   default: return false;
@@ -326,20 +326,17 @@ template<typename T> struct Constant {
   static_assert(T::isSpecificIntrinsicType);
   using Result = T;
   using Value = Scalar<Result>;
+
   CLASS_BOILERPLATE(Constant)
   template<typename A> Constant(const A &x) : value{x} {}
   template<typename A>
   Constant(std::enable_if_t<!std::is_reference_v<A>, A> &&x)
     : value(std::move(x)) {}
-  constexpr DynamicType GetType() const {
-    if constexpr (Result::isSpecificIntrinsicType) {
-      return Result::GetType();
-    } else {
-      return value.GetType();
-    }
-  }
+
+  constexpr DynamicType GetType() const { return Result::GetType(); }
   int Rank() const { return 0; }
   std::ostream &Dump(std::ostream &) const;
+
   Value value;
 };
 }

--- a/lib/evaluate/type.h
+++ b/lib/evaluate/type.h
@@ -239,7 +239,7 @@ template<TypeCategory CATEGORY> struct SomeKind {
 
 template<> class SomeKind<TypeCategory::Derived> {
 public:
-  static constexpr bool isSpecificIntrinsicType{true};
+  static constexpr bool isSpecificIntrinsicType{false};
   static constexpr TypeCategory category{TypeCategory::Derived};
 
   CLASS_BOILERPLATE(SomeKind)

--- a/lib/evaluate/type.h
+++ b/lib/evaluate/type.h
@@ -322,7 +322,7 @@ struct SomeType {
 // and derived type constants are structure constructors; generic
 // constants are generic expressions wrapping these constants.
 template<typename T> struct Constant {
-  // TODO: static_assert(T::isSpecificIntrinsicType);
+  static_assert(T::isSpecificIntrinsicType);
   using Result = T;
   using Value = Scalar<Result>;
   CLASS_BOILERPLATE(Constant)

--- a/lib/evaluate/type.h
+++ b/lib/evaluate/type.h
@@ -70,9 +70,7 @@ template<TypeCategory CATEGORY, int KIND> struct TypeBase {
   // data types will have set this flag to true.
   static constexpr bool isSpecificIntrinsicType{true};
   static constexpr DynamicType dynamicType{CATEGORY, KIND};
-  static constexpr std::optional<DynamicType> GetType() {
-    return {dynamicType};
-  }
+  static constexpr DynamicType GetType() { return {dynamicType}; }
   static constexpr TypeCategory category{CATEGORY};
   static constexpr int kind{KIND};
   static std::string Dump() { return dynamicType.Dump(); }
@@ -167,6 +165,11 @@ using SubscriptInteger = Type<TypeCategory::Integer, 8>;
 using LogicalResult = Type<TypeCategory::Logical, 1>;
 using LargestReal = Type<TypeCategory::Real, 16>;
 
+// Many expressions, including subscripts, CHARACTER lengths, array bounds,
+// and effective type parameter values, are of a maximal kind of INTEGER.
+using IndirectSubscriptIntegerExpr =
+    CopyableIndirection<Expr<SubscriptInteger>>;
+
 // A predicate that is true when a kind value is a kind that could possibly
 // be supported for an intrinsic type category on some target instruction
 // set architecture.
@@ -244,9 +247,7 @@ public:
   CLASS_BOILERPLATE(SomeKind)
   explicit SomeKind(const semantics::DerivedTypeSpec &s) : spec_{&s} {}
 
-  std::optional<DynamicType> GetType() const {
-    return {DynamicType{category, 0, spec_}};
-  }
+  DynamicType GetType() const { return DynamicType{category, 0, spec_}; }
   const semantics::DerivedTypeSpec &spec() const { return *spec_; }
   std::string Dump() const;
 
@@ -330,7 +331,7 @@ template<typename T> struct Constant {
   template<typename A>
   Constant(std::enable_if_t<!std::is_reference_v<A>, A> &&x)
     : value(std::move(x)) {}
-  constexpr std::optional<DynamicType> GetType() const {
+  constexpr DynamicType GetType() const {
     if constexpr (Result::isSpecificIntrinsicType) {
       return Result::GetType();
     } else {

--- a/lib/evaluate/variable.cc
+++ b/lib/evaluate/variable.cc
@@ -192,10 +192,10 @@ std::optional<Expr<SomeCharacter>> Substring::Fold(FoldingContext &context) {
   return std::nullopt;
 }
 
-// Variable dumping
+// Variable formatting
 
 template<typename A> std::ostream &Emit(std::ostream &o, const A &x) {
-  return x.Dump(o);
+  return x.AsFortran(o);
 }
 
 template<> std::ostream &Emit(std::ostream &o, const std::string &lit) {
@@ -263,14 +263,16 @@ template<> std::ostream &Emit(std::ostream &o, const IntrinsicProcedure &p) {
   return o << p;
 }
 
-std::ostream &BaseObject::Dump(std::ostream &o) const { return Emit(o, u); }
+std::ostream &BaseObject::AsFortran(std::ostream &o) const {
+  return Emit(o, u);
+}
 
-std::ostream &Component::Dump(std::ostream &o) const {
-  base_->Dump(o);
+std::ostream &Component::AsFortran(std::ostream &o) const {
+  base_->AsFortran(o);
   return Emit(o << '%', symbol_);
 }
 
-std::ostream &Triplet::Dump(std::ostream &o) const {
+std::ostream &Triplet::AsFortran(std::ostream &o) const {
   Emit(o, lower_) << ':';
   Emit(o, upper_);
   if (stride_) {
@@ -279,19 +281,19 @@ std::ostream &Triplet::Dump(std::ostream &o) const {
   return o;
 }
 
-std::ostream &Subscript::Dump(std::ostream &o) const { return Emit(o, u); }
+std::ostream &Subscript::AsFortran(std::ostream &o) const { return Emit(o, u); }
 
-std::ostream &ArrayRef::Dump(std::ostream &o) const {
+std::ostream &ArrayRef::AsFortran(std::ostream &o) const {
   Emit(o, u);
   char separator{'('};
   for (const Subscript &ss : subscript) {
-    ss.Dump(o << separator);
+    ss.AsFortran(o << separator);
     separator = ',';
   }
   return o << ')';
 }
 
-std::ostream &CoarrayRef::Dump(std::ostream &o) const {
+std::ostream &CoarrayRef::AsFortran(std::ostream &o) const {
   for (const Symbol *sym : base_) {
     Emit(o, *sym);
   }
@@ -318,26 +320,27 @@ std::ostream &CoarrayRef::Dump(std::ostream &o) const {
   return o << ']';
 }
 
-std::ostream &DataRef::Dump(std::ostream &o) const { return Emit(o, u); }
+std::ostream &DataRef::AsFortran(std::ostream &o) const { return Emit(o, u); }
 
-std::ostream &Substring::Dump(std::ostream &o) const {
+std::ostream &Substring::AsFortran(std::ostream &o) const {
   Emit(o, parent_) << '(';
   Emit(o, first_) << ':';
   return Emit(o, last_);
 }
 
-std::ostream &ComplexPart::Dump(std::ostream &o) const {
-  return complex_.Dump(o) << '%' << EnumToString(part_);
+std::ostream &ComplexPart::AsFortran(std::ostream &o) const {
+  return complex_.AsFortran(o) << '%' << EnumToString(part_);
 }
 
-std::ostream &ProcedureDesignator::Dump(std::ostream &o) const {
+std::ostream &ProcedureDesignator::AsFortran(std::ostream &o) const {
   return Emit(o, u);
 }
 
-template<typename T> std::ostream &Designator<T>::Dump(std::ostream &o) const {
+template<typename T>
+std::ostream &Designator<T>::AsFortran(std::ostream &o) const {
   std::visit(
       common::visitors{[&](const Symbol *sym) { o << sym->name().ToString(); },
-          [&](const auto &x) { x.Dump(o); }},
+          [&](const auto &x) { x.AsFortran(o); }},
       u);
   return o;
 }

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -211,8 +211,7 @@ public:
   Expr<SubscriptInteger> LEN() const;
   std::ostream &Dump(std::ostream &) const;
 
-  void Fold(FoldingContext &);
-  std::optional<std::string> AsConstantString() const;
+  std::optional<Expr<SomeCharacter>> Fold(FoldingContext &);
 
 private:
   void SetBounds(std::optional<Expr<SubscriptInteger>> &,

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -193,14 +193,14 @@ public:
     SetBounds(first, last);
   }
   Substring(StaticDataObject::Pointer &&parent,
-      std::optional<Expr<SubscriptInteger>> &&first,
-      std::optional<Expr<SubscriptInteger>> &&last)
+      std::optional<Expr<SubscriptInteger>> &&lower,
+      std::optional<Expr<SubscriptInteger>> &&upper)
     : parent_{std::move(parent)} {
-    SetBounds(first, last);
+    SetBounds(lower, upper);
   }
 
-  Expr<SubscriptInteger> first() const;  // TODO pmk: lower/upper
-  Expr<SubscriptInteger> last() const;
+  Expr<SubscriptInteger> lower() const;
+  Expr<SubscriptInteger> upper() const;
   int Rank() const;
   BaseObject GetBaseObject() const;
   const Symbol *GetLastSymbol() const;
@@ -213,7 +213,7 @@ private:
   void SetBounds(std::optional<Expr<SubscriptInteger>> &,
       std::optional<Expr<SubscriptInteger>> &);
   std::variant<DataRef, StaticDataObject::Pointer> parent_;
-  std::optional<IndirectSubscriptIntegerExpr> first_, last_;
+  std::optional<IndirectSubscriptIntegerExpr> lower_, upper_;
 };
 
 // R915 complex-part-designator

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -185,8 +185,7 @@ struct DataRef {
 };
 
 // R908 substring, R909 parent-string, R910 substring-range.
-// The base object of a substring can be a literal, but those are represented
-// as a LiteralSubstring expression.
+// The base object of a substring can be a literal.
 // In the F2018 standard, substrings of array sections are parsed as
 // variants of sections instead.
 class Substring {
@@ -204,7 +203,7 @@ public:
     SetBounds(first, last);
   }
 
-  Expr<SubscriptInteger> first() const;
+  Expr<SubscriptInteger> first() const;  // TODO pmk: lower/upper
   Expr<SubscriptInteger> last() const;
   int Rank() const;
   BaseObject GetBaseObject() const;
@@ -213,6 +212,7 @@ public:
   std::ostream &Dump(std::ostream &) const;
 
   void Fold(FoldingContext &);
+  std::optional<std::string> AsConstantString() const;
 
 private:
   void SetBounds(std::optional<Expr<SubscriptInteger>> &,

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -56,7 +56,7 @@ struct BaseObject {
   explicit BaseObject(StaticDataObject::Pointer &&p) : u{std::move(p)} {}
   int Rank() const;
   Expr<SubscriptInteger> LEN() const;
-  std::ostream &Dump(std::ostream &) const;
+  std::ostream &AsFortran(std::ostream &) const;
   std::variant<const Symbol *, StaticDataObject::Pointer> u;
 };
 
@@ -79,7 +79,7 @@ public:
   const Symbol &GetFirstSymbol() const;
   const Symbol &GetLastSymbol() const { return *symbol_; }
   Expr<SubscriptInteger> LEN() const;
-  std::ostream &Dump(std::ostream &) const;
+  std::ostream &AsFortran(std::ostream &) const;
 
 private:
   CopyableIndirection<DataRef> base_;
@@ -97,7 +97,7 @@ public:
   std::optional<Expr<SubscriptInteger>> lower() const;
   std::optional<Expr<SubscriptInteger>> upper() const;
   std::optional<Expr<SubscriptInteger>> stride() const;
-  std::ostream &Dump(std::ostream &) const;
+  std::ostream &AsFortran(std::ostream &) const;
 
 private:
   std::optional<IndirectSubscriptIntegerExpr> lower_, upper_, stride_;
@@ -109,7 +109,7 @@ struct Subscript {
   explicit Subscript(Expr<SubscriptInteger> &&s)
     : u{IndirectSubscriptIntegerExpr::Make(std::move(s))} {}
   int Rank() const;
-  std::ostream &Dump(std::ostream &) const;
+  std::ostream &AsFortran(std::ostream &) const;
   std::variant<IndirectSubscriptIntegerExpr, Triplet> u;
 };
 
@@ -129,7 +129,7 @@ struct ArrayRef {
   const Symbol &GetFirstSymbol() const;
   const Symbol &GetLastSymbol() const;
   Expr<SubscriptInteger> LEN() const;
-  std::ostream &Dump(std::ostream &) const;
+  std::ostream &AsFortran(std::ostream &) const;
 
   std::variant<const Symbol *, Component> u;
   std::vector<Subscript> subscript;
@@ -157,7 +157,7 @@ public:
   const Symbol &GetFirstSymbol() const { return *base_.front(); }
   const Symbol &GetLastSymbol() const { return *base_.back(); }
   Expr<SubscriptInteger> LEN() const;
-  std::ostream &Dump(std::ostream &) const;
+  std::ostream &AsFortran(std::ostream &) const;
 
 private:
   std::vector<const Symbol *> base_;
@@ -179,7 +179,7 @@ struct DataRef {
   const Symbol &GetFirstSymbol() const;
   const Symbol &GetLastSymbol() const;
   Expr<SubscriptInteger> LEN() const;
-  std::ostream &Dump(std::ostream &) const;
+  std::ostream &AsFortran(std::ostream &) const;
 
   std::variant<const Symbol *, Component, ArrayRef, CoarrayRef> u;
 };
@@ -209,7 +209,7 @@ public:
   BaseObject GetBaseObject() const;
   const Symbol *GetLastSymbol() const;
   Expr<SubscriptInteger> LEN() const;
-  std::ostream &Dump(std::ostream &) const;
+  std::ostream &AsFortran(std::ostream &) const;
 
   std::optional<Expr<SomeCharacter>> Fold(FoldingContext &);
 
@@ -233,7 +233,7 @@ public:
   int Rank() const;
   const Symbol &GetFirstSymbol() const { return complex_.GetFirstSymbol(); }
   const Symbol &GetLastSymbol() const { return complex_.GetLastSymbol(); }
-  std::ostream &Dump(std::ostream &) const;
+  std::ostream &AsFortran(std::ostream &) const;
 
 private:
   DataRef complex_;
@@ -268,7 +268,7 @@ public:
   BaseObject GetBaseObject() const;
   const Symbol *GetLastSymbol() const;
   Expr<SubscriptInteger> LEN() const;
-  std::ostream &Dump(std::ostream &o) const;
+  std::ostream &AsFortran(std::ostream &o) const;
 
   Variant u;
 };
@@ -287,7 +287,7 @@ public:
   Expr<SubscriptInteger> LEN() const;
   int Rank() const { return proc_.Rank(); }
   bool IsElemental() const { return proc_.IsElemental(); }
-  std::ostream &Dump(std::ostream &) const;
+  std::ostream &AsFortran(std::ostream &) const;
 
 protected:
   ProcedureDesignator proc_;
@@ -329,8 +329,8 @@ template<typename A> struct Variable {
   int Rank() const {
     return std::visit([](const auto &x) { return x.Rank(); }, u);
   }
-  std::ostream &Dump(std::ostream &o) const {
-    std::visit([&](const auto &x) { x.Dump(o); }, u);
+  std::ostream &AsFortran(std::ostream &o) const {
+    std::visit([&](const auto &x) { x.AsFortran(o); }, u);
     return o;
   }
   std::variant<Designator<Result>, FunctionRef<Result>> u;

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -44,10 +44,6 @@ using semantics::Symbol;
 struct DataRef;
 template<typename A> struct Variable;
 
-// pmk: are these still needed?
-int GetSymbolRank(const Symbol &);
-const parser::CharBlock &GetSymbolName(const Symbol &);
-
 // Reference a base object in memory.  This can be a Fortran symbol,
 // static data (e.g., CHARACTER literal), or compiler-created temporary.
 struct BaseObject {

--- a/lib/parser/characters.cc
+++ b/lib/parser/characters.cc
@@ -23,16 +23,16 @@ std::optional<int> UTF8CharacterBytes(const char *p) {
     return {1};
   }
   if ((*p & 0xf8) == 0xf0) {
-    if ((p[1] & 0xc0) == 0x80 && (p[2] & 0xc0) == 0x80 &&
+    if (*p != 0xf0 && (p[1] & 0xc0) == 0x80 && (p[2] & 0xc0) == 0x80 &&
         (p[3] & 0xc0) == 0x80) {
       return {4};
     }
   } else if ((*p & 0xf0) == 0xe0) {
-    if ((p[1] & 0xc0) == 0x80 && (p[2] & 0xc0) == 0x80) {
+    if (*p != 0xe0 && (p[1] & 0xc0) == 0x80 && (p[2] & 0xc0) == 0x80) {
       return {3};
     }
   } else if ((*p & 0xe0) == 0xc0) {
-    if ((p[1] & 0xc0) == 0x80) {
+    if (*p != 0xc0 && (p[1] & 0xc0) == 0x80) {
       return {2};
     }
   }
@@ -107,5 +107,36 @@ std::string QuoteCharacterLiteral(
 std::string QuoteCharacterLiteral(
     const std::u32string &str, bool doubleDoubleQuotes, bool doubleBackslash) {
   return QuoteCharacterLiteralHelper(str, doubleDoubleQuotes, doubleBackslash);
+}
+
+std::optional<std::u32string> DecodeUTF8(const std::string &s) {
+  std::u32string result;
+  const std::uint8_t *p{reinterpret_cast<const std::uint8_t *>(s.data())};
+  for (auto bytes{s.size()}; bytes != 0;) {
+    decltype(bytes) charBytes{1};
+    char32_t ch{*p++};
+    if ((ch & 0xc0) > 0x40) {
+      if ((ch & 0xf8) == 0xf0 && bytes >= 4 && ch > 0xf0 &&
+          ((p[0] | p[1] | p[2]) & 0xc0) == 0x80) {
+        charBytes = 4;
+        ch = ((ch & 7) << 6) | (*p++ & 0x3f);
+        ch = (ch << 6) | (*p++ & 0x3f);
+        ch = (ch << 6) | (*p++ & 0x3f);
+      } else if ((ch & 0xf0) == 0xe0 && bytes >= 3 && ch > 0xe0 &&
+          ((p[0] | p[1]) & 0xc0) == 0x80) {
+        charBytes = 3;
+        ch = ((ch & 0xf) << 6) | (*p++ & 0x3f);
+        ch = (ch << 6) | (*p++ & 0x3f);
+      } else if ((ch & 0xe0) == 0xc0 && bytes >= 2 && ch > 0xc0 &&
+          (*p & 0xc0) == 0x80) {
+        charBytes = 2;
+        ch = ((ch & 0x1f) << 6) | (*p++ & 0x3f);
+      } else {
+        return std::nullopt;  // not valid UTF-8
+      }
+    }
+    bytes -= charBytes;
+  }
+  return {result};
 }
 }

--- a/lib/parser/characters.cc
+++ b/lib/parser/characters.cc
@@ -82,14 +82,30 @@ std::optional<std::size_t> CountCharacters(
   return {chars};
 }
 
-std::string QuoteCharacterLiteral(
-    const std::string &str, bool doubleDoubleQuotes, bool doubleBackslash) {
+template<typename STRING>
+std::string QuoteCharacterLiteralHelper(
+    const STRING &str, bool doubleDoubleQuotes, bool doubleBackslash) {
   std::string result{'"'};
   const auto emit{[&](char ch) { result += ch; }};
-  for (char ch : str) {
+  for (auto ch : str) {
     EmitQuotedChar(ch, emit, emit, doubleDoubleQuotes, doubleBackslash);
   }
   result += '"';
   return result;
+}
+
+std::string QuoteCharacterLiteral(
+    const std::string &str, bool doubleDoubleQuotes, bool doubleBackslash) {
+  return QuoteCharacterLiteralHelper(str, doubleDoubleQuotes, doubleBackslash);
+}
+
+std::string QuoteCharacterLiteral(
+    const std::u16string &str, bool doubleDoubleQuotes, bool doubleBackslash) {
+  return QuoteCharacterLiteralHelper(str, doubleDoubleQuotes, doubleBackslash);
+}
+
+std::string QuoteCharacterLiteral(
+    const std::u32string &str, bool doubleDoubleQuotes, bool doubleBackslash) {
+  return QuoteCharacterLiteralHelper(str, doubleDoubleQuotes, doubleBackslash);
 }
 }

--- a/lib/parser/characters.cc
+++ b/lib/parser/characters.cc
@@ -23,16 +23,16 @@ std::optional<int> UTF8CharacterBytes(const char *p) {
     return {1};
   }
   if ((*p & 0xf8) == 0xf0) {
-    if (*p != 0xf0 && (p[1] & 0xc0) == 0x80 && (p[2] & 0xc0) == 0x80 &&
+    if ((*p & 0x07) != 0 && (p[1] & 0xc0) == 0x80 && (p[2] & 0xc0) == 0x80 &&
         (p[3] & 0xc0) == 0x80) {
       return {4};
     }
   } else if ((*p & 0xf0) == 0xe0) {
-    if (*p != 0xe0 && (p[1] & 0xc0) == 0x80 && (p[2] & 0xc0) == 0x80) {
+    if ((*p & 0x0f) != 0 && (p[1] & 0xc0) == 0x80 && (p[2] & 0xc0) == 0x80) {
       return {3};
     }
   } else if ((*p & 0xe0) == 0xc0) {
-    if (*p != 0xc0 && (p[1] & 0xc0) == 0x80) {
+    if ((*p & 0x1f) != 0 && (p[1] & 0xc0) == 0x80) {
       return {2};
     }
   }

--- a/lib/parser/characters.h
+++ b/lib/parser/characters.h
@@ -184,5 +184,6 @@ std::optional<int> UTF8CharacterBytes(const char *);
 std::optional<int> EUC_JPCharacterBytes(const char *);
 std::optional<std::size_t> CountCharacters(
     const char *, std::size_t bytes, std::optional<int> (*)(const char *));
+std::optional<std::u32string> DecodeUTF8(const std::string &);
 }
 #endif  // FORTRAN_PARSER_CHARACTERS_H_

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -827,9 +827,14 @@ MaybeExpr ExprAnalyzer::Analyze(const parser::CharLiteralConstantSubstring &x) {
             using Result = ResultType<decltype(ckExpr)>;
             auto *cp{std::get_if<Constant<Result>>(&ckExpr.u)};
             CHECK(cp != nullptr);  // the parent was parsed as a constant string
-            return AsGenericExpr(Expr<SomeCharacter>{Expr<Result>{
-                LiteralSubstring<Result::kind>{std::move(cp->value),
-                    std::move(*lower), std::move(*upper)}}});
+            StaticDataObject::Pointer staticData{StaticDataObject::Create()};
+            staticData->set_alignment(Result::kind)
+                .set_itemBytes(Result::kind)
+                .Push(cp->value);
+            Substring substring{
+                std::move(staticData), std::move(*lower), std::move(*upper)};
+            return AsGenericExpr(Expr<SomeCharacter>{
+                Expr<Result>{Designator<Result>{std::move(substring)}}});
           },
           std::move(charExpr->u));
     }

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1270,7 +1270,7 @@ public:
   bool Pre(parser::Expr &expr) {
     if (expr.typedExpr.get() == nullptr) {
       if (MaybeExpr checked{AnalyzeExpr(context_, expr)}) {
-        checked->Dump(std::cout << "checked expression: ") << '\n';
+        checked->AsFortran(std::cout << "checked expression: ") << '\n';
         expr.typedExpr.reset(
             new evaluate::GenericExprWrapper{std::move(*checked)});
       } else {

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -520,7 +520,7 @@ MaybeExpr TypedWrapper(DynamicType &&dyType, WRAPPED &&x) {
 
 // Wraps a data reference in a typed Designator<>.
 static MaybeExpr Designate(DataRef &&dataRef) {
-  const Symbol &symbol{*dataRef.GetSymbol(false)};
+  const Symbol &symbol{*dataRef.GetLastSymbol()};
   if (std::optional<DynamicType> dyType{GetSymbolType(symbol)}) {
     return TypedWrapper<Designator, DataRef>(
         std::move(*dyType), std::move(dataRef));
@@ -577,7 +577,7 @@ MaybeExpr ExprAnalyzer::Analyze(const parser::Substring &ss) {
               GetSubstringBound(std::get<0>(range.t))};
           std::optional<Expr<SubscriptInteger>> last{
               GetSubstringBound(std::get<1>(range.t))};
-          const Symbol &symbol{*checked->GetSymbol(false)};
+          const Symbol &symbol{*checked->GetLastSymbol()};
           if (std::optional<DynamicType> dynamicType{GetSymbolType(symbol)}) {
             if (dynamicType->category == TypeCategory::Character) {
               return WrapperHelper<TypeCategory::Character, Designator,
@@ -693,7 +693,7 @@ MaybeExpr ExprAnalyzer::ApplySubscripts(
 }
 
 MaybeExpr ExprAnalyzer::CompleteSubscripts(ArrayRef &&ref) {
-  const Symbol &symbol{*ref.GetSymbol(false)};
+  const Symbol &symbol{*ref.GetLastSymbol()};
   int symbolRank{symbol.Rank()};
   if (ref.subscript.empty()) {
     // A -> A(:,:)

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -718,7 +718,7 @@ MaybeExpr ExprAnalyzer::CompleteSubscripts(ArrayRef &&ref) {
                  symbol.detailsIf<semantics::ObjectEntityDetails>()}) {
     // C928 & C1002
     if (Triplet * last{std::get_if<Triplet>(&ref.subscript.back().u)}) {
-      if (!last->upper().has_value() && details->isAssumedSize()) {
+      if (!last->upper().has_value() && details->IsAssumedSize()) {
         Say("assumed-size array '%s' must have explicit final subscript upper bound value"_err_en_US,
             symbol.name().ToString().data());
       }

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -20,8 +20,8 @@
 #include <optional>
 
 namespace Fortran::parser {
-class Expr;
-class Program;
+struct Expr;
+struct Program;
 }
 
 namespace Fortran::semantics {

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -387,9 +387,8 @@ void PutBound(std::ostream &os, const Bound &x) {
 }
 
 void PutExpr(std::ostream &os, const LazyExpr &expr) {
-  if (expr.Get()) {
-    // TODO: Dump does not necessarily produce Fortran code
-    expr.Get()->Dump(os);
+  if (auto x{expr.Get()}) {
+    x->AsFortran(os);
   }
 }
 

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -124,9 +124,13 @@ public:
   void set_shape(const ArraySpec &shape);
   bool isDummy() const { return isDummy_; }
   bool isArray() const { return !shape_.empty(); }
-  bool isAssumedSize() const {
+  bool IsAssumedSize() const {
     return isDummy() && isArray() && shape_.back().ubound().isAssumed() &&
         !shape_.back().lbound().isAssumed();
+  }
+  bool IsAssumedRank() const {
+    return isDummy() && isArray() && shape_.back().ubound().isAssumed() &&
+        shape_.back().lbound().isAssumed();
   }
 
 private:

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -270,7 +270,9 @@ void ExprResolver::Resolve(Symbol &symbol) {
   if (auto *type{symbol.GetType()}) {
     if (type->category() == DeclTypeSpec::TypeDerived) {
       DerivedTypeSpec &dts{type->derivedTypeSpec()};
-      for (auto &[name, value] : dts.paramValues()) {
+      for (auto &nameAndValue : dts.paramValues()) {
+        // &[name, value] elicits "unused variable" warnings
+        auto &value{nameAndValue.second};
         if (value.isExplicit()) {
           value.ResolveExplicit(context_);
         }

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -54,7 +54,7 @@ std::ostream &operator<<(std::ostream &o, const LazyExpr &x) {
       common::visitors{
           [&](const parser::Expr *x) { o << (x ? "UNRESOLVED" : "EMPTY"); },
           [&](const LazyExpr::ErrorInExpr &) { o << "ERROR"; },
-          [&](const LazyExpr::CopyableExprPtr &x) { x->Dump(o); },
+          [&](const LazyExpr::CopyableExprPtr &x) { x->AsFortran(o); },
       },
       x.u_);
   return o;
@@ -270,7 +270,7 @@ void ExprResolver::Resolve(Symbol &symbol) {
   if (auto *type{symbol.GetType()}) {
     if (type->category() == DeclTypeSpec::TypeDerived) {
       DerivedTypeSpec &dts{type->derivedTypeSpec()};
-      for (auto & [ name, value ] : dts.paramValues()) {
+      for (auto &[name, value] : dts.paramValues()) {
         if (value.isExplicit()) {
           value.ResolveExplicit(context_);
         }

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -30,7 +30,7 @@
 #include <variant>
 
 namespace Fortran::parser {
-class Expr;
+struct Expr;
 }
 
 namespace Fortran::semantics {

--- a/test/evaluate/ISO-Fortran-binding.cc
+++ b/test/evaluate/ISO-Fortran-binding.cc
@@ -26,8 +26,8 @@ using namespace Fortran::ISO;
 // CFI_CDESC_T test helpers
 template<int rank> class Test_CFI_CDESC_T {
 public:
-  Test_CFI_CDESC_T() : dvStorage_{0} {};
-  ~Test_CFI_CDESC_T(){};
+  Test_CFI_CDESC_T() {}
+  ~Test_CFI_CDESC_T() {}
   void Check() {
     // Test CFI_CDESC_T macro defined in section 18.5.4 of F2018 standard
     // CFI_CDESC_T must give storage that is:
@@ -48,7 +48,7 @@ public:
   }
 
 private:
-  static constexpr int rank_ = rank;
+  static constexpr int rank_{rank};
   CFI_CDESC_T(rank) dvStorage_;
 };
 

--- a/test/evaluate/expression.cc
+++ b/test/evaluate/expression.cc
@@ -24,31 +24,31 @@
 
 using namespace Fortran::evaluate;
 
-template<typename A> std::string Dump(const A &x) {
+template<typename A> std::string AsFortran(const A &x) {
   std::stringstream ss;
-  x.Dump(ss);
+  x.AsFortran(ss);
   return ss.str();
 }
 
 int main() {
   using DefaultIntegerExpr = Expr<Type<TypeCategory::Integer, 4>>;
-  TEST(DefaultIntegerExpr::Result::Dump() == "Integer(4)");
-  MATCH("666_4", Dump(DefaultIntegerExpr{666}));
-  MATCH("(-1_4)", Dump(-DefaultIntegerExpr{1}));
+  TEST(DefaultIntegerExpr::Result::AsFortran() == "Integer(4)");
+  MATCH("666_4", AsFortran(DefaultIntegerExpr{666}));
+  MATCH("(-1_4)", AsFortran(-DefaultIntegerExpr{1}));
   auto ex1{
       DefaultIntegerExpr{2} + DefaultIntegerExpr{3} * -DefaultIntegerExpr{4}};
-  MATCH("(2_4+(3_4*(-4_4)))", Dump(ex1));
+  MATCH("(2_4+(3_4*(-4_4)))", AsFortran(ex1));
   Fortran::parser::CharBlock src;
   Fortran::parser::ContextualMessages messages{src, nullptr};
   FoldingContext context{messages};
   ex1 = Fold(context, std::move(ex1));
-  MATCH("-10_4", Dump(ex1));
-  MATCH("(1_4/2_4)", Dump(DefaultIntegerExpr{1} / DefaultIntegerExpr{2}));
+  MATCH("-10_4", AsFortran(ex1));
+  MATCH("(1_4/2_4)", AsFortran(DefaultIntegerExpr{1} / DefaultIntegerExpr{2}));
   DefaultIntegerExpr a{1};
   DefaultIntegerExpr b{2};
-  MATCH("1_4", Dump(a));
+  MATCH("1_4", AsFortran(a));
   a = b;
-  MATCH("2_4", Dump(a));
-  MATCH("2_4", Dump(b));
+  MATCH("2_4", AsFortran(a));
+  MATCH("2_4", AsFortran(b));
   return testing::Complete();
 }

--- a/test/evaluate/intrinsics.cc
+++ b/test/evaluate/intrinsics.cc
@@ -103,7 +103,7 @@ struct TestCall {
     for (const auto &a : args) {
       std::cout << sep;
       sep = ',';
-      a->Dump(std::cout);
+      a->AsFortran(std::cout);
     }
     if (sep == '(') {
       std::cout << '(';


### PR DESCRIPTION
This is a large pull request that really should have been implemented
as multiple smaller sets of changes.

- Documentation updates
- Renaming Dump() member functions to AsFortran() for use in module file
  output
- Implementing conversions of Real to scaled decimals for use in
  formatting for use in AsFortran()
- Fixing Real::Read() for decimal->binary conversion
- Initial placeholder declarations for static compiler-created data
- Use of static data for literal strings used as anonymous parents of
  substring references, in place of special-purpose representations
  of character literal substrings (e.g. 'FORTRAN'(2:4))
- Changed ActualArgument::isAssumedRank data flag member into a predicate
  function of the argument expression
- Representation of array constructors in expressions
- Cleaned up warning messages from recent merges into master
- Implemented Real::AINT() because I needed it for an early take on
  real -> scaled decimal conversion; turned out not to be necessary for that
- Split up GetSymbol(bool first/last) member functions into two separate
  functions (per class), GetBaseObject() and GetLastSymbol(), for readability
  reasons and so that GetBaseObject() could return a reference to static data
  as well as to a symbol.  GetFirstSymbol() is provided for those classes
  that can always return a symbol.  (E.g., for A(J,K)%F, the last symbol
  is F and the first symbol is A.)
- Renamed the lower and upper indices of a substring reference to
  "lower" and "upper", in place of "first" and "last", to avoid confusion
  with those names in the STL.
