### PR TITLE
Define non-inline versions of ExpressionBase::derived()

### DIFF
--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -189,6 +189,7 @@ template<typename T> DynamicType ArrayConstructor<T>::GetType() const {
   return result.GetType();
 }
 
+#if defined(__APPLE__) && defined(__GNUC__)
 template<typename A>
 typename ExpressionBase<A>::Derived &ExpressionBase<A>::derived() {
   return *static_cast<Derived *>(this);
@@ -198,6 +199,7 @@ template<typename A>
 const typename ExpressionBase<A>::Derived &ExpressionBase<A>::derived() const {
   return *static_cast<const Derived *>(this);
 }
+#endif
 
 template<typename A>
 std::optional<DynamicType> ExpressionBase<A>::GetType() const {

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -190,6 +190,16 @@ template<typename T> DynamicType ArrayConstructor<T>::GetType() const {
 }
 
 template<typename A>
+typename ExpressionBase<A>::Derived &ExpressionBase<A>::derived() {
+  return *static_cast<Derived *>(this);
+}
+
+template<typename A>
+const typename ExpressionBase<A>::Derived &ExpressionBase<A>::derived() const {
+  return *static_cast<const Derived *>(this);
+}
+
+template<typename A>
 std::optional<DynamicType> ExpressionBase<A>::GetType() const {
   if constexpr (IsSpecificIntrinsicType<Result>) {
     return Result::GetType();

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -67,8 +67,8 @@ public:
 
 private:
   using Derived = Expr<Result>;
-  Derived &derived() { return *static_cast<Derived *>(this); }
-  const Derived &derived() const { return *static_cast<const Derived *>(this); }
+  Derived &derived();
+  const Derived &derived() const;
 
 public:
   template<typename A> Derived &operator=(const A &x) {

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -67,8 +67,13 @@ public:
 
 private:
   using Derived = Expr<Result>;
+#if defined(__APPLE__) && defined(__GNUC__)
   Derived &derived();
   const Derived &derived() const;
+#else
+  Derived &derived() { return *static_cast<Derived *>(this); }
+  const Derived &derived() const { return *static_cast<const Derived *>(this); }
+#endif
 
 public:
   template<typename A> Derived &operator=(const A &x) {


### PR DESCRIPTION
Addresses issue #242 by making non-inline definitions for the two versions of `ExpressionBase::derived()` declared in `lib/evaluate/expression.h`.  GCC-8.2 on macOS was choosing to create non-inline instances of derived() during the explicit instantiations of `ExpressionBase` found in `expression.cc` and `fold.cc`.  During the linking phase of any executable, the linker failed when it found these duplicate definitions.

While this solution works, it removes the opportunity to inline the trivial derived() functions.  Another solution would be to make all of the templates related to `ExpressionBase` in `expression.cc` and `fold.cc` available in a single .cc file, where the explicit instantiation `FOR_EACH_TYPE_AND_KIND(template class ExpressionBase)` is done once. This approach would allow inlining, but would require something like template implementation headers that could be included into the instantiation .cc file.