### PR TITLE
Extend `AnalyzeExpr` to handle wrapped expression parse trees

### DIFF
--- a/lib/evaluate/real.h
+++ b/lib/evaluate/real.h
@@ -50,12 +50,13 @@ public:
   static constexpr std::uint64_t exponentBias{maxExponent / 2};
 
   // Decimal precision of a binary floating-point representation is
-  // actual the base-5 precision.
+  // actually the same as the base-5 precision, as factors of two
+  // can be accommodated by the binary exponent.
   // log(2)/log(5) = 0.430+ in any base.
   // Calculate "precision*0.43" with integer arithmetic so as to be constexpr.
   static constexpr int decimalDigits{(precision * 43) / 100};
 
-  // Associates a decimal exponent with an integral value for formmatting.
+  // Associates a decimal exponent with an integral value for formatting.
   struct ScaledDecimal {
     bool negative{false};
     Word integer;  // unsigned

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1260,6 +1260,43 @@ evaluate::MaybeExpr AnalyzeExpr(
   return evaluate::ExprAnalyzer{context}.Analyze(expr);
 }
 
+template<typename A>
+evaluate::MaybeExpr AnalyzeWrappedExpr(
+    SemanticsContext &context, const A &expr) {
+  evaluate::ExprAnalyzer ea{context};
+  return evaluate::AnalyzeHelper(ea, expr);
+}
+
+evaluate::MaybeExpr AnalyzeExpr(
+    SemanticsContext &context, const parser::Scalar<parser::Expr> &expr) {
+  return AnalyzeWrappedExpr(context, expr);
+}
+evaluate::MaybeExpr AnalyzeExpr(
+    SemanticsContext &context, const parser::Constant<parser::Expr> &expr) {
+  return AnalyzeWrappedExpr(context, expr);
+}
+evaluate::MaybeExpr AnalyzeExpr(
+    SemanticsContext &context, const parser::Integer<parser::Expr> &expr) {
+  return AnalyzeWrappedExpr(context, expr);
+}
+evaluate::MaybeExpr AnalyzeExpr(SemanticsContext &context,
+    const parser::Scalar<parser::Constant<parser::Expr>> &expr) {
+  return AnalyzeWrappedExpr(context, expr);
+}
+evaluate::MaybeExpr AnalyzeExpr(SemanticsContext &context,
+    const parser::Scalar<parser::Integer<parser::Expr>> &expr) {
+  return AnalyzeWrappedExpr(context, expr);
+}
+evaluate::MaybeExpr AnalyzeExpr(SemanticsContext &context,
+    const parser::Integer<parser::Constant<parser::Expr>> &expr) {
+  return AnalyzeWrappedExpr(context, expr);
+}
+evaluate::MaybeExpr AnalyzeExpr(SemanticsContext &context,
+    const parser::Scalar<parser::Integer<parser::Constant<parser::Expr>>>
+        &expr) {
+  return AnalyzeWrappedExpr(context, expr);
+}
+
 class Mutator {
 public:
   Mutator(SemanticsContext &context) : context_{context} {}

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -22,17 +22,35 @@
 namespace Fortran::parser {
 struct Expr;
 struct Program;
+template<typename> struct Scalar;
+template<typename> struct Integer;
+template<typename> struct Constant;
 }
 
 namespace Fortran::semantics {
 
 class SemanticsContext;
 
-using MaybeExpr = std::optional<evaluate::Expr<evaluate::SomeType>>;
-
 // Semantic analysis of one expression.
 std::optional<evaluate::Expr<evaluate::SomeType>> AnalyzeExpr(
     SemanticsContext &, const parser::Expr &);
+
+std::optional<evaluate::Expr<evaluate::SomeType>> AnalyzeExpr(
+    SemanticsContext &, const parser::Scalar<parser::Expr> &);
+std::optional<evaluate::Expr<evaluate::SomeType>> AnalyzeExpr(
+    SemanticsContext &, const parser::Constant<parser::Expr> &);
+std::optional<evaluate::Expr<evaluate::SomeType>> AnalyzeExpr(
+    SemanticsContext &, const parser::Integer<parser::Expr> &);
+std::optional<evaluate::Expr<evaluate::SomeType>> AnalyzeExpr(
+    SemanticsContext &, const parser::Scalar<parser::Constant<parser::Expr>> &);
+std::optional<evaluate::Expr<evaluate::SomeType>> AnalyzeExpr(
+    SemanticsContext &, const parser::Scalar<parser::Integer<parser::Expr>> &);
+std::optional<evaluate::Expr<evaluate::SomeType>> AnalyzeExpr(
+    SemanticsContext &,
+    const parser::Integer<parser::Constant<parser::Expr>> &);
+std::optional<evaluate::Expr<evaluate::SomeType>> AnalyzeExpr(
+    SemanticsContext &,
+    const parser::Scalar<parser::Integer<parser::Constant<parser::Expr>>> &);
 
 // Semantic analysis of all expressions in a parse tree, which is
 // decorated with typed representations for top-level expressions.


### PR DESCRIPTION
The parse tree includes wrapped expression productions from the Standard like `scalar-int-constant-expr`.  Support analyzing them with their constraint checks to ease semantic analysis of declarations.