### PR TITLE
Preserve order of type parameters

### DIFF
--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -176,14 +176,12 @@ void ModFileWriter::PutDerivedType(const Symbol &typeSymbol) {
   }
   PutLower(decls_ << "::", typeSymbol);
   auto &typeScope{*typeSymbol.scope()};
-  if (details.hasTypeParams()) {
+  if (!details.paramNames().empty()) {
     bool first{true};
     decls_ << '(';
-    for (const auto *symbol : CollectSymbols(typeScope)) {
-      if (symbol->has<TypeParamDetails>()) {
-        PutLower(first ? decls_ : decls_ << ',', *symbol);
-        first = false;
-      }
+    for (const auto &name : details.paramNames()) {
+      PutLower(first ? decls_ : decls_ << ',', name.ToString());
+      first = false;
     }
     decls_ << ')';
   }

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -160,15 +160,15 @@ private:
 
 class DerivedTypeDetails {
 public:
-  bool hasTypeParams() const { return hasTypeParams_; }
+  const std::list<SourceName> &paramNames() const { return paramNames_; }
   const Symbol *extends() const { return extends_; }
   bool sequence() const { return sequence_; }
-  void set_hasTypeParams(bool x = true) { hasTypeParams_ = x; }
+  void add_paramName(const SourceName &name) { paramNames_.emplace_back(name); }
   void set_extends(const Symbol *extends) { extends_ = extends; }
   void set_sequence(bool x = true) { sequence_ = x; }
 
 private:
-  bool hasTypeParams_{false};
+  std::list<SourceName> paramNames_;
   const Symbol *extends_{nullptr};
   bool sequence_{false};
 };

--- a/test/semantics/modfile12.f90
+++ b/test/semantics/modfile12.f90
@@ -24,6 +24,11 @@ module m
   type(t(a+3,:)), allocatable :: z
   real*2 :: f
   complex*32 :: g
+  type t2(i, j, h)
+    integer, len :: h
+    integer, kind :: j
+    integer, len :: i
+  end type
 contains
   subroutine foo(x)
     real :: x(2:)
@@ -49,6 +54,11 @@ end
 !  type(t(4_4,:)),allocatable::z
 !  real(2)::f
 !  complex(16)::g
+!  type::t2(i,j,h)
+!    integer(4),len::h
+!    integer(4),kind::j
+!    integer(4),len::i
+!  end type
 !contains
 !  subroutine foo(x)
 !    real(4)::x(2_4:)

--- a/test/semantics/resolve33.f90
+++ b/test/semantics/resolve33.f90
@@ -35,4 +35,10 @@ module m
     !ERROR: 'd' is not a type parameter of this derived type
     integer(8), len :: d
   end type
+  type t5(a, b)
+    integer, len :: a
+    integer, len :: b
+    !ERROR: Type parameter, component, or procedure binding 'a' already defined in this type
+    integer, len :: a
+  end type
 end module


### PR DESCRIPTION
Type parameters were sorted by the order of the type-param-def-stmts.
But we need to preserve the order of the type-param-name-list.
The is the order of positional parameters in a derived-type-spec.

So add `paramNames` to `DerivedTypeDetails` to preserve the original
order. Using this allows us to write module files with both the
type-param-name-list and type-param-def-stmts in the original order.

Also fix a bug where a duplicate type-param-def caused a spurious
extra error. If `MakeTypeSymbol()` reports an error we should not
call `SetType()` because it will just report another error.