### PR TITLE
Change formatting of common::visitors{}

### DIFF
--- a/documentation/C++style.md
+++ b/documentation/C++style.md
@@ -96,6 +96,10 @@ easily read and understood with a minimum of scrolling.
 
 Avoid using assignments in controlling expressions of `if()` &c., even with
 the idiom of wrapping them with extra parentheses.
+
+In multi-element initializer lists (especially `common::visitors{...}`),
+including a comma after the last element often causes `clang-format` to do
+a better jobs of formatting.
 ### C++ language
 Use *C++17*, unless some compiler to which we must be portable lacks a feature
 you are considering.

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -144,11 +144,13 @@ std::ostream &ArrayConstructor<T>::AsFortran(std::ostream &o) const {
 template<typename RESULT>
 std::ostream &ExpressionBase<RESULT>::AsFortran(std::ostream &o) const {
   std::visit(
-      common::visitors{[&](const BOZLiteralConstant &x) {
-                         o << "z'" << x.Hexadecimal() << "'";
-                       },
+      common::visitors{
+          [&](const BOZLiteralConstant &x) {
+            o << "z'" << x.Hexadecimal() << "'";
+          },
           [&](const CopyableIndirection<Substring> &s) { s->AsFortran(o); },
-          [&](const auto &x) { x.AsFortran(o); }},
+          [&](const auto &x) { x.AsFortran(o); },
+      },
       derived().u);
   return o;
 }
@@ -161,10 +163,10 @@ template<typename T> Expr<SubscriptInteger> ArrayConstructor<T>::LEN() const {
 template<int KIND>
 Expr<SubscriptInteger> Expr<Type<TypeCategory::Character, KIND>>::LEN() const {
   return std::visit(
-      common::visitors{[](const Constant<Result> &c) {
-                         return AsExpr(
-                             Constant<SubscriptInteger>{c.value.size()});
-                       },
+      common::visitors{
+          [](const Constant<Result> &c) {
+            return AsExpr(Constant<SubscriptInteger>{c.value.size()});
+          },
           [](const ArrayConstructor<Result> &a) { return a.LEN(); },
           [](const Parentheses<Result> &x) { return x.left().LEN(); },
           [](const Concat<KIND> &c) {
@@ -175,7 +177,8 @@ Expr<SubscriptInteger> Expr<Type<TypeCategory::Character, KIND>>::LEN() const {
                 Extremum<SubscriptInteger>{c.left().LEN(), c.right().LEN()}};
           },
           [](const Designator<Result> &dr) { return dr.LEN(); },
-          [](const FunctionRef<Result> &fr) { return fr.LEN(); }},
+          [](const FunctionRef<Result> &fr) { return fr.LEN(); },
+      },
       u);
 }
 

--- a/lib/evaluate/tools.cc
+++ b/lib/evaluate/tools.cc
@@ -27,16 +27,17 @@ ConvertRealOperandsResult ConvertRealOperands(
     parser::ContextualMessages &messages, Expr<SomeType> &&x,
     Expr<SomeType> &&y, int defaultRealKind) {
   return std::visit(
-      common::visitors{[&](Expr<SomeInteger> &&ix, Expr<SomeInteger> &&iy)
-                           -> ConvertRealOperandsResult {
-                         // Can happen in a CMPLX() constructor.  Per F'2018,
-                         // both integer operands are converted to default REAL.
-                         return {AsSameKindExprs<TypeCategory::Real>(
-                             ConvertToKind<TypeCategory::Real>(
-                                 defaultRealKind, std::move(ix)),
-                             ConvertToKind<TypeCategory::Real>(
-                                 defaultRealKind, std::move(iy)))};
-                       },
+      common::visitors{
+          [&](Expr<SomeInteger> &&ix,
+              Expr<SomeInteger> &&iy) -> ConvertRealOperandsResult {
+            // Can happen in a CMPLX() constructor.  Per F'2018,
+            // both integer operands are converted to default REAL.
+            return {AsSameKindExprs<TypeCategory::Real>(
+                ConvertToKind<TypeCategory::Real>(
+                    defaultRealKind, std::move(ix)),
+                ConvertToKind<TypeCategory::Real>(
+                    defaultRealKind, std::move(iy)))};
+          },
           [&](Expr<SomeInteger> &&ix,
               Expr<SomeReal> &&ry) -> ConvertRealOperandsResult {
             return {AsSameKindExprs<TypeCategory::Real>(
@@ -81,7 +82,8 @@ ConvertRealOperandsResult ConvertRealOperands(
           [&](auto &&, auto &&) -> ConvertRealOperandsResult {
             messages.Say("operands must be INTEGER or REAL"_err_en_US);
             return std::nullopt;
-          }},
+          },
+      },
       std::move(x.u), std::move(y.u));
 }
 
@@ -248,11 +250,11 @@ std::optional<Expr<SomeType>> NumericOperation(
     parser::ContextualMessages &messages, Expr<SomeType> &&x,
     Expr<SomeType> &&y, int defaultRealKind) {
   return std::visit(
-      common::visitors{[](Expr<SomeInteger> &&ix, Expr<SomeInteger> &&iy) {
-                         return Package(
-                             PromoteAndCombine<OPR, TypeCategory::Integer>(
-                                 std::move(ix), std::move(iy)));
-                       },
+      common::visitors{
+          [](Expr<SomeInteger> &&ix, Expr<SomeInteger> &&iy) {
+            return Package(PromoteAndCombine<OPR, TypeCategory::Integer>(
+                std::move(ix), std::move(iy)));
+          },
           [](Expr<SomeReal> &&rx, Expr<SomeReal> &&ry) {
             return Package(PromoteAndCombine<OPR, TypeCategory::Real>(
                 std::move(rx), std::move(ry)));
@@ -316,7 +318,8 @@ std::optional<Expr<SomeType>> NumericOperation(
             // TODO: defined operator
             messages.Say("non-numeric operands to numeric operation"_err_en_US);
             return NoExpr();
-          }},
+          },
+      },
       std::move(x.u), std::move(y.u));
 }
 
@@ -396,10 +399,11 @@ Expr<LogicalResult> PromoteAndRelate(
 std::optional<Expr<LogicalResult>> Relate(parser::ContextualMessages &messages,
     RelationalOperator opr, Expr<SomeType> &&x, Expr<SomeType> &&y) {
   return std::visit(
-      common::visitors{[=](Expr<SomeInteger> &&ix, Expr<SomeInteger> &&iy) {
-                         return std::make_optional(PromoteAndRelate(
-                             opr, std::move(ix), std::move(iy)));
-                       },
+      common::visitors{
+          [=](Expr<SomeInteger> &&ix, Expr<SomeInteger> &&iy) {
+            return std::make_optional(
+                PromoteAndRelate(opr, std::move(ix), std::move(iy)));
+          },
           [=](Expr<SomeReal> &&rx, Expr<SomeReal> &&ry) {
             return std::make_optional(
                 PromoteAndRelate(opr, std::move(rx), std::move(ry)));
@@ -478,7 +482,8 @@ std::optional<Expr<LogicalResult>> Relate(parser::ContextualMessages &messages,
             messages.Say(
                 "relational operands do not have comparable types"_err_en_US);
             return std::optional<Expr<LogicalResult>>{};
-          }},
+          },
+      },
       std::move(x.u), std::move(y.u));
 }
 

--- a/lib/parser/parse-tree.cc
+++ b/lib/parser/parse-tree.cc
@@ -30,13 +30,15 @@ ImportStmt::ImportStmt(common::ImportKind &&k, std::list<Name> &&n)
 // R901 designator
 bool Designator::EndsInBareName() const {
   return std::visit(
-      common::visitors{[](const ObjectName &) { return true; },
+      common::visitors{
+          [](const ObjectName &) { return true; },
           [](const DataRef &dr) {
             return std::holds_alternative<Name>(dr.u) ||
                 std::holds_alternative<common::Indirection<StructureComponent>>(
                     dr.u);
           },
-          [](const Substring &) { return false; }},
+          [](const Substring &) { return false; },
+      },
       u);
 }
 

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -137,10 +137,12 @@ public:
   }
   void Unparse(const KindSelector &x) {  // R706
     std::visit(
-        common::visitors{[&](const ScalarIntConstantExpr &y) {
-                           Put('('), Word("KIND="), Walk(y), Put(')');
-                         },
-            [&](const KindSelector::StarSize &y) { Put('*'), Walk(y.v); }},
+        common::visitors{
+            [&](const ScalarIntConstantExpr &y) {
+              Put('('), Word("KIND="), Walk(y), Put(')');
+            },
+            [&](const KindSelector::StarSize &y) { Put('*'), Walk(y.v); },
+        },
         x.u);
   }
   void Unparse(const SignedIntLiteralConstant &x) {  // R707
@@ -165,17 +167,21 @@ public:
     Walk(", LEN=", x.length), Put(')');
   }
   void Unparse(const LengthSelector &x) {  // R722
-    std::visit(common::visitors{[&](const TypeParamValue &y) {
-                                  Put('('), Word("LEN="), Walk(y), Put(')');
-                                },
-                   [&](const CharLength &y) { Put('*'), Walk(y); }},
+    std::visit(
+        common::visitors{
+            [&](const TypeParamValue &y) {
+              Put('('), Word("LEN="), Walk(y), Put(')');
+            },
+            [&](const CharLength &y) { Put('*'), Walk(y); },
+        },
         x.u);
   }
   void Unparse(const CharLength &x) {  // R723
-    std::visit(common::visitors{[&](const TypeParamValue &y) {
-                                  Put('('), Walk(y), Put(')');
-                                },
-                   [&](const std::int64_t &y) { Walk(y); }},
+    std::visit(
+        common::visitors{
+            [&](const TypeParamValue &y) { Put('('), Walk(y), Put(')'); },
+            [&](const std::int64_t &y) { Walk(y); },
+        },
         x.u);
   }
   void Unparse(const CharLiteralConstant &x) {  // R724
@@ -259,15 +265,20 @@ public:
   void Unparse(const Contiguous &x) { Word("CONTIGUOUS"); }
   void Before(const ComponentAttrSpec &x) {
     std::visit(
-        common::visitors{[&](const CoarraySpec &) { Word("CODIMENSION["); },
+        common::visitors{
+            [&](const CoarraySpec &) { Word("CODIMENSION["); },
             [&](const ComponentArraySpec &) { Word("DIMENSION("); },
-            [](const auto &) {}},
+            [](const auto &) {},
+        },
         x.u);
   }
   void Post(const ComponentAttrSpec &x) {
     std::visit(
-        common::visitors{[&](const CoarraySpec &) { Put(']'); },
-            [&](const ComponentArraySpec &) { Put(')'); }, [](const auto &) {}},
+        common::visitors{
+            [&](const CoarraySpec &) { Put(']'); },
+            [&](const ComponentArraySpec &) { Put(')'); },
+            [](const auto &) {},
+        },
         x.u);
   }
   void Unparse(const ComponentDecl &x) {  // R739
@@ -278,10 +289,11 @@ public:
     Walk(std::get<std::optional<Initialization>>(x.t));
   }
   void Unparse(const ComponentArraySpec &x) {  // R740
-    std::visit(common::visitors{[&](const std::list<ExplicitShapeSpec> &y) {
-                                  Walk(y, ",");
-                                },
-                   [&](const DeferredShapeSpecList &y) { Walk(y); }},
+    std::visit(
+        common::visitors{
+            [&](const std::list<ExplicitShapeSpec> &y) { Walk(y, ","); },
+            [&](const DeferredShapeSpecList &y) { Walk(y); },
+        },
         x.u);
   }
   void Unparse(const ProcComponentDefStmt &x) {  // R741
@@ -296,12 +308,14 @@ public:
   void Unparse(const Pass &x) { Word("PASS"), Walk("(", x.v, ")"); }
   void Unparse(const Initialization &x) {  // R743 & R805
     std::visit(
-        common::visitors{[&](const ConstantExpr &y) { Put(" = "), Walk(y); },
+        common::visitors{
+            [&](const ConstantExpr &y) { Put(" = "), Walk(y); },
             [&](const NullInit &y) { Put(" => "), Walk(y); },
             [&](const InitialDataTarget &y) { Put(" => "), Walk(y); },
             [&](const std::list<common::Indirection<DataStmtValue>> &y) {
               Walk("/", y, ", ", "/");
-            }},
+            },
+        },
         x.u);
   }
   void Unparse(const PrivateStmt &x) {  // R745
@@ -442,14 +456,20 @@ public:
   }
   void Before(const AttrSpec &x) {  // R802
     std::visit(
-        common::visitors{[&](const CoarraySpec &y) { Word("CODIMENSION["); },
+        common::visitors{
+            [&](const CoarraySpec &y) { Word("CODIMENSION["); },
             [&](const ArraySpec &y) { Word("DIMENSION("); },
-            [](const auto &) {}},
+            [](const auto &) {},
+        },
         x.u);
   }
   void Post(const AttrSpec &x) {
-    std::visit(common::visitors{[&](const CoarraySpec &y) { Put(']'); },
-                   [&](const ArraySpec &y) { Put(')'); }, [](const auto &) {}},
+    std::visit(
+        common::visitors{
+            [&](const CoarraySpec &y) { Put(']'); },
+            [&](const ArraySpec &y) { Put(')'); },
+            [](const auto &) {},
+        },
         x.u);
   }
   void Unparse(const EntityDecl &x) {  // R803
@@ -467,8 +487,10 @@ public:
   }
   void Unparse(const CoarraySpec &x) {  // R809
     std::visit(
-        common::visitors{[&](const DeferredCoshapeSpecList &y) { Walk(y); },
-            [&](const ExplicitCoshapeSpec &y) { Walk(y); }},
+        common::visitors{
+            [&](const DeferredCoshapeSpecList &y) { Walk(y); },
+            [&](const ExplicitCoshapeSpec &y) { Walk(y); },
+        },
         x.u);
   }
   void Unparse(const DeferredCoshapeSpecList &x) {  // R810
@@ -488,14 +510,15 @@ public:
     Walk(std::get<SpecificationExpr>(x.t));
   }
   void Unparse(const ArraySpec &x) {  // R815
-    std::visit(common::visitors{[&](const std::list<ExplicitShapeSpec> &y) {
-                                  Walk(y, ",");
-                                },
-                   [&](const std::list<AssumedShapeSpec> &y) { Walk(y, ","); },
-                   [&](const DeferredShapeSpecList &y) { Walk(y); },
-                   [&](const AssumedSizeSpec &y) { Walk(y); },
-                   [&](const ImpliedShapeSpec &y) { Walk(y); },
-                   [&](const AssumedRankSpec &y) { Walk(y); }},
+    std::visit(
+        common::visitors{
+            [&](const std::list<ExplicitShapeSpec> &y) { Walk(y, ","); },
+            [&](const std::list<AssumedShapeSpec> &y) { Walk(y, ","); },
+            [&](const DeferredShapeSpecList &y) { Walk(y); },
+            [&](const AssumedSizeSpec &y) { Walk(y); },
+            [&](const ImpliedShapeSpec &y) { Walk(y); },
+            [&](const AssumedRankSpec &y) { Walk(y); },
+        },
         x.u);
   }
   void Post(const AssumedShapeSpec &) { Put(':'); }  // R819
@@ -630,12 +653,13 @@ public:
   }
   void Unparse(const ImplicitStmt &x) {  // R863
     Word("IMPLICIT ");
-    std::visit(common::visitors{[&](const std::list<ImplicitSpec> &y) {
-                                  Walk(y, ", ");
-                                },
-                   [&](const std::list<ImplicitStmt::ImplicitNoneNameSpec> &y) {
-                     Word("NONE"), Walk(" (", y, ", ", ")");
-                   }},
+    std::visit(
+        common::visitors{
+            [&](const std::list<ImplicitSpec> &y) { Walk(y, ", "); },
+            [&](const std::list<ImplicitStmt::ImplicitNoneNameSpec> &y) {
+              Word("NONE"), Walk(" (", y, ", ", ")");
+            },
+        },
         x.u);
   }
   void Unparse(const ImplicitSpec &x) {  // R864
@@ -742,9 +766,12 @@ public:
     Walk(", ", std::get<std::list<AllocOpt>>(x.t), ", "), Put(')');
   }
   void Before(const AllocOpt &x) {  // R928, R931
-    std::visit(common::visitors{[&](const AllocOpt::Mold &) { Word("MOLD="); },
-                   [&](const AllocOpt::Source &) { Word("SOURCE="); },
-                   [](const StatOrErrmsg &) {}},
+    std::visit(
+        common::visitors{
+            [&](const AllocOpt::Mold &) { Word("MOLD="); },
+            [&](const AllocOpt::Source &) { Word("SOURCE="); },
+            [](const StatOrErrmsg &) {},
+        },
         x.u);
   }
   void Unparse(const Allocation &x) {  // R932
@@ -769,8 +796,11 @@ public:
     Walk(", ", std::get<std::list<StatOrErrmsg>>(x.t), ", "), Put(')');
   }
   void Before(const StatOrErrmsg &x) {  // R942 & R1165
-    std::visit(common::visitors{[&](const StatVariable &) { Word("STAT="); },
-                   [&](const MsgVariable &) { Word("ERRMSG="); }},
+    std::visit(
+        common::visitors{
+            [&](const StatVariable &) { Word("STAT="); },
+            [&](const MsgVariable &) { Word("ERRMSG="); },
+        },
         x.u);
   }
 
@@ -816,10 +846,12 @@ public:
   void Unparse(const PointerAssignmentStmt &x) {  // R1033, R1034, R1038
     Walk(std::get<DataRef>(x.t));
     std::visit(
-        common::visitors{[&](const std::list<BoundsRemapping> &y) {
-                           Put('('), Walk(y), Put(')');
-                         },
-            [&](const std::list<BoundsSpec> &y) { Walk("(", y, ", ", ")"); }},
+        common::visitors{
+            [&](const std::list<BoundsRemapping> &y) {
+              Put('('), Walk(y), Put(')');
+            },
+            [&](const std::list<BoundsSpec> &y) { Walk("(", y, ", ", ")"); },
+        },
         std::get<PointerAssignmentStmt::Bounds>(x.t).u);
     Put(" => "), Walk(std::get<Expr>(x.t));
   }
@@ -916,10 +948,13 @@ public:
     Word("DO "), Walk(std::get<std::optional<LoopControl>>(x.t));
   }
   void Unparse(const LoopControl &x) {  // R1123
-    std::visit(common::visitors{[&](const ScalarLogicalExpr &y) {
-                                  Word("WHILE ("), Walk(y), Put(')');
-                                },
-                   [&](const auto &y) { Walk(y); }},
+    std::visit(
+        common::visitors{
+            [&](const ScalarLogicalExpr &y) {
+              Word("WHILE ("), Walk(y), Put(')');
+            },
+            [&](const auto &y) { Walk(y); },
+        },
         x.u);
   }
   void Unparse(const ConcurrentHeader &x) {  // R1125
@@ -983,10 +1018,13 @@ public:
     Outdent(), Word("END SELECT"), Walk(" ", x.v);
   }
   void Unparse(const CaseSelector &x) {  // R1145
-    std::visit(common::visitors{[&](const std::list<CaseValueRange> &y) {
-                                  Put('('), Walk(y), Put(')');
-                                },
-                   [&](const Default &) { Word("DEFAULT"); }},
+    std::visit(
+        common::visitors{
+            [&](const std::list<CaseValueRange> &y) {
+              Put('('), Walk(y), Put(')');
+            },
+            [&](const Default &) { Word("DEFAULT"); },
+        },
         x.u);
   }
   void Unparse(const CaseValueRange::Range &x) {  // R1146
@@ -999,11 +1037,14 @@ public:
   }
   void Unparse(const SelectRankCaseStmt &x) {  // R1150
     Outdent(), Word("RANK ");
-    std::visit(common::visitors{[&](const ScalarIntConstantExpr &y) {
-                                  Put('('), Walk(y), Put(')');
-                                },
-                   [&](const Star &) { Put("(*)"); },
-                   [&](const Default &) { Word("DEFAULT"); }},
+    std::visit(
+        common::visitors{
+            [&](const ScalarIntConstantExpr &y) {
+              Put('('), Walk(y), Put(')');
+            },
+            [&](const Star &) { Put("(*)"); },
+            [&](const Default &) { Word("DEFAULT"); },
+        },
         std::get<SelectRankCaseStmt::Rank>(x.t).u);
     Walk(" ", std::get<std::optional<Name>>(x.t)), Indent();
   }
@@ -1017,13 +1058,14 @@ public:
     Walk(" ", std::get<std::optional<Name>>(x.t)), Indent();
   }
   void Unparse(const TypeGuardStmt::Guard &x) {
-    std::visit(common::visitors{[&](const TypeSpec &y) {
-                                  Word("TYPE IS ("), Walk(y), Put(')');
-                                },
-                   [&](const DerivedTypeSpec &y) {
-                     Word("CLASS IS ("), Walk(y), Put(')');
-                   },
-                   [&](const Default &) { Word("CLASS DEFAULT"); }},
+    std::visit(
+        common::visitors{
+            [&](const TypeSpec &y) { Word("TYPE IS ("), Walk(y), Put(')'); },
+            [&](const DerivedTypeSpec &y) {
+              Word("CLASS IS ("), Walk(y), Put(')');
+            },
+            [&](const Default &) { Word("CLASS DEFAULT"); },
+        },
         x.u);
   }
   void Unparse(const ExitStmt &x) {  // R1156
@@ -1069,8 +1111,10 @@ public:
   }
   void Before(const EventWaitStmt::EventWaitSpec &x) {  // R1173, R1174
     std::visit(
-        common::visitors{[&](const ScalarIntExpr &x) { Word("UNTIL_COUNT="); },
-            [](const StatOrErrmsg &) {}},
+        common::visitors{
+            [&](const ScalarIntExpr &x) { Word("UNTIL_COUNT="); },
+            [](const StatOrErrmsg &) {},
+        },
         x.u);
   }
   void Unparse(const EventWaitStmt &x) {  // R1170
@@ -1086,8 +1130,10 @@ public:
   }
   void Before(const FormTeamStmt::FormTeamSpec &x) {  // R1176, R1177
     std::visit(
-        common::visitors{[&](const ScalarIntExpr &x) { Word("NEW_INDEX="); },
-            [](const StatOrErrmsg &) {}},
+        common::visitors{
+            [&](const ScalarIntExpr &x) { Word("NEW_INDEX="); },
+            [](const StatOrErrmsg &) {},
+        },
         x.u);
   }
   void Unparse(const LockStmt &x) {  // R1178
@@ -1096,10 +1142,11 @@ public:
     Put(')');
   }
   void Before(const LockStmt::LockStat &x) {  // R1179
-    std::visit(common::visitors{[&](const ScalarLogicalVariable &) {
-                                  Word("ACQUIRED_LOCK=");
-                                },
-                   [](const StatOrErrmsg &y) {}},
+    std::visit(
+        common::visitors{
+            [&](const ScalarLogicalVariable &) { Word("ACQUIRED_LOCK="); },
+            [](const StatOrErrmsg &y) {},
+        },
         x.u);
   }
   void Unparse(const UnlockStmt &x) {  // R1180
@@ -1112,53 +1159,59 @@ public:
     Word("OPEN ("), Walk(x.v, ", "), Put(')');
   }
   bool Pre(const ConnectSpec &x) {  // R1205
-    return std::visit(common::visitors{[&](const FileUnitNumber &) {
-                                         Word("UNIT=");
-                                         return true;
-                                       },
-                          [&](const FileNameExpr &) {
-                            Word("FILE=");
-                            return true;
-                          },
-                          [&](const ConnectSpec::CharExpr &y) {
-                            Walk(y.t, "=");
-                            return false;
-                          },
-                          [&](const MsgVariable &) {
-                            Word("IOMSG=");
-                            return true;
-                          },
-                          [&](const StatVariable &) {
-                            Word("IOSTAT=");
-                            return true;
-                          },
-                          [&](const ConnectSpec::Recl &) {
-                            Word("RECL=");
-                            return true;
-                          },
-                          [&](const ConnectSpec::Newunit &) {
-                            Word("NEWUNIT=");
-                            return true;
-                          },
-                          [&](const ErrLabel &) {
-                            Word("ERR=");
-                            return true;
-                          },
-                          [&](const StatusExpr &) {
-                            Word("STATUS=");
-                            return true;
-                          }},
+    return std::visit(
+        common::visitors{
+            [&](const FileUnitNumber &) {
+              Word("UNIT=");
+              return true;
+            },
+            [&](const FileNameExpr &) {
+              Word("FILE=");
+              return true;
+            },
+            [&](const ConnectSpec::CharExpr &y) {
+              Walk(y.t, "=");
+              return false;
+            },
+            [&](const MsgVariable &) {
+              Word("IOMSG=");
+              return true;
+            },
+            [&](const StatVariable &) {
+              Word("IOSTAT=");
+              return true;
+            },
+            [&](const ConnectSpec::Recl &) {
+              Word("RECL=");
+              return true;
+            },
+            [&](const ConnectSpec::Newunit &) {
+              Word("NEWUNIT=");
+              return true;
+            },
+            [&](const ErrLabel &) {
+              Word("ERR=");
+              return true;
+            },
+            [&](const StatusExpr &) {
+              Word("STATUS=");
+              return true;
+            },
+        },
         x.u);
   }
   void Unparse(const CloseStmt &x) {  // R1208
     Word("CLOSE ("), Walk(x.v, ", "), Put(')');
   }
   void Before(const CloseStmt::CloseSpec &x) {  // R1209
-    std::visit(common::visitors{[&](const FileUnitNumber &) { Word("UNIT="); },
-                   [&](const StatVariable &) { Word("IOSTAT="); },
-                   [&](const MsgVariable &) { Word("IOMSG="); },
-                   [&](const ErrLabel &) { Word("ERR="); },
-                   [&](const StatusExpr &) { Word("STATUS="); }},
+    std::visit(
+        common::visitors{
+            [&](const FileUnitNumber &) { Word("UNIT="); },
+            [&](const StatVariable &) { Word("IOSTAT="); },
+            [&](const MsgVariable &) { Word("IOMSG="); },
+            [&](const ErrLabel &) { Word("ERR="); },
+            [&](const StatusExpr &) { Word("STATUS="); },
+        },
         x.u);
   }
   void Unparse(const ReadStmt &x) {  // R1210
@@ -1198,62 +1251,65 @@ public:
     Walk(", ", std::get<std::list<OutputItem>>(x.t), ", ");
   }
   bool Pre(const IoControlSpec &x) {  // R1213
-    return std::visit(common::visitors{[&](const IoUnit &) {
-                                         Word("UNIT=");
-                                         return true;
-                                       },
-                          [&](const Format &) {
-                            Word("FMT=");
-                            return true;
-                          },
-                          [&](const Name &) {
-                            Word("NML=");
-                            return true;
-                          },
-                          [&](const IoControlSpec::CharExpr &y) {
-                            Walk(y.t, "=");
-                            return false;
-                          },
-                          [&](const IoControlSpec::Asynchronous &) {
-                            Word("ASYNCHRONOUS=");
-                            return true;
-                          },
-                          [&](const EndLabel &) {
-                            Word("END=");
-                            return true;
-                          },
-                          [&](const EorLabel &) {
-                            Word("EOR=");
-                            return true;
-                          },
-                          [&](const ErrLabel &) {
-                            Word("ERR=");
-                            return true;
-                          },
-                          [&](const IdVariable &) {
-                            Word("ID=");
-                            return true;
-                          },
-                          [&](const MsgVariable &) {
-                            Word("IOMSG=");
-                            return true;
-                          },
-                          [&](const StatVariable &) {
-                            Word("IOSTAT=");
-                            return true;
-                          },
-                          [&](const IoControlSpec::Pos &) {
-                            Word("POS=");
-                            return true;
-                          },
-                          [&](const IoControlSpec::Rec &) {
-                            Word("REC=");
-                            return true;
-                          },
-                          [&](const IoControlSpec::Size &) {
-                            Word("SIZE=");
-                            return true;
-                          }},
+    return std::visit(
+        common::visitors{
+            [&](const IoUnit &) {
+              Word("UNIT=");
+              return true;
+            },
+            [&](const Format &) {
+              Word("FMT=");
+              return true;
+            },
+            [&](const Name &) {
+              Word("NML=");
+              return true;
+            },
+            [&](const IoControlSpec::CharExpr &y) {
+              Walk(y.t, "=");
+              return false;
+            },
+            [&](const IoControlSpec::Asynchronous &) {
+              Word("ASYNCHRONOUS=");
+              return true;
+            },
+            [&](const EndLabel &) {
+              Word("END=");
+              return true;
+            },
+            [&](const EorLabel &) {
+              Word("EOR=");
+              return true;
+            },
+            [&](const ErrLabel &) {
+              Word("ERR=");
+              return true;
+            },
+            [&](const IdVariable &) {
+              Word("ID=");
+              return true;
+            },
+            [&](const MsgVariable &) {
+              Word("IOMSG=");
+              return true;
+            },
+            [&](const StatVariable &) {
+              Word("IOSTAT=");
+              return true;
+            },
+            [&](const IoControlSpec::Pos &) {
+              Word("POS=");
+              return true;
+            },
+            [&](const IoControlSpec::Rec &) {
+              Word("REC=");
+              return true;
+            },
+            [&](const IoControlSpec::Size &) {
+              Word("SIZE=");
+              return true;
+            },
+        },
         x.u);
   }
   void Unparse(const InputImpliedDo &x) {  // R1218
@@ -1268,13 +1324,16 @@ public:
     Word("WAIT ("), Walk(x.v, ", "), Put(')');
   }
   void Before(const WaitSpec &x) {  // R1223
-    std::visit(common::visitors{[&](const FileUnitNumber &) { Word("UNIT="); },
-                   [&](const EndLabel &) { Word("END="); },
-                   [&](const EorLabel &) { Word("EOR="); },
-                   [&](const ErrLabel &) { Word("ERR="); },
-                   [&](const IdExpr &) { Word("ID="); },
-                   [&](const MsgVariable &) { Word("IOMSG="); },
-                   [&](const StatVariable &) { Word("IOSTAT="); }},
+    std::visit(
+        common::visitors{
+            [&](const FileUnitNumber &) { Word("UNIT="); },
+            [&](const EndLabel &) { Word("END="); },
+            [&](const EorLabel &) { Word("EOR="); },
+            [&](const ErrLabel &) { Word("ERR="); },
+            [&](const IdExpr &) { Word("ID="); },
+            [&](const MsgVariable &) { Word("IOMSG="); },
+            [&](const StatVariable &) { Word("IOSTAT="); },
+        },
         x.u);
   }
   void Unparse(const BackspaceStmt &x) {  // R1224
@@ -1287,10 +1346,13 @@ public:
     Word("REWIND ("), Walk(x.v, ", "), Put(')');
   }
   void Before(const PositionOrFlushSpec &x) {  // R1227 & R1229
-    std::visit(common::visitors{[&](const FileUnitNumber &) { Word("UNIT="); },
-                   [&](const MsgVariable &) { Word("IOMSG="); },
-                   [&](const StatVariable &) { Word("IOSTAT="); },
-                   [&](const ErrLabel &) { Word("ERR="); }},
+    std::visit(
+        common::visitors{
+            [&](const FileUnitNumber &) { Word("UNIT="); },
+            [&](const MsgVariable &) { Word("IOMSG="); },
+            [&](const StatVariable &) { Word("IOSTAT="); },
+            [&](const ErrLabel &) { Word("ERR="); },
+        },
         x.u);
   }
   void Unparse(const FlushStmt &x) {  // R1228
@@ -1299,41 +1361,46 @@ public:
   void Unparse(const InquireStmt &x) {  // R1230
     Word("INQUIRE (");
     std::visit(
-        common::visitors{[&](const InquireStmt::Iolength &y) {
-                           Word("IOLENGTH="), Walk(y.t, ") ");
-                         },
-            [&](const std::list<InquireSpec> &y) { Walk(y, ", "), Put(')'); }},
+        common::visitors{
+            [&](const InquireStmt::Iolength &y) {
+              Word("IOLENGTH="), Walk(y.t, ") ");
+            },
+            [&](const std::list<InquireSpec> &y) { Walk(y, ", "), Put(')'); },
+        },
         x.u);
   }
   bool Pre(const InquireSpec &x) {  // R1231
-    return std::visit(common::visitors{[&](const FileUnitNumber &) {
-                                         Word("UNIT=");
-                                         return true;
-                                       },
-                          [&](const FileNameExpr &) {
-                            Word("FILE=");
-                            return true;
-                          },
-                          [&](const InquireSpec::CharVar &y) {
-                            Walk(y.t, "=");
-                            return false;
-                          },
-                          [&](const InquireSpec::IntVar &y) {
-                            Walk(y.t, "=");
-                            return false;
-                          },
-                          [&](const InquireSpec::LogVar &y) {
-                            Walk(y.t, "=");
-                            return false;
-                          },
-                          [&](const IdExpr &) {
-                            Word("ID=");
-                            return true;
-                          },
-                          [&](const ErrLabel &) {
-                            Word("ERR=");
-                            return true;
-                          }},
+    return std::visit(
+        common::visitors{
+            [&](const FileUnitNumber &) {
+              Word("UNIT=");
+              return true;
+            },
+            [&](const FileNameExpr &) {
+              Word("FILE=");
+              return true;
+            },
+            [&](const InquireSpec::CharVar &y) {
+              Walk(y.t, "=");
+              return false;
+            },
+            [&](const InquireSpec::IntVar &y) {
+              Walk(y.t, "=");
+              return false;
+            },
+            [&](const InquireSpec::LogVar &y) {
+              Walk(y.t, "=");
+              return false;
+            },
+            [&](const IdExpr &) {
+              Word("ID=");
+              return true;
+            },
+            [&](const ErrLabel &) {
+              Word("ERR=");
+              return true;
+            },
+        },
         x.u);
   }
 
@@ -1348,14 +1415,16 @@ public:
     if (x.repeatCount.has_value()) {
       Walk(*x.repeatCount);
     }
-    std::visit(common::visitors{[&](const std::string &y) {
-                                  Put(QuoteCharacterLiteral(
-                                      y, true, backslashEscapes_));
-                                },
-                   [&](const std::list<format::FormatItem> &y) {
-                     Walk("(", y, ",", ")");
-                   },
-                   [&](const auto &y) { Walk(y); }},
+    std::visit(
+        common::visitors{
+            [&](const std::string &y) {
+              Put(QuoteCharacterLiteral(y, true, backslashEscapes_));
+            },
+            [&](const std::list<format::FormatItem> &y) {
+              Walk("(", y, ",", ")");
+            },
+            [&](const auto &y) { Walk(y); },
+        },
         x.u);
   }
   void Unparse(
@@ -1461,15 +1530,18 @@ public:
     std::visit(
         common::visitors{
             [&](const std::list<Rename> &y) { Walk(", ", y, ", "); },
-            [&](const std::list<Only> &y) { Walk(", ONLY: ", y, ", "); }},
+            [&](const std::list<Only> &y) { Walk(", ONLY: ", y, ", "); },
+        },
         x.u);
   }
   void Unparse(const Rename &x) {  // R1411
     std::visit(
-        common::visitors{[&](const Rename::Names &y) { Walk(y.t, " => "); },
+        common::visitors{
+            [&](const Rename::Names &y) { Walk(y.t, " => "); },
             [&](const Rename::Operators &y) {
               Word("OPERATOR("), Walk(y.t, ") => OPERATOR("), Put(")");
-            }},
+            },
+        },
         x.u);
   }
   void Unparse(const SubmoduleStmt &x) {  // R1417
@@ -1489,10 +1561,13 @@ public:
   }
 
   void Unparse(const InterfaceStmt &x) {  // R1503
-    std::visit(common::visitors{[&](const std::optional<GenericSpec> &y) {
-                                  Word("INTERFACE"), Walk(" ", y);
-                                },
-                   [&](const Abstract &) { Word("ABSTRACT INTERFACE"); }},
+    std::visit(
+        common::visitors{
+            [&](const std::optional<GenericSpec> &y) {
+              Word("INTERFACE"), Walk(" ", y);
+            },
+            [&](const Abstract &) { Word("ABSTRACT INTERFACE"); },
+        },
         x.u);
     Indent();
   }
@@ -1509,7 +1584,8 @@ public:
   }
   void Before(const GenericSpec &x) {  // R1508, R1509
     std::visit(
-        common::visitors{[&](const DefinedOperator &x) { Word("OPERATOR("); },
+        common::visitors{
+            [&](const DefinedOperator &x) { Word("OPERATOR("); },
             [&](const GenericSpec::Assignment &) { Word("ASSIGNMENT(=)"); },
             [&](const GenericSpec::ReadFormatted &) {
               Word("READ(FORMATTED)");
@@ -1523,12 +1599,16 @@ public:
             [&](const GenericSpec::WriteUnformatted &) {
               Word("WRITE(UNFORMATTED)");
             },
-            [](const auto &) {}},
+            [](const auto &) {},
+        },
         x.u);
   }
   void Post(const GenericSpec &x) {
-    std::visit(common::visitors{[&](const DefinedOperator &x) { Put(')'); },
-                   [](const auto &) {}},
+    std::visit(
+        common::visitors{
+            [&](const DefinedOperator &x) { Put(')'); },
+            [](const auto &) {},
+        },
         x.u);
   }
   void Unparse(const GenericStmt &x) {  // R1510
@@ -1652,7 +1732,8 @@ public:
               Word("!DIR$ IGNORE_TKR");
               Walk(" ", tkr, ", ");
             },
-            [&](const CompilerDirective::IVDEP &) { Word("!DIR$ IVDEP\n"); }},
+            [&](const CompilerDirective::IVDEP &) { Word("!DIR$ IVDEP\n"); },
+        },
         x.u);
     Put('\n');
   }
@@ -1736,20 +1817,23 @@ public:
     Put(")");
   }
   bool Pre(const OmpDependClause &x) {
-    return std::visit(common::visitors{[&](const OmpDependClause::Source &y) {
-                                         Word("DEPEND(SOURCE)");
-                                         return false;
-                                       },
-                          [&](const OmpDependClause::Sink &y) {
-                            Word("DEPEND(SINK:");
-                            Walk(y.v);
-                            Put(")");
-                            return false;
-                          },
-                          [&](const OmpDependClause::InOut &y) {
-                            Word("DEPEND");
-                            return true;
-                          }},
+    return std::visit(
+        common::visitors{
+            [&](const OmpDependClause::Source &y) {
+              Word("DEPEND(SOURCE)");
+              return false;
+            },
+            [&](const OmpDependClause::Sink &y) {
+              Word("DEPEND(SINK:");
+              Walk(y.v);
+              Put(")");
+              return false;
+            },
+            [&](const OmpDependClause::InOut &y) {
+              Word("DEPEND");
+              return true;
+            },
+        },
         x.u);
   }
   bool Pre(const OmpDefaultClause &x) {
@@ -1939,21 +2023,24 @@ public:
             },
             [&](const OmpLoopDirective::TeamsDistribute &) {
               Word("TEAMS DISTRIBUTE ");
-            }},
+            },
+        },
         x.u);
   }
   void Unparse(const OmpObjectList &x) { Walk(x.v, ","); }
   void Unparse(const OmpStandaloneDirective &x) {
     std::visit(
-        common::visitors{[&](const OmpStandaloneDirective::TargetEnterData &) {
-                           Word("TARGET ENTER DATA ");
-                         },
+        common::visitors{
+            [&](const OmpStandaloneDirective::TargetEnterData &) {
+              Word("TARGET ENTER DATA ");
+            },
             [&](const OmpStandaloneDirective::TargetExitData &) {
               Word("TARGET EXIT DATA ");
             },
             [&](const OmpStandaloneDirective::TargetUpdate &) {
               Word("TARGET UPDATE ");
-            }},
+            },
+        },
         x.u);
   }
   void Unparse(const OmpBlockDirective &x) {
@@ -1977,7 +2064,8 @@ public:
             [&](const OmpBlockDirective::Target &) { Word("TARGET "); },
             [&](const OmpBlockDirective::Taskgroup &) { Word("TASKGROUP "); },
             [&](const OmpBlockDirective::Task &) { Word("TASK "); },
-            [&](const OmpBlockDirective::Teams &) { Word("TEAMS "); }},
+            [&](const OmpBlockDirective::Teams &) { Word("TEAMS "); },
+        },
         x.u);
   }
   void Unparse(const OmpAtomic &x) {
@@ -2099,10 +2187,11 @@ public:
     BeginOpenMP();
     Word("!$OMP ");
     return std::visit(
-        common::visitors{[&](const OpenMPDeclareReductionConstruct &y) {
-                           Word("DECLARE REDUCTION ");
-                           return true;
-                         },
+        common::visitors{
+            [&](const OpenMPDeclareReductionConstruct &y) {
+              Word("DECLARE REDUCTION ");
+              return true;
+            },
             [&](const OpenMPDeclareSimdConstruct &y) {
               Word("DECLARE SIMD ");
               Walk("(", std::get<std::optional<Name>>(y.t), ")");
@@ -2118,7 +2207,8 @@ public:
             [&](const OpenMPDeclarativeConstruct::Threadprivate &y) {
               Word("THREADPRIVATE (");
               return true;
-            }},
+            },
+        },
         x.u);
   }
   void Post(const OpenMPDeclarativeConstruct &x) {

--- a/lib/semantics/canonicalize-do.cc
+++ b/lib/semantics/canonicalize-do.cc
@@ -31,7 +31,8 @@ public:
     for (auto i{block.begin()}, end{block.end()}; i != end; ++i) {
       if (auto *executableConstruct{std::get_if<ExecutableConstruct>(&i->u)}) {
         std::visit(
-            common::visitors{[](auto &) {},
+            common::visitors{
+                [](auto &) {},
                 [&](Statement<common::Indirection<LabelDoStmt>> &labelDoStmt) {
                   auto &label{std::get<Label>(labelDoStmt.statement->t)};
                   stack.push_back(LabelInfo{i, label});
@@ -41,7 +42,8 @@ public:
                 },
                 [&](Statement<ActionStmt> &actionStmt) {
                   CanonicalizeIfMatch(block, stack, i, actionStmt);
-                }},
+                },
+            },
             executableConstruct->u);
       }
     }

--- a/lib/semantics/check-do-concurrent.cc
+++ b/lib/semantics/check-do-concurrent.cc
@@ -233,25 +233,28 @@ static CS GatherAllVariableNames(
     const std::list<parser::LocalitySpec> &localitySpecs) {
   CS names;
   for (auto &ls : localitySpecs) {
-    std::visit(common::visitors{[](auto &) {},
-                   [&](const parser::LocalitySpec::Local &local) {
-                     for (auto &v : local.v) {
-                       CHECK(v.symbol);
-                       names.push_back(v.symbol);
-                     }
-                   },
-                   [&](const parser::LocalitySpec::LocalInit &localInit) {
-                     for (auto &v : localInit.v) {
-                       CHECK(v.symbol);
-                       names.push_back(v.symbol);
-                     }
-                   },
-                   [&](const parser::LocalitySpec::Shared &shared) {
-                     for (auto &v : shared.v) {
-                       CHECK(v.symbol);
-                       names.push_back(v.symbol);
-                     }
-                   }},
+    std::visit(
+        common::visitors{
+            [](auto &) {},
+            [&](const parser::LocalitySpec::Local &local) {
+              for (auto &v : local.v) {
+                CHECK(v.symbol);
+                names.push_back(v.symbol);
+              }
+            },
+            [&](const parser::LocalitySpec::LocalInit &localInit) {
+              for (auto &v : localInit.v) {
+                CHECK(v.symbol);
+                names.push_back(v.symbol);
+              }
+            },
+            [&](const parser::LocalitySpec::Shared &shared) {
+              for (auto &v : shared.v) {
+                CHECK(v.symbol);
+                names.push_back(v.symbol);
+              }
+            },
+        },
         ls.u);
   }
   return names;
@@ -260,19 +263,22 @@ static CS GatherNotSharedVariableNames(
     const std::list<parser::LocalitySpec> &localitySpecs) {
   CS names;
   for (auto &ls : localitySpecs) {
-    std::visit(common::visitors{[](auto &) {},
-                   [&](const parser::LocalitySpec::Local &local) {
-                     for (auto &v : local.v) {
-                       CHECK(v.symbol);
-                       names.push_back(v.symbol);
-                     }
-                   },
-                   [&](const parser::LocalitySpec::LocalInit &localInit) {
-                     for (auto &v : localInit.v) {
-                       CHECK(v.symbol);
-                       names.push_back(v.symbol);
-                     }
-                   }},
+    std::visit(
+        common::visitors{
+            [](auto &) {},
+            [&](const parser::LocalitySpec::Local &local) {
+              for (auto &v : local.v) {
+                CHECK(v.symbol);
+                names.push_back(v.symbol);
+              }
+            },
+            [&](const parser::LocalitySpec::LocalInit &localInit) {
+              for (auto &v : localInit.v) {
+                CHECK(v.symbol);
+                names.push_back(v.symbol);
+              }
+            },
+        },
         ls.u);
   }
   return names;
@@ -281,13 +287,16 @@ static CS GatherLocalVariableNames(
     const std::list<parser::LocalitySpec> &localitySpecs) {
   CS names;
   for (auto &ls : localitySpecs) {
-    std::visit(common::visitors{[](auto &) {},
-                   [&](const parser::LocalitySpec::Local &local) {
-                     for (auto &v : local.v) {
-                       CHECK(v.symbol);
-                       names.push_back(v.symbol);
-                     }
-                   }},
+    std::visit(
+        common::visitors{
+            [](auto &) {},
+            [&](const parser::LocalitySpec::Local &local) {
+              for (auto &v : local.v) {
+                CHECK(v.symbol);
+                names.push_back(v.symbol);
+              }
+            },
+        },
         ls.u);
   }
   return names;

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -162,7 +162,8 @@ void ModFileWriter::PutSymbol(const Symbol &symbol, bool &didContains) {
             PutLower(decls_ << "final::", symbol) << '\n';
           },
           [](const HostAssocDetails &) {},
-          [&](const auto &) { PutEntity(decls_, symbol); }},
+          [&](const auto &) { PutEntity(decls_, symbol); },
+      },
       symbol.details());
 }
 


### PR DESCRIPTION
Including a comma after the last lambda in a `common::visitors{}` list
causes clang-format to do a better job of formatting them.

Add that recommendation to C++style.md, insert the missing commas,
and reformat the changed files.