### PR TITLE
Add mapping of source location to Scope

### DIFF
--- a/lib/parser/char-block.h
+++ b/lib/parser/char-block.h
@@ -48,6 +48,10 @@ public:
     return interval_.start()[j];
   }
 
+  bool Contains(const CharBlock &that) const {
+    return interval_.Contains(that.interval_);
+  }
+
   bool IsBlank() const {
     for (char ch : *this) {
       if (ch != ' ' && ch != '\t') {

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -134,6 +134,28 @@ bool Scope::CanImport(const SourceName &name) const {
   }
 }
 
+const Scope *Scope::FindScope(const parser::CharBlock &source) const {
+  if (!sourceRange_.Contains(source)) {
+    return nullptr;
+  }
+  for (const auto &child : children_) {
+    if (const auto *scope{child.FindScope(source)}) {
+      return scope;
+    }
+  }
+  return this;
+}
+
+void Scope::AddSourceRange(const parser::CharBlock &source) {
+  if (sourceRange_.empty()) {
+    sourceRange_ = source;
+  } else if (!source.empty()) {
+    sourceRange_ =
+        parser::CharBlock(std::min(sourceRange_.begin(), source.begin()),
+            std::max(sourceRange_.end(), source.end()));
+  }
+}
+
 std::ostream &operator<<(std::ostream &os, const Scope &scope) {
   os << Scope::EnumToString(scope.kind()) << " scope: ";
   if (auto *symbol{scope.symbol()}) {

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -137,9 +137,16 @@ public:
 
   bool add_importName(const SourceName &);
 
+  // The range of the source of this and nested scopes.
+  const parser::CharBlock &sourceRange() const { return sourceRange_; }
+  void AddSourceRange(const parser::CharBlock &);
+  // Find the smallest scope under this one that contains source
+  const Scope *FindScope(const parser::CharBlock &) const;
+
 private:
   Scope &parent_;
   const Kind kind_;
+  parser::CharBlock sourceRange_;
   Symbol *const symbol_;
   std::list<Scope> children_;
   mapType symbols_;

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -74,6 +74,14 @@ bool Semantics::Perform() {
   return !AnyFatalError();
 }
 
+const Scope &Semantics::FindScope(const parser::CharBlock &source) const {
+  if (const auto *scope{context_.globalScope().FindScope(source)}) {
+    return *scope;
+  } else {
+    common::die("invalid source location");
+  }
+}
+
 void Semantics::EmitMessages(std::ostream &os) const {
   context_.messages().Emit(os, cooked_);
 }

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -89,10 +89,13 @@ class Semantics {
 public:
   explicit Semantics(SemanticsContext &context, parser::Program &program,
       parser::CookedSource &cooked)
-    : context_{context}, program_{program}, cooked_{cooked} {}
+    : context_{context}, program_{program}, cooked_{cooked} {
+    context.globalScope().AddSourceRange(parser::CharBlock{cooked.data()});
+  }
 
   SemanticsContext &context() const { return context_; }
   bool Perform();
+  const Scope &FindScope(const parser::CharBlock &) const;
   bool AnyFatalError() const { return context_.AnyFatalError(); }
   void EmitMessages(std::ostream &) const;
   void DumpSymbols(std::ostream &);


### PR DESCRIPTION
Each Scope now tracks the source locations that it and its nested scopes
span. This is achieved by extending the source range of a scope for each
statement encountered while it is the current scope.

Semantics::FindScope maps a source location (from the cooked character
stream) to the narrowest scope that contains it.