### PR TITLE
Change expression constraint checking

### DIFF
--- a/lib/parser/parse-tree-visitor.h
+++ b/lib/parser/parse-tree-visitor.h
@@ -264,6 +264,7 @@ template<typename T, typename M> void Walk(DefaultChar<T> &x, M &mutator) {
 template<typename T, typename V> void Walk(const Statement<T> &x, V &visitor) {
   if (visitor.Pre(x)) {
     // N.B. the label is not traversed
+    Walk(x.source, visitor);
     Walk(x.statement, visitor);
     visitor.Post(x);
   }
@@ -271,6 +272,7 @@ template<typename T, typename V> void Walk(const Statement<T> &x, V &visitor) {
 template<typename T, typename M> void Walk(Statement<T> &x, M &mutator) {
   if (mutator.Pre(x)) {
     // N.B. the label is not traversed
+    Walk(x.source, mutator);
     Walk(x.statement, mutator);
     mutator.Post(x);
   }
@@ -278,11 +280,13 @@ template<typename T, typename M> void Walk(Statement<T> &x, M &mutator) {
 
 template<typename V> void Walk(const Name &x, V &visitor) {
   if (visitor.Pre(x)) {
+    Walk(x.source, visitor);
     visitor.Post(x);
   }
 }
 template<typename M> void Walk(Name &x, M &mutator) {
   if (mutator.Pre(x)) {
+    Walk(x.source, mutator);
     mutator.Post(x);
   }
 }
@@ -464,6 +468,20 @@ template<typename T, typename M> void Walk(LoopBounds<T> &x, M &mutator) {
     mutator.Post(x);
   }
 }
+template<typename V> void Walk(const Expr &x, V &visitor) {
+  if (visitor.Pre(x)) {
+    Walk(x.source, visitor);
+    Walk(x.u, visitor);
+    visitor.Post(x);
+  }
+}
+template<typename M> void Walk(Expr &x, M &mutator) {
+  if (mutator.Pre(x)) {
+    Walk(x.source, mutator);
+    Walk(x.u, mutator);
+    mutator.Post(x);
+  }
+}
 template<typename V> void Walk(const PartRef &x, V &visitor) {
   if (visitor.Pre(x)) {
     Walk(x.name, visitor);
@@ -498,6 +516,20 @@ template<typename M> void Walk(ReadStmt &x, M &mutator) {
     mutator.Post(x);
   }
 }
+template<typename V> void Walk(const SignedIntLiteralConstant &x, V &visitor) {
+  if (visitor.Pre(x)) {
+    Walk(x.source, visitor);
+    Walk(x.t, visitor);
+    visitor.Post(x);
+  }
+}
+template<typename M> void Walk(SignedIntLiteralConstant &x, M &mutator) {
+  if (mutator.Pre(x)) {
+    Walk(x.source, mutator);
+    Walk(x.t, mutator);
+    mutator.Post(x);
+  }
+}
 template<typename V> void Walk(const RealLiteralConstant &x, V &visitor) {
   if (visitor.Pre(x)) {
     Walk(x.real, visitor);
@@ -514,11 +546,13 @@ template<typename M> void Walk(RealLiteralConstant &x, M &mutator) {
 }
 template<typename V> void Walk(const RealLiteralConstant::Real &x, V &visitor) {
   if (visitor.Pre(x)) {
+    Walk(x.source, visitor);
     visitor.Post(x);
   }
 }
 template<typename M> void Walk(RealLiteralConstant::Real &x, M &mutator) {
   if (mutator.Pre(x)) {
+    Walk(x.source, mutator);
     mutator.Post(x);
   }
 }
@@ -691,6 +725,20 @@ void Walk(format::IntrinsicTypeDataEditDesc &x, M &mutator) {
     Walk(x.width, mutator);
     Walk(x.digits, mutator);
     Walk(x.exponentWidth, mutator);
+    mutator.Post(x);
+  }
+}
+template<typename V> void Walk(const CompilerDirective &x, V &visitor) {
+  if (visitor.Pre(x)) {
+    Walk(x.source, visitor);
+    Walk(x.u, visitor);
+    visitor.Post(x);
+  }
+}
+template<typename M> void Walk(CompilerDirective &x, M &mutator) {
+  if (mutator.Pre(x)) {
+    Walk(x.source, mutator);
+    Walk(x.u, mutator);
     mutator.Post(x);
   }
 }

--- a/lib/semantics/dump-parse-tree.h
+++ b/lib/semantics/dump-parse-tree.h
@@ -779,6 +779,9 @@ public:
 
   // A few types we want to ignore
 
+  bool Pre(const parser::CharBlock &) { return true; }
+  void Post(const parser::CharBlock &) {}
+
   template<typename T> bool Pre(const parser::Statement<T> &) { return true; }
 
   template<typename T> void Post(const parser::Statement<T> &) {}

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -66,9 +66,7 @@ template<typename A> CharBlock FindSourceLocation(const A &x) {
 namespace Fortran::evaluate {
 class ExpressionAnalysisContext {
 public:
-  ExpressionAnalysisContext(semantics::SemanticsContext &sc) : context_{sc} {}
-  ExpressionAnalysisContext(ExpressionAnalysisContext &i)
-    : context_{i.context_}, inner_{&i} {}
+  explicit ExpressionAnalysisContext(semantics::SemanticsContext &sc) : context_{sc} {}
 
   semantics::SemanticsContext &context() const { return context_; }
 
@@ -83,11 +81,8 @@ public:
 
   std::optional<Expr<SomeType>> Analyze(const parser::Expr &);
 
-protected:
-  semantics::SemanticsContext &context_;
-
 private:
-  ExpressionAnalysisContext *inner_{nullptr};
+  semantics::SemanticsContext &context_;
 };
 
 template<typename PARSED>

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -75,8 +75,7 @@ public:
   }
 
   template<typename T, typename... A> void SayAt(const T &parsed, A... args) {
-    context_.foldingContext().messages.Say(
-        parser::FindSourceLocation(parsed), std::forward<A>(args)...);
+    Say(parser::FindSourceLocation(parsed), std::forward<A>(args)...);
   }
 
   std::optional<Expr<SomeType>> Analyze(const parser::Expr &);

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -1115,10 +1115,11 @@ int DeclTypeSpecVisitor::GetKindParamValue(
       common::visitors{
           [&](const parser::ScalarIntConstantExpr &x) -> int {
             if (auto maybeExpr{EvaluateExpr(x)}) {
-              return evaluate::ToInt64(*maybeExpr).value();
-            } else {
-              return 0;
+              if (auto intConst{evaluate::ToInt64(*maybeExpr)}) {
+                return *intConst;
+              }
             }
+            return 0;
           },
           [&](const parser::KindSelector::StarSize &x) -> int {
             std::uint64_t size{x.v};

--- a/test/semantics/resolve37.f90
+++ b/test/semantics/resolve37.f90
@@ -15,20 +15,20 @@
 integer, parameter :: k = 8
 real, parameter :: l = 8.0
 integer :: n = 2
-!ERROR: expression must be constant
+!ERROR: Must be a constant value
 parameter(m=n)
 integer(k) :: x
-!ERROR: expression must be INTEGER
+!ERROR: Must have INTEGER type
 integer(l) :: y
-!ERROR: expression must be constant
+!ERROR: Must be a constant value
 integer(n) :: z
 type t(k)
   integer, kind :: k
 end type
-!ERROR: expression must be INTEGER
+!ERROR: Must have INTEGER type
 type(t(.true.)) :: w
-!ERROR: expression must be INTEGER
+!ERROR: Must have INTEGER type
 real :: w(l*2)
-!ERROR: expression must be INTEGER
+!ERROR: Must have INTEGER type
 character(len=l) :: v
 end


### PR DESCRIPTION
Back out the recent change for deferred expression constraint checking, revert to more straightforward model with improved error locations.