### PR TITLE
small TODO: eliminate per-specialization flag in expression type representation

### DIFF
--- a/lib/common/template.h
+++ b/lib/common/template.h
@@ -250,7 +250,7 @@ std::optional<R> MapOptional(
 //   };
 // SearchDynamicTypes will traverse the indices 0 .. (Types-1) and
 // invoke VISITOR::Test<J>() until it returns a value that casts
-// to a true Boolean.  If no invocation of Test succeeds, it returns a
+// to true.  If no invocation of Test succeeds, it returns a
 // default-constructed Result.
 template<std::size_t J, typename VISITOR>
 typename VISITOR::Result SearchDynamicTypesHelper(VISITOR &&visitor) {

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -188,7 +188,7 @@ template<typename T> DynamicType ArrayConstructor<T>::GetType() const {
 
 template<typename A>
 std::optional<DynamicType> ExpressionBase<A>::GetType() const {
-  if constexpr (Result::isSpecificIntrinsicType) {
+  if constexpr (IsSpecificIntrinsicType<Result>) {
     return Result::GetType();
   } else {
     return std::visit(

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -115,7 +115,7 @@ class Operation {
 public:
   using Derived = DERIVED;
   using Result = RESULT;
-  static_assert(Result::isSpecificIntrinsicType);
+  static_assert(IsSpecificIntrinsicType<Result>);
   static constexpr std::size_t operands{sizeof...(OPERANDS)};
   template<int J> using Operand = std::tuple_element_t<J, OperandTypes>;
 

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -423,7 +423,7 @@ template<typename T>
 Expr<T> ExpressionBase<T>::Rewrite(FoldingContext &context, Expr<T> &&expr) {
   return std::visit(
       [&](auto &&x) -> Expr<T> {
-        if constexpr (T::isSpecificIntrinsicType) {
+        if constexpr (IsSpecificIntrinsicType<T>) {
           return FoldOperation(context, std::move(x));
         } else if constexpr (std::is_same_v<T, SomeDerived>) {
           return FoldOperation(context, std::move(x));

--- a/lib/evaluate/tools.cc
+++ b/lib/evaluate/tools.cc
@@ -378,7 +378,7 @@ Expr<SomeLogical> LogicalNegation(Expr<SomeLogical> &&x) {
 template<typename T>
 Expr<LogicalResult> PackageRelation(
     RelationalOperator opr, Expr<T> &&x, Expr<T> &&y) {
-  static_assert(T::isSpecificIntrinsicType);
+  static_assert(IsSpecificIntrinsicType<T>);
   return Expr<LogicalResult>{
       Relational<SomeType>{Relational<T>{opr, std::move(x), std::move(y)}}};
 }

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -135,7 +135,7 @@ template<typename A> Expr<ResultType<A>> AsExpr(A &&x) {
 }
 
 template<typename T> Expr<T> AsExpr(Expr<T> &&x) {
-  static_assert(T::isSpecificIntrinsicType);
+  static_assert(IsSpecificIntrinsicType<T>);
   return std::move(x);
 }
 
@@ -176,7 +176,7 @@ Expr<SomeComplex> MakeComplex(Expr<Type<TypeCategory::Real, KIND>> &&re,
 
 template<typename TO, TypeCategory FROMCAT>
 Expr<TO> ConvertToType(Expr<SomeKind<FROMCAT>> &&x) {
-  static_assert(TO::isSpecificIntrinsicType);
+  static_assert(IsSpecificIntrinsicType<TO>);
   if constexpr (FROMCAT != TO::category) {
     if constexpr (TO::category == TypeCategory::Complex) {
       using Part = typename TO::Part;
@@ -214,7 +214,7 @@ Expr<TO> ConvertToType(Expr<SomeKind<FROMCAT>> &&x) {
 }
 
 template<typename TO> Expr<TO> ConvertToType(BOZLiteralConstant &&x) {
-  static_assert(TO::isSpecificIntrinsicType);
+  static_assert(IsSpecificIntrinsicType<TO>);
   using Value = typename Constant<TO>::Value;
   if constexpr (TO::category == TypeCategory::Integer) {
     return Expr<TO>{Constant<TO>{Value::ConvertUnsigned(std::move(x)).value}};
@@ -368,7 +368,7 @@ template<typename A> Expr<TypeOf<A>> ScalarConstantToExpr(const A &x) {
 // for COMPLEX.
 template<template<typename> class OPR, typename SPECIFIC>
 Expr<SPECIFIC> Combine(Expr<SPECIFIC> &&x, Expr<SPECIFIC> &&y) {
-  static_assert(SPECIFIC::isSpecificIntrinsicType);
+  static_assert(IsSpecificIntrinsicType<SPECIFIC>);
   if constexpr (SPECIFIC::category == TypeCategory::Complex &&
       (std::is_same_v<OPR<LargestReal>, Add<LargestReal>> ||
           std::is_same_v<OPR<LargestReal>, Subtract<LargestReal>>)) {

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -252,7 +252,7 @@ template<typename A> class Designator {
 
 public:
   using Result = A;
-  static_assert(Result::isSpecificIntrinsicType ||
+  static_assert(IsSpecificIntrinsicType<Result> ||
       std::is_same_v<Result, SomeKind<TypeCategory::Derived>>);
   EVALUATE_UNION_CLASS_BOILERPLATE(Designator)
   Designator(const DataRef &that) : u{common::MoveVariant<Variant>(that.u)} {}
@@ -292,7 +292,7 @@ protected:
 
 template<typename A> struct FunctionRef : public ProcedureRef {
   using Result = A;
-  static_assert(Result::isSpecificIntrinsicType ||
+  static_assert(IsSpecificIntrinsicType<Result> ||
       std::is_same_v<Result, SomeKind<TypeCategory::Derived>>);
   CLASS_BOILERPLATE(FunctionRef)
   FunctionRef(ProcedureRef &&pr) : ProcedureRef{std::move(pr)} {}
@@ -316,7 +316,7 @@ FOR_EACH_SPECIFIC_TYPE(extern template struct FunctionRef)
 
 template<typename A> struct Variable {
   using Result = A;
-  static_assert(Result::isSpecificIntrinsicType ||
+  static_assert(IsSpecificIntrinsicType<Result> ||
       std::is_same_v<Result, SomeKind<TypeCategory::Derived>>);
   EVALUATE_UNION_CLASS_BOILERPLATE(Variable)
   std::optional<DynamicType> GetType() const {

--- a/test/evaluate/logical.cc
+++ b/test/evaluate/logical.cc
@@ -19,7 +19,7 @@
 template<int KIND> void testKind() {
   using Type =
       Fortran::evaluate::Type<Fortran::common::TypeCategory::Logical, KIND>;
-  TEST(Type::isSpecificIntrinsicType);
+  TEST(Fortran::evaluate::IsSpecificIntrinsicType<Type>);
   TEST(Type::category == Fortran::common::TypeCategory::Logical);
   TEST(Type::kind == KIND);
   using Value = Fortran::evaluate::Scalar<Type>;
@@ -52,6 +52,5 @@ int main() {
   testKind<2>();
   testKind<4>();
   testKind<8>();
-  testKind<16>();
   return testing::Complete();
 }


### PR DESCRIPTION
The `Type` class specializations all used to contain a Boolean member `isSpecificIntrinsicType` that was true for things like `REAL*4` and false for derived types and the generic category types.  This flag is now possible to replace with a type predicate function, and so I've done so as a simplification.