### PR TITLE
Fix bug converting actual argument to Fortran

### DIFF
--- a/lib/evaluate/call.cc
+++ b/lib/evaluate/call.cc
@@ -49,8 +49,10 @@ std::ostream &ProcedureRef::AsFortran(std::ostream &o) const {
   proc_.AsFortran(o);
   char separator{'('};
   for (const auto &arg : arguments_) {
-    arg->AsFortran(o << separator);
-    separator = ',';
+    if (arg.has_value()) {
+      arg->AsFortran(o << separator);
+      separator = ',';
+    }
   }
   if (separator == '(') {
     o << '(';


### PR DESCRIPTION
This fixes a problem with converting the ubound call in the example
below back to Fortran (in this case, for writing to the .mod file).
One of the ActualArguments encountered in ProcedureRef::AsFortran is
a `std::nullopt`, so we need to handle that case.

```
module m
  real :: x(10)
  real :: y(ubound(x, dim=1))
end module
```