### PR TITLE
Roll up folding & expression changes

### DIFF
--- a/lib/evaluate/call.cc
+++ b/lib/evaluate/call.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/evaluate/call.cc
+++ b/lib/evaluate/call.cc
@@ -59,11 +59,9 @@ std::ostream &SpecificIntrinsic::AsFortran(std::ostream &o) const {
 std::optional<DynamicType> ProcedureDesignator::GetType() const {
   if (const auto *intrinsic{std::get_if<SpecificIntrinsic>(&u)}) {
     return intrinsic->type;
+  } else {
+    return GetSymbolType(GetSymbol());
   }
-  if (const Symbol * symbol{GetSymbol()}) {
-    return GetSymbolType(symbol);
-  }
-  return std::nullopt;
 }
 
 int ProcedureDesignator::Rank() const {

--- a/lib/evaluate/common.h
+++ b/lib/evaluate/common.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/evaluate/common.h
+++ b/lib/evaluate/common.h
@@ -27,6 +27,10 @@ namespace Fortran::semantics {
 class DerivedTypeSpec;
 }
 
+namespace Fortran::semantics {
+class DerivedTypeSpec;
+}
+
 namespace Fortran::evaluate {
 
 using common::RelationalOperator;

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/evaluate/fold.h
+++ b/lib/evaluate/fold.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -14,6 +14,7 @@
 
 #include "intrinsics.h"
 #include "expression.h"
+#include "fold.h"
 #include "tools.h"
 #include "type.h"
 #include "../common/enum-set.h"
@@ -543,11 +544,7 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
     {"sin", {{"x", SameFloating}}, SameFloating},
     {"sinh", {{"x", SameFloating}}, SameFloating},
     {"size",
-        {{"array", Anything, Rank::anyOrAssumedRank}, SubscriptDefaultKIND},
-        KINDInt, Rank::vector},
-    {"size",
-        {{"array", Anything, Rank::anyOrAssumedRank},
-            {"dim", {IntType, KindCode::dimArg}, Rank::scalar},
+        {{"array", Anything, Rank::anyOrAssumedRank}, OptionalDIM,
             SubscriptDefaultKIND},
         KINDInt, Rank::scalar},
     {"spacing", {{"x", SameReal}}, SameReal},

--- a/lib/evaluate/tools.cc
+++ b/lib/evaluate/tools.cc
@@ -371,10 +371,7 @@ std::optional<Expr<SomeType>> Negation(
 
 Expr<SomeLogical> LogicalNegation(Expr<SomeLogical> &&x) {
   return std::visit(
-      [](auto &&xk) {
-        return AsCategoryExpr(
-            AsExpr(Not<ResultType<decltype(xk)>::kind>{std::move(xk)}));
-      },
+      [](auto &&xk) { return AsCategoryExpr(LogicalNegation(std::move(xk))); },
       std::move(x.u));
 }
 
@@ -492,8 +489,8 @@ Expr<SomeLogical> BinaryLogicalOperation(
   return std::visit(
       [=](auto &&xy) {
         using Ty = ResultType<decltype(xy[0])>;
-        return Expr<SomeLogical>{Expr<Ty>{LogicalOperation<Ty::kind>{
-            opr, std::move(xy[0]), std::move(xy[1])}}};
+        return Expr<SomeLogical>{BinaryLogicalOperation<Ty::kind>(
+            opr, std::move(xy[0]), std::move(xy[1]))};
       },
       AsSameKindExprs(std::move(x), std::move(y)));
 }

--- a/lib/evaluate/tools.cc
+++ b/lib/evaluate/tools.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -715,7 +715,7 @@ MaybeExpr AnalyzeExpr(
   if (MaybeExpr value{AnalyzeExpr(context, n.v)}) {
     Expr<SomeType> folded{
         Fold(context.context().foldingContext(), std::move(*value))};
-    if (IsConstant(folded)) {
+    if (IsConstantExpr(folded)) {
       return {folded};
     }
     context.Say(n.v.source, "must be a constant"_err_en_US);

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -66,7 +66,8 @@ template<typename A> CharBlock FindSourceLocation(const A &x) {
 namespace Fortran::evaluate {
 class ExpressionAnalysisContext {
 public:
-  explicit ExpressionAnalysisContext(semantics::SemanticsContext &sc) : context_{sc} {}
+  explicit ExpressionAnalysisContext(semantics::SemanticsContext &sc)
+    : context_{sc} {}
 
   semantics::SemanticsContext &context() const { return context_; }
 
@@ -130,7 +131,7 @@ std::optional<Expr<SomeType>> AnalyzeExpr(
   if (result.has_value()) {
     if (int rank{result->Rank()}; rank != 0) {
       context.SayAt(
-          x, "Must be a scalar value, but is a rank-%d array"_err_en_US);
+          x, "Must be a scalar value, but is a rank-%d array"_err_en_US, rank);
     }
   }
   return result;
@@ -142,7 +143,7 @@ std::optional<Expr<SomeType>> AnalyzeExpr(
   auto result{AnalyzeExpr(context, x.thing)};
   if (result.has_value()) {
     *result = Fold(context.context().foldingContext(), std::move(*result));
-    if (!IsConstant(*result)) {
+    if (!IsConstantExpr(*result)) {
       context.SayAt(x, "Must be a constant value"_err_en_US);
     }
   }


### PR DESCRIPTION
This PR collects a sheaf of improvements and extensions made to the expression representation and rewriting code in lib/evaluate in preparation for support of instantiating parameterized derived types.  These changes build and work on their own, so I've carved them off for independent review so as to make the PDT PR that is to come somewhat more focused.

Also contains a fix to a problem Tim isolated for me this morning: the semantic analysis of the `size` intrinsic was just wrong in the intrinsics table in the case of an omitted optional `DIM=` argument, and the error message for a failed scalar constraint check was omitting a value.