### PR TITLE
 Implement CFI_set_pointer, CFI_section, CFI_select_part. Minor changes in other CFI funcs

### DIFF
--- a/include/flang/ISO_Fortran_binding.h
+++ b/include/flang/ISO_Fortran_binding.h
@@ -130,13 +130,12 @@ typedef struct CFI_cdesc_t {
 // C++ does not support zero-sized array (rank=0)
 // Also, CFI_cdesc_t already contains 1 dim in cpp
 namespace cfi_internal {
-template<int rank> struct CdescStorage {
-  static_assert((rank > 1 && rank <= CFI_MAX_RANK), "CFI_INVALID_RANK");
-  CFI_cdesc_t cdesc;
-  CFI_dim_t dim[rank - 1];
+template<int r> struct CdescStorage : public CFI_cdesc_t {
+  static_assert((r > 1 && r <= CFI_MAX_RANK), "CFI_INVALID_RANK");
+  CFI_dim_t dim[r - 1];
 };
-template<> struct CdescStorage<1> { CFI_cdesc_t cdesc; };
-template<> struct CdescStorage<0> { CFI_cdesc_t cdesc; };
+template<> struct CdescStorage<1> : public CFI_cdesc_t {};
+template<> struct CdescStorage<0> : public CFI_cdesc_t {};
 }
 #define CFI_CDESC_T(rank) cfi_internal::CdescStorage<rank>
 #else

--- a/runtime/ISO_Fortran_binding.cc
+++ b/runtime/ISO_Fortran_binding.cc
@@ -252,7 +252,7 @@ int CFI_section(CFI_cdesc_t *result, const CFI_cdesc_t *source,
     return CFI_INVALID_DESCRIPTOR;
   }
 
-  // For zero-sized arrays, base_addr is proc-dep (see 18.5.3).
+  // For zero-sized arrays, base_addr is processor-dependent (see 18.5.3).
   // We keep it on the source base_addr
   result->base_addr = isZeroSized ? source->base_addr
                                   : reinterpret_cast<void *>(shiftedBaseAddr);

--- a/runtime/ISO_Fortran_binding.cc
+++ b/runtime/ISO_Fortran_binding.cc
@@ -225,12 +225,12 @@ int CFI_section(CFI_cdesc_t *result, const CFI_cdesc_t *source,
 
   bool isZeroSized{false};
   for (int j{0}; j < source->rank; ++j) {
-    const CFI_dim_t &dim = source->dim[j];
-    const CFI_index_t srcLB = dim.lower_bound;
-    const CFI_index_t srcUB = srcLB + dim.extent - 1;
-    const CFI_index_t lb = (lower_bounds != nullptr) ? lower_bounds[j] : srcLB;
-    const CFI_index_t ub = (upper_bounds != nullptr) ? upper_bounds[j] : srcUB;
-    const CFI_index_t stride = (strides != nullptr) ? strides[j] : 1;
+    const CFI_dim_t &dim{source->dim[j]};
+    const CFI_index_t srcLB{dim.lower_bound};
+    const CFI_index_t srcUB{srcLB + dim.extent - 1};
+    const CFI_index_t lb{lower_bounds != nullptr ? lower_bounds[j] : srcLB};
+    const CFI_index_t ub{upper_bounds != nullptr ? upper_bounds[j] : srcUB};
+    const CFI_index_t stride{strides != nullptr ? strides[j] : 1};
 
     if (stride == 0 && lb != ub) {
       return CFI_ERROR_OUT_OF_BOUNDS;
@@ -240,7 +240,7 @@ int CFI_section(CFI_cdesc_t *result, const CFI_cdesc_t *source,
         return CFI_ERROR_OUT_OF_BOUNDS;
       }
       shiftedBaseAddr += (lb - srcLB) * dim.sm;
-      extent[j] = (stride != 0) ? 1 + (ub - lb) / stride : 1;
+      extent[j] = stride != 0 ? 1 + (ub - lb) / stride : 1;
     } else {
       isZeroSized = true;
       extent[j] = 0;

--- a/runtime/ISO_Fortran_binding.cc
+++ b/runtime/ISO_Fortran_binding.cc
@@ -33,6 +33,9 @@ void *CFI_address(
 
 int CFI_allocate(CFI_cdesc_t *descriptor, const CFI_index_t lower_bounds[],
     const CFI_index_t upper_bounds[], std::size_t elem_len) {
+  if (descriptor == nullptr) {
+    return CFI_INVALID_DESCRIPTOR;
+  }
   if (descriptor->version != CFI_VERSION) {
     return CFI_INVALID_DESCRIPTOR;
   }
@@ -80,6 +83,9 @@ int CFI_allocate(CFI_cdesc_t *descriptor, const CFI_index_t lower_bounds[],
 }
 
 int CFI_deallocate(CFI_cdesc_t *descriptor) {
+  if (descriptor == nullptr) {
+    return CFI_INVALID_DESCRIPTOR;
+  }
   if (descriptor->version != CFI_VERSION) {
     return CFI_INVALID_DESCRIPTOR;
   }
@@ -157,6 +163,9 @@ int CFI_establish(CFI_cdesc_t *descriptor, void *base_addr,
   if (type < CFI_type_signed_char || type > CFI_type_struct) {
     return CFI_INVALID_TYPE;
   }
+  if (descriptor == nullptr) {
+    return CFI_INVALID_DESCRIPTOR;
+  }
   std::size_t minElemLen{MinElemLen(type)};
   if (minElemLen > 0) {
     elem_len = minElemLen;
@@ -204,8 +213,10 @@ int CFI_section(CFI_cdesc_t *result, const CFI_cdesc_t *source,
   CFI_index_t extent[CFI_MAX_RANK];
   CFI_index_t actualStride[CFI_MAX_RANK];
   CFI_rank_t resRank{0};
-  char *shiftedBaseAddr{static_cast<char *>(source->base_addr)};
 
+  if (result == nullptr || source == nullptr) {
+    return CFI_INVALID_DESCRIPTOR;
+  }
   if (source->rank == 0) {
     return CFI_INVALID_RANK;
   }
@@ -223,6 +234,7 @@ int CFI_section(CFI_cdesc_t *result, const CFI_cdesc_t *source,
     return CFI_ERROR_BASE_ADDR_NULL;
   }
 
+  char *shiftedBaseAddr{static_cast<char *>(source->base_addr)};
   bool isZeroSized{false};
   for (int j{0}; j < source->rank; ++j) {
     const CFI_dim_t &dim{source->dim[j]};
@@ -269,6 +281,9 @@ int CFI_section(CFI_cdesc_t *result, const CFI_cdesc_t *source,
 
 int CFI_select_part(CFI_cdesc_t *result, const CFI_cdesc_t *source,
     std::size_t displacement, std::size_t elem_len) {
+  if (result == nullptr || source == nullptr) {
+    return CFI_INVALID_DESCRIPTOR;
+  }
   if (result->rank != source->rank) {
     return CFI_INVALID_RANK;
   }
@@ -302,6 +317,9 @@ int CFI_select_part(CFI_cdesc_t *result, const CFI_cdesc_t *source,
 
 int CFI_setpointer(CFI_cdesc_t *result, const CFI_cdesc_t *source,
     const CFI_index_t lower_bounds[]) {
+  if (result == nullptr) {
+    return CFI_INVALID_DESCRIPTOR;
+  }
   if (result->attribute != CFI_attribute_pointer) {
     return CFI_INVALID_ATTRIBUTE;
   }

--- a/runtime/ISO_Fortran_binding.cc
+++ b/runtime/ISO_Fortran_binding.cc
@@ -20,6 +20,13 @@
 namespace Fortran::ISO {
 extern "C" {
 
+static inline constexpr bool IsCharacterType(CFI_type_t ty) {
+  return ty == CFI_type_char;
+}
+static inline constexpr bool IsAssumedSize(const CFI_cdesc_t *dv) {
+  return dv->rank > 0 && dv->dim[dv->rank - 1].extent == -1;
+}
+
 void *CFI_address(
     const CFI_cdesc_t *descriptor, const CFI_index_t subscripts[]) {
   auto p = reinterpret_cast<char *>(descriptor->base_addr);
@@ -55,7 +62,7 @@ int CFI_allocate(CFI_cdesc_t *descriptor, const CFI_index_t lower_bounds[],
       descriptor->type > CFI_type_struct) {
     return CFI_INVALID_TYPE;
   }
-  if (descriptor->type != CFI_type_char) {
+  if (!IsCharacterType(descriptor->type)) {
     elem_len = descriptor->elem_len;
     if (elem_len <= 0) {
       return CFI_INVALID_ELEM_LEN;
@@ -203,10 +210,6 @@ int CFI_is_contiguous(const CFI_cdesc_t *descriptor) {
   return 1;
 }
 
-static inline bool IsAssumedSize(const CFI_cdesc_t *dv) {
-  return dv->rank > 0 && dv->dim[dv->rank - 1].extent == -1;
-}
-
 int CFI_section(CFI_cdesc_t *result, const CFI_cdesc_t *source,
     const CFI_index_t lower_bounds[], const CFI_index_t upper_bounds[],
     const CFI_index_t strides[]) {
@@ -297,7 +300,7 @@ int CFI_select_part(CFI_cdesc_t *result, const CFI_cdesc_t *source,
     return CFI_INVALID_DESCRIPTOR;
   }
 
-  if (result->type != CFI_type_char) {
+  if (!IsCharacterType(result->type)) {
     elem_len = result->elem_len;
   }
   if (displacement + elem_len > source->elem_len) {

--- a/runtime/ISO_Fortran_binding.cc
+++ b/runtime/ISO_Fortran_binding.cc
@@ -39,7 +39,7 @@ int CFI_allocate(CFI_cdesc_t *descriptor, const CFI_index_t lower_bounds[],
   if (descriptor->attribute != CFI_attribute_allocatable &&
       descriptor->attribute != CFI_attribute_pointer) {
     // Non-interoperable object
-    return CFI_INVALID_DESCRIPTOR;
+    return CFI_INVALID_ATTRIBUTE;
   }
   if (descriptor->attribute == CFI_attribute_allocatable &&
       descriptor->base_addr != nullptr) {
@@ -52,7 +52,7 @@ int CFI_allocate(CFI_cdesc_t *descriptor, const CFI_index_t lower_bounds[],
       descriptor->type > CFI_type_struct) {
     return CFI_INVALID_TYPE;
   }
-  if (descriptor->type != CFI_type_cptr) {
+  if (descriptor->type != CFI_type_char) {
     elem_len = descriptor->elem_len;
     if (elem_len <= 0) {
       return CFI_INVALID_ELEM_LEN;
@@ -133,6 +133,7 @@ static constexpr std::size_t MinElemLen(CFI_type_t type) {
     minElemLen = 2 * sizeof(long double);
     break;
   case CFI_type_Bool: minElemLen = 1; break;
+  case CFI_type_cptr: minElemLen = sizeof(void *); break;
   }
   return minElemLen;
 }

--- a/runtime/ISO_Fortran_binding.cc
+++ b/runtime/ISO_Fortran_binding.cc
@@ -195,7 +195,7 @@ int CFI_is_contiguous(const CFI_cdesc_t *descriptor) {
 }
 
 static inline bool IsAssumedSize(const CFI_cdesc_t *dv) {
-  return (dv->rank > 0 && dv->dim[dv->rank - 1].extent == -1);
+  return dv->rank > 0 && dv->dim[dv->rank - 1].extent == -1;
 }
 
 int CFI_section(CFI_cdesc_t *result, const CFI_cdesc_t *source,

--- a/runtime/ISO_Fortran_binding.cc
+++ b/runtime/ISO_Fortran_binding.cc
@@ -179,12 +179,6 @@ int CFI_establish(CFI_cdesc_t *descriptor, void *base_addr,
       descriptor->dim[j].sm = byteSize;
       byteSize *= extents[j];
     }
-  } else {
-    for (std::size_t j{0}; j < rank; ++j) {
-      descriptor->dim[j].lower_bound = lower_bound;
-      descriptor->dim[j].extent = 0;
-      descriptor->dim[j].sm = 0;
-    }
   }
   return CFI_SUCCESS;
 }
@@ -265,6 +259,7 @@ int CFI_section(CFI_cdesc_t *result, const CFI_cdesc_t *source,
   resRank = 0;
   for (int j{0}; j < source->rank; ++j) {
     if (actualStride[j] != 0) {
+      result->dim[resRank].lower_bound = 0;
       result->dim[resRank].extent = extent[j];
       result->dim[resRank].sm = actualStride[j] * source->dim[j].sm;
       ++resRank;
@@ -291,9 +286,6 @@ int CFI_select_part(CFI_cdesc_t *result, const CFI_cdesc_t *source,
   if (result->type != CFI_type_char) {
     elem_len = result->elem_len;
   }
-  if (elem_len == 0) {
-    return CFI_INVALID_ELEM_LEN;  // TODO: is it wrong to forbid this?
-  }
   if (displacement + elem_len > source->elem_len) {
     return CFI_INVALID_ELEM_LEN;
   }
@@ -302,7 +294,9 @@ int CFI_select_part(CFI_cdesc_t *result, const CFI_cdesc_t *source,
       displacement + reinterpret_cast<char *>(source->base_addr));
   result->elem_len = elem_len;
   for (int j{0}; j < source->rank; ++j) {
-    result->dim[j] = source->dim[j];
+    result->dim[j].lower_bound = 0;
+    result->dim[j].extent = source->dim[j].extent;
+    result->dim[j].sm = source->dim[j].sm;
   }
   return CFI_SUCCESS;
 }

--- a/runtime/ISO_Fortran_binding.cc
+++ b/runtime/ISO_Fortran_binding.cc
@@ -204,7 +204,7 @@ int CFI_section(CFI_cdesc_t *result, const CFI_cdesc_t *source,
   CFI_index_t extent[CFI_MAX_RANK];
   CFI_index_t actualStride[CFI_MAX_RANK];
   CFI_rank_t resRank{0};
-  char *shiftedBaseAddr{reinterpret_cast<char *>(source->base_addr)};
+  char *shiftedBaseAddr{static_cast<char *>(source->base_addr)};
 
   if (source->rank == 0) {
     return CFI_INVALID_RANK;
@@ -254,8 +254,7 @@ int CFI_section(CFI_cdesc_t *result, const CFI_cdesc_t *source,
 
   // For zero-sized arrays, base_addr is processor-dependent (see 18.5.3).
   // We keep it on the source base_addr
-  result->base_addr = isZeroSized ? source->base_addr
-                                  : reinterpret_cast<void *>(shiftedBaseAddr);
+  result->base_addr = isZeroSized ? source->base_addr : shiftedBaseAddr;
   resRank = 0;
   for (int j{0}; j < source->rank; ++j) {
     if (actualStride[j] != 0) {

--- a/runtime/type-code.cc
+++ b/runtime/type-code.cc
@@ -45,7 +45,7 @@ TypeCode::TypeCode(TypeCategory f, int kind) {
     break;
   case TypeCategory::Character:
     if (kind == 1) {
-      raw_ = CFI_type_cptr;
+      raw_ = CFI_type_char;
     }
     break;
   case TypeCategory::Logical:

--- a/runtime/type-code.h
+++ b/runtime/type-code.h
@@ -43,7 +43,7 @@ public:
     return raw_ >= CFI_type_float_Complex &&
         raw_ <= CFI_type_long_double_Complex;
   }
-  constexpr bool IsCharacter() const { return raw_ == CFI_type_cptr; }
+  constexpr bool IsCharacter() const { return raw_ == CFI_type_char; }
   constexpr bool IsLogical() const { return raw_ == CFI_type_Bool; }
   constexpr bool IsDerived() const { return raw_ == CFI_type_struct; }
 

--- a/test/evaluate/ISO-Fortran-binding.cc
+++ b/test/evaluate/ISO-Fortran-binding.cc
@@ -52,13 +52,14 @@ private:
   CFI_CDESC_T(rank) dvStorage_;
 };
 
-template<int rank> static void TestForAllSmallerRanks() {
+template<int rank> static void TestCdescMacroForAllRanksSmallerThan() {
   static_assert(rank > 0, "rank<0!");
   Test_CFI_CDESC_T<rank> obj;
   obj.Check();
-  TestForAllSmallerRanks<rank - 1>();
+  TestCdescMacroForAllRanksSmallerThan<rank - 1>();
 }
-template<> void TestForAllSmallerRanks<0>() {
+
+template<> void TestCdescMacroForAllRanksSmallerThan<0>() {
   Test_CFI_CDESC_T<0> obj;
   obj.Check();
 }
@@ -79,8 +80,9 @@ static void AddNoiseToCdesc(CFI_cdesc_t *dv, CFI_rank_t rank) {
 }
 
 #ifdef VERBOSE
-static void DumpTestWorld(void *bAddr, CFI_attribute_t attr, CFI_type_t ty,
-    std::size_t eLen, CFI_rank_t rank, CFI_index_t *eAddr) {
+static void DumpTestWorld(const void *bAddr, CFI_attribute_t attr,
+    CFI_type_t ty, std::size_t eLen, CFI_rank_t rank,
+    const CFI_index_t *eAddr) {
   std::cout << " base_addr: " << std::hex
             << reinterpret_cast<std::intptr_t>(bAddr)
             << " attribute: " << static_cast<int>(attr) << std::dec
@@ -108,6 +110,7 @@ static void check_CFI_establish(CFI_cdesc_t *dv, void *base_addr,
     MATCH(rank, res->rank());
     MATCH(reinterpret_cast<std::intptr_t>(dv->base_addr),
         reinterpret_cast<std::intptr_t>(base_addr));
+    MATCH(true, dv->version == CFI_VERSION);
     if (base_addr != nullptr) {
       MATCH(true, res->IsContiguous());
       for (int i{0}; i < rank; ++i) {
@@ -163,10 +166,7 @@ static void check_CFI_establish(CFI_cdesc_t *dv, void *base_addr,
   }
 }
 
-int main() {
-  // Testing CFI_CDESC_T macro for rank CFI_MAX_Rank to 0
-  TestForAllSmallerRanks<CFI_MAX_RANK>();
-
+static void run_CFI_establish_tests() {
   // Testing CFI_establish definied in section 18.5.5
   CFI_index_t extents[CFI_MAX_RANK];
   for (int i{0}; i < CFI_MAX_RANK; ++i) {
@@ -210,14 +210,469 @@ int main() {
       rank3d, extents);
   MATCH(false,
       dv_3darray->dim[2].extent == 2 + 66);  // extents was read
+}
 
-  // TODO: test CFI_address
-  // TODO: test CFI_allocate
+static void check_CFI_address(
+    const CFI_cdesc_t *dv, const CFI_index_t subscripts[]) {
+  // 18.5.5.2
+  void *addr = CFI_address(dv, subscripts);
+  const Descriptor *desc = reinterpret_cast<const Descriptor *>(dv);
+  void *addrCheck = desc->Element<void>(subscripts);
+  MATCH(true, addr == addrCheck);
+}
+
+// Helper function to set lower bound of decsriptor
+static void EstablishLowerBounds(CFI_cdesc_t *dv, CFI_index_t *sub) {
+  for (int i{0}; i < dv->rank; ++i) {
+    dv->dim[i].lower_bound = sub[i];
+  }
+}
+
+// Helper to get size without making internal compiler functions accessible
+static std::size_t ByteSize(CFI_type_t ty, std::size_t size) {
+  CFI_CDESC_T(0) storage;
+  CFI_cdesc_t *dv = reinterpret_cast<CFI_cdesc_t *>(&storage);
+  int retCode =
+      CFI_establish(dv, nullptr, CFI_attribute_other, ty, size, 0, nullptr);
+  return (retCode == CFI_SUCCESS) ? dv->elem_len : 0;
+}
+
+static void run_CFI_address_tests() {
+  // Test CFI_address defined in 18.5.5.2
+  // Create test world
+  CFI_index_t extents[CFI_MAX_RANK];
+  CFI_CDESC_T(CFI_MAX_RANK) dv_storage;
+  CFI_cdesc_t *dv{reinterpret_cast<CFI_cdesc_t *>(&dv_storage)};
+  static char base;
+  void *dummyAddr = reinterpret_cast<void *>(&base);
+  CFI_attribute_t attrCases[]{
+      CFI_attribute_pointer, CFI_attribute_allocatable, CFI_attribute_other};
+  CFI_type_t validTypeCases[]{
+      CFI_type_int, CFI_type_struct, CFI_type_double, CFI_type_char};
+  CFI_index_t subscripts[CFI_MAX_RANK];
+  CFI_index_t negativeLowerBounds[CFI_MAX_RANK];
+  CFI_index_t zeroLowerBounds[CFI_MAX_RANK];
+  CFI_index_t positiveLowerBounds[CFI_MAX_RANK];
+  CFI_index_t *lowerBoundCases[] = {
+      negativeLowerBounds, zeroLowerBounds, positiveLowerBounds};
+  for (int i{0}; i < CFI_MAX_RANK; ++i) {
+    negativeLowerBounds[i] = -1;
+    zeroLowerBounds[i] = 0;
+    positiveLowerBounds[i] = 1;
+    extents[i] = i + 2;
+    subscripts[i] = i + 1;
+  }
+
+  // test for scalar
+  for (CFI_attribute_t attribute : attrCases) {
+    for (CFI_type_t type : validTypeCases) {
+      CFI_establish(dv, dummyAddr, attribute, type, 42, 0, nullptr);
+      check_CFI_address(dv, nullptr);
+    }
+  }
+  // test for arrays
+  CFI_establish(dv, dummyAddr, CFI_attribute_other, CFI_type_int, 0,
+      CFI_MAX_RANK, extents);
+  for (CFI_index_t *lowerBounds : lowerBoundCases) {
+    EstablishLowerBounds(dv, lowerBounds);
+    for (CFI_type_t type : validTypeCases) {
+      for (bool contiguous : {true, false}) {
+        std::size_t size = ByteSize(type, 12);
+        dv->elem_len = size;
+        for (int i{0}; i < dv->rank; ++i) {
+          // contiguous
+          dv->dim[i].sm = size;
+          // non contiguous
+          dv->dim[i].sm = size + (contiguous ? 0 : dv->elem_len);
+          size = dv->dim[i].sm * dv->dim[i].extent;
+        }
+        for (CFI_attribute_t attribute : attrCases) {
+          dv->attribute = attribute;
+          check_CFI_address(dv, subscripts);
+        }
+      }
+    }
+  }
+  // Test on an assumed size array.
+  CFI_establish(
+      dv, dummyAddr, CFI_attribute_other, CFI_type_int, 0, 3, extents);
+  dv->dim[2].extent = -1;
+  check_CFI_address(dv, subscripts);
+}
+
+static void check_CFI_allocate(CFI_cdesc_t *dv,
+    const CFI_index_t lower_bounds[], const CFI_index_t upper_bounds[],
+    std::size_t elem_len) {
+  // 18.5.5.3
+  // Backup descriptor data for futur checks
+  const CFI_rank_t rank = dv->rank;
+  const std::size_t desc_elem_len = dv->elem_len;
+  const CFI_attribute_t attribute = dv->attribute;
+  const CFI_type_t type = dv->type;
+  const void *base_addr = dv->base_addr;
+  const int version = dv->version;
+#ifdef VERBOSE
+  DumpTestWorld(base_addr, attribute, type, elem_len, rank, nullptr);
+#endif
+  int retCode = CFI_allocate(dv, lower_bounds, upper_bounds, elem_len);
+  Descriptor *desc = reinterpret_cast<Descriptor *>(dv);
+  if (retCode == CFI_SUCCESS) {
+    // check res properties from 18.5.5.3 par 3
+    MATCH(true, dv->base_addr != nullptr);
+    for (int i{0}; i < rank; ++i) {
+      MATCH(lower_bounds[i], dv->dim[i].lower_bound);
+      MATCH(upper_bounds[i], dv->dim[i].extent + dv->dim[i].lower_bound - 1);
+    }
+    // if (type == CFI_type_char) {//what I expect
+    if (type == CFI_type_cptr) {  // current imple
+      MATCH(elem_len, dv->elem_len);
+    } else {
+      MATCH(true, desc_elem_len == dv->elem_len);
+    }
+    MATCH(true, desc->IsContiguous());
+  } else {
+    MATCH(true, base_addr == dv->base_addr);
+  }
+  // check dv properties that should not have been altered were not
+  // regardless of success/failure
+  MATCH(true, attribute == dv->attribute);
+  MATCH(true, rank == dv->rank);
+  MATCH(true, type == dv->type);
+  MATCH(true, version == dv->version);
+
+  // Success/failure according to standard
+  int numErr{0};
+  int expectedRetCode{CFI_SUCCESS};
+  if (rank < 0 || rank > CFI_MAX_RANK) {
+    ++numErr;
+    expectedRetCode = CFI_INVALID_RANK;
+  }
+  if (type < 0 || type > CFI_type_struct) {
+    ++numErr;
+    expectedRetCode = CFI_INVALID_TYPE;
+  }
+  if (base_addr != nullptr && attribute == CFI_attribute_allocatable) {
+    // This is less restrictive than 18.5.5.3 arg req for which pointers arg
+    // shall be unsassociated. However, this match ALLOCATE behavior
+    // (9.7.3/9.7.4)
+    ++numErr;
+    expectedRetCode = CFI_ERROR_BASE_ADDR_NOT_NULL;
+  }
+  if (type == CFI_type_cptr && elem_len <= 0) {  // current implem
+    // if (type == CFI_type_char && elem_len <= 0) {//what I expect
+    ++numErr;
+    expectedRetCode = CFI_INVALID_ELEM_LEN;
+  }
+  if (attribute != CFI_attribute_pointer &&
+      attribute != CFI_attribute_allocatable) {
+    ++numErr;
+    // expectedRetCode = CFI_INVALID_ATTRIBUTE;//what I expect
+    expectedRetCode = CFI_INVALID_DESCRIPTOR;  // current implem
+  }
+  if (rank > 0 && (lower_bounds == nullptr || upper_bounds == nullptr)) {
+    ++numErr;
+    expectedRetCode = CFI_INVALID_EXTENT;
+  }
+
+  // memory allocation is the only remaining unpredicatble failure
+  if (numErr == 0 && retCode != CFI_SUCCESS) {
+    MATCH(true, retCode == CFI_ERROR_MEM_ALLOCATION);
+  } else if (numErr > 1) {
+    MATCH(true, retCode != CFI_SUCCESS);
+  } else {
+    MATCH(expectedRetCode, retCode);
+  }
+  // clean-up
+  if (retCode == CFI_SUCCESS) {
+    CFI_deallocate(dv);
+  }
+}
+
+static void run_CFI_allocate_tests() {
+  // 18.5.5.3
+  // create test world
+  CFI_CDESC_T(CFI_MAX_RANK) dv_storage;
+  CFI_cdesc_t *dv{reinterpret_cast<CFI_cdesc_t *>(&dv_storage)};
+  static char base;
+  void *dummyAddr = reinterpret_cast<void *>(&base);
+  CFI_attribute_t attrCases[]{
+      CFI_attribute_pointer, CFI_attribute_allocatable, CFI_attribute_other};
+  CFI_type_t typeCases[]{CFI_type_int, CFI_type_struct, CFI_type_double,
+      CFI_type_char, CFI_type_other, CFI_type_struct + 1};
+  void *baseAddrCases[]{dummyAddr, static_cast<void *>(nullptr)};
+  CFI_rank_t rankCases[]{0, 1, CFI_MAX_RANK, CFI_MAX_RANK + 1};
+  std::size_t lenCases[]{0, 42};
+  CFI_index_t lb1[CFI_MAX_RANK];
+  CFI_index_t ub1[CFI_MAX_RANK];
+  for (int i{0}; i < CFI_MAX_RANK; ++i) {
+    lb1[i] = -1;
+    ub1[i] = 0;
+  }
+
+  check_CFI_establish(
+      dv, nullptr, CFI_attribute_other, CFI_type_int, 0, 0, nullptr);
+  for (CFI_type_t type : typeCases) {
+    std::size_t ty_len = ByteSize(type, 12);
+    for (CFI_attribute_t attribute : attrCases) {
+      for (void *base_addr : baseAddrCases) {
+        for (CFI_rank_t rank : rankCases) {
+          for (size_t elem_len : lenCases) {
+            dv->base_addr = base_addr;
+            dv->rank = rank;
+            dv->attribute = attribute;
+            dv->type = type;
+            dv->elem_len = ty_len;
+            check_CFI_allocate(dv, lb1, ub1, elem_len);
+          }
+        }
+      }
+    }
+  }
+}
+
+static void run_CFI_section_tests() {
+  // simple tests
+  bool testPreConditions{true};
+  constexpr CFI_index_t m = 5, n = 6, o = 7;
+  constexpr CFI_rank_t rank = 3;
+  long long array[o][n][m];  // Fortran A(m,n,o)
+  long long counter{1};
+
+  for (CFI_index_t k{0}; k < o; ++k) {
+    for (CFI_index_t j{0}; j < n; ++j) {
+      for (CFI_index_t i{0}; i < m; ++i) {
+        array[k][j][i] = counter++;  // Fortran A(i,j,k)
+      }
+    }
+  }
+  CFI_CDESC_T(rank) sourceStorage;
+  CFI_cdesc_t *source = reinterpret_cast<CFI_cdesc_t *>(&sourceStorage);
+  CFI_index_t extent[rank] = {m, n, o};
+  int retCode = CFI_establish(
+      source, &array, CFI_attribute_other, CFI_type_long_long, 0, rank, extent);
+  testPreConditions &= (retCode == CFI_SUCCESS);
+
+  CFI_index_t lb[rank] = {2, 5, 4};
+  CFI_index_t ub[rank] = {4, 5, 6};
+  CFI_index_t strides[rank] = {2, 0, 2};
+  constexpr CFI_rank_t resultRank = rank - 1;
+
+  CFI_CDESC_T(resultRank) resultStorage;
+  CFI_cdesc_t *result = reinterpret_cast<CFI_cdesc_t *>(&resultStorage);
+  retCode = CFI_establish(result, nullptr, CFI_attribute_other,
+      CFI_type_long_long, 0, resultRank, nullptr);
+  testPreConditions &= (retCode == CFI_SUCCESS);
+
+  if (!testPreConditions) {
+    MATCH(true, testPreConditions);
+    return;
+  }
+
+  retCode = CFI_section(
+      result, source, lb, ub, strides);  // Fortran B = A(2:4:2, 5:5:0, 4:6:2)
+  MATCH(true, retCode == CFI_SUCCESS);
+
+  const int lbs0 = source->dim[0].lower_bound;
+  const int lbs1 = source->dim[1].lower_bound;
+  const int lbs2 = source->dim[2].lower_bound;
+
+  CFI_index_t resJ{result->dim[1].lower_bound};
+  for (CFI_index_t k{lb[2]}; k <= ub[2]; k += strides[2]) {
+    for (CFI_index_t j{lb[1]}; j <= ub[1]; j += (strides[1] ? strides[1] : 1)) {
+      CFI_index_t resI{result->dim[0].lower_bound};
+      for (CFI_index_t i{lb[0]}; i <= ub[0]; i += strides[0]) {
+        // check A(i,j,k) == B(resI, resJ) == array[k-1][j-1][i-1]
+        const CFI_index_t resSubcripts[] = {resI, resJ};
+        const CFI_index_t srcSubcripts[] = {i, j, k};
+        MATCH(true,
+            CFI_address(source, srcSubcripts) ==
+                CFI_address(result, resSubcripts));
+        MATCH(true,
+            CFI_address(source, srcSubcripts) ==
+                &array[k - lbs2][j - lbs1][i - lbs0]);
+        ++resI;
+      }
+    }
+    ++resJ;
+  }
+
+  strides[0] = -1;
+  lb[0] = 4;
+  ub[0] = 2;
+  retCode = CFI_section(
+      result, source, lb, ub, strides);  // Fortran B = A(4:2:-1, 5:5:0, 4:6:2)
+  MATCH(true, retCode == CFI_SUCCESS);
+
+  resJ = result->dim[1].lower_bound;
+  for (CFI_index_t k{lb[2]}; k <= ub[2]; k += strides[2]) {
+    for (CFI_index_t j{lb[1]}; j <= ub[1]; j += 1) {
+      CFI_index_t resI{result->dim[1].lower_bound + result->dim[0].extent - 1};
+      for (CFI_index_t i{2}; i <= 4; ++i) {
+        // check A(i,j,k) == B(resI, resJ) == array[k-1][j-1][i-1]
+        const CFI_index_t resSubcripts[] = {resI, resJ};
+        const CFI_index_t srcSubcripts[] = {i, j, k};
+        MATCH(true,
+            CFI_address(source, srcSubcripts) ==
+                CFI_address(result, resSubcripts));
+        MATCH(true,
+            CFI_address(source, srcSubcripts) ==
+                &array[k - lbs2][j - lbs1][i - lbs0]);
+        --resI;
+      }
+    }
+    ++resJ;
+  }
+}
+
+static void run_CFI_select_part_tests() {
+  constexpr std::size_t name_len = 5;
+  typedef struct {
+    double distance;
+    int stars;
+    char name[name_len];
+  } Galaxy;
+
+  const CFI_rank_t rank{2};
+  constexpr CFI_index_t universeSize[] = {2, 3};
+  Galaxy universe[universeSize[1]][universeSize[0]];
+
+  for (int j{0}; j < universeSize[1]; ++j) {
+    for (int i{0}; i < universeSize[0]; ++i) {
+      universe[j][i].distance = i + j * 32;
+      universe[j][i].stars = i * 2 + j * 64;
+      universe[j][i].name[2] = static_cast<char>(i);
+      universe[j][i].name[3] = static_cast<char>(j);
+    }
+  }
+
+  CFI_CDESC_T(rank) resStorage, srcStorage;
+  CFI_cdesc_t *result = reinterpret_cast<CFI_cdesc_t *>(&resStorage);
+  CFI_cdesc_t *source = reinterpret_cast<CFI_cdesc_t *>(&srcStorage);
+
+  bool testPreConditions{true};
+  int retCode = CFI_establish(result, nullptr, CFI_attribute_other,
+      CFI_type_int, sizeof(int), rank, nullptr);
+  testPreConditions &= (retCode == CFI_SUCCESS);
+  retCode = CFI_establish(source, &universe, CFI_attribute_other,
+      CFI_type_struct, sizeof(Galaxy), rank, universeSize);
+  testPreConditions &= (retCode == CFI_SUCCESS);
+  if (!testPreConditions) {
+    MATCH(true, testPreConditions);
+    return;
+  }
+
+  std::size_t displacement{offsetof(Galaxy, stars)};
+  std::size_t elem_len{0};  // ignored
+  retCode = CFI_select_part(result, source, displacement, elem_len);
+  MATCH(CFI_SUCCESS, retCode);
+
+  bool baseAddrShiftedOk =
+      (reinterpret_cast<char *>(source->base_addr) + displacement ==
+          result->base_addr);
+  MATCH(true, baseAddrShiftedOk);
+  if (!baseAddrShiftedOk) {
+    return;
+  }
+
+  MATCH(sizeof(int), result->elem_len);
+  for (CFI_index_t j{0}; j < universeSize[1]; ++j) {
+    for (CFI_index_t i{0}; i < universeSize[0]; ++i) {
+      CFI_index_t subscripts[]{
+          result->dim[0].lower_bound + i, result->dim[1].lower_bound + j};
+      MATCH(i * 2 + j * 64,
+          *reinterpret_cast<int *>(CFI_address(result, subscripts)));
+    }
+  }
+
+  // Test for Fortran character type
+  retCode = CFI_establish(
+      result, nullptr, CFI_attribute_other, CFI_type_char, 2, rank, nullptr);
+  testPreConditions &= (retCode == CFI_SUCCESS);
+  if (!testPreConditions) {
+    MATCH(true, testPreConditions);
+    return;
+  }
+
+  displacement = offsetof(Galaxy, name) + 2;
+  elem_len = 2;  // not ignored this time
+  retCode = CFI_select_part(result, source, displacement, elem_len);
+  MATCH(CFI_SUCCESS, retCode);
+
+  baseAddrShiftedOk =
+      (reinterpret_cast<char *>(source->base_addr) + displacement ==
+          result->base_addr);
+  MATCH(true, baseAddrShiftedOk);
+  if (!baseAddrShiftedOk) {
+    return;
+  }
+
+  MATCH(elem_len, result->elem_len);
+  for (CFI_index_t j{0}; j < universeSize[1]; ++j) {
+    for (CFI_index_t i{0}; i < universeSize[0]; ++i) {
+      CFI_index_t subscripts[]{
+          result->dim[0].lower_bound + i, result->dim[1].lower_bound + j};
+      MATCH(static_cast<char>(i),
+          reinterpret_cast<char *>(CFI_address(result, subscripts))[0]);
+      MATCH(static_cast<char>(j),
+          reinterpret_cast<char *>(CFI_address(result, subscripts))[1]);
+    }
+  }
+}
+
+static void run_CFI_setpointer_tests() {
+  constexpr CFI_rank_t rank = 3;
+  CFI_CDESC_T(rank) resStorage, srcStorage;
+  CFI_cdesc_t *result = reinterpret_cast<CFI_cdesc_t *>(&resStorage);
+  CFI_cdesc_t *source = reinterpret_cast<CFI_cdesc_t *>(&srcStorage);
+  CFI_index_t lower_bounds[rank];
+  CFI_index_t extents[rank];
+  for (int i{0}; i < rank; ++i) {
+    lower_bounds[i] = i;
+    extents[i] = 2;
+  }
+
+  static char target;
+  char *dummyBaseAddress = &target;
+  bool testPreConditions{true};
+  CFI_type_t type{CFI_type_int};
+  std::size_t elem_len{ByteSize(type, 42)};
+  int retCode = CFI_establish(
+      result, nullptr, CFI_attribute_pointer, type, elem_len, rank, nullptr);
+  testPreConditions &= (retCode == CFI_SUCCESS);
+  retCode = CFI_establish(source, dummyBaseAddress, CFI_attribute_other, type,
+      elem_len, rank, extents);
+  testPreConditions &= (retCode == CFI_SUCCESS);
+  if (!testPreConditions) {
+    MATCH(true, testPreConditions);
+    return;
+  }
+
+  retCode = CFI_setpointer(result, source, lower_bounds);
+  MATCH(CFI_SUCCESS, retCode);
+
+  // The follwoing members must be invariant
+  MATCH(rank, result->rank);
+  MATCH(elem_len, result->elem_len);
+  MATCH(type, result->type);
+  // check pointer association
+  MATCH(true, result->base_addr == source->base_addr);
+  for (int j{0}; j < rank; ++j) {
+    MATCH(source->dim[j].extent, result->dim[j].extent);
+    MATCH(source->dim[j].sm, result->dim[j].sm);
+    MATCH(lower_bounds[j], result->dim[j].lower_bound);
+  }
+}
+
+int main() {
+  TestCdescMacroForAllRanksSmallerThan<CFI_MAX_RANK>();:
+  run_CFI_establish_tests();
+  run_CFI_address_tests();
+  // TODO: calrify CFI_allocate -> CFI_type_cptr/CFI_type_char
+  run_CFI_allocate_tests();
   // TODO: test CFI_deallocate
-  // TODO: test CFI_establish
   // TODO: test CFI_is_contiguous
-  // TODO: test CFI_section
-  // TODO: test CFI_select_part
-  // TODO: test CFI_setpointer
+  run_CFI_section_tests();
+  run_CFI_select_part_tests();
+  run_CFI_setpointer_tests();
   return testing::Complete();
 }

--- a/test/evaluate/ISO-Fortran-binding.cc
+++ b/test/evaluate/ISO-Fortran-binding.cc
@@ -323,8 +323,7 @@ static void check_CFI_allocate(CFI_cdesc_t *dv,
       MATCH(lower_bounds[i], dv->dim[i].lower_bound);
       MATCH(upper_bounds[i], dv->dim[i].extent + dv->dim[i].lower_bound - 1);
     }
-    // if (type == CFI_type_char) {//what I expect
-    if (type == CFI_type_cptr) {  // current imple
+    if (type == CFI_type_char) {
       MATCH(elem_len, dv->elem_len);
     } else {
       MATCH(true, desc_elem_len == dv->elem_len);
@@ -333,8 +332,9 @@ static void check_CFI_allocate(CFI_cdesc_t *dv,
   } else {
     MATCH(true, base_addr == dv->base_addr);
   }
-  // check dv properties that should not have been altered were not
-  // regardless of success/failure
+
+  // Below dv members shall not be altered by CFI_allocate regardless of
+  // success/failure
   MATCH(true, attribute == dv->attribute);
   MATCH(true, rank == dv->rank);
   MATCH(true, type == dv->type);
@@ -358,23 +358,17 @@ static void check_CFI_allocate(CFI_cdesc_t *dv,
     ++numErr;
     expectedRetCode = CFI_ERROR_BASE_ADDR_NOT_NULL;
   }
-  if (type == CFI_type_cptr && elem_len <= 0) {  // current implem
-    // if (type == CFI_type_char && elem_len <= 0) {//what I expect
-    ++numErr;
-    expectedRetCode = CFI_INVALID_ELEM_LEN;
-  }
   if (attribute != CFI_attribute_pointer &&
       attribute != CFI_attribute_allocatable) {
     ++numErr;
-    // expectedRetCode = CFI_INVALID_ATTRIBUTE;//what I expect
-    expectedRetCode = CFI_INVALID_DESCRIPTOR;  // current implem
+    expectedRetCode = CFI_INVALID_ATTRIBUTE;
   }
   if (rank > 0 && (lower_bounds == nullptr || upper_bounds == nullptr)) {
     ++numErr;
     expectedRetCode = CFI_INVALID_EXTENT;
   }
 
-  // memory allocation is the only remaining unpredicatble failure
+  // Memory allocation failures are unpredicatble in this test.
   if (numErr == 0 && retCode != CFI_SUCCESS) {
     MATCH(true, retCode == CFI_ERROR_MEM_ALLOCATION);
   } else if (numErr > 1) {
@@ -664,7 +658,7 @@ static void run_CFI_setpointer_tests() {
 }
 
 int main() {
-  TestCdescMacroForAllRanksSmallerThan<CFI_MAX_RANK>();:
+  TestCdescMacroForAllRanksSmallerThan<CFI_MAX_RANK>();
   run_CFI_establish_tests();
   run_CFI_address_tests();
   // TODO: calrify CFI_allocate -> CFI_type_cptr/CFI_type_char

--- a/test/evaluate/ISO-Fortran-binding.cc
+++ b/test/evaluate/ISO-Fortran-binding.cc
@@ -38,7 +38,7 @@ public:
     // suitable in size
     if (rank > 0) {
       MATCH(sizeof(dvStorage_), Descriptor::SizeInBytes(rank_, false));
-    } else {  // C++ implem overalocates for rank=0 by 24bytes.
+    } else {  // C++ implementation over-allocates for rank=0 by 24bytes.
       MATCH(true, sizeof(dvStorage_) >= Descriptor::SizeInBytes(rank_, false));
     }
     // suitable in alignment
@@ -167,7 +167,7 @@ static void check_CFI_establish(CFI_cdesc_t *dv, void *base_addr,
 }
 
 static void run_CFI_establish_tests() {
-  // Testing CFI_establish definied in section 18.5.5
+  // Testing CFI_establish defined in section 18.5.5
   CFI_index_t extents[CFI_MAX_RANK];
   for (int i{0}; i < CFI_MAX_RANK; ++i) {
     extents[i] = i + 66;
@@ -221,7 +221,7 @@ static void check_CFI_address(
   MATCH(true, addr == addrCheck);
 }
 
-// Helper function to set lower bound of decsriptor
+// Helper function to set lower bound of descriptor
 static void EstablishLowerBounds(CFI_cdesc_t *dv, CFI_index_t *sub) {
   for (int i{0}; i < dv->rank; ++i) {
     dv->dim[i].lower_bound = sub[i];
@@ -280,9 +280,6 @@ static void run_CFI_address_tests() {
         std::size_t size = ByteSize(type, 12);
         dv->elem_len = size;
         for (int i{0}; i < dv->rank; ++i) {
-          // contiguous
-          dv->dim[i].sm = size;
-          // non contiguous
           dv->dim[i].sm = size + (contiguous ? 0 : dv->elem_len);
           size = dv->dim[i].sm * dv->dim[i].extent;
         }
@@ -304,7 +301,7 @@ static void check_CFI_allocate(CFI_cdesc_t *dv,
     const CFI_index_t lower_bounds[], const CFI_index_t upper_bounds[],
     std::size_t elem_len) {
   // 18.5.5.3
-  // Backup descriptor data for futur checks
+  // Backup descriptor data for future checks
   const CFI_rank_t rank = dv->rank;
   const std::size_t desc_elem_len = dv->elem_len;
   const CFI_attribute_t attribute = dv->attribute;
@@ -353,7 +350,7 @@ static void check_CFI_allocate(CFI_cdesc_t *dv,
   }
   if (base_addr != nullptr && attribute == CFI_attribute_allocatable) {
     // This is less restrictive than 18.5.5.3 arg req for which pointers arg
-    // shall be unsassociated. However, this match ALLOCATE behavior
+    // shall be unassociated. However, this match ALLOCATE behavior
     // (9.7.3/9.7.4)
     ++numErr;
     expectedRetCode = CFI_ERROR_BASE_ADDR_NOT_NULL;
@@ -368,7 +365,7 @@ static void check_CFI_allocate(CFI_cdesc_t *dv,
     expectedRetCode = CFI_INVALID_EXTENT;
   }
 
-  // Memory allocation failures are unpredicatble in this test.
+  // Memory allocation failures are unpredictable in this test.
   if (numErr == 0 && retCode != CFI_SUCCESS) {
     MATCH(true, retCode == CFI_ERROR_MEM_ALLOCATION);
   } else if (numErr > 1) {
@@ -644,7 +641,7 @@ static void run_CFI_setpointer_tests() {
   retCode = CFI_setpointer(result, source, lower_bounds);
   MATCH(CFI_SUCCESS, retCode);
 
-  // The follwoing members must be invariant
+  // The following members must be invariant
   MATCH(rank, result->rank);
   MATCH(elem_len, result->elem_len);
   MATCH(type, result->type);
@@ -661,7 +658,6 @@ int main() {
   TestCdescMacroForAllRanksSmallerThan<CFI_MAX_RANK>();
   run_CFI_establish_tests();
   run_CFI_address_tests();
-  // TODO: calrify CFI_allocate -> CFI_type_cptr/CFI_type_char
   run_CFI_allocate_tests();
   // TODO: test CFI_deallocate
   // TODO: test CFI_is_contiguous

--- a/test/evaluate/ISO-Fortran-binding.cc
+++ b/test/evaluate/ISO-Fortran-binding.cc
@@ -48,7 +48,7 @@ public:
   }
 
 private:
-  static constexpr int rank_ = rank;
+  static constexpr int rank_{rank};
   CFI_CDESC_T(rank) dvStorage_;
 };
 
@@ -66,9 +66,11 @@ template<> void TestCdescMacroForAllRanksSmallerThan<0>() {
 
 // CFI_establish test helper
 static void AddNoiseToCdesc(CFI_cdesc_t *dv, CFI_rank_t rank) {
-  static int trap;
+  static const int trap{0};
   dv->rank = 16;
-  dv->base_addr = reinterpret_cast<void *>(&trap);
+  // This address is not supposed to be used. Any write attempt should trigger
+  // program termination
+  dv->base_addr = const_cast<int *>(&trap);
   dv->elem_len = 320;
   dv->type = CFI_type_struct;
   dv->attribute = CFI_attribute_pointer;
@@ -100,9 +102,9 @@ static void check_CFI_establish(CFI_cdesc_t *dv, void *base_addr,
   DumpTestWorld(base_addr, attribute, type, elem_len, rank, extent);
 #endif
   // CFI_establish reqs from F2018 section 18.5.5
-  int retCode =
-      CFI_establish(dv, base_addr, attribute, type, elem_len, rank, extents);
-  Descriptor *res = reinterpret_cast<Descriptor *>(dv);
+  int retCode{
+      CFI_establish(dv, base_addr, attribute, type, elem_len, rank, extents)};
+  Descriptor *res{reinterpret_cast<Descriptor *>(dv)};
   if (retCode == CFI_SUCCESS) {
     res->Check();
     MATCH((attribute == CFI_attribute_pointer), res->IsPointer());
@@ -173,16 +175,16 @@ static void run_CFI_establish_tests() {
     extents[i] = i + 66;
   }
   CFI_CDESC_T(CFI_MAX_RANK) dv_storage;
-  CFI_cdesc_t *dv{reinterpret_cast<CFI_cdesc_t *>(&dv_storage)};
-  static char base;
-  void *dummyAddr = reinterpret_cast<void *>(&base);
+  CFI_cdesc_t *dv{&dv_storage};
+  char base;
+  void *dummyAddr{&base};
   // Define test space
   CFI_attribute_t attrCases[]{
       CFI_attribute_pointer, CFI_attribute_allocatable, CFI_attribute_other};
   CFI_type_t typeCases[]{CFI_type_int, CFI_type_struct, CFI_type_double,
       CFI_type_char, CFI_type_other, CFI_type_struct + 1};
-  CFI_index_t *extentCases[]{extents, static_cast<CFI_index_t *>(nullptr)};
-  void *baseAddrCases[]{dummyAddr, static_cast<void *>(nullptr)};
+  CFI_index_t *extentCases[]{extents, nullptr};
+  void *baseAddrCases[]{dummyAddr, nullptr};
   CFI_rank_t rankCases[]{0, 1, CFI_MAX_RANK, CFI_MAX_RANK + 1};
   std::size_t lenCases[]{0, 42};
 
@@ -203,8 +205,8 @@ static void run_CFI_establish_tests() {
   }
   // If base_addr is null, extents shall be ignored even if rank !=0
   const int rank3d{3};
-  static CFI_CDESC_T(rank3d) dv3darrayStorage;
-  CFI_cdesc_t *dv_3darray{reinterpret_cast<CFI_cdesc_t *>(&dv3darrayStorage)};
+  CFI_CDESC_T(rank3d) dv3darrayStorage;
+  CFI_cdesc_t *dv_3darray{&dv3darrayStorage};
   AddNoiseToCdesc(dv_3darray, rank3d);  // => dv_3darray->dim[2].extent = -42
   check_CFI_establish(dv_3darray, nullptr, CFI_attribute_other, CFI_type_int, 4,
       rank3d, extents);
@@ -215,9 +217,9 @@ static void run_CFI_establish_tests() {
 static void check_CFI_address(
     const CFI_cdesc_t *dv, const CFI_index_t subscripts[]) {
   // 18.5.5.2
-  void *addr = CFI_address(dv, subscripts);
-  const Descriptor *desc = reinterpret_cast<const Descriptor *>(dv);
-  void *addrCheck = desc->Element<void>(subscripts);
+  void *addr{CFI_address(dv, subscripts)};
+  const Descriptor *desc{reinterpret_cast<const Descriptor *>(dv)};
+  void *addrCheck{desc->Element<void>(subscripts)};
   MATCH(true, addr == addrCheck);
 }
 
@@ -231,10 +233,10 @@ static void EstablishLowerBounds(CFI_cdesc_t *dv, CFI_index_t *sub) {
 // Helper to get size without making internal compiler functions accessible
 static std::size_t ByteSize(CFI_type_t ty, std::size_t size) {
   CFI_CDESC_T(0) storage;
-  CFI_cdesc_t *dv = reinterpret_cast<CFI_cdesc_t *>(&storage);
-  int retCode =
-      CFI_establish(dv, nullptr, CFI_attribute_other, ty, size, 0, nullptr);
-  return (retCode == CFI_SUCCESS) ? dv->elem_len : 0;
+  CFI_cdesc_t *dv{&storage};
+  int retCode{
+      CFI_establish(dv, nullptr, CFI_attribute_other, ty, size, 0, nullptr)};
+  return retCode == CFI_SUCCESS ? dv->elem_len : 0;
 }
 
 static void run_CFI_address_tests() {
@@ -242,9 +244,9 @@ static void run_CFI_address_tests() {
   // Create test world
   CFI_index_t extents[CFI_MAX_RANK];
   CFI_CDESC_T(CFI_MAX_RANK) dv_storage;
-  CFI_cdesc_t *dv{reinterpret_cast<CFI_cdesc_t *>(&dv_storage)};
-  static char base;
-  void *dummyAddr = reinterpret_cast<void *>(&base);
+  CFI_cdesc_t *dv{&dv_storage};
+  char base;
+  void *dummyAddr{&base};
   CFI_attribute_t attrCases[]{
       CFI_attribute_pointer, CFI_attribute_allocatable, CFI_attribute_other};
   CFI_type_t validTypeCases[]{
@@ -253,7 +255,7 @@ static void run_CFI_address_tests() {
   CFI_index_t negativeLowerBounds[CFI_MAX_RANK];
   CFI_index_t zeroLowerBounds[CFI_MAX_RANK];
   CFI_index_t positiveLowerBounds[CFI_MAX_RANK];
-  CFI_index_t *lowerBoundCases[] = {
+  CFI_index_t *lowerBoundCases[]{
       negativeLowerBounds, zeroLowerBounds, positiveLowerBounds};
   for (int i{0}; i < CFI_MAX_RANK; ++i) {
     negativeLowerBounds[i] = -1;
@@ -277,7 +279,7 @@ static void run_CFI_address_tests() {
     EstablishLowerBounds(dv, lowerBounds);
     for (CFI_type_t type : validTypeCases) {
       for (bool contiguous : {true, false}) {
-        std::size_t size = ByteSize(type, 12);
+        std::size_t size{ByteSize(type, 12)};
         dv->elem_len = size;
         for (int i{0}; i < dv->rank; ++i) {
           dv->dim[i].sm = size + (contiguous ? 0 : dv->elem_len);
@@ -302,16 +304,16 @@ static void check_CFI_allocate(CFI_cdesc_t *dv,
     std::size_t elem_len) {
   // 18.5.5.3
   // Backup descriptor data for future checks
-  const CFI_rank_t rank = dv->rank;
-  const std::size_t desc_elem_len = dv->elem_len;
-  const CFI_attribute_t attribute = dv->attribute;
-  const CFI_type_t type = dv->type;
-  const void *base_addr = dv->base_addr;
-  const int version = dv->version;
+  const CFI_rank_t rank{dv->rank};
+  const std::size_t desc_elem_len{dv->elem_len};
+  const CFI_attribute_t attribute{dv->attribute};
+  const CFI_type_t type{dv->type};
+  const void *base_addr{dv->base_addr};
+  const int version{dv->version};
 #ifdef VERBOSE
   DumpTestWorld(base_addr, attribute, type, elem_len, rank, nullptr);
 #endif
-  int retCode = CFI_allocate(dv, lower_bounds, upper_bounds, elem_len);
+  int retCode{CFI_allocate(dv, lower_bounds, upper_bounds, elem_len)};
   Descriptor *desc = reinterpret_cast<Descriptor *>(dv);
   if (retCode == CFI_SUCCESS) {
     // check res properties from 18.5.5.3 par 3
@@ -383,14 +385,14 @@ static void run_CFI_allocate_tests() {
   // 18.5.5.3
   // create test world
   CFI_CDESC_T(CFI_MAX_RANK) dv_storage;
-  CFI_cdesc_t *dv{reinterpret_cast<CFI_cdesc_t *>(&dv_storage)};
-  static char base;
-  void *dummyAddr = reinterpret_cast<void *>(&base);
+  CFI_cdesc_t *dv{&dv_storage};
+  char base;
+  void *dummyAddr{&base};
   CFI_attribute_t attrCases[]{
       CFI_attribute_pointer, CFI_attribute_allocatable, CFI_attribute_other};
   CFI_type_t typeCases[]{CFI_type_int, CFI_type_struct, CFI_type_double,
       CFI_type_char, CFI_type_other, CFI_type_struct + 1};
-  void *baseAddrCases[]{dummyAddr, static_cast<void *>(nullptr)};
+  void *baseAddrCases[]{dummyAddr, nullptr};
   CFI_rank_t rankCases[]{0, 1, CFI_MAX_RANK, CFI_MAX_RANK + 1};
   std::size_t lenCases[]{0, 42};
   CFI_index_t lb1[CFI_MAX_RANK];
@@ -403,7 +405,7 @@ static void run_CFI_allocate_tests() {
   check_CFI_establish(
       dv, nullptr, CFI_attribute_other, CFI_type_int, 0, 0, nullptr);
   for (CFI_type_t type : typeCases) {
-    std::size_t ty_len = ByteSize(type, 12);
+    std::size_t ty_len{ByteSize(type, 12)};
     for (CFI_attribute_t attribute : attrCases) {
       for (void *base_addr : baseAddrCases) {
         for (CFI_rank_t rank : rankCases) {
@@ -424,8 +426,8 @@ static void run_CFI_allocate_tests() {
 static void run_CFI_section_tests() {
   // simple tests
   bool testPreConditions{true};
-  constexpr CFI_index_t m = 5, n = 6, o = 7;
-  constexpr CFI_rank_t rank = 3;
+  constexpr CFI_index_t m{5}, n{6}, o{7};
+  constexpr CFI_rank_t rank{3};
   long long array[o][n][m];  // Fortran A(m,n,o)
   long long counter{1};
 
@@ -437,19 +439,19 @@ static void run_CFI_section_tests() {
     }
   }
   CFI_CDESC_T(rank) sourceStorage;
-  CFI_cdesc_t *source = reinterpret_cast<CFI_cdesc_t *>(&sourceStorage);
+  CFI_cdesc_t *source{&sourceStorage};
   CFI_index_t extent[rank] = {m, n, o};
-  int retCode = CFI_establish(
-      source, &array, CFI_attribute_other, CFI_type_long_long, 0, rank, extent);
+  int retCode{CFI_establish(source, &array, CFI_attribute_other,
+      CFI_type_long_long, 0, rank, extent)};
   testPreConditions &= (retCode == CFI_SUCCESS);
 
   CFI_index_t lb[rank] = {2, 5, 4};
   CFI_index_t ub[rank] = {4, 5, 6};
   CFI_index_t strides[rank] = {2, 0, 2};
-  constexpr CFI_rank_t resultRank = rank - 1;
+  constexpr CFI_rank_t resultRank{rank - 1};
 
   CFI_CDESC_T(resultRank) resultStorage;
-  CFI_cdesc_t *result = reinterpret_cast<CFI_cdesc_t *>(&resultStorage);
+  CFI_cdesc_t *result{&resultStorage};
   retCode = CFI_establish(result, nullptr, CFI_attribute_other,
       CFI_type_long_long, 0, resultRank, nullptr);
   testPreConditions &= (retCode == CFI_SUCCESS);
@@ -463,18 +465,18 @@ static void run_CFI_section_tests() {
       result, source, lb, ub, strides);  // Fortran B = A(2:4:2, 5:5:0, 4:6:2)
   MATCH(true, retCode == CFI_SUCCESS);
 
-  const int lbs0 = source->dim[0].lower_bound;
-  const int lbs1 = source->dim[1].lower_bound;
-  const int lbs2 = source->dim[2].lower_bound;
+  const CFI_index_t lbs0{source->dim[0].lower_bound};
+  const CFI_index_t lbs1{source->dim[1].lower_bound};
+  const CFI_index_t lbs2{source->dim[2].lower_bound};
 
   CFI_index_t resJ{result->dim[1].lower_bound};
   for (CFI_index_t k{lb[2]}; k <= ub[2]; k += strides[2]) {
-    for (CFI_index_t j{lb[1]}; j <= ub[1]; j += (strides[1] ? strides[1] : 1)) {
+    for (CFI_index_t j{lb[1]}; j <= ub[1]; j += strides[1] ? strides[1] : 1) {
       CFI_index_t resI{result->dim[0].lower_bound};
       for (CFI_index_t i{lb[0]}; i <= ub[0]; i += strides[0]) {
         // check A(i,j,k) == B(resI, resJ) == array[k-1][j-1][i-1]
-        const CFI_index_t resSubcripts[] = {resI, resJ};
-        const CFI_index_t srcSubcripts[] = {i, j, k};
+        const CFI_index_t resSubcripts[]{resI, resJ};
+        const CFI_index_t srcSubcripts[]{i, j, k};
         MATCH(true,
             CFI_address(source, srcSubcripts) ==
                 CFI_address(result, resSubcripts));
@@ -500,8 +502,8 @@ static void run_CFI_section_tests() {
       CFI_index_t resI{result->dim[1].lower_bound + result->dim[0].extent - 1};
       for (CFI_index_t i{2}; i <= 4; ++i) {
         // check A(i,j,k) == B(resI, resJ) == array[k-1][j-1][i-1]
-        const CFI_index_t resSubcripts[] = {resI, resJ};
-        const CFI_index_t srcSubcripts[] = {i, j, k};
+        const CFI_index_t resSubcripts[]{resI, resJ};
+        const CFI_index_t srcSubcripts[]{i, j, k};
         MATCH(true,
             CFI_address(source, srcSubcripts) ==
                 CFI_address(result, resSubcripts));
@@ -516,7 +518,7 @@ static void run_CFI_section_tests() {
 }
 
 static void run_CFI_select_part_tests() {
-  constexpr std::size_t name_len = 5;
+  constexpr std::size_t name_len{5};
   typedef struct {
     double distance;
     int stars;
@@ -524,25 +526,26 @@ static void run_CFI_select_part_tests() {
   } Galaxy;
 
   const CFI_rank_t rank{2};
-  constexpr CFI_index_t universeSize[] = {2, 3};
+  constexpr CFI_index_t universeSize[]{2, 3};
   Galaxy universe[universeSize[1]][universeSize[0]];
 
-  for (int j{0}; j < universeSize[1]; ++j) {
-    for (int i{0}; i < universeSize[0]; ++i) {
-      universe[j][i].distance = i + j * 32;
-      universe[j][i].stars = i * 2 + j * 64;
-      universe[j][i].name[2] = static_cast<char>(i);
-      universe[j][i].name[3] = static_cast<char>(j);
+  for (int i{0}; i < universeSize[1]; ++i) {
+    for (int j{0}; j < universeSize[0]; ++j) {
+      // Initializing Fortran var universe(j,i)
+      universe[i][j].distance = j + i * 32;
+      universe[i][j].stars = j * 2 + i * 64;
+      universe[i][j].name[2] = static_cast<char>(j);
+      universe[i][j].name[3] = static_cast<char>(i);
     }
   }
 
   CFI_CDESC_T(rank) resStorage, srcStorage;
-  CFI_cdesc_t *result = reinterpret_cast<CFI_cdesc_t *>(&resStorage);
-  CFI_cdesc_t *source = reinterpret_cast<CFI_cdesc_t *>(&srcStorage);
+  CFI_cdesc_t *result{&resStorage};
+  CFI_cdesc_t *source{&srcStorage};
 
   bool testPreConditions{true};
-  int retCode = CFI_establish(result, nullptr, CFI_attribute_other,
-      CFI_type_int, sizeof(int), rank, nullptr);
+  int retCode{CFI_establish(result, nullptr, CFI_attribute_other, CFI_type_int,
+      sizeof(int), rank, nullptr)};
   testPreConditions &= (retCode == CFI_SUCCESS);
   retCode = CFI_establish(source, &universe, CFI_attribute_other,
       CFI_type_struct, sizeof(Galaxy), rank, universeSize);
@@ -557,9 +560,9 @@ static void run_CFI_select_part_tests() {
   retCode = CFI_select_part(result, source, displacement, elem_len);
   MATCH(CFI_SUCCESS, retCode);
 
-  bool baseAddrShiftedOk =
-      (reinterpret_cast<char *>(source->base_addr) + displacement ==
-          result->base_addr);
+  bool baseAddrShiftedOk{
+      static_cast<char *>(source->base_addr) + displacement ==
+      result->base_addr};
   MATCH(true, baseAddrShiftedOk);
   if (!baseAddrShiftedOk) {
     return;
@@ -570,8 +573,8 @@ static void run_CFI_select_part_tests() {
     for (CFI_index_t i{0}; i < universeSize[0]; ++i) {
       CFI_index_t subscripts[]{
           result->dim[0].lower_bound + i, result->dim[1].lower_bound + j};
-      MATCH(i * 2 + j * 64,
-          *reinterpret_cast<int *>(CFI_address(result, subscripts)));
+      MATCH(
+          i * 2 + j * 64, *static_cast<int *>(CFI_address(result, subscripts)));
     }
   }
 
@@ -589,9 +592,8 @@ static void run_CFI_select_part_tests() {
   retCode = CFI_select_part(result, source, displacement, elem_len);
   MATCH(CFI_SUCCESS, retCode);
 
-  baseAddrShiftedOk =
-      (reinterpret_cast<char *>(source->base_addr) + displacement ==
-          result->base_addr);
+  baseAddrShiftedOk = static_cast<char *>(source->base_addr) + displacement ==
+      result->base_addr;
   MATCH(true, baseAddrShiftedOk);
   if (!baseAddrShiftedOk) {
     return;
@@ -603,18 +605,18 @@ static void run_CFI_select_part_tests() {
       CFI_index_t subscripts[]{
           result->dim[0].lower_bound + i, result->dim[1].lower_bound + j};
       MATCH(static_cast<char>(i),
-          reinterpret_cast<char *>(CFI_address(result, subscripts))[0]);
+          static_cast<char *>(CFI_address(result, subscripts))[0]);
       MATCH(static_cast<char>(j),
-          reinterpret_cast<char *>(CFI_address(result, subscripts))[1]);
+          static_cast<char *>(CFI_address(result, subscripts))[1]);
     }
   }
 }
 
 static void run_CFI_setpointer_tests() {
-  constexpr CFI_rank_t rank = 3;
+  constexpr CFI_rank_t rank{3};
   CFI_CDESC_T(rank) resStorage, srcStorage;
-  CFI_cdesc_t *result = reinterpret_cast<CFI_cdesc_t *>(&resStorage);
-  CFI_cdesc_t *source = reinterpret_cast<CFI_cdesc_t *>(&srcStorage);
+  CFI_cdesc_t *result{&resStorage};
+  CFI_cdesc_t *source{&srcStorage};
   CFI_index_t lower_bounds[rank];
   CFI_index_t extents[rank];
   for (int i{0}; i < rank; ++i) {
@@ -622,13 +624,13 @@ static void run_CFI_setpointer_tests() {
     extents[i] = 2;
   }
 
-  static char target;
-  char *dummyBaseAddress = &target;
+  char target;
+  char *dummyBaseAddress{&target};
   bool testPreConditions{true};
   CFI_type_t type{CFI_type_int};
   std::size_t elem_len{ByteSize(type, 42)};
-  int retCode = CFI_establish(
-      result, nullptr, CFI_attribute_pointer, type, elem_len, rank, nullptr);
+  int retCode{CFI_establish(
+      result, nullptr, CFI_attribute_pointer, type, elem_len, rank, nullptr)};
   testPreConditions &= (retCode == CFI_SUCCESS);
   retCode = CFI_establish(source, dummyBaseAddress, CFI_attribute_other, type,
       elem_len, rank, extents);


### PR DESCRIPTION
This commit contains:

- Implementation of 18.5.5 CFI_setpointer, CFI_select_part and CFI_section as well as related unit tests.
Note that CFI_select_part and CFI_section also set lower bounds to zero. For nonallocatable nonpointer, this is to be in line with 18.5.3 par 3. For pointers, I have not found a clear indication, but based on CFI_establish behavior, it seems reasonable to set them to zero also.

- Fix of lower bound value in C descriptor:
CFI_establish now also sets lower bounds to zero for nonallocatable nonpointer data object descriptors according to 18.5.3 par 3. This is not done if no base_addr is given because it will be done in CFI_select_part and CFI_section in this case.

- Fix for character type in CFI_allocate:
It seems that CFI_type_cptr was used to refer to Fortran character type instead of CFI_type_char. The elem_len argument has to be considered for Fortran character type data objects for which the type encoding in the descriptor is CFI_type_char from what I understand.
