### PR TITLE
Support operator== for expressions.

### DIFF
--- a/lib/common/indirection.h
+++ b/lib/common/indirection.h
@@ -58,6 +58,8 @@ public:
   A *operator->() { return p_; }
   const A *operator->() const { return p_; }
 
+  bool operator==(const Indirection &that) const { return *p_ == *that.p_; }
+
   template<typename... ARGS> static Indirection Make(ARGS &&... args) {
     return {new A(std::forward<ARGS>(args)...)};
   }
@@ -106,6 +108,8 @@ public:
   A *operator->() { return p_; }
   const A *operator->() const { return p_; }
 
+  bool operator==(const Indirection &that) const { return *p_ == *that.p_; }
+
   template<typename... ARGS> static Indirection Make(ARGS &&... args) {
     return {new A(std::forward<ARGS>(args)...)};
   }
@@ -147,6 +151,11 @@ public:
   void reset(A *p) {
     this->~OwningPointer();
     p_ = p;
+  }
+
+  bool operator==(const OwningPointer &that) const {
+    return (p_ == nullptr && that.p_ == nullptr) ||
+        (p_ != nullptr && that.p_ != nullptr && *p_ == *that.p_);
   }
 
 private:

--- a/lib/evaluate/call.h
+++ b/lib/evaluate/call.h
@@ -37,6 +37,7 @@ struct ActualArgument {
 
   std::optional<DynamicType> GetType() const;
   int Rank() const;
+  bool operator==(const ActualArgument &) const;
   std::ostream &AsFortran(std::ostream &) const;
   std::optional<int> VectorSize() const;
 
@@ -64,6 +65,7 @@ struct SpecificIntrinsic {
   SpecificIntrinsic(IntrinsicProcedure n, std::optional<DynamicType> &&dt,
       int r, semantics::Attrs a)
     : name{n}, type{std::move(dt)}, rank{r}, attrs{a} {}
+  bool operator==(const SpecificIntrinsic &) const;
   std::ostream &AsFortran(std::ostream &) const;
 
   IntrinsicProcedure name;

--- a/lib/evaluate/common.h
+++ b/lib/evaluate/common.h
@@ -19,8 +19,13 @@
 #include "../common/fortran.h"
 #include "../common/idioms.h"
 #include "../common/indirection.h"
+#include "../parser/char-block.h"
 #include "../parser/message.h"
 #include <cinttypes>
+
+namespace Fortran::semantics {
+class DerivedTypeSpec;
+}
 
 namespace Fortran::evaluate {
 
@@ -145,7 +150,7 @@ using HostUnsignedInt =
 //   need for std::monostate as a default constituent in a std::variant<>.
 // - There are full copy and move semantics for construction and assignment.
 // - Discriminated unions have a std::variant<> member "u" and support
-//   explicit copy and move constructors.
+//   explicit copy and move constructors as well as comparison for equality.
 #define DEFAULT_CONSTRUCTORS_AND_ASSIGNMENTS(t) \
   t(const t &) = default; \
   t(t &&) = default; \
@@ -161,7 +166,8 @@ using HostUnsignedInt =
   template<typename _A> explicit t(const _A &x) : u{x} {} \
   template<typename _A> \
   explicit t(std::enable_if_t<!std::is_reference_v<_A>, _A> &&x) \
-    : u(std::move(x)) {}
+    : u(std::move(x)) {} \
+  bool operator==(const t &that) const { return u == that.u; }
 
 // Force availability of copy construction and assignment
 template<typename A> using CopyableIndirection = common::Indirection<A, true>;
@@ -174,19 +180,21 @@ struct FoldingContext {
   explicit FoldingContext(const parser::ContextualMessages &m,
       Rounding round = defaultRounding, bool flush = false)
     : messages{m}, rounding{round}, flushDenormalsToZero{flush} {}
-  FoldingContext(const parser::ContextualMessages &m, const FoldingContext &c)
-    : messages{m}, rounding{c.rounding}, flushDenormalsToZero{
-                                             c.flushDenormalsToZero} {}
-
-  // For narrowed contexts
-  FoldingContext(const FoldingContext &c, const parser::ContextualMessages &m)
-    : messages{m}, rounding{c.rounding}, flushDenormalsToZero{
-                                             c.flushDenormalsToZero} {}
+  FoldingContext(const FoldingContext &that)
+    : messages{that.messages}, rounding{that.rounding},
+      flushDenormalsToZero{that.flushDenormalsToZero}, pdtInstance{
+                                                           that.pdtInstance} {}
+  FoldingContext(
+      const FoldingContext &that, const parser::ContextualMessages &m)
+    : messages{m}, rounding{that.rounding},
+      flushDenormalsToZero{that.flushDenormalsToZero}, pdtInstance{
+                                                           that.pdtInstance} {}
 
   parser::ContextualMessages messages;
   Rounding rounding{defaultRounding};
   bool flushDenormalsToZero{false};
   bool bigEndian{false};
+  const semantics::DerivedTypeSpec *pdtInstance{nullptr};
 };
 
 void RealFlagWarnings(FoldingContext &, const RealFlags &, const char *op);

--- a/lib/evaluate/complex.h
+++ b/lib/evaluate/complex.h
@@ -32,6 +32,10 @@ public:
   constexpr Complex &operator=(const Complex &) = default;
   constexpr Complex &operator=(Complex &&) = default;
 
+  constexpr bool operator==(const Complex &that) const {
+    return re_ == that.re_ && im_ == that.im_;
+  }
+
   constexpr const Part &REAL() const { return re_; }
   constexpr const Part &AIMAG() const { return im_; }
   constexpr Complex CONJG() const { return {re_, im_.Negate()}; }

--- a/lib/evaluate/integer.h
+++ b/lib/evaluate/integer.h
@@ -180,6 +180,10 @@ public:
 
   constexpr Integer &operator=(const Integer &) = default;
 
+  constexpr bool operator==(const Integer &that) const {
+    return CompareUnsigned(that) == Ordering::Equal;
+  }
+
   // Left-justified mask (e.g., MASKL(1) has only its sign bit set)
   static constexpr Integer MASKL(int places) {
     if (places <= 0) {

--- a/lib/evaluate/logical.h
+++ b/lib/evaluate/logical.h
@@ -28,6 +28,10 @@ public:
   constexpr Logical(bool truth) : word_{-std::uint64_t{truth}} {}
   constexpr Logical &operator=(const Logical &) = default;
 
+  template<int B> constexpr bool operator==(const Logical<B> &that) const {
+    return IsTrue() == that.IsTrue();
+  }
+
   // For static expression evaluation, all the bits will have the same value.
   constexpr bool IsTrue() const { return word_.BTEST(0); }
 

--- a/lib/evaluate/real.h
+++ b/lib/evaluate/real.h
@@ -59,6 +59,10 @@ public:
   constexpr Real &operator=(const Real &) = default;
   constexpr Real &operator=(Real &&) = default;
 
+  constexpr bool operator==(const Real &that) const {
+    return word_ == that.word_;
+  }
+
   // TODO ANINT, CEILING, FLOOR, DIM, MAX, MIN, DPROD, FRACTION
   // HUGE, INT/NINT, MAXEXPONENT, MINEXPONENT, NEAREST, OUT_OF_RANGE,
   // PRECISION, HUGE, TINY, RRSPACING/SPACING, SCALE, SET_EXPONENT, SIGN

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -287,7 +287,7 @@ MaybeExpr TypedWrapper(DynamicType &&dyType, WRAPPED &&x) {
 // Wraps a data reference in a typed Designator<>.
 static MaybeExpr Designate(DataRef &&dataRef) {
   const Symbol &symbol{dataRef.GetLastSymbol()};
-  if (std::optional<DynamicType> dyType{GetSymbolType(symbol)}) {
+  if (std::optional<DynamicType> dyType{GetSymbolType(&symbol)}) {
     return TypedWrapper<Designator, DataRef>(
         std::move(*dyType), std::move(dataRef));
   }
@@ -764,7 +764,7 @@ MaybeExpr AnalyzeExpr(
           std::optional<Expr<SubscriptInteger>> last{
               GetSubstringBound(context, std::get<1>(range.t))};
           const Symbol &symbol{checked->GetLastSymbol()};
-          if (std::optional<DynamicType> dynamicType{GetSymbolType(symbol)}) {
+          if (std::optional<DynamicType> dynamicType{GetSymbolType(&symbol)}) {
             if (dynamicType->category == TypeCategory::Character) {
               return WrapperHelper<TypeCategory::Character, Designator,
                   Substring>(dynamicType->kind,

--- a/test/evaluate/intrinsics.cc
+++ b/test/evaluate/intrinsics.cc
@@ -156,8 +156,8 @@ void TestIntrinsics() {
       .DoCall();  // bad intrinsic name
   TestCall{table, "abs"}
       .Push(Named("a", Const(Scalar<Int4>{})))
-      .DoCall(Int4::dynamicType);
-  TestCall{table, "abs"}.Push(Const(Scalar<Int4>{})).DoCall(Int4::dynamicType);
+      .DoCall(Int4::GetType());
+  TestCall{table, "abs"}.Push(Const(Scalar<Int4>{})).DoCall(Int4::GetType());
   TestCall{table, "abs"}
       .Push(Named("bad", Const(Scalar<Int4>{})))
       .DoCall();  // bad keyword
@@ -174,21 +174,17 @@ void TestIntrinsics() {
       .Push(Named("a", Const(Scalar<Int4>{})))
       .Push(Const(Scalar<Int4>{}))
       .DoCall();
-  TestCall{table, "abs"}.Push(Const(Scalar<Int1>{})).DoCall(Int1::dynamicType);
-  TestCall{table, "abs"}.Push(Const(Scalar<Int4>{})).DoCall(Int4::dynamicType);
-  TestCall{table, "abs"}.Push(Const(Scalar<Int8>{})).DoCall(Int8::dynamicType);
-  TestCall{table, "abs"}
-      .Push(Const(Scalar<Real4>{}))
-      .DoCall(Real4::dynamicType);
-  TestCall{table, "abs"}
-      .Push(Const(Scalar<Real8>{}))
-      .DoCall(Real8::dynamicType);
+  TestCall{table, "abs"}.Push(Const(Scalar<Int1>{})).DoCall(Int1::GetType());
+  TestCall{table, "abs"}.Push(Const(Scalar<Int4>{})).DoCall(Int4::GetType());
+  TestCall{table, "abs"}.Push(Const(Scalar<Int8>{})).DoCall(Int8::GetType());
+  TestCall{table, "abs"}.Push(Const(Scalar<Real4>{})).DoCall(Real4::GetType());
+  TestCall{table, "abs"}.Push(Const(Scalar<Real8>{})).DoCall(Real8::GetType());
   TestCall{table, "abs"}
       .Push(Const(Scalar<Complex4>{}))
-      .DoCall(Real4::dynamicType);
+      .DoCall(Real4::GetType());
   TestCall{table, "abs"}
       .Push(Const(Scalar<Complex8>{}))
-      .DoCall(Real8::dynamicType);
+      .DoCall(Real8::GetType());
   TestCall{table, "abs"}.Push(Const(Scalar<Char>{})).DoCall();
   TestCall{table, "abs"}.Push(Const(Scalar<Log4>{})).DoCall();
 
@@ -202,10 +198,10 @@ void TestIntrinsics() {
     amin0Call.Push(Const(Scalar<Int4>{}));
     amin1Call.Push(Const(Scalar<Int4>{}));
   }
-  maxCall.DoCall(Real4::dynamicType);
+  maxCall.DoCall(Real4::GetType());
   max0Call.DoCall();
-  max1Call.DoCall(Int4::dynamicType);
-  amin0Call.DoCall(Real4::dynamicType);
+  max1Call.DoCall(Int4::GetType());
+  amin0Call.DoCall(Real4::GetType());
   amin1Call.DoCall();
 
   // TODO: test other intrinsics


### PR DESCRIPTION
This change prepares for the implementation of parameterized derived type instantiation that will follow in a later pull request.

So that it is possible to implement a collection of instantiated parameterized derived types, it is necessary to be able to compare two expressions for equality.  This change adds `operator==` to all the necessary classes.

Also, fine-tune `Unwrap`'s handling of `const`-qualified alternatives in variants.