### PR TITLE
Symbol changes for PDT instantiation

### DIFF
--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019-2019, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/evaluate/type.cc
+++ b/lib/evaluate/type.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -927,7 +927,7 @@ MaybeExpr AnalyzeExpr(
         // TODO: extended derived types - insert explicit reference to base?
         context.Say(sc.component.source,
             "component is not in scope of derived TYPE(%s)"_err_en_US,
-            dtSpec->name().ToString().data());
+            dtSpec->typeSymbol().name().ToString().data());
       } else if (std::optional<DataRef> dataRef{
                      ExtractDataRef(std::move(*dtExpr))}) {
         Component component{std::move(*dataRef), *sym};

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019-2019, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -44,8 +44,8 @@ static void PutProcEntity(std::ostream &, const Symbol &);
 static void PutTypeParam(std::ostream &, const Symbol &);
 static void PutEntity(std::ostream &, const Symbol &, std::function<void()>);
 static void PutInit(std::ostream &, const MaybeExpr &);
+static void PutInit(std::ostream &, const MaybeIntExpr &);
 static void PutBound(std::ostream &, const Bound &);
-static void PutExpr(std::ostream &, const SomeExpr &);
 static std::ostream &PutAttrs(
     std::ostream &, Attrs, std::string before = ","s, std::string after = ""s);
 static std::ostream &PutLower(std::ostream &, const Symbol &);
@@ -174,8 +174,8 @@ void ModFileWriter::PutSymbol(
 void ModFileWriter::PutDerivedType(const Symbol &typeSymbol) {
   auto &details{typeSymbol.get<DerivedTypeDetails>()};
   PutAttrs(decls_ << "type", typeSymbol.attrs(), ","s, ""s);
-  if (details.extends()) {
-    PutLower(decls_ << ",extends(", *details.extends()) << ')';
+  if (!details.extends().empty()) {
+    PutLower(decls_ << ",extends(", details.extends().ToString()) << ')';
   }
   PutLower(decls_ << "::", typeSymbol);
   auto &typeScope{*typeSymbol.scope()};
@@ -375,7 +375,13 @@ void PutTypeParam(std::ostream &os, const Symbol &symbol) {
 
 void PutInit(std::ostream &os, const MaybeExpr &init) {
   if (init) {
-    PutExpr(os << '=', *init);
+    init->AsFortran(os << '=');
+  }
+}
+
+void PutInit(std::ostream &os, const MaybeIntExpr &init) {
+  if (init) {
+    init->AsFortran(os << '=');
   }
 }
 
@@ -388,8 +394,6 @@ void PutBound(std::ostream &os, const Bound &x) {
     x.GetExplicit()->AsFortran(os);
   }
 }
-
-void PutExpr(std::ostream &os, const SomeExpr &expr) { expr.AsFortran(os); }
 
 // Write an entity (object or procedure) declaration.
 // writeType is called to write out the type.

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -142,8 +142,9 @@ public:
   template<typename T>
   MaybeSubscriptIntExpr EvaluateSubscriptIntExpr(const T &expr) {
     if (MaybeIntExpr maybeIntExpr{EvaluateIntExpr(expr)}) {
-      return {evaluate::ConvertToType<evaluate::SubscriptInteger>(
-          std::move(*maybeIntExpr))};
+      return evaluate::Fold(context_->foldingContext(),
+          evaluate::ConvertToType<evaluate::SubscriptInteger>(
+              std::move(*maybeIntExpr)));
     } else {
       return std::nullopt;
     }

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -100,11 +100,9 @@ DeclTypeSpec &Scope::MakeCharacterType(ParamValue &&length, int kind) {
   return declTypeSpecs_.back();
 }
 
-DeclTypeSpec &Scope::MakeDerivedType(const SourceName &name) {
-  derivedTypeSpecs_.emplace_back(name);
-  declTypeSpecs_.emplace_back(
-      DeclTypeSpec::TypeDerived, derivedTypeSpecs_.back());
-  return declTypeSpecs_.back();
+DeclTypeSpec &Scope::MakeDerivedType(const Symbol &typeSymbol) {
+  DerivedTypeSpec &spec{derivedTypeSpecs_.emplace_back(typeSymbol)};
+  return declTypeSpecs_.emplace_back(DeclTypeSpec::TypeDerived, spec);
 }
 
 Scope::ImportKind Scope::GetImportKind() const {

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -124,7 +124,7 @@ public:
   DeclTypeSpec &MakeNumericType(TypeCategory, int kind);
   DeclTypeSpec &MakeLogicalType(int kind);
   DeclTypeSpec &MakeCharacterType(ParamValue &&length, int kind = 0);
-  DeclTypeSpec &MakeDerivedType(const SourceName &);
+  DeclTypeSpec &MakeDerivedType(const Symbol &);
   DeclTypeSpec &MakeTypeStarType();
   DeclTypeSpec &MakeClassStarType();
 

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -93,8 +93,7 @@ bool ObjectEntityDetails::IsDescriptor() const {
           }
         }
       }
-    } else if (type_->category() == DeclTypeSpec::Category::ClassDerived ||
-        type_->category() == DeclTypeSpec::Category::TypeStar ||
+    } else if (type_->category() == DeclTypeSpec::Category::TypeStar ||
         type_->category() == DeclTypeSpec::Category::ClassStar) {
       return true;
     }

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -588,7 +588,7 @@ Symbol &Symbol::Instantiate(Scope &scope, const DerivedTypeSpec &spec,
                     foldingContext, std::move(dim.ubound().GetExplicit())));
               }
             }
-            // TODO: fold cobounds too once we can represent them them
+            // TODO: fold cobounds too once we can represent them
           },
           [&](const ProcBindingDetails &that) {
             symbol.details_ = ProcBindingDetails{

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -39,7 +39,7 @@ void DerivedTypeSpec::AddParamValue(
 }
 
 std::ostream &operator<<(std::ostream &o, const DerivedTypeSpec &x) {
-  o << x.name().ToString();
+  o << x.typeSymbol().name().ToString();
   if (!x.paramValues_.empty()) {
     bool first = true;
     o << '(';
@@ -62,8 +62,6 @@ std::ostream &operator<<(std::ostream &o, const DerivedTypeSpec &x) {
 Bound::Bound(int bound)
   : category_{Category::Explicit},
     expr_{evaluate::Expr<evaluate::SubscriptInteger>{bound}} {}
-
-Bound Bound::Clone() const { return Bound(category_, MaybeExpr{expr_}); }
 
 std::ostream &operator<<(std::ostream &o, const Bound &x) {
   if (x.isAssumed()) {
@@ -94,10 +92,10 @@ std::ostream &operator<<(std::ostream &o, const ShapeSpec &x) {
   return o;
 }
 
-ParamValue::ParamValue(MaybeExpr &&expr)
-  : category_{Category::Explicit}, expr_{std::move(expr)} {}
+ParamValue::ParamValue(MaybeIntExpr &&expr) : expr_{std::move(expr)} {}
 ParamValue::ParamValue(std::int64_t value)
-  : ParamValue(SomeExpr{evaluate::Expr<evaluate::SubscriptInteger>{value}}) {}
+  : ParamValue(SomeIntExpr{evaluate::Expr<evaluate::SubscriptInteger>{value}}) {
+}
 
 std::ostream &operator<<(std::ostream &o, const ParamValue &x) {
   if (x.isAssumed()) {

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/test/semantics/modfile12.f90
+++ b/test/semantics/modfile12.f90
@@ -48,14 +48,14 @@ end
 !  integer(4),parameter::n=3_4
 !  integer(4),parameter::l=-3_4
 !  real(4),parameter::e=3.333333432674407958984375e-1_4
-!  real(4)::x(int(1_4,kind=8):13_8)
-!  real(4)::y(1_8:int(8_4,kind=8))
+!  real(4)::x(1_8:13_8)
+!  real(4)::y(1_8:8_8)
 !  type::t(c,d)
 !    integer(4),kind::c=1_4
 !    integer(4),len::d=3_8
 !  end type
-!  type(t(4_4,:)),allocatable::z
-!  class(t(5_4,:)),allocatable::z2
+!  type(t(c=4_4,d=:)),allocatable::z
+!  class(t(c=5_4,d=:)),allocatable::z2
 !  type(*),allocatable::z3
 !  class(*),allocatable::z4
 !  real(2)::f
@@ -67,7 +67,7 @@ end
 !  end type
 !contains
 !  subroutine foo(x)
-!    real(4)::x(int(2_4,kind=8):)
+!    real(4)::x(2_8:)
 !  end
 !  subroutine bar(x)
 !    real(4)::x(..)

--- a/test/semantics/modfile12.f90
+++ b/test/semantics/modfile12.f90
@@ -48,8 +48,8 @@ end
 !  integer(4),parameter::n=3_4
 !  integer(4),parameter::l=-3_4
 !  real(4),parameter::e=3.333333432674407958984375e-1_4
-!  real(4)::x(1_4:13_8)
-!  real(4)::y(1_8:8_4)
+!  real(4)::x(int(1_4,kind=8):13_8)
+!  real(4)::y(1_8:int(8_4,kind=8))
 !  type::t(c,d)
 !    integer(4),kind::c=1_4
 !    integer(4),len::d=3_8
@@ -67,7 +67,7 @@ end
 !  end type
 !contains
 !  subroutine foo(x)
-!    real(4)::x(2_4:)
+!    real(4)::x(int(2_4,kind=8):)
 !  end
 !  subroutine bar(x)
 !    real(4)::x(..)

--- a/test/semantics/symbol06.f90
+++ b/test/semantics/symbol06.f90
@@ -97,7 +97,7 @@ subroutine s1
  i = x%t1
  !REF: /s1/i
  !REF: /s1/x
- !DEF: /s1/t3/t2 ObjectEntity TYPE(t2)
+ !DEF: /s1/t3/t2 ObjectEntity TYPE(t1)
  !REF: /m1/t1/t1
  i = x%t2%t1
 end subroutine


### PR DESCRIPTION
These are all of the changes to `lib/semantics/symbol.{h,cc}` needed in order to implement instantiation of parameterized derived types.  Changes to other files in `lib/semantics` necessary to build & pass tests have been included as necessary but are incomplete.  Changes to folding that were withheld from the previous PR because they depended on these symbol table changes are also included.

Some places in the symbol table that admitted generic expressions have been restricted to INTEGER expressions (of any kind).

A new predicate, `Symbol::IsDescriptor()`, is included.  It is intended to be true when a symbol denotes an object that at runtime will have (i.e., will *be*) a descriptor.

Other changes will follow to complete the implementation of PDTs in types, scopes, and name resolution.  When complete, these changes will make `DerivedTypeSpec` represent each (potentially) distinct instantiation of a derived type in a scope.  The scope associated with each of those `DerivedTypeSpec` instances will (in the case of a PDT) be a clone of the original abstract derived type's scope in which each appearance of a type parameter will have been replaced with the actual parameter expression's value.  This change includes the implementation of `Symbol::Instantiate` which is the member function that clones a symbol in a new scope.

The expected results of some tests have been tweaked.





