### PR TITLE
Complete parameterized derived type instantiation

### DIFF
--- a/lib/evaluate/call.h
+++ b/lib/evaluate/call.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -58,13 +58,17 @@ using ActualArguments = std::vector<std::optional<ActualArgument>>;
 
 // Intrinsics are identified by their names and the characteristics
 // of their arguments, at least for now.
-using IntrinsicProcedure = const char *;  // not an owning pointer
+using IntrinsicProcedure = std::string;
 
 struct SpecificIntrinsic {
   explicit SpecificIntrinsic(IntrinsicProcedure n) : name{n} {}
   SpecificIntrinsic(IntrinsicProcedure n, std::optional<DynamicType> &&dt,
       int r, semantics::Attrs a)
     : name{n}, type{std::move(dt)}, rank{r}, attrs{a} {}
+  SpecificIntrinsic(const SpecificIntrinsic &) = default;
+  SpecificIntrinsic(SpecificIntrinsic &&) = default;
+  SpecificIntrinsic &operator=(const SpecificIntrinsic &) = default;
+  SpecificIntrinsic &operator=(SpecificIntrinsic &&) = default;
   bool operator==(const SpecificIntrinsic &) const;
   std::ostream &AsFortran(std::ostream &) const;
 

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -113,10 +113,10 @@ using BOZLiteralConstant = typename LargestReal::Scalar::Word;
 // from it via its derived() member function with compile-time type safety.
 template<typename DERIVED, typename RESULT, typename... OPERANDS>
 class Operation {
-  // The extra "int" member is a dummy that allows a safe unused reference
+  // The extra final member is a dummy that allows a safe unused reference
   // to element 1 to arise indirectly in the definition of "right()" below
   // when the operation has but a single operand.
-  using OperandTypes = std::tuple<OPERANDS..., int>;
+  using OperandTypes = std::tuple<OPERANDS..., std::monostate>;
 
 public:
   using Derived = DERIVED;

--- a/lib/evaluate/fold.h
+++ b/lib/evaluate/fold.h
@@ -82,7 +82,7 @@ const Scalar<T> *GetScalarConstantValue(const Expr<SomeType> &expr) {
 bool IsConstantExpr(const Expr<SomeType> &);
 
 // When an expression is a constant integer, ToInt64() extracts its value.
-// Ensure that the expression has been folded beforehand if folding might
+// Ensure that the expression has been folded beforehand when folding might
 // be required.
 template<int KIND>
 std::optional<std::int64_t> ToInt64(

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -111,6 +111,7 @@ static constexpr TypePattern AnyNumeric{NumericType, KindCode::any};
 static constexpr TypePattern AnyChar{CharType, KindCode::any};
 static constexpr TypePattern AnyLogical{LogicalType, KindCode::any};
 static constexpr TypePattern AnyRelatable{RelatableType, KindCode::any};
+static constexpr TypePattern AnyIntrinsic{IntrinsicType, KindCode::any};
 static constexpr TypePattern Anything{AnyType, KindCode::any};
 
 // Match some kind of some intrinsic type(s); all "Same" values must match,
@@ -385,6 +386,7 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
         SameInt},
     {"is_iostat_end", {{"i", AnyInt}}, DefaultLogical},
     {"is_iostat_eor", {{"i", AnyInt}}, DefaultLogical},
+    {"kind", {{"x", AnyIntrinsic}}, DefaultInt},
     {"lbound",
         {{"array", Anything, Rank::anyOrAssumedRank}, SubscriptDefaultKIND},
         KINDInt, Rank::vector},

--- a/lib/evaluate/variable.cc
+++ b/lib/evaluate/variable.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -208,10 +208,6 @@ std::optional<Expr<SomeCharacter>> Substring::Fold(FoldingContext &context) {
 
 std::ostream &Emit(std::ostream &o, const Symbol &symbol) {
   return o << symbol.name().ToString();
-}
-
-std::ostream &Emit(std::ostream &o, const IntrinsicProcedure &p) {
-  return o << p;
 }
 
 std::ostream &Emit(std::ostream &o, const std::string &lit) {

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ using SymbolOrComponent = std::variant<const Symbol *, Component>;
 // x%KIND for intrinsic types is similarly rewritten in semantics to
 // KIND(x), which is then folded to a constant value.
 // "Bare" type parameter references within a derived type definition do
-// not have base objects here.
+// not have base objects here, only symbols.
 template<int KIND> struct TypeParamInquiry {
   using Result = Type<TypeCategory::Integer, KIND>;
   CLASS_BOILERPLATE(TypeParamInquiry)
@@ -109,6 +109,7 @@ template<int KIND> struct TypeParamInquiry {
   static constexpr int Rank() { return 0; }  // always scalar
   bool operator==(const TypeParamInquiry &) const;
   std::ostream &AsFortran(std::ostream &) const;
+
   SymbolOrComponent u{nullptr};
   const Symbol *parameter;
 };
@@ -331,7 +332,9 @@ public:
   ProcedureRef(ProcedureDesignator &&p, ActualArguments &&a)
     : proc_{std::move(p)}, arguments_(std::move(a)) {}
 
+  ProcedureDesignator &proc() { return proc_; }
   const ProcedureDesignator &proc() const { return proc_; }
+  ActualArguments &arguments() { return arguments_; }
   const ActualArguments &arguments() const { return arguments_; }
 
   Expr<SubscriptInteger> LEN() const;

--- a/lib/parser/parse-tree-visitor.h
+++ b/lib/parser/parse-tree-visitor.h
@@ -230,35 +230,65 @@ void Walk(common::Indirection<T> &x, M &mutator) {
 
 // Walk a class with a single field 'thing'.
 template<typename T, typename V> void Walk(const Scalar<T> &x, V &visitor) {
-  Walk(x.thing, visitor);
+  if (visitor.Pre(x)) {
+    Walk(x.thing, visitor);
+    visitor.Post(x);
+  }
 }
 template<typename T, typename M> void Walk(Scalar<T> &x, M &mutator) {
-  Walk(x.thing, mutator);
+  if (mutator.Pre(x)) {
+    Walk(x.thing, mutator);
+    mutator.Post(x);
+  }
 }
 template<typename T, typename V> void Walk(const Constant<T> &x, V &visitor) {
-  Walk(x.thing, visitor);
+  if (visitor.Pre(x)) {
+    Walk(x.thing, visitor);
+    visitor.Post(x);
+  }
 }
 template<typename T, typename M> void Walk(Constant<T> &x, M &mutator) {
-  Walk(x.thing, mutator);
+  if (mutator.Pre(x)) {
+    Walk(x.thing, mutator);
+    mutator.Post(x);
+  }
 }
 template<typename T, typename V> void Walk(const Integer<T> &x, V &visitor) {
-  Walk(x.thing, visitor);
+  if (visitor.Pre(x)) {
+    Walk(x.thing, visitor);
+    visitor.Post(x);
+  }
 }
 template<typename T, typename M> void Walk(Integer<T> &x, M &mutator) {
-  Walk(x.thing, mutator);
+  if (mutator.Pre(x)) {
+    Walk(x.thing, mutator);
+    mutator.Post(x);
+  }
 }
 template<typename T, typename V> void Walk(const Logical<T> &x, V &visitor) {
-  Walk(x.thing, visitor);
+  if (visitor.Pre(x)) {
+    Walk(x.thing, visitor);
+    visitor.Post(x);
+  }
 }
 template<typename T, typename M> void Walk(Logical<T> &x, M &mutator) {
-  Walk(x.thing, mutator);
+  if (mutator.Pre(x)) {
+    Walk(x.thing, mutator);
+    mutator.Post(x);
+  }
 }
 template<typename T, typename V>
 void Walk(const DefaultChar<T> &x, V &visitor) {
-  Walk(x.thing, visitor);
+  if (visitor.Pre(x)) {
+    Walk(x.thing, visitor);
+    visitor.Post(x);
+  }
 }
 template<typename T, typename M> void Walk(DefaultChar<T> &x, M &mutator) {
-  Walk(x.thing, mutator);
+  if (mutator.Pre(x)) {
+    Walk(x.thing, mutator);
+    mutator.Post(x);
+  }
 }
 
 template<typename T, typename V> void Walk(const Statement<T> &x, V &visitor) {

--- a/lib/semantics/assignment.cc
+++ b/lib/semantics/assignment.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,63 +18,318 @@
 #include "symbol.h"
 #include "../common/idioms.h"
 #include "../evaluate/expression.h"
+#include "../evaluate/fold.h"
+#include "../evaluate/tools.h"
+#include "../parser/message.h"
 #include "../parser/parse-tree-visitor.h"
 #include "../parser/parse-tree.h"
+#include <optional>
+#include <set>
 
 using namespace Fortran::parser::literals;
 
 namespace Fortran::semantics {
 
-template<typename A>
-void AnalyzeExecutableStmt(SemanticsContext &, const parser::Statement<A> &) {}
-template<>
-void AnalyzeExecutableStmt(SemanticsContext &context,
-    const parser::Statement<parser::AssignmentStmt> &stmt) {}
-template<>
-void AnalyzeExecutableStmt(SemanticsContext &context,
-    const parser::Statement<parser::PointerAssignmentStmt> &stmt) {}
-template<>
-void AnalyzeExecutableStmt(SemanticsContext &context,
-    const parser::Statement<parser::WhereStmt> &stmt) {}
-template<>
-void AnalyzeExecutableStmt(SemanticsContext &context,
-    const parser::Statement<parser::ForallStmt> &stmt) {}
+using ControlExpr = evaluate::Expr<evaluate::SubscriptInteger>;
+using MaskExpr = evaluate::Expr<evaluate::LogicalResult>;
 
-void AnalyzeAssignment(SemanticsContext &context,
-    const parser::Statement<parser::AssignmentStmt> &stmt) {
-  AnalyzeExecutableStmt(context, stmt);
-}
-void AnalyzeAssignment(SemanticsContext &context,
-    const parser::Statement<parser::PointerAssignmentStmt> &stmt) {
-  AnalyzeExecutableStmt(context, stmt);
-}
-void AnalyzeAssignment(SemanticsContext &context,
-    const parser::Statement<parser::WhereStmt> &stmt) {
-  AnalyzeExecutableStmt(context, stmt);
-}
-void AnalyzeAssignment(SemanticsContext &context,
-    const parser::Statement<parser::ForallStmt> &stmt) {
-  AnalyzeExecutableStmt(context, stmt);
-}
+// The context tracks some number of active FORALL statements/constructs
+// and some number of active WHERE statements/constructs.  WHERE can nest
+// in FORALL but not vice versa.  Pointer assignments are allowed in
+// FORALL but not in WHERE.  These constraints are manifest in the grammar
+// and don't need to be rechecked here, since they cannot appear in the
+// parse tree.
+struct Control {
+  Symbol *name;
+  ControlExpr lower, upper, step;
+};
 
-class Mutator {
+struct ForallContext {
+  explicit ForallContext(const ForallContext *that) : outer{that} {}
+
+  // TODO pmk: Is this needed?  Does semantics already track these kinds?
+  std::optional<int> GetActiveIntKind(const parser::CharBlock &name) const {
+    const auto iter{activeNames.find(name)};
+    if (iter != activeNames.cend()) {
+      return {integerKind};
+    } else if (outer != nullptr) {
+      return outer->GetActiveIntKind(name);
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  const ForallContext *outer{nullptr};
+  std::optional<parser::CharBlock> constructName;
+  int integerKind;
+  std::vector<Control> control;
+  std::optional<MaskExpr> maskExpr;
+  std::set<parser::CharBlock> activeNames;
+};
+
+struct WhereContext {
+  explicit WhereContext(MaskExpr &&x) : thisMaskExpr{std::move(x)} {}
+
+  const WhereContext *outer{nullptr};
+  const ForallContext *forall{nullptr};  // innermost FORALL
+  std::optional<parser::CharBlock> constructName;
+  MaskExpr thisMaskExpr;  // independent of outer WHERE, if any
+  MaskExpr cumulativeMaskExpr{thisMaskExpr};
+};
+
+class AssignmentContext {
 public:
-  Mutator(SemanticsContext &context) : context_{context} {}
+  explicit AssignmentContext(
+      SemanticsContext &c, parser::CharBlock at = parser::CharBlock{})
+    : context_{c}, messages_{at, &c.messages()} {}
+  AssignmentContext(const AssignmentContext &that, parser::CharBlock at)
+    : context_{that.context_}, messages_{at, that.messages_.messages()},
+      where_{that.where_}, forall_{that.forall_} {}
+  AssignmentContext(const AssignmentContext &c, WhereContext &w)
+    : context_{c.context_}, messages_{c.messages_}, where_{&w} {}
+  AssignmentContext(const AssignmentContext &c, ForallContext &f)
+    : context_{c.context_}, messages_{c.messages_}, forall_{&f} {}
 
-  template<typename A> bool Pre(A &) { return true /* visit children */; }
-  template<typename A> void Post(A &) {}
+  void Analyze(const parser::AssignmentStmt &);
+  void Analyze(const parser::PointerAssignmentStmt &);
+  void Analyze(const parser::WhereStmt &);
+  void Analyze(const parser::WhereConstruct &);
+  void Analyze(const parser::ForallStmt &);
+  void Analyze(const parser::ForallConstruct &);
+  void Analyze(const parser::ConcurrentHeader &);
 
-  bool Pre(parser::Statement<parser::AssignmentStmt> &stmt) {
-    AnalyzeAssignment(context_, stmt);
+  template<typename A> void Analyze(const parser::Statement<A> &stmt) {
+    AssignmentContext nested{*this, stmt.source};
+    nested.Analyze(stmt.statement);
+  }
+  template<typename A> void Analyze(const common::Indirection<A> &x) {
+    Analyze(*x);
+  }
+  template<typename... As> void Analyze(const std::variant<As...> &u) {
+    std::visit([&](const auto &x) { Analyze(x); }, u);
+  }
+
+private:
+  void Analyze(const parser::WhereBodyConstruct &constr) { Analyze(constr.u); }
+  void Analyze(const parser::WhereConstruct::MaskedElsewhere &);
+  void Analyze(const parser::WhereConstruct::Elsewhere &);
+  void Analyze(const parser::ForallAssignmentStmt &stmt) { Analyze(stmt.u); }
+
+  int GetIntegerKind(const std::optional<parser::IntegerTypeSpec> &);
+
+  MaskExpr GetMask(const parser::LogicalExpr &, bool defaultValue = true) const;
+
+  template<typename... A> parser::Message *Say(A... args) {
+    return messages_.Say(std::forward<A>(args)...);
+  }
+
+  SemanticsContext &context_;
+  parser::ContextualMessages messages_;
+  WhereContext *where_{nullptr};
+  ForallContext *forall_{nullptr};
+};
+
+void AssignmentContext::Analyze(const parser::AssignmentStmt &stmt) {
+  if (forall_ != nullptr) {
+    // TODO: Warn if some name in forall_->activeNames or its outer
+    // contexts does not appear on LHS
+  }
+  // TODO: Fortran 2003 ALLOCATABLE assignment semantics (automatic
+  // (re)allocation of LHS array when unallocated or nonconformable)
+}
+
+void AssignmentContext::Analyze(const parser::PointerAssignmentStmt &stmt) {
+  CHECK(!where_);
+  if (forall_ != nullptr) {
+    // TODO: Warn if some name in forall_->activeNames or its outer
+    // contexts does not appear on LHS
+  }
+}
+
+void AssignmentContext::Analyze(const parser::WhereStmt &stmt) {
+  WhereContext where{GetMask(std::get<parser::LogicalExpr>(stmt.t))};
+  AssignmentContext nested{*this, where};
+  nested.Analyze(std::get<parser::AssignmentStmt>(stmt.t));
+}
+
+// N.B. Construct name matching is checked during label resolution.
+void AssignmentContext::Analyze(const parser::WhereConstruct &construct) {
+  const auto &whereStmt{
+      std::get<parser::Statement<parser::WhereConstructStmt>>(construct.t)};
+  WhereContext where{
+      GetMask(std::get<parser::LogicalExpr>(whereStmt.statement.t))};
+  if (const auto &name{
+          std::get<std::optional<parser::Name>>(whereStmt.statement.t)}) {
+    where.constructName = name->source;
+  }
+  AssignmentContext nested{*this, where};
+  for (const auto &x :
+      std::get<std::list<parser::WhereBodyConstruct>>(construct.t)) {
+    nested.Analyze(x);
+  }
+  for (const auto &x :
+      std::get<std::list<parser::WhereConstruct::MaskedElsewhere>>(
+          construct.t)) {
+    nested.Analyze(x);
+  }
+  if (const auto &x{std::get<std::optional<parser::WhereConstruct::Elsewhere>>(
+          construct.t)}) {
+    nested.Analyze(*x);
+  }
+}
+
+void AssignmentContext::Analyze(const parser::ForallStmt &stmt) {
+  CHECK(!where_);
+  ForallContext forall{forall_};
+  AssignmentContext nested{*this, forall};
+  nested.Analyze(
+      std::get<common::Indirection<parser::ConcurrentHeader>>(stmt.t));
+  nested.Analyze(std::get<parser::ForallAssignmentStmt>(stmt.t));
+}
+
+// N.B. Construct name matching is checked during label resolution;
+// index name distinction is checked during name resolution.
+void AssignmentContext::Analyze(const parser::ForallConstruct &construct) {
+  CHECK(!where_);
+  ForallContext forall{forall_};
+  AssignmentContext nested{*this, forall};
+  const auto &forallStmt{
+      std::get<parser::Statement<parser::ForallConstructStmt>>(construct.t)
+          .statement};
+  nested.Analyze(
+      std::get<common::Indirection<parser::ConcurrentHeader>>(forallStmt.t));
+  for (const auto &body :
+      std::get<std::list<parser::ForallBodyConstruct>>(construct.t)) {
+    nested.Analyze(body.u);
+  }
+}
+
+void AssignmentContext::Analyze(
+    const parser::WhereConstruct::MaskedElsewhere &elsewhere) {
+  CHECK(where_ != nullptr);
+  const auto &elsewhereStmt{
+      std::get<parser::Statement<parser::MaskedElsewhereStmt>>(elsewhere.t)};
+  MaskExpr mask{
+      GetMask(std::get<parser::LogicalExpr>(elsewhereStmt.statement.t))};
+  MaskExpr copyCumulative{where_->cumulativeMaskExpr};
+  MaskExpr notOldMask{evaluate::LogicalNegation(std::move(copyCumulative))};
+  if (!evaluate::AreConformable(notOldMask, mask)) {
+    Say(elsewhereStmt.source,
+        "mask of ELSEWHERE statement is not conformable with "
+        "the prior mask(s) in its WHERE construct"_err_en_US);
+  }
+  MaskExpr copyMask{mask};
+  where_->cumulativeMaskExpr =
+      evaluate::BinaryLogicalOperation(evaluate::LogicalOperator::Or,
+          std::move(where_->cumulativeMaskExpr), std::move(copyMask));
+  where_->thisMaskExpr = evaluate::BinaryLogicalOperation(
+      evaluate::LogicalOperator::And, std::move(notOldMask), std::move(mask));
+  if (where_->outer != nullptr &&
+      !evaluate::AreConformable(
+          where_->outer->thisMaskExpr, where_->thisMaskExpr)) {
+    Say(elsewhereStmt.source,
+        "effective mask of ELSEWHERE statement is not conformable "
+        "with the mask of the surrounding WHERE construct"_err_en_US);
+  }
+  for (const auto &x :
+      std::get<std::list<parser::WhereBodyConstruct>>(elsewhere.t)) {
+    Analyze(x);
+  }
+}
+
+void AssignmentContext::Analyze(
+    const parser::WhereConstruct::Elsewhere &elsewhere) {
+  CHECK(where_ != nullptr);
+  MaskExpr copyCumulative{where_->cumulativeMaskExpr};
+  where_->thisMaskExpr = evaluate::LogicalNegation(std::move(copyCumulative));
+  for (const auto &x :
+      std::get<std::list<parser::WhereBodyConstruct>>(elsewhere.t)) {
+    Analyze(x);
+  }
+}
+
+void AssignmentContext::Analyze(const parser::ConcurrentHeader &header) {
+  CHECK(forall_ != nullptr);
+  forall_->integerKind = GetIntegerKind(
+      std::get<std::optional<parser::IntegerTypeSpec>>(header.t));
+  for (const auto &control :
+      std::get<std::list<parser::ConcurrentControl>>(header.t)) {
+    const parser::CharBlock &name{std::get<parser::Name>(control.t).source};
+    bool inserted{forall_->activeNames.insert(name).second};
+    CHECK(inserted);
+  }
+}
+
+int AssignmentContext::GetIntegerKind(
+    const std::optional<parser::IntegerTypeSpec> &spec) {
+  std::optional<parser::KindSelector> empty;
+  evaluate::Expr<evaluate::SubscriptInteger> kind{AnalyzeKindSelector(
+      context_, messages_.at(), TypeCategory::Integer, spec ? spec->v : empty)};
+  if (auto value{evaluate::ToInt64(kind)}) {
+    return static_cast<int>(*value);
+  } else {
+    Say("Kind of INTEGER type must be a constant value"_err_en_US);
+    return context_.defaultKinds().GetDefaultKind(TypeCategory::Integer);
+  }
+}
+
+MaskExpr AssignmentContext::GetMask(
+    const parser::LogicalExpr &expr, bool defaultValue) const {
+  MaskExpr mask{defaultValue};
+  if (auto maybeExpr{AnalyzeExpr(context_, expr)}) {
+    auto *logical{
+        std::get_if<evaluate::Expr<evaluate::SomeLogical>>(&maybeExpr->u)};
+    CHECK(logical != nullptr);
+    mask = evaluate::ConvertTo(mask, std::move(*logical));
+  }
+  return mask;
+}
+
+void AnalyzeConcurrentHeader(
+    SemanticsContext &context, const parser::ConcurrentHeader &header) {
+  AssignmentContext{context}.Analyze(header);
+}
+
+namespace {
+class Visitor {
+public:
+  Visitor(SemanticsContext &context) : context_{context} {}
+
+  template<typename A> bool Pre(const A &) { return true /* visit children */; }
+  template<typename A> void Post(const A &) {}
+
+  bool Pre(const parser::Statement<parser::AssignmentStmt> &stmt) {
+    AssignmentContext{context_, stmt.source}.Analyze(stmt.statement);
+    return false;
+  }
+  bool Pre(const parser::Statement<parser::PointerAssignmentStmt> &stmt) {
+    AssignmentContext{context_, stmt.source}.Analyze(stmt.statement);
+    return false;
+  }
+  bool Pre(const parser::Statement<parser::WhereStmt> &stmt) {
+    AssignmentContext{context_, stmt.source}.Analyze(stmt.statement);
+    return false;
+  }
+  bool Pre(const parser::WhereConstruct &construct) {
+    AssignmentContext{context_}.Analyze(construct);
+    return false;
+  }
+  bool Pre(const parser::Statement<parser::ForallStmt> &stmt) {
+    AssignmentContext{context_, stmt.source}.Analyze(stmt.statement);
+    return false;
+  }
+  bool Pre(const parser::ForallConstruct &construct) {
+    AssignmentContext{context_}.Analyze(construct);
     return false;
   }
 
 private:
   SemanticsContext &context_;
 };
+}
 
 void AnalyzeAssignments(parser::Program &program, SemanticsContext &context) {
-  Mutator mutator{context};
-  parser::Walk(program, mutator);
+  Visitor visitor{context};
+  parser::Walk(program, visitor);
 }
 }

--- a/lib/semantics/assignment.h
+++ b/lib/semantics/assignment.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 namespace Fortran::parser {
 template<typename> struct Statement;
 struct AssignmentStmt;
+struct ConcurrentHeader;
 struct ForallStmt;
 struct PointerAssignmentStmt;
 struct Program;
@@ -36,6 +37,11 @@ void AnalyzeAssignment(
     SemanticsContext &, const parser::Statement<parser::WhereStmt> &);
 void AnalyzeAssignment(
     SemanticsContext &, const parser::Statement<parser::ForallStmt> &);
+
+// R1125 concurrent-header is used in FORALL statements & constructs as
+// well as in DO CONCURRENT loops.
+void AnalyzeConcurrentHeader(
+    SemanticsContext &, const parser::ConcurrentHeader &);
 
 // Semantic analysis of all assignment statements and related constructs.
 void AnalyzeAssignments(parser::Program &, SemanticsContext &);

--- a/lib/semantics/dump-parse-tree.h
+++ b/lib/semantics/dump-parse-tree.h
@@ -715,11 +715,10 @@ public:
 #undef NODE_NAME
 
   template<typename T> bool Pre(const T &x) {
-    IndentEmptyLine();
     if (UnionTrait<T> || WrapperTrait<T>) {
-      out_ << GetNodeName(x) << " -> ";
-      emptyline_ = false;
+      Prefix(GetNodeName(x));
     } else {
+      IndentEmptyLine();
       out_ << GetNodeName(x);
       EndLine();
       ++indent_;
@@ -786,10 +785,16 @@ public:
   template<typename T> bool Pre(const common::Indirection<T> &) { return true; }
   template<typename T> void Post(const common::Indirection<T> &) {}
 
+  template<typename A> bool Pre(const parser::Scalar<A> &) {
+    Prefix("Scalar");
+    return true;
+  }
+  template<typename A> void Post(const parser::Scalar<A> &) {
+    EndLineIfNonempty();
+  }
+
   template<typename A> bool Pre(const parser::Constant<A> &) {
-    IndentEmptyLine();
-    out_ << "Constant ->";
-    emptyline_ = false;
+    Prefix("Constant");
     return true;
   }
   template<typename A> void Post(const parser::Constant<A> &) {
@@ -797,20 +802,26 @@ public:
   }
 
   template<typename A> bool Pre(const parser::Integer<A> &) {
-    IndentEmptyLine();
-    out_ << "Integer ->";
-    emptyline_ = false;
+    Prefix("Integer");
     return true;
   }
-  template<typename A> void Post(const parser::Integer<A> &) {}
+  template<typename A> void Post(const parser::Integer<A> &) {
+    EndLineIfNonempty();
+  }
 
-  template<typename A> bool Pre(const parser::Scalar<A> &) {
-    IndentEmptyLine();
-    out_ << "Scalar ->";
-    emptyline_ = false;
+  template<typename A> bool Pre(const parser::Logical<A> &) {
+    Prefix("Logical");
     return true;
   }
-  template<typename A> void Post(const parser::Scalar<A> &) {
+  template<typename A> void Post(const parser::Logical<A> &) {
+    EndLineIfNonempty();
+  }
+
+  template<typename A> bool Pre(const parser::DefaultChar<A> &) {
+    Prefix("DefaultChar");
+    return true;
+  }
+  template<typename A> void Post(const parser::DefaultChar<A> &) {
     EndLineIfNonempty();
   }
 
@@ -828,6 +839,18 @@ protected:
       }
       emptyline_ = false;
     }
+  }
+
+  void Prefix(const char *str) {
+    IndentEmptyLine();
+    out_ << str << " -> ";
+    emptyline_ = false;
+  }
+
+  void Prefix(const std::string &str) {
+    IndentEmptyLine();
+    out_ << str << " -> ";
+    emptyline_ = false;
   }
 
   void EndLine() {

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -92,7 +92,7 @@ public:
 
   std::optional<Expr<SomeType>> Analyze(const parser::Expr &);
   std::optional<Expr<SomeType>> Analyze(const parser::Variable &);
-  int Analyze(common::TypeCategory category,
+  Expr<SubscriptInteger> Analyze(common::TypeCategory category,
       const std::optional<parser::KindSelector> &);
 
   int GetDefaultKind(common::TypeCategory);
@@ -245,8 +245,8 @@ std::optional<evaluate::Expr<evaluate::SomeType>> AnalyzeExpr(
 void AnalyzeExpressions(parser::Program &, SemanticsContext &);
 
 // Semantic analysis of an intrinsic type's KIND parameter expression.
-// Always returns a valid kind value for the type category.
-int AnalyzeKindSelector(SemanticsContext &, parser::CharBlock,
-    common::TypeCategory, const std::optional<parser::KindSelector> &);
+evaluate::Expr<evaluate::SubscriptInteger> AnalyzeKindSelector(
+    SemanticsContext &, parser::CharBlock, common::TypeCategory,
+    const std::optional<parser::KindSelector> &);
 }
 #endif  // FORTRAN_SEMANTICS_EXPRESSION_H_

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -263,7 +263,6 @@ public:
   using AttrsVisitor::Pre;
   void Post(const parser::IntrinsicTypeSpec::DoublePrecision &);
   void Post(const parser::IntrinsicTypeSpec::DoubleComplex &);
-  bool Pre(const parser::DeclarationTypeSpec::Class &);
   void Post(const parser::DeclarationTypeSpec::ClassStar &);
   void Post(const parser::DeclarationTypeSpec::TypeStar &);
   bool Pre(const parser::TypeGuardStmt &);
@@ -1176,10 +1175,6 @@ void DeclTypeSpecVisitor::MakeNumericType(TypeCategory category, int kind) {
   SetDeclTypeSpec(context().MakeNumericType(category, kind));
 }
 
-bool DeclTypeSpecVisitor::Pre(const parser::DeclarationTypeSpec::Class &x) {
-  state_.derived.category = DeclTypeSpec::ClassDerived;
-  return true;
-}
 void DeclTypeSpecVisitor::Post(const parser::DeclarationTypeSpec::ClassStar &) {
   SetDeclTypeSpec(context().globalScope().MakeClassStarType());
 }

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -134,13 +134,16 @@ public:
   Scope *FindSubmodule(const SourceName &) const;
   bool AddSubmodule(const SourceName &, Scope &);
 
-  DeclTypeSpec &MakeDerivedType(const Symbol &);
-
   const DeclTypeSpec &MakeNumericType(TypeCategory, KindExpr &&kind);
   const DeclTypeSpec &MakeLogicalType(KindExpr &&kind);
   const DeclTypeSpec &MakeCharacterType(
       ParamValue &&length, KindExpr &&kind = KindExpr{0});
-  const DeclTypeSpec &MakeDerivedType(DeclTypeSpec::Category, DerivedTypeSpec &&);
+  const DeclTypeSpec &MakeDerivedType(
+      DeclTypeSpec::Category, DerivedTypeSpec &&);
+  const DeclTypeSpec &MakeDerivedType(
+      DeclTypeSpec::Category, DerivedTypeSpec &&, evaluate::FoldingContext &);
+  DeclTypeSpec &MakeDerivedType(const Symbol &);
+  DeclTypeSpec &MakeDerivedType(DerivedTypeSpec &&, DeclTypeSpec::Category);
   const DeclTypeSpec &MakeTypeStarType();
   const DeclTypeSpec &MakeClassStarType();
 
@@ -205,7 +208,7 @@ private:
   static Symbols<1024> allSymbols;
 
   bool CanImport(const SourceName &) const;
-  const DeclTypeSpec &MakeLengthlessType(const DeclTypeSpec &);
+  const DeclTypeSpec &MakeLengthlessType(DeclTypeSpec &&);
 
   friend std::ostream &operator<<(std::ostream &, const Scope &);
 };

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "semantics.h"
+#include "assignment.h"
 #include "canonicalize-do.h"
 #include "check-do-concurrent.h"
 #include "default-kinds.h"
@@ -42,13 +43,13 @@ const DeclTypeSpec &SemanticsContext::MakeNumericType(
   if (kind == 0) {
     kind = defaultKinds_.GetDefaultKind(category);
   }
-  return globalScope_.MakeNumericType(category, kind);
+  return globalScope_.MakeNumericType(category, KindExpr{kind});
 }
 const DeclTypeSpec &SemanticsContext::MakeLogicalType(int kind) {
   if (kind == 0) {
     kind = defaultKinds_.GetDefaultKind(TypeCategory::Logical);
   }
-  return globalScope_.MakeLogicalType(kind);
+  return globalScope_.MakeLogicalType(KindExpr{kind});
 }
 
 bool SemanticsContext::AnyFatalError() const {
@@ -84,6 +85,7 @@ bool Semantics::Perform() {
   }
   if (context_.debugExpressions()) {
     AnalyzeExpressions(program_, context_);
+    AnalyzeAssignments(program_, context_);
   }
   return !AnyFatalError();
 }

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -368,7 +368,9 @@ std::ostream &operator<<(std::ostream &os, const ObjectEntityDetails &x) {
 
 std::ostream &operator<<(std::ostream &os, const AssocEntityDetails &x) {
   os << *static_cast<const EntityDetails *>(&x);
-  x.expr().AsFortran(os << ' ');
+  if (x.expr().has_value()) {
+    x.expr()->AsFortran(os << ' ');
+  }
   return os;
 }
 

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -437,12 +437,13 @@ public:
   int Rank() const;
 
   // Clones the Symbol in the context of a parameterized derived type instance
-  Symbol &Instantiate(
-      Scope &, const DerivedTypeSpec &, evaluate::FoldingContext &) const;
+  Symbol &Instantiate(Scope &, evaluate::FoldingContext &) const;
 
-  // If the symbol refers to a derived type with a parent component,
-  // return the symbol of the parent component's derived type.
-  const Symbol *GetParent() const;
+  // If there is a parent component, return a pointer to its
+  // derived type spec.
+  // The Scope * argument defaults to this->scope_ but should be overridden
+  // for a parameterized derived type instantiation with the instance's scope.
+  const DerivedTypeSpec *GetParentTypeSpec(const Scope * = nullptr) const;
 
 private:
   const Scope *owner_;
@@ -456,6 +457,11 @@ private:
   const std::string GetDetailsName() const;
   friend std::ostream &operator<<(std::ostream &, const Symbol &);
   friend std::ostream &DumpForUnparse(std::ostream &, const Symbol &, bool);
+
+  // If the symbol refers to a derived type with a parent component,
+  // return that parent component's symbol.
+  const Symbol *GetParentComponent(const Scope * = nullptr) const;
+
   template<std::size_t> friend class Symbols;
   template<class, std::size_t> friend struct std::array;
 };

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -108,7 +108,7 @@ private:
 // A name from an entity-decl -- could be object or function.
 class EntityDetails {
 public:
-  EntityDetails(bool isDummy = false) : isDummy_{isDummy} {}
+  explicit EntityDetails(bool isDummy = false) : isDummy_{isDummy} {}
   const DeclTypeSpec *type() const { return type_; }
   void set_type(const DeclTypeSpec &);
   void ReplaceType(const DeclTypeSpec &);
@@ -126,11 +126,16 @@ private:
 // Symbol is associated with a name or expression in a SELECT TYPE or ASSOCIATE.
 class AssocEntityDetails : public EntityDetails {
 public:
-  AssocEntityDetails(SomeExpr &&expr) : expr_{std::move(expr)} {}
-  const SomeExpr &expr() const { return expr_; }
+  AssocEntityDetails() {}
+  explicit AssocEntityDetails(SomeExpr &&expr) : expr_{std::move(expr)} {}
+  AssocEntityDetails(const AssocEntityDetails &) = default;
+  AssocEntityDetails(AssocEntityDetails &&) = default;
+  AssocEntityDetails &operator=(const AssocEntityDetails &) = default;
+  AssocEntityDetails &operator=(AssocEntityDetails &&) = default;
+  const MaybeExpr &expr() const { return expr_; }
 
 private:
-  SomeExpr expr_;
+  MaybeExpr expr_;
 };
 
 // An entity known to be an object.
@@ -175,7 +180,7 @@ private:
 class ProcEntityDetails : public EntityDetails {
 public:
   ProcEntityDetails() = default;
-  ProcEntityDetails(EntityDetails &&d);
+  explicit ProcEntityDetails(EntityDetails &&d);
 
   const ProcInterface &interface() const { return interface_; }
   ProcInterface &interface() { return interface_; }

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -205,6 +205,7 @@ std::ostream &operator<<(std::ostream &o, const ShapeSpec &x) {
 }
 
 ParamValue::ParamValue(MaybeIntExpr &&expr) : expr_{std::move(expr)} {}
+ParamValue::ParamValue(SomeIntExpr &&expr) : expr_{std::move(expr)} {}
 ParamValue::ParamValue(std::int64_t value)
   : ParamValue(SomeIntExpr{evaluate::Expr<evaluate::SubscriptInteger>{value}}) {
 }

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -90,10 +90,11 @@ private:
 // A type parameter value: integer expression or assumed or deferred.
 class ParamValue {
 public:
-  static constexpr ParamValue Assumed() { return Category::Assumed; }
-  static constexpr ParamValue Deferred() { return Category::Deferred; }
+  static ParamValue Assumed() { return Category::Assumed; }
+  static ParamValue Deferred() { return Category::Deferred; }
   ParamValue(const ParamValue &) = default;
   explicit ParamValue(MaybeIntExpr &&);
+  explicit ParamValue(SomeIntExpr &&);
   explicit ParamValue(std::int64_t);
   bool isExplicit() const { return category_ == Category::Explicit; }
   bool isAssumed() const { return category_ == Category::Assumed; }

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -25,6 +25,7 @@ set(ERROR_TESTS
   implicit06.f90
   implicit07.f90
   implicit08.f90
+  kinds02.f90
   resolve01.f90
   resolve02.f90
   resolve03.f90
@@ -79,6 +80,8 @@ set(SYMBOL_TESTS
   symbol09.f90
   symbol10.f90
   symbol11.f90
+  kinds01.f90
+  kinds03.f90
 )
 
 # These test files have expected .mod file contents in the source
@@ -99,6 +102,7 @@ set(MODFILE_TESTS
   modfile14.f90
   modfile15.f90
   modfile16.f90
+  modfile17.f90
 )
 
 set(LABEL_TESTS

--- a/test/semantics/kinds01.f90
+++ b/test/semantics/kinds01.f90
@@ -1,0 +1,95 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+ !DEF: /MainProgram1/jk1 ObjectEntity INTEGER(1)
+ integer(kind=1) jk1
+ !DEF: /MainProgram1/js1 ObjectEntity INTEGER(1)
+ integer*1 js1
+ !DEF: /MainProgram1/jk2 ObjectEntity INTEGER(2)
+ integer(kind=2) jk2
+ !DEF: /MainProgram1/js2 ObjectEntity INTEGER(2)
+ integer*2 js2
+ !DEF: /MainProgram1/jk4 ObjectEntity INTEGER(4)
+ integer(kind=4) jk4
+ !DEF: /MainProgram1/js4 ObjectEntity INTEGER(4)
+ integer*4 js4
+ !DEF: /MainProgram1/jk8 ObjectEntity INTEGER(8)
+ integer(kind=8) jk8
+ !DEF: /MainProgram1/js8 ObjectEntity INTEGER(8)
+ integer*8 js8
+ !DEF: /MainProgram1/jk16 ObjectEntity INTEGER(16)
+ integer(kind=16) jk16
+ !DEF: /MainProgram1/js16 ObjectEntity INTEGER(16)
+ integer*16 js16
+ !DEF: /MainProgram1/ak2 ObjectEntity REAL(2)
+ real(kind=2) ak2
+ !DEF: /MainProgram1/as2 ObjectEntity REAL(2)
+ real*2 as2
+ !DEF: /MainProgram1/ak4 ObjectEntity REAL(4)
+ real(kind=4) ak4
+ !DEF: /MainProgram1/as4 ObjectEntity REAL(4)
+ real*4 as4
+ !DEF: /MainProgram1/ak8 ObjectEntity REAL(8)
+ real(kind=8) ak8
+ !DEF: /MainProgram1/as8 ObjectEntity REAL(8)
+ real*8 as8
+ !DEF: /MainProgram1/dp ObjectEntity REAL(8)
+ double precision dp
+ !DEF: /MainProgram1/ak10 ObjectEntity REAL(10)
+ real(kind=10) ak10
+ !DEF: /MainProgram1/as10 ObjectEntity REAL(10)
+ real*10 as10
+ !DEF: /MainProgram1/ak16 ObjectEntity REAL(16)
+ real(kind=16) ak16
+ !DEF: /MainProgram1/as16 ObjectEntity REAL(16)
+ real*16 as16
+ !DEF: /MainProgram1/zk2 ObjectEntity COMPLEX(2)
+ complex(kind=2) zk2
+ !DEF: /MainProgram1/zs2 ObjectEntity COMPLEX(2)
+ complex*4 zs2
+ !DEF: /MainProgram1/zk4 ObjectEntity COMPLEX(4)
+ complex(kind=4) zk4
+ !DEF: /MainProgram1/zs4 ObjectEntity COMPLEX(4)
+ complex*8 zs4
+ !DEF: /MainProgram1/zk8 ObjectEntity COMPLEX(8)
+ complex(kind=8) zk8
+ !DEF: /MainProgram1/zs8 ObjectEntity COMPLEX(8)
+ complex*16 zs8
+ !DEF: /MainProgram1/zdp ObjectEntity COMPLEX(8)
+ double complex zdp
+ !DEF: /MainProgram1/zk10 ObjectEntity COMPLEX(10)
+ complex(kind=10) zk10
+ !DEF: /MainProgram1/zs10 ObjectEntity COMPLEX(10)
+ complex*20 zs10
+ !DEF: /MainProgram1/zk16 ObjectEntity COMPLEX(16)
+ complex(kind=16) zk16
+ !DEF: /MainProgram1/zs16 ObjectEntity COMPLEX(16)
+ complex*32 zs16
+ !DEF: /MainProgram1/lk1 ObjectEntity LOGICAL(1)
+ logical(kind=1) lk1
+ !DEF: /MainProgram1/ls1 ObjectEntity LOGICAL(1)
+ logical*1 ls1
+ !DEF: /MainProgram1/lk2 ObjectEntity LOGICAL(2)
+ logical(kind=2) lk2
+ !DEF: /MainProgram1/ls2 ObjectEntity LOGICAL(2)
+ logical*2 ls2
+ !DEF: /MainProgram1/lk4 ObjectEntity LOGICAL(4)
+ logical(kind=4) lk4
+ !DEF: /MainProgram1/ls4 ObjectEntity LOGICAL(4)
+ logical*4 ls4
+ !DEF: /MainProgram1/lk8 ObjectEntity LOGICAL(8)
+ logical(kind=8) lk8
+ !DEF: /MainProgram1/ls8 ObjectEntity LOGICAL(8)
+ logical*8 ls8
+end program

--- a/test/semantics/kinds02.f90
+++ b/test/semantics/kinds02.f90
@@ -1,0 +1,57 @@
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+!ERROR: INTEGER(KIND=0) is not a supported type
+integer(kind=0) :: j0
+!ERROR: INTEGER(KIND=-1) is not a supported type
+integer(kind=-1) :: jm1
+!ERROR: INTEGER(KIND=3) is not a supported type
+integer(kind=3) :: j3
+!ERROR: INTEGER(KIND=32) is not a supported type
+integer(kind=32) :: j32
+!ERROR: REAL(KIND=0) is not a supported type
+real(kind=0) :: a0
+!ERROR: REAL(KIND=-1) is not a supported type
+real(kind=-1) :: am1
+!ERROR: REAL(KIND=1) is not a supported type
+real(kind=1) :: a1
+!ERROR: REAL(KIND=7) is not a supported type
+real(kind=7) :: a7
+!ERROR: REAL(KIND=32) is not a supported type
+real(kind=32) :: a32
+!ERROR: COMPLEX(KIND=0) is not a supported type
+complex(kind=0) :: z0
+!ERROR: COMPLEX(KIND=-1) is not a supported type
+complex(kind=-1) :: zm1
+!ERROR: COMPLEX(KIND=1) is not a supported type
+complex(kind=1) :: z1
+!ERROR: COMPLEX(KIND=7) is not a supported type
+complex(kind=7) :: z7
+!ERROR: COMPLEX(KIND=32) is not a supported type
+complex(kind=32) :: z32
+!ERROR: COMPLEX*1 is not a supported type
+complex*1 :: zs1
+!ERROR: COMPLEX*2 is not a supported type
+complex*2 :: zs2
+!ERROR: COMPLEX*64 is not a supported type
+complex*64 :: zs64
+!ERROR: LOGICAL(KIND=0) is not a supported type
+logical(kind=0) :: l0
+!ERROR: LOGICAL(KIND=-1) is not a supported type
+logical(kind=-1) :: lm1
+!ERROR: LOGICAL(KIND=3) is not a supported type
+logical(kind=3) :: l3
+!ERROR: LOGICAL(KIND=16) is not a supported type
+logical(kind=16) :: l16
+end program

--- a/test/semantics/kinds03.f90
+++ b/test/semantics/kinds03.f90
@@ -12,44 +12,97 @@
 ! See the License for the specific language governing permissions and
 ! limitations under the License.
 
-type ipdt(k)
- integer, kind :: k
- integer(kind=k) :: x
-end type ipdt
-
-type rpdt(k)
- integer, kind :: k
- real(kind=k) :: x
-end type rpdt
-
-type zpdt(k)
- integer, kind :: k
- complex(kind=k) :: x
-end type zpdt
-
-type lpdt(k)
- integer, kind :: k
- logical(kind=k) :: x
-end type lpdt
-
-type(ipdt(1)) i1
-type(ipdt(2)) i2
-type(ipdt(4)) i4
-type(ipdt(8)) i8
-type(ipdt(16)) i16
-type(rpdt(2)) a2
-type(rpdt(4)) a4
-type(rpdt(8)) a8
-type(rpdt(10)) a10
-type(rpdt(16)) a16
-type(zpdt(2)) z2
-type(zpdt(4)) z4
-type(zpdt(8)) z8
-type(zpdt(10)) z10
-type(zpdt(16)) z16
-type(lpdt(1)) l1
-type(lpdt(2)) l2
-type(lpdt(4)) l4
-type(lpdt(8)) l8
-
+ !DEF: /MainProgram1/ipdt DerivedType
+ !DEF: /MainProgram1/ipdt/k TypeParam INTEGER(4)
+ type :: ipdt(k)
+  !REF: /MainProgram1/ipdt/k
+  integer, kind :: k
+  !REF: /MainProgram1/ipdt/k
+  !DEF: /MainProgram1/ipdt/x ObjectEntity INTEGER(int(k,kind=8))
+  integer(kind=k) :: x
+ end type ipdt
+ !DEF: /MainProgram1/rpdt DerivedType
+ !DEF: /MainProgram1/rpdt/k TypeParam INTEGER(4)
+ type :: rpdt(k)
+  !REF: /MainProgram1/rpdt/k
+  integer, kind :: k
+  !REF: /MainProgram1/rpdt/k
+  !DEF: /MainProgram1/rpdt/x ObjectEntity REAL(int(k,kind=8))
+  real(kind=k) :: x
+ end type rpdt
+ !DEF: /MainProgram1/zpdt DerivedType
+ !DEF: /MainProgram1/zpdt/k TypeParam INTEGER(4)
+ type :: zpdt(k)
+  !REF: /MainProgram1/zpdt/k
+  integer, kind :: k
+  !REF: /MainProgram1/zpdt/k
+  !DEF: /MainProgram1/zpdt/x ObjectEntity COMPLEX(int(k,kind=8))
+  complex(kind=k) :: x
+ end type zpdt
+ !DEF: /MainProgram1/lpdt DerivedType
+ !DEF: /MainProgram1/lpdt/k TypeParam INTEGER(4)
+ type :: lpdt(k)
+  !REF: /MainProgram1/lpdt/k
+  integer, kind :: k
+  !REF: /MainProgram1/lpdt/k
+  !DEF: /MainProgram1/lpdt/x ObjectEntity LOGICAL(int(k,kind=8))
+  logical(kind=k) :: x
+ end type lpdt
+ !REF: /MainProgram1/ipdt
+ !DEF: /MainProgram1/i1 ObjectEntity TYPE(ipdt(k=1_4))
+ type(ipdt(1)) :: i1
+ !REF: /MainProgram1/ipdt
+ !DEF: /MainProgram1/i2 ObjectEntity TYPE(ipdt(k=2_4))
+ type(ipdt(2)) :: i2
+ !REF: /MainProgram1/ipdt
+ !DEF: /MainProgram1/i4 ObjectEntity TYPE(ipdt(k=4_4))
+ type(ipdt(4)) :: i4
+ !REF: /MainProgram1/ipdt
+ !DEF: /MainProgram1/i8 ObjectEntity TYPE(ipdt(k=8_4))
+ type(ipdt(8)) :: i8
+ !REF: /MainProgram1/ipdt
+ !DEF: /MainProgram1/i16 ObjectEntity TYPE(ipdt(k=16_4))
+ type(ipdt(16)) :: i16
+ !REF: /MainProgram1/rpdt
+ !DEF: /MainProgram1/a2 ObjectEntity TYPE(rpdt(k=2_4))
+ type(rpdt(2)) :: a2
+ !REF: /MainProgram1/rpdt
+ !DEF: /MainProgram1/a4 ObjectEntity TYPE(rpdt(k=4_4))
+ type(rpdt(4)) :: a4
+ !REF: /MainProgram1/rpdt
+ !DEF: /MainProgram1/a8 ObjectEntity TYPE(rpdt(k=8_4))
+ type(rpdt(8)) :: a8
+ !REF: /MainProgram1/rpdt
+ !DEF: /MainProgram1/a10 ObjectEntity TYPE(rpdt(k=10_4))
+ type(rpdt(10)) :: a10
+ !REF: /MainProgram1/rpdt
+ !DEF: /MainProgram1/a16 ObjectEntity TYPE(rpdt(k=16_4))
+ type(rpdt(16)) :: a16
+ !REF: /MainProgram1/zpdt
+ !DEF: /MainProgram1/z2 ObjectEntity TYPE(zpdt(k=2_4))
+ type(zpdt(2)) :: z2
+ !REF: /MainProgram1/zpdt
+ !DEF: /MainProgram1/z4 ObjectEntity TYPE(zpdt(k=4_4))
+ type(zpdt(4)) :: z4
+ !REF: /MainProgram1/zpdt
+ !DEF: /MainProgram1/z8 ObjectEntity TYPE(zpdt(k=8_4))
+ type(zpdt(8)) :: z8
+ !REF: /MainProgram1/zpdt
+ !DEF: /MainProgram1/z10 ObjectEntity TYPE(zpdt(k=10_4))
+ type(zpdt(10)) :: z10
+ !REF: /MainProgram1/zpdt
+ !DEF: /MainProgram1/z16 ObjectEntity TYPE(zpdt(k=16_4))
+ type(zpdt(16)) :: z16
+ !REF: /MainProgram1/lpdt
+ !DEF: /MainProgram1/l1 ObjectEntity TYPE(lpdt(k=1_4))
+ type(lpdt(1)) :: l1
+ !REF: /MainProgram1/lpdt
+ !DEF: /MainProgram1/l2 ObjectEntity TYPE(lpdt(k=2_4))
+ type(lpdt(2)) :: l2
+ !REF: /MainProgram1/lpdt
+ !DEF: /MainProgram1/l4 ObjectEntity TYPE(lpdt(k=4_4))
+ type(lpdt(4)) :: l4
+ !REF: /MainProgram1/lpdt
+ !DEF: /MainProgram1/l8 ObjectEntity TYPE(lpdt(k=8_4))
+ type(lpdt(8)) :: l8
 end program

--- a/test/semantics/kinds03.f90
+++ b/test/semantics/kinds03.f90
@@ -1,0 +1,55 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+type ipdt(k)
+ integer, kind :: k
+ integer(kind=k) :: x
+end type ipdt
+
+type rpdt(k)
+ integer, kind :: k
+ real(kind=k) :: x
+end type rpdt
+
+type zpdt(k)
+ integer, kind :: k
+ complex(kind=k) :: x
+end type zpdt
+
+type lpdt(k)
+ integer, kind :: k
+ logical(kind=k) :: x
+end type lpdt
+
+type(ipdt(1)) i1
+type(ipdt(2)) i2
+type(ipdt(4)) i4
+type(ipdt(8)) i8
+type(ipdt(16)) i16
+type(rpdt(2)) a2
+type(rpdt(4)) a4
+type(rpdt(8)) a8
+type(rpdt(10)) a10
+type(rpdt(16)) a16
+type(zpdt(2)) z2
+type(zpdt(4)) z4
+type(zpdt(8)) z8
+type(zpdt(10)) z10
+type(zpdt(16)) z16
+type(lpdt(1)) l1
+type(lpdt(2)) l2
+type(lpdt(4)) l4
+type(lpdt(8)) l8
+
+end program

--- a/test/semantics/modfile12.f90
+++ b/test/semantics/modfile12.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -54,8 +54,8 @@ end
 !    integer(4),kind::c=1_4
 !    integer(4),len::d=3_8
 !  end type
-!  type(t(4_4,:)),allocatable::z
-!  class(t(5_4,:)),allocatable::z2
+!  type(t(c=4_4,d=:)),allocatable::z
+!  class(t(c=5_4,d=:)),allocatable::z2
 !  type(*),allocatable::z3
 !  class(*),allocatable::z4
 !  real(2)::f

--- a/test/semantics/modfile17.f90
+++ b/test/semantics/modfile17.f90
@@ -1,0 +1,182 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Tests parameterized derived type instantiation with KIND parameters
+
+module m
+  type :: capture(k1,k2,k4,k8)
+    integer(kind=1), kind :: k1
+    integer(kind=2), kind :: k2
+    integer(kind=4), kind :: k4
+    integer(kind=8), kind :: k8
+    integer(kind=k1) :: j1
+    integer(kind=k2) :: j2
+    integer(kind=k4) :: j4
+    integer(kind=k8) :: j8
+  end type capture
+  type :: defaulted(n1,n2,n4,n8)
+    integer(kind=1), kind :: n1 = 1
+    integer(kind=2), kind :: n2 = n1 * 2
+    integer(kind=4), kind :: n4 = 2 * n2
+    integer(kind=8), kind :: n8 = 12 - n4
+    type(capture(n1,n2,n4,n8)) :: cap
+  end type defaulted
+  type, extends(defaulted) :: extension(k5)
+    integer(kind=4), kind :: k5 = 4
+    integer(kind=k5) :: j5
+  end type extension
+  type(capture(1,1,1,1)) :: x1111
+  integer(kind=x1111%j1%kind) :: res01_1
+  integer(kind=x1111%j2%kind) :: res02_1
+  integer(kind=x1111%j4%kind) :: res03_1
+  integer(kind=x1111%j8%kind) :: res04_1
+  type(capture(8,8,8,8)) :: x8888
+  integer(kind=x8888%j1%kind) :: res05_8
+  integer(kind=x8888%j2%kind) :: res06_8
+  integer(kind=x8888%j4%kind) :: res07_8
+  integer(kind=x8888%j8%kind) :: res08_8
+  type(capture(2,k8=1,k4=8,k2=4)) :: x2481
+  integer(kind=x2481%j1%kind) :: res09_2
+  integer(kind=x2481%j2%kind) :: res10_4
+  integer(kind=x2481%j4%kind) :: res11_8
+  integer(kind=x2481%j8%kind) :: res12_1
+  type(capture(2,1,k4=8,k8=4)) :: x2184
+  integer(kind=x2184%j1%kind) :: res13_2
+  integer(kind=x2184%j2%kind) :: res14_1
+  integer(kind=x2184%j4%kind) :: res15_8
+  integer(kind=x2184%j8%kind) :: res16_4
+  type(defaulted) :: x1248
+  integer(kind=x1248%cap%j1%kind) :: res17_1
+  integer(kind=x1248%cap%j2%kind) :: res18_2
+  integer(kind=x1248%cap%j4%kind) :: res19_4
+  integer(kind=x1248%cap%j8%kind) :: res20_8
+  type(defaulted(2)) :: x2484
+  integer(kind=x2484%cap%j1%kind) :: res21_2
+  integer(kind=x2484%cap%j2%kind) :: res22_4
+  integer(kind=x2484%cap%j4%kind) :: res23_8
+  integer(kind=x2484%cap%j8%kind) :: res24_4
+  type(defaulted(n8=2)) :: x1242
+  integer(kind=x1242%cap%j1%kind) :: res25_1
+  integer(kind=x1242%cap%j2%kind) :: res26_2
+  integer(kind=x1242%cap%j4%kind) :: res27_4
+  integer(kind=x1242%cap%j8%kind) :: res28_2
+  type(extension(1,1,1,1,1)) :: x11111
+  integer(kind=x11111%defaulted%cap%j1%kind) :: res29_1
+  integer(kind=x11111%cap%j2%kind) :: res30_1
+  integer(kind=x11111%cap%j4%kind) :: res31_1
+  integer(kind=x11111%cap%j8%kind) :: res32_1
+  integer(kind=x11111%j5%kind) :: res33_1
+  type(extension(2,8,4,1,8)) :: x28418
+  integer(kind=x28418%defaulted%cap%j1%kind) :: res34_2
+  integer(kind=x28418%cap%j2%kind) :: res35_8
+  integer(kind=x28418%cap%j4%kind) :: res36_4
+  integer(kind=x28418%cap%j8%kind) :: res37_1
+  integer(kind=x28418%j5%kind) :: res38_8
+  type(extension(8,n8=1,k5=2,n2=4,n4=8)) :: x84812
+  integer(kind=x84812%defaulted%cap%j1%kind) :: res39_8
+  integer(kind=x84812%cap%j2%kind) :: res40_4
+  integer(kind=x84812%cap%j4%kind) :: res41_8
+  integer(kind=x84812%cap%j8%kind) :: res42_1
+  integer(kind=x84812%j5%kind) :: res43_2
+  type(extension(k5=2)) :: x12482
+  integer(kind=x12482%defaulted%cap%j1%kind) :: res44_1
+  integer(kind=x12482%cap%j2%kind) :: res45_2
+  integer(kind=x12482%cap%j4%kind) :: res46_4
+  integer(kind=x12482%cap%j8%kind) :: res47_8
+  integer(kind=x12482%j5%kind) :: res48_2
+end module
+
+!Expect: m.mod
+!module m
+!type::capture(k1,k2,k4,k8)
+!integer(1),kind::k1
+!integer(2),kind::k2
+!integer(4),kind::k4
+!integer(8),kind::k8
+!integer(int(k1,kind=8))::j1
+!integer(int(k2,kind=8))::j2
+!integer(int(k4,kind=8))::j4
+!integer(k8)::j8
+!end type
+!type::defaulted(n1,n2,n4,n8)
+!integer(1),kind::n1=1_4
+!integer(2),kind::n2=(int(n1,kind=4)*2_4)
+!integer(4),kind::n4=(2_4*int(n2,kind=4))
+!integer(8),kind::n8=(12_4-n4)
+!type(capture(k1=n1,k2=n2,k4=n4,k8=n8))::cap
+!end type
+!type,extends(defaulted)::extension(k5)
+!integer(4),kind::k5=4_4
+!integer(int(k5,kind=8))::j5
+!end type
+!type(capture(k1=1_4,k2=1_4,k4=1_4,k8=1_4))::x1111
+!integer(1)::res01_1
+!integer(1)::res02_1
+!integer(1)::res03_1
+!integer(1)::res04_1
+!type(capture(k1=8_4,k2=8_4,k4=8_4,k8=8_4))::x8888
+!integer(8)::res05_8
+!integer(8)::res06_8
+!integer(8)::res07_8
+!integer(8)::res08_8
+!type(capture(k1=2_4,k2=4_4,k4=8_4,k8=1_4))::x2481
+!integer(2)::res09_2
+!integer(4)::res10_4
+!integer(8)::res11_8
+!integer(1)::res12_1
+!type(capture(k1=2_4,k2=1_4,k4=8_4,k8=4_4))::x2184
+!integer(2)::res13_2
+!integer(1)::res14_1
+!integer(8)::res15_8
+!integer(4)::res16_4
+!type(defaulted)::x1248
+!integer(1)::res17_1
+!integer(2)::res18_2
+!integer(4)::res19_4
+!integer(8)::res20_8
+!type(defaulted(n1=2_4))::x2484
+!integer(2)::res21_2
+!integer(4)::res22_4
+!integer(8)::res23_8
+!integer(4)::res24_4
+!type(defaulted(n8=2_4))::x1242
+!integer(1)::res25_1
+!integer(2)::res26_2
+!integer(4)::res27_4
+!integer(2)::res28_2
+!type(extension(k5=1_4,n1=1_4,n2=1_4,n4=1_4,n8=1_4))::x11111
+!integer(1)::res29_1
+!integer(1)::res30_1
+!integer(1)::res31_1
+!integer(1)::res32_1
+!integer(1)::res33_1
+!type(extension(k5=8_4,n1=2_4,n2=8_4,n4=4_4,n8=1_4))::x28418
+!integer(2)::res34_2
+!integer(8)::res35_8
+!integer(4)::res36_4
+!integer(1)::res37_1
+!integer(8)::res38_8
+!type(extension(k5=2_4,n1=8_4,n2=4_4,n4=8_4,n8=1_4))::x84812
+!integer(8)::res39_8
+!integer(4)::res40_4
+!integer(8)::res41_8
+!integer(1)::res42_1
+!integer(2)::res43_2
+!type(extension(k5=2_4,n1=1_4,n2=2_4,n4=4_4,n8=8_4))::x12482
+!integer(1)::res44_1
+!integer(2)::res45_2
+!integer(4)::res46_4
+!integer(8)::res47_8
+!integer(2)::res48_2
+!end

--- a/test/semantics/resolve37.f90
+++ b/test/semantics/resolve37.f90
@@ -30,7 +30,7 @@ type(t( &
 !ERROR: Must have INTEGER type
   .true.)) :: w
 !ERROR: Must have INTEGER type
-real :: w(l*2)
+real :: u(l*2)
 !ERROR: Must have INTEGER type
 character(len=l) :: v
 end

--- a/test/semantics/resolve37.f90
+++ b/test/semantics/resolve37.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -25,8 +25,10 @@ integer(n) :: z
 type t(k)
   integer, kind :: k
 end type
+!ERROR: Type parameter 'k' lacks a value and has no default
+type(t( &
 !ERROR: Must have INTEGER type
-type(t(.true.)) :: w
+  .true.)) :: w
 !ERROR: Must have INTEGER type
 real :: w(l*2)
 !ERROR: Must have INTEGER type

--- a/test/semantics/symbol09.f90
+++ b/test/semantics/symbol09.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ subroutine s4
   integer :: a
  end type t
  !REF: /s4/t
- !DEF: /s4/x ObjectEntity TYPE(t(1_4))
+ !DEF: /s4/x ObjectEntity TYPE(t(k=1_4))
  type(t(1)) :: x
  !REF: /s4/x
  !REF: /s4/t
@@ -100,7 +100,7 @@ subroutine s5
   integer, len :: l
  end type t
  !REF: /s5/t
- !DEF: /s5/x ALLOCATABLE ObjectEntity TYPE(t(:))
+ !DEF: /s5/x ALLOCATABLE ObjectEntity TYPE(t(l=:))
  type(t(:)), allocatable :: x
  !DEF: /s5/y ALLOCATABLE ObjectEntity REAL(4)
  real, allocatable :: y

--- a/test/semantics/symbol11.f90
+++ b/test/semantics/symbol11.f90
@@ -49,7 +49,7 @@ subroutine s2
   print *, "z:", z
  end associate
  !TODO: need correct length for z
- !DEF: /s2/Block2/z AssocEntity CHARACTER(:,1)
+ !DEF: /s2/Block2/z AssocEntity CHARACTER(0_8,1)
  !REF: /s2/x
  !REF: /s2/y
  associate (z => x//y)


### PR DESCRIPTION
This change got larger than I had planned.  I had to replace `int`-valued `kind()` values in types in the symbol table with integer-valued expressions so that component declarations like `REAL(KIND=kindParam)` would be representable in parameterized derived type definitions.  This turned into a bit of a restructuring job on `DeclTypeSpec`'s alternatives, which are now in a `variant` rather than an undiscriminated union.  Several `Pre` and `Post` visitation actions have moved between visitor classes in order to make scope information available.

If this is too much for you (Tim) to review before vacation, or if the changes are problematic, we'll pick this up when you get back. There didn't seem to be an obvious way to break up a broad refactoring up into smaller and more easily reviewable changes, but I can try harder to do that if you like.