### PR TITLE
Strengthen FORALL scoping check

### DIFF
--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -3169,8 +3169,7 @@ void ResolveNamesVisitor::Post(const parser::ProcedureDesignator &x) {
         // OK
       } else if (symbol->has<DerivedTypeDetails>()) {
         // OK: type constructor
-      } else if (auto *details{symbol->detailsIf<ObjectEntityDetails>()};
-                 details && details->IsArray()) {
+      } else if (symbol->has<ObjectEntityDetails>()) {
         // OK: array mis-parsed as a call
       } else if (symbol->test(Symbol::Flag::Implicit)) {
         Say(*name,

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -33,8 +33,8 @@ class Scope {
   using mapType = std::map<SourceName, Symbol *>;
 
 public:
-  ENUM_CLASS(
-      Kind, System, Global, Module, MainProgram, Subprogram, DerivedType, Block)
+  ENUM_CLASS(Kind, System, Global, Module, MainProgram, Subprogram, DerivedType,
+      Block, Forall)
   using ImportKind = common::ImportKind;
 
   // Create the Global scope -- the root of the scope tree

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -124,13 +124,13 @@ public:
   const ArraySpec &shape() const { return shape_; }
   void set_shape(const ArraySpec &shape);
   bool isDummy() const { return isDummy_; }
-  bool isArray() const { return !shape_.empty(); }
+  bool IsArray() const { return !shape_.empty(); }
   bool IsAssumedSize() const {
-    return isDummy() && isArray() && shape_.back().ubound().isAssumed() &&
+    return isDummy() && IsArray() && shape_.back().ubound().isAssumed() &&
         !shape_.back().lbound().isAssumed();
   }
   bool IsAssumedRank() const {
-    return isDummy() && isArray() && shape_.back().ubound().isAssumed() &&
+    return isDummy() && IsArray() && shape_.back().ubound().isAssumed() &&
         shape_.back().lbound().isAssumed();
   }
 

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -105,6 +105,10 @@ set(CANONDO_TESTS
   canondo*.[Ff]90
 )
 
+set(FORALL_TESTS
+  forall*.[Ff]90
+)
+
 foreach(test ${ERROR_TESTS})
   add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_errors.sh ${test})
 endforeach()
@@ -126,5 +130,9 @@ foreach(test ${CANONDO_TESTS})
 endforeach()
 
 foreach(test ${DOCONCURRENT_TESTS})
+  add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_any.sh ${test})
+endforeach()
+
+foreach(test ${FORALL_TESTS})
   add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_any.sh ${test})
 endforeach()

--- a/test/semantics/forall01.f90
+++ b/test/semantics/forall01.f90
@@ -1,0 +1,28 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! RUN: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
+! CHECK: error: 'i' is already declared in this scoping unit
+! CHECK: Previous declaration of 'i'
+! CHECK: error: 'j' is already declared in this scoping unit
+! CHECK: Previous declaration of 'j'
+
+subroutine forall
+  real :: a(9)
+  forall (i=1:8, i=1:9)  a(i) = i
+  forall (j=1:8)
+    forall (j=1:9)
+    end forall
+  end forall
+end subroutine forall

--- a/test/semantics/forall01.f90
+++ b/test/semantics/forall01.f90
@@ -13,15 +13,15 @@
 ! limitations under the License.
 
 ! RUN: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
-! CHECK: error: 'i' is already declared in this scoping unit
 ! CHECK: Previous declaration of 'i'
-! CHECK: error: 'j' is already declared in this scoping unit
 ! CHECK: Previous declaration of 'j'
 
 subroutine forall
   real :: a(9)
+! ERROR: 'i' is already declared in this scoping unit
   forall (i=1:8, i=1:9)  a(i) = i
   forall (j=1:8)
+! ERROR: 'j' is already declared in this scoping unit
     forall (j=1:9)
     end forall
   end forall

--- a/test/semantics/symbol09.f90
+++ b/test/semantics/symbol09.f90
@@ -19,14 +19,14 @@ subroutine s1
  real a(10), b(10)
  !DEF: /s1/i ObjectEntity INTEGER(8)
  integer(kind=8) i
- !DEF: /s1/Block1/i ObjectEntity INTEGER(8)
+ !DEF: /s1/Forall1/i ObjectEntity INTEGER(8)
  forall(i=1:10)
   !REF: /s1/a
-  !REF: /s1/Block1/i
+  !REF: /s1/Forall1/i
   !REF: /s1/b
   a(i) = b(i)
  end forall
- !DEF: /s1/Block2/i ObjectEntity INTEGER(8)
+ !DEF: /s1/Forall2/i ObjectEntity INTEGER(8)
  !REF: /s1/a
  !REF: /s1/b
  forall(i=1:10)a(i) = b(i)


### PR DESCRIPTION
Per 10.2.4.4 paragraph 2, `FORALL` index names must be distinct from those in enclosing `FORALL` constructs.