### PR TITLE
add Unwrap

### DIFF
--- a/lib/common/unwrap.h
+++ b/lib/common/unwrap.h
@@ -1,0 +1,158 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_COMMON_UNWRAP_H_
+#define FORTRAN_COMMON_UNWRAP_H_
+
+#include "indirection.h"
+#include "reference-counted.h"
+#include <memory>
+#include <optional>
+#include <type_traits>
+#include <variant>
+
+// Given a nest of variants, optionals, &/or pointers, Unwrap<>() isolates
+// a packaged value of a specific type if it is present and returns a pointer
+// thereto; otherwise, it returns a null pointer.  It's analogous to
+// std::get_if<>() but it accepts a reference argument and is recursive.
+// The type parameter cannot be omitted.
+//
+// UnwrapCopy<>() is a variation of Unwrap<>() that returns an optional copy
+// of the value if one is present with the desired type.
+
+namespace Fortran::common {
+
+// Utility: Produces "const A" if B is const and A is not already so.
+template<typename A, typename B>
+using Constify = std::conditional_t<std::is_const_v<B> && !std::is_const_v<A>,
+    std::add_const_t<A>, A>;
+
+// Base case
+template<typename A, typename B> auto Unwrap(B &x) -> Constify<A, B> * {
+  if constexpr (std::is_same_v<std::decay_t<A>, std::decay_t<B>>) {
+    return &x;
+  } else {
+    return nullptr;
+  }
+}
+
+// Prototypes of specializations, to enable mutual recursion
+template<typename A, typename B>
+auto Unwrap(B *) -> Constify<A, std::remove_pointer<B>> *;
+template<typename A, typename B>
+auto Unwrap(const std::unique_ptr<B> &) -> Constify<A, B> *;
+template<typename A, typename B>
+auto Unwrap(const std::shared_ptr<B> &) -> Constify<A, B> *;
+template<typename A, typename B>
+auto Unwrap(std::optional<B> &) -> Constify<A, B> *;
+template<typename A, typename B>
+auto Unwrap(const std::optional<B> &) -> std::add_const_t<A> *;
+template<typename A, typename... Bs> A *Unwrap(std::variant<Bs...> &);
+template<typename A, typename... Bs>
+auto Unwrap(const std::variant<Bs...> &) -> std::add_const_t<A> *;
+template<typename A, typename B, bool COPY>
+auto Unwrap(const Indirection<B, COPY> &) -> Constify<A, B> *;
+template<typename A, typename B>
+auto Unwrap(const OwningPointer<B> &) -> Constify<A, B> *;
+template<typename A, typename B>
+auto Unwrap(const CountedReference<B> &) -> Constify<A, B> *;
+
+// Implementations of specializations
+template<typename A, typename B>
+auto Unwrap(B *p) -> Constify<A, std::remove_pointer<B>> * {
+  if (p != nullptr) {
+    return Unwrap<A>(*p);
+  } else {
+    return nullptr;
+  }
+}
+
+template<typename A, typename B>
+auto Unwrap(const std::unique_ptr<B> &p) -> Constify<A, B> * {
+  if (p.get() != nullptr) {
+    return Unwrap<A>(*p);
+  } else {
+    return nullptr;
+  }
+}
+
+template<typename A, typename B>
+auto Unwrap(const std::shared_ptr<B> &p) -> Constify<A, B> * {
+  if (p.get() != nullptr) {
+    return Unwrap<A>(*p);
+  } else {
+    return nullptr;
+  }
+}
+
+template<typename A, typename B>
+auto Unwrap(std::optional<B> &x) -> Constify<A, B> * {
+  if (x.has_value()) {
+    return Unwrap<A>(*x);
+  } else {
+    return nullptr;
+  }
+}
+
+template<typename A, typename B>
+auto Unwrap(const std::optional<B> &x) -> Constify<A, B> * {
+  if (x.has_value()) {
+    return Unwrap<A>(*x);
+  } else {
+    return nullptr;
+  }
+}
+
+template<typename A, typename... Bs> A *Unwrap(std::variant<Bs...> &u) {
+  return std::visit([](auto &x) { return Unwrap<A>(x); }, u);
+}
+
+template<typename A, typename... Bs>
+auto Unwrap(const std::variant<Bs...> &u) -> std::add_const_t<A> * {
+  return std::visit([](const auto &x) { return Unwrap<A>(x); }, u);
+}
+
+template<typename A, typename B, bool COPY>
+auto Unwrap(const Indirection<B, COPY> &p) -> Constify<A, B> * {
+  return Unwrap<A>(*p);
+}
+
+template<typename A, typename B>
+auto Unwrap(const OwningPointer<B> &p) -> Constify<A, B> * {
+  if (p.get() != nullptr) {
+    return Unwrap<A>(*p);
+  } else {
+    return nullptr;
+  }
+}
+
+template<typename A, typename B>
+auto Unwrap(const CountedReference<B> &p) -> Constify<A, B> * {
+  if (p.get() != nullptr) {
+    return Unwrap<A>(*p);
+  } else {
+    return nullptr;
+  }
+}
+
+// Returns a copy of a wrapped value, if present, otherwise a vacant optional.
+template<typename A, typename B> std::optional<A> UnwrapCopy(const B &x) {
+  if (const A * p{Unwrap<A>(x)}) {
+    return std::make_optional<A>(*p);
+  } else {
+    return std::nullopt;
+  }
+}
+}
+#endif  // FORTRAN_COMMON_UNWRAP_H_


### PR DESCRIPTION
This is a code review of a new template function that I've extracted from work in progress so that it can be reviewed independently.

`Unwrap` automates digging into data structures and indirections.  Think of it as a very motivated form of `std::get_if` that will bring back a pointer to a value if one exists, no matter how deeply buried that value may be in pointers of various flavors, optionals, &/or variants.  Its use avoids writing nests of `if` statements that would otherwise be needed to conditionally descend into such structures.