### PR TITLE
More precise locations for construct name errors; some refactoring

### DIFF
--- a/test/semantics/label08.f90
+++ b/test/semantics/label08.f90
@@ -15,11 +15,11 @@
 ! negative test -- invalid labels, out of range
 
 ! RUN: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
-! CHECK: CYCLE construct-name 'label3' is not in scope
-! CHECK: IF construct name mismatch
-! CHECK: mismatched IF
+! CHECK: CYCLE construct-name is not in scope
+! CHECK: IF construct name unexpected
+! CHECK: unnamed IF statement
 ! CHECK: DO construct name mismatch
-! CHECK: mismatched construct
+! CHECK: should be
 
 subroutine sub00(a,b,n,m)
   real a(n,m)

--- a/test/semantics/label11.f90
+++ b/test/semantics/label11.f90
@@ -13,24 +13,17 @@
 ! limitations under the License.
 
 ! RUN: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
-! CHECK: END BLOCK DATA name mismatch
-! CHECK: mismatched BLOCK DATA
-! CHECK: END FUNCTION name mismatch
-! CHECK: mismatched FUNCTION
-! CHECK: END SUBROUTINE name mismatch
-! CHECK: mismatched SUBROUTINE
-! CHECK: END PROGRAM name mismatch
-! CHECK: mismatched PROGRAM
-! CHECK: END SUBMODULE name mismatch
-! CHECK: mismatched SUBMODULE
+! CHECK: BLOCK DATA subprogram name mismatch
+! CHECK: should be
+! CHECK: FUNCTION name mismatch
+! CHECK: SUBROUTINE name mismatch
+! CHECK: PROGRAM name mismatch
+! CHECK: SUBMODULE name mismatch
 ! CHECK: INTERFACE generic-name .t7. mismatch
 ! CHECK: mismatched INTERFACE
-! CHECK: END TYPE name mismatch
-! CHECK: mismatched TYPE
-! CHECK: END MODULE PROCEDURE name mismatch
-! CHECK: mismatched MODULE PROCEDURE
-! CHECK: END MODULE name mismatch
-! CHECK: mismatched MODULE
+! CHECK: derived type definition name mismatch
+! CHECK: MODULE PROCEDURE name mismatch
+! CHECK: MODULE name mismatch
 
 block data t1
 end block data t2


### PR DESCRIPTION
While beginning work on FORALL and WHERE constructs, I noticed that locations on construct name errors could be made more precise (highlighting the names themselves rather than entire statements).  So I went and made them so, doing some refactoring along the way to abstract some common code patterns in resolve-labels.cc and reduce code.