### PR TITLE
Rework expression evaluation in symbol table

### DIFF
--- a/lib/evaluate/tools.cc
+++ b/lib/evaluate/tools.cc
@@ -347,7 +347,7 @@ std::optional<Expr<SomeType>> Negation(
             messages.Say("BOZ literal cannot be negated"_err_en_US);
             return NoExpr();
           },
-          [&](Expr<SomeInteger> &&x) { return Package(std::move(x)); },
+          [&](Expr<SomeInteger> &&x) { return Package(-std::move(x)); },
           [&](Expr<SomeReal> &&x) { return Package(-std::move(x)); },
           [&](Expr<SomeComplex> &&x) { return Package(-std::move(x)); },
           [&](Expr<SomeCharacter> &&x) {

--- a/lib/evaluate/type.cc
+++ b/lib/evaluate/type.cc
@@ -25,23 +25,20 @@ using namespace std::literals::string_literals;
 namespace Fortran::evaluate {
 
 std::optional<DynamicType> GetSymbolType(const semantics::Symbol &symbol) {
-  if (auto *details{symbol.detailsIf<semantics::ObjectEntityDetails>()}) {
-    if (details->type().has_value()) {
-      switch (details->type()->category()) {
-      case semantics::DeclTypeSpec::Category::Intrinsic: {
-        TypeCategory category{details->type()->intrinsicTypeSpec().category()};
-        int kind{details->type()->intrinsicTypeSpec().kind()};
-        if (IsValidKindOfIntrinsicType(category, kind)) {
-          return std::make_optional(DynamicType{category, kind});
-        }
-        break;
+  if (const auto *type{symbol.GetType()}) {
+    switch (type->category()) {
+    case semantics::DeclTypeSpec::Category::Intrinsic: {
+      TypeCategory category{type->intrinsicTypeSpec().category()};
+      int kind{type->intrinsicTypeSpec().kind()};
+      if (IsValidKindOfIntrinsicType(category, kind)) {
+        return DynamicType{category, kind};
       }
-      case semantics::DeclTypeSpec::Category::TypeDerived:
-      case semantics::DeclTypeSpec::Category::ClassDerived:
-        return std::make_optional(DynamicType{
-            TypeCategory::Derived, 0, &details->type()->derivedTypeSpec()});
-      default:;
-      }
+      break;
+    }
+    case semantics::DeclTypeSpec::Category::TypeDerived:
+    case semantics::DeclTypeSpec::Category::ClassDerived:
+      return DynamicType{TypeCategory::Derived, 0, &type->derivedTypeSpec()};
+    default:;
     }
   }
   return std::nullopt;

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -541,7 +541,7 @@ struct Name {
   COPY_AND_ASSIGN_BOILERPLATE(Name);
   std::string ToString() const { return source.ToString(); }
   CharBlock source;
-  semantics::Symbol *symbol{nullptr};  // filled in later by semantic analysis
+  mutable semantics::Symbol *symbol{nullptr};  // filled in during semantics
 };
 
 // R516 keyword -> name

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -742,9 +742,8 @@ MaybeExpr AnalyzeExpr(
         n.ToString().data());
   } else if (n.symbol->attrs().test(semantics::Attr::PARAMETER)) {
     if (auto *details{n.symbol->detailsIf<semantics::ObjectEntityDetails>()}) {
-      auto &init{details->init()};
-      if (init.Resolve(context.context())) {
-        return init.Get();
+      if (auto &init{details->init()}) {
+        return init;
       }
     }
     context.Say(n.source, "parameter '%s' does not have a value"_err_en_US,

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -43,9 +43,9 @@ static void PutObjectEntity(std::ostream &, const Symbol &);
 static void PutProcEntity(std::ostream &, const Symbol &);
 static void PutTypeParam(std::ostream &, const Symbol &);
 static void PutEntity(std::ostream &, const Symbol &, std::function<void()>);
-static void PutInit(std::ostream &, const LazyExpr &);
+static void PutInit(std::ostream &, const MaybeExpr &);
 static void PutBound(std::ostream &, const Bound &);
-static void PutExpr(std::ostream &, const LazyExpr &);
+static void PutExpr(std::ostream &, const SomeExpr &);
 static std::ostream &PutAttrs(
     std::ostream &, Attrs, std::string before = ","s, std::string after = ""s);
 static std::ostream &PutLower(std::ostream &, const Symbol &);
@@ -372,9 +372,9 @@ void PutTypeParam(std::ostream &os, const Symbol &symbol) {
   PutInit(os, details.init());
 }
 
-void PutInit(std::ostream &os, const LazyExpr &init) {
-  if (init.Get()) {
-    PutExpr(os << '=', init);
+void PutInit(std::ostream &os, const MaybeExpr &init) {
+  if (init) {
+    PutExpr(os << '=', *init);
   }
 }
 
@@ -384,15 +384,11 @@ void PutBound(std::ostream &os, const Bound &x) {
   } else if (x.isDeferred()) {
     os << ':';
   } else {
-    PutExpr(os, x.GetExplicit());
+    x.GetExplicit()->AsFortran(os);
   }
 }
 
-void PutExpr(std::ostream &os, const LazyExpr &expr) {
-  if (auto x{expr.Get()}) {
-    x->AsFortran(os);
-  }
-}
+void PutExpr(std::ostream &os, const SomeExpr &expr) { expr.AsFortran(os); }
 
 // Write an entity (object or procedure) declaration.
 // writeType is called to write out the type.

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -162,6 +162,7 @@ void ModFileWriter::PutSymbol(const Symbol &symbol, bool &didContains) {
             PutLower(decls_ << "final::", symbol) << '\n';
           },
           [](const HostAssocDetails &) {},
+          [](const MiscDetails &) {},
           [&](const auto &) { PutEntity(decls_, symbol); },
       },
       symbol.details());
@@ -525,7 +526,6 @@ Scope *ModFileReader::Read(const SourceName &name, Scope *ancestor) {
   std::string ancestorName;  // empty for module
   if (ancestor) {
     if (auto *scope{ancestor->FindSubmodule(name)}) {
-      scope->symbol()->add_occurrence(name);
       return scope;
     }
     ancestorName = ancestor->name().ToString();

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -30,11 +30,7 @@ Scope &Scope::MakeScope(Kind kind, Symbol *symbol) {
 }
 
 Scope::iterator Scope::find(const SourceName &name) {
-  auto it{symbols_.find(name)};
-  if (it != end()) {
-    it->second->add_occurrence(name);
-  }
-  return it;
+  return symbols_.find(name);
 }
 Scope::const_iterator Scope::find(const SourceName &name) const {
   return symbols_.find(name);
@@ -42,14 +38,13 @@ Scope::const_iterator Scope::find(const SourceName &name) const {
 Scope::size_type Scope::erase(const SourceName &name) {
   auto it{symbols_.find(name)};
   if (it != end()) {
-    it->second->remove_occurrence(name);
     symbols_.erase(it);
     return 1;
   } else {
     return 0;
   }
 }
-Symbol *Scope::FindSymbol(const SourceName &name) {
+Symbol *Scope::FindSymbol(const SourceName &name) const {
   if (kind() == Kind::DerivedType) {
     return parent_.FindSymbol(name);
   }
@@ -112,12 +107,8 @@ std::optional<parser::MessageFixedText> Scope::SetImportKind(ImportKind kind) {
   }
 }
 
-bool Scope::add_importName(const SourceName &name) {
-  if (!parent_.FindSymbol(name)) {
-    return false;
-  }
+void Scope::add_importName(const SourceName &name) {
   importNames_.insert(name);
-  return true;
 }
 
 // true if name can be imported or host-associated from parent scope.

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -87,7 +87,7 @@ public:
   size_type size() const { return symbols_.size(); }
 
   // Look for symbol by name in this scope and host (depending on imports).
-  Symbol *FindSymbol(const SourceName &);
+  Symbol *FindSymbol(const SourceName &) const;
 
   /// Make a Symbol with unknown details.
   std::pair<iterator, bool> try_emplace(
@@ -135,7 +135,7 @@ public:
   // Return an error message for incompatible kinds.
   std::optional<parser::MessageFixedText> SetImportKind(ImportKind);
 
-  bool add_importName(const SourceName &);
+  void add_importName(const SourceName &);
 
   // The range of the source of this and nested scopes.
   const parser::CharBlock &sourceRange() const { return sourceRange_; }

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -56,7 +56,6 @@ bool Semantics::Perform() {
   if (AnyFatalError()) {
     return false;
   }
-  ResolveSymbolExprs(context_);
   if (AnyFatalError()) {
     return false;
   }

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -69,10 +69,6 @@ ProcEntityDetails::ProcEntityDetails(const EntityDetails &d) {
   }
 }
 
-void TypeParamDetails::set_init(const parser::Expr &expr) {
-  init_ = LazyExpr{expr};
-}
-
 const Symbol &UseDetails::module() const {
   // owner is a module so it must have a symbol:
   return *symbol_->owner().symbol();
@@ -277,10 +273,6 @@ int Symbol::Rank() const {
 ObjectEntityDetails::ObjectEntityDetails(const EntityDetails &d)
   : isDummy_{d.isDummy()}, type_{d.type()} {}
 
-void ObjectEntityDetails::set_init(const parser::Expr &x) {
-  init_ = LazyExpr{x};
-}
-
 std::ostream &operator<<(std::ostream &os, const EntityDetails &x) {
   if (x.type()) {
     os << " type: " << *x.type();
@@ -298,8 +290,8 @@ std::ostream &operator<<(std::ostream &os, const ObjectEntityDetails &x) {
       os << ' ' << s;
     }
   }
-  if (x.init_.Get()) {
-    os << " init:" << x.init_;
+  if (x.init_) {
+    x.init_->AsFortran(os << " init:");
   }
   return os;
 }
@@ -409,8 +401,8 @@ std::ostream &operator<<(std::ostream &os, const Details &details) {
               os << ' ' << *x.type();
             }
             os << ' ' << common::EnumToString(x.attr());
-            if (x.init().Get()) {
-              os << " init:" << x.init();
+            if (x.init()) {
+              x.init()->AsFortran(os << " init:");
             }
           },
           [&](const MiscDetails &x) {

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -115,9 +115,9 @@ class ObjectEntityDetails {
 public:
   ObjectEntityDetails(const EntityDetails &);
   ObjectEntityDetails(bool isDummy = false) : isDummy_{isDummy} {}
-  LazyExpr &init() { return init_; }
-  const LazyExpr &init() const { return init_; }
-  void set_init(const parser::Expr &);
+  MaybeExpr &init() { return init_; }
+  const MaybeExpr &init() const { return init_; }
+  void set_init(MaybeExpr &&expr) { init_ = std::move(expr); }
   const std::optional<DeclTypeSpec> &type() const { return type_; }
   void set_type(const DeclTypeSpec &type);
   ArraySpec &shape() { return shape_; }
@@ -136,7 +136,7 @@ public:
 
 private:
   bool isDummy_;
-  LazyExpr init_;
+  MaybeExpr init_;
   std::optional<DeclTypeSpec> type_;
   ArraySpec shape_;
   friend std::ostream &operator<<(std::ostream &, const ObjectEntityDetails &);
@@ -200,11 +200,9 @@ class TypeParamDetails {
 public:
   TypeParamDetails(common::TypeParamAttr attr) : attr_{attr} {}
   common::TypeParamAttr attr() const { return attr_; }
-  // std::optional<LazyExpr> &init() { return init_; }
-  // const std::optional<LazyExpr> &init() const { return init_; }
-  LazyExpr &init() { return init_; }
-  const LazyExpr &init() const { return init_; }
-  void set_init(const parser::Expr &);
+  MaybeExpr &init() { return init_; }
+  const MaybeExpr &init() const { return init_; }
+  void set_init(MaybeExpr &&expr) { init_ = std::move(expr); }
   const std::optional<DeclTypeSpec> &type() const { return type_; }
   void set_type(const DeclTypeSpec &type) {
     CHECK(!type_);
@@ -213,7 +211,7 @@ public:
 
 private:
   common::TypeParamAttr attr_;
-  LazyExpr init_;
+  MaybeExpr init_;
   std::optional<DeclTypeSpec> type_;
 };
 

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -67,21 +67,29 @@ void DerivedTypeSpec::set_scope(const Scope &scope) {
   scope_ = &scope;
 }
 
+void DerivedTypeSpec::AddParamValue(ParamValue &&value) {
+  paramValues_.emplace_back(std::nullopt, std::move(value));
+}
+void DerivedTypeSpec::AddParamValue(
+    const SourceName &name, ParamValue &&value) {
+  paramValues_.emplace_back(name, std::move(value));
+}
+
 std::ostream &operator<<(std::ostream &o, const DerivedTypeSpec &x) {
   o << "TYPE(" << x.name().ToString();
   if (!x.paramValues_.empty()) {
     bool first = true;
     o << '(';
-    for (auto &pair : x.paramValues_) {
+    for (const auto &[name, value] : x.paramValues_) {
       if (first) {
         first = false;
       } else {
         o << ',';
       }
-      if (auto &name{pair.first}) {
+      if (name) {
         o << name->ToString() << '=';
       }
-      o << pair.second;
+      o << value;
     }
     o << ')';
   }
@@ -211,38 +219,6 @@ void ProcInterface::set_symbol(const Symbol &symbol) {
 void ProcInterface::set_type(const DeclTypeSpec &type) {
   CHECK(!symbol_);
   type_ = type;
-}
-
-std::ostream &operator<<(std::ostream &o, const GenericSpec &x) {
-  switch (x.kind()) {
-  case GenericSpec::GENERIC_NAME: return o << x.genericName().ToString();
-  case GenericSpec::OP_DEFINED:
-    return o << '(' << x.definedOp().ToString() << ')';
-  case GenericSpec::ASSIGNMENT: return o << "ASSIGNMENT(=)";
-  case GenericSpec::READ_FORMATTED: return o << "READ(FORMATTED)";
-  case GenericSpec::READ_UNFORMATTED: return o << "READ(UNFORMATTED)";
-  case GenericSpec::WRITE_FORMATTED: return o << "WRITE(FORMATTED)";
-  case GenericSpec::WRITE_UNFORMATTED: return o << "WRITE(UNFORMATTED)";
-  case GenericSpec::OP_ADD: return o << "OPERATOR(+)";
-  case GenericSpec::OP_CONCAT: return o << "OPERATOR(//)";
-  case GenericSpec::OP_DIVIDE: return o << "OPERATOR(/)";
-  case GenericSpec::OP_MULTIPLY: return o << "OPERATOR(*)";
-  case GenericSpec::OP_POWER: return o << "OPERATOR(**)";
-  case GenericSpec::OP_SUBTRACT: return o << "OPERATOR(-)";
-  case GenericSpec::OP_AND: return o << "OPERATOR(.AND.)";
-  case GenericSpec::OP_EQ: return o << "OPERATOR(.EQ.)";
-  case GenericSpec::OP_EQV: return o << "OPERATOR(.EQV.)";
-  case GenericSpec::OP_GE: return o << "OPERATOR(.GE.)";
-  case GenericSpec::OP_GT: return o << "OPERATOR(.GT.)";
-  case GenericSpec::OP_LE: return o << "OPERATOR(.LE.)";
-  case GenericSpec::OP_LT: return o << "OPERATOR(.LT.)";
-  case GenericSpec::OP_NE: return o << "OPERATOR(.NE.)";
-  case GenericSpec::OP_NEQV: return o << "OPERATOR(.NEQV.)";
-  case GenericSpec::OP_NOT: return o << "OPERATOR(.NOT.)";
-  case GenericSpec::OP_OR: return o << "OPERATOR(.OR.)";
-  case GenericSpec::OP_XOR: return o << "OPERATOR(.XOR.)";
-  default: CRASH_NO_CASE;
-  }
 }
 
 class ExprResolver {

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -169,62 +169,6 @@ private:
 
 using ArraySpec = std::list<ShapeSpec>;
 
-class GenericSpec {
-public:
-  enum Kind {
-    GENERIC_NAME,
-    OP_DEFINED,
-    ASSIGNMENT,
-    READ_FORMATTED,
-    READ_UNFORMATTED,
-    WRITE_FORMATTED,
-    WRITE_UNFORMATTED,
-    OP_ADD,
-    OP_AND,
-    OP_CONCAT,
-    OP_DIVIDE,
-    OP_EQ,
-    OP_EQV,
-    OP_GE,
-    OP_GT,
-    OP_LE,
-    OP_LT,
-    OP_MULTIPLY,
-    OP_NE,
-    OP_NEQV,
-    OP_NOT,
-    OP_OR,
-    OP_POWER,
-    OP_SUBTRACT,
-    OP_XOR,
-  };
-  static GenericSpec IntrinsicOp(Kind kind) {
-    return GenericSpec(kind, nullptr);
-  }
-  static GenericSpec DefinedOp(const SourceName &name) {
-    return GenericSpec(OP_DEFINED, &name);
-  }
-  static GenericSpec GenericName(const SourceName &name) {
-    return GenericSpec(GENERIC_NAME, &name);
-  }
-
-  const Kind kind() const { return kind_; }
-  const SourceName &genericName() const {
-    CHECK(kind_ == GENERIC_NAME);
-    return *name_;
-  }
-  const SourceName &definedOp() const {
-    CHECK(kind_ == OP_DEFINED);
-    return *name_;
-  }
-
-private:
-  GenericSpec(Kind kind, const SourceName *name) : kind_{kind}, name_{name} {}
-  const Kind kind_;
-  const SourceName *const name_;  // only for GENERIC_NAME & OP_DEFINED
-  friend std::ostream &operator<<(std::ostream &, const GenericSpec &);
-};
-
 // A type parameter value: integer expression or assumed or deferred.
 class ParamValue {
 public:
@@ -248,22 +192,18 @@ private:
 class DerivedTypeSpec {
 public:
   using listType = std::list<std::pair<std::optional<SourceName>, ParamValue>>;
-  explicit DerivedTypeSpec(const SourceName &name) : name_{&name} {}
+  explicit DerivedTypeSpec(const SourceName &name) : name_{name} {}
   DerivedTypeSpec() = delete;
-  const SourceName &name() const { return *name_; }
+  const SourceName &name() const { return name_; }
   const Scope *scope() const { return scope_; }
   void set_scope(const Scope &);
   listType &paramValues() { return paramValues_; }
   const listType &paramValues() const { return paramValues_; }
-  void AddParamValue(ParamValue &&value) {
-    paramValues_.emplace_back(std::nullopt, std::move(value));
-  }
-  void AddParamValue(const SourceName &name, ParamValue &&value) {
-    paramValues_.emplace_back(name, std::move(value));
-  }
+  void AddParamValue(ParamValue &&);
+  void AddParamValue(const SourceName &, ParamValue &&);
 
 private:
-  const SourceName *name_;
+  const SourceName name_;
   const Scope *scope_{nullptr};
   listType paramValues_;
   friend std::ostream &operator<<(std::ostream &, const DerivedTypeSpec &);

--- a/lib/semantics/unparse-with-symbols.cc
+++ b/lib/semantics/unparse-with-symbols.cc
@@ -74,8 +74,10 @@ void SymbolDumpVisitor::Indent(std::ostream &out, int indent) const {
 
 void SymbolDumpVisitor::Post(const parser::Name &name) {
   if (const auto *symbol{name.symbol}) {
-    CHECK(currStmt_);
-    symbols_.emplace(currStmt_->begin(), symbol);
+    if (!symbol->has<MiscDetails>()) {
+      CHECK(currStmt_);
+      symbols_.emplace(currStmt_->begin(), symbol);
+    }
   }
 }
 

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -61,6 +61,7 @@ set(ERROR_TESTS
   resolve34.f90
   resolve35.f90
   resolve36.f90
+  resolve37.f90
 )
 
 # These test files have expected symbols in the source

--- a/test/semantics/label01.F90
+++ b/test/semantics/label01.F90
@@ -24,6 +24,7 @@
 
 
 subroutine sub00(a,b,n,m)
+  integer :: n, m
   real a(n)
   real :: b(m)
 1 print *, n, m
@@ -32,6 +33,7 @@ subroutine sub00(a,b,n,m)
 end subroutine sub00
 
 subroutine do_loop01(a,n)
+  integer :: n
   real, dimension(n) :: a
   do 10 i = 1, n
      print *, i, a(i)
@@ -39,6 +41,7 @@ subroutine do_loop01(a,n)
 end subroutine do_loop01
 
 subroutine do_loop02(a,n)
+  integer :: n
   real, dimension(n,n) :: a
   do 10 j = 1, n
      do 10 i = 1, n
@@ -48,12 +51,14 @@ end subroutine do_loop02
 
 #ifndef STRICT_F18
 subroutine do_loop03(a,n)
+  integer :: n
   real, dimension(n) :: a
   do 10 i = 1, n
 10   print *, i, a(i)		! extension (not f18)
 end subroutine do_loop03
 
 subroutine do_loop04(a,n)
+  integer :: n
   real :: a(n,n)
   do 10 j = 1, n
      do 10 i = 1, n
@@ -61,6 +66,7 @@ subroutine do_loop04(a,n)
 end subroutine do_loop04
 
 subroutine do_loop05(a,n)
+  integer :: n
   real a(n,n,n)
   do 10 k = 1, n
      do 10 j = 1, n
@@ -70,6 +76,7 @@ end subroutine do_loop05
 #endif
 
 subroutine do_loop06(a,n)
+  integer :: n
   real, dimension(n) :: a
   loopname: do i = 1, n
      print *, i, a(i)
@@ -80,6 +87,7 @@ subroutine do_loop06(a,n)
 end subroutine do_loop06
 
 subroutine do_loop07(a,n)
+  integer :: n
   real, dimension(n,n) :: a
   loopone: do j = 1, n
      looptwo: do i = 1, n
@@ -89,6 +97,7 @@ subroutine do_loop07(a,n)
 end subroutine do_loop07
 
 subroutine do_loop08(a,b,n,m,nn)
+  integer :: n, m, nn
   real, dimension(n,n) :: a
   real b(m,nn)
   loopone: do j = 1, n
@@ -122,6 +131,7 @@ end subroutine do_loop08
 #ifndef STRICT_F18
 ! extended ranges supported by PGI, gfortran gives warnings
 subroutine do_loop09(a,n,j)
+  integer :: n
   real a(n)
   goto 400
 200 print *, "found the index", j

--- a/test/semantics/modfile12.f90
+++ b/test/semantics/modfile12.f90
@@ -14,14 +14,16 @@
 
 module m
   integer(8), parameter :: a = 1, b = 2_8
-  parameter(n=3)
+  parameter(n=3,l=-3,e=1.0/3.0)
   real :: x(a:2*(a+b*n)-1)
   real, dimension(8) :: y
   type t(c, d)
     integer, kind :: c = 1
     integer, len :: d = a + b
   end type
-  type(t(3,:)), allocatable :: z
+  type(t(a+3,:)), allocatable :: z
+  real*2 :: f
+  complex*32 :: g
 contains
   subroutine foo(x)
     real :: x(2:)
@@ -36,13 +38,17 @@ end
 !  integer(8),parameter::a=1_4
 !  integer(8),parameter::b=2_8
 !  integer(4),parameter::n=3_4
+!  integer(4),parameter::l=-3_4
+!  real(4),parameter::e=3.333333432674407958984375e-1_4
 !  real(4)::x(1_4:13_8)
 !  real(4)::y(1_8:8_4)
 !  type::t(c,d)
 !    integer(4),kind::c=1_4
 !    integer(4),len::d=3_8
 !  end type
-!  type(t(3_4,:)),allocatable::z
+!  type(t(4_4,:)),allocatable::z
+!  real(2)::f
+!  complex(16)::g
 !contains
 !  subroutine foo(x)
 !    real(4)::x(2_4:)

--- a/test/semantics/resolve36.f90
+++ b/test/semantics/resolve36.f90
@@ -67,3 +67,14 @@ contains
   module subroutine i
   end
 end module
+
+! Separate module procedure defined in same module as declared
+module m3
+  interface
+    module subroutine sub
+    end subroutine
+  end interface
+contains
+  module procedure sub
+  end procedure
+end module

--- a/test/semantics/resolve37.f90
+++ b/test/semantics/resolve37.f90
@@ -1,0 +1,32 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+integer, parameter :: k = 8
+real, parameter :: l = 8.0
+integer :: n = 2
+!ERROR: expression must be constant
+parameter(m=n)
+integer(k) :: x
+!ERROR: expression must be INTEGER
+integer(l) :: y
+!ERROR: expression must be constant
+integer(n) :: z
+type t(k)
+  integer, kind :: k
+end type
+!ERROR: expression must be INTEGER
+type(t(.true.)) :: w
+!ERROR: expression must be INTEGER
+real :: w(l*2)
+end


### PR DESCRIPTION
Rather than fill inserting symbols into the symbol table and evaluating expressions after name resolution, now do it at the same time. When we create or find a symbol for a Name, enter it immediately. When we encounter an expression that goes in the symbol table (bound, kind parameter, etc.), evaluate it immediately.