### PR TITLE
Resolve names in ASSOCIATE and SELECT TYPE

### DIFF
--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -804,7 +804,7 @@ public:
   void Post(const parser::ExitStmt &x) { CheckRef(x.v); }
 
 private:
-  // The represents: associate-name => expr | variable
+  // This represents: associate-name => expr | variable
   // expr is set unless there were errors
   struct {
     const parser::Name *name{nullptr};

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -70,21 +70,21 @@ bool Scope::AddSubmodule(const SourceName &name, Scope &submodule) {
   return submodules_.emplace(name, &submodule).second;
 }
 
-DeclTypeSpec &Scope::MakeNumericType(TypeCategory category, int kind) {
+const DeclTypeSpec &Scope::MakeNumericType(TypeCategory category, int kind) {
   return MakeLengthlessType(NumericTypeSpec{category, kind});
 }
-DeclTypeSpec &Scope::MakeLogicalType(int kind) {
+const DeclTypeSpec &Scope::MakeLogicalType(int kind) {
   return MakeLengthlessType(LogicalTypeSpec{kind});
 }
-DeclTypeSpec &Scope::MakeTypeStarType() {
+const DeclTypeSpec &Scope::MakeTypeStarType() {
   return MakeLengthlessType(DeclTypeSpec{DeclTypeSpec::TypeStar});
 }
-DeclTypeSpec &Scope::MakeClassStarType() {
+const DeclTypeSpec &Scope::MakeClassStarType() {
   return MakeLengthlessType(DeclTypeSpec{DeclTypeSpec::ClassStar});
 }
 // Types that can't have length parameters can be reused without having to
 // compare length expressions. They are stored in the global scope.
-DeclTypeSpec &Scope::MakeLengthlessType(const DeclTypeSpec &type) {
+const DeclTypeSpec &Scope::MakeLengthlessType(const DeclTypeSpec &type) {
   auto it{std::find(declTypeSpecs_.begin(), declTypeSpecs_.end(), type)};
   if (it != declTypeSpecs_.end()) {
     return *it;
@@ -94,15 +94,18 @@ DeclTypeSpec &Scope::MakeLengthlessType(const DeclTypeSpec &type) {
   }
 }
 
-DeclTypeSpec &Scope::MakeCharacterType(ParamValue &&length, int kind) {
+const DeclTypeSpec &Scope::MakeCharacterType(ParamValue &&length, int kind) {
   characterTypeSpecs_.emplace_back(std::move(length), kind);
   declTypeSpecs_.emplace_back(characterTypeSpecs_.back());
   return declTypeSpecs_.back();
 }
 
-DeclTypeSpec &Scope::MakeDerivedType(const Symbol &typeSymbol) {
-  DerivedTypeSpec &spec{derivedTypeSpecs_.emplace_back(typeSymbol)};
-  return declTypeSpecs_.emplace_back(DeclTypeSpec::TypeDerived, spec);
+DerivedTypeSpec &Scope::MakeDerivedType(const Symbol &typeSymbol) {
+  return derivedTypeSpecs_.emplace_back(typeSymbol);
+}
+const DeclTypeSpec &Scope::MakeDerivedType(
+    DeclTypeSpec::Category category, const DerivedTypeSpec &derived) {
+  return declTypeSpecs_.emplace_back(category, derived);
 }
 
 Scope::ImportKind Scope::GetImportKind() const {

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -121,12 +121,15 @@ public:
   Scope *FindSubmodule(const SourceName &) const;
   bool AddSubmodule(const SourceName &, Scope &);
 
-  DeclTypeSpec &MakeNumericType(TypeCategory, int kind);
-  DeclTypeSpec &MakeLogicalType(int kind);
-  DeclTypeSpec &MakeCharacterType(ParamValue &&length, int kind = 0);
-  DeclTypeSpec &MakeDerivedType(const Symbol &);
-  DeclTypeSpec &MakeTypeStarType();
-  DeclTypeSpec &MakeClassStarType();
+  DerivedTypeSpec &MakeDerivedType(const Symbol &);
+
+  const DeclTypeSpec &MakeNumericType(TypeCategory, int kind);
+  const DeclTypeSpec &MakeLogicalType(int kind);
+  const DeclTypeSpec &MakeCharacterType(ParamValue &&length, int kind = 0);
+  const DeclTypeSpec &MakeDerivedType(
+      DeclTypeSpec::Category, const DerivedTypeSpec &);
+  const DeclTypeSpec &MakeTypeStarType();
+  const DeclTypeSpec &MakeClassStarType();
 
   // For modules read from module files, this is the stream of characters
   // that are referenced by SourceName objects.
@@ -168,7 +171,7 @@ private:
   static Symbols<1024> allSymbols;
 
   bool CanImport(const SourceName &) const;
-  DeclTypeSpec &MakeLengthlessType(const DeclTypeSpec &);
+  const DeclTypeSpec &MakeLengthlessType(const DeclTypeSpec &);
 
   friend std::ostream &operator<<(std::ostream &, const Scope &);
 };

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,14 +37,14 @@ SemanticsContext::SemanticsContext(
     foldingContext_{evaluate::FoldingContext{
         parser::ContextualMessages{parser::CharBlock{}, &messages_}}} {}
 
-DeclTypeSpec &SemanticsContext::MakeNumericType(
+const DeclTypeSpec &SemanticsContext::MakeNumericType(
     TypeCategory category, int kind) {
   if (kind == 0) {
     kind = defaultKinds_.GetDefaultKind(category);
   }
   return globalScope_.MakeNumericType(category, kind);
 }
-DeclTypeSpec &SemanticsContext::MakeLogicalType(int kind) {
+const DeclTypeSpec &SemanticsContext::MakeLogicalType(int kind) {
   if (kind == 0) {
     kind = defaultKinds_.GetDefaultKind(TypeCategory::Logical);
   }

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -67,8 +67,8 @@ public:
     return *this;
   }
 
-  DeclTypeSpec &MakeNumericType(TypeCategory, int kind = 0);
-  DeclTypeSpec &MakeLogicalType(int kind = 0);
+  const DeclTypeSpec &MakeNumericType(TypeCategory, int kind = 0);
+  const DeclTypeSpec &MakeLogicalType(int kind = 0);
 
   bool AnyFatalError() const;
   template<typename... A> parser::Message &Say(A... args) {

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -123,6 +123,16 @@ private:
   friend std::ostream &operator<<(std::ostream &, const EntityDetails &);
 };
 
+// Symbol is associated with a name or expression in a SELECT TYPE or ASSOCIATE.
+class AssocEntityDetails : public EntityDetails {
+public:
+  AssocEntityDetails(SomeExpr &&expr) : expr_{std::move(expr)} {}
+  const SomeExpr &expr() const { return expr_; }
+
+private:
+  SomeExpr expr_;
+};
+
 // An entity known to be an object.
 class ObjectEntityDetails : public EntityDetails {
 public:
@@ -241,7 +251,8 @@ class FinalProcDetails {};
 class MiscDetails {
 public:
   ENUM_CLASS(Kind, None, ConstructName, ScopeName, PassName, ComplexPartRe,
-      ComplexPartIm, KindParamInquiry, LenParamInquiry);
+      ComplexPartIm, KindParamInquiry, LenParamInquiry,
+      SelectTypeAssociateName);
   MiscDetails(Kind kind) : kind_{kind} {}
   Kind kind() const { return kind_; }
 
@@ -340,9 +351,10 @@ class UnknownDetails {};
 
 using Details = std::variant<UnknownDetails, MainProgramDetails, ModuleDetails,
     SubprogramDetails, SubprogramNameDetails, EntityDetails,
-    ObjectEntityDetails, ProcEntityDetails, DerivedTypeDetails, UseDetails,
-    UseErrorDetails, HostAssocDetails, GenericDetails, ProcBindingDetails,
-    GenericBindingDetails, FinalProcDetails, TypeParamDetails, MiscDetails>;
+    ObjectEntityDetails, ProcEntityDetails, AssocEntityDetails,
+    DerivedTypeDetails, UseDetails, UseErrorDetails, HostAssocDetails,
+    GenericDetails, ProcBindingDetails, GenericBindingDetails, FinalProcDetails,
+    TypeParamDetails, MiscDetails>;
 std::ostream &operator<<(std::ostream &, const Details &);
 std::string DetailsToString(const Details &);
 

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -134,7 +134,7 @@ DeclTypeSpec::DeclTypeSpec(const LogicalTypeSpec &typeSpec)
   : category_{Logical}, typeSpec_{typeSpec} {}
 DeclTypeSpec::DeclTypeSpec(CharacterTypeSpec &typeSpec)
   : category_{Character}, typeSpec_{&typeSpec} {}
-DeclTypeSpec::DeclTypeSpec(Category category, DerivedTypeSpec &typeSpec)
+DeclTypeSpec::DeclTypeSpec(Category category, const DerivedTypeSpec &typeSpec)
   : category_{category}, typeSpec_{&typeSpec} {
   CHECK(category == TypeDerived || category == ClassDerived);
 }
@@ -170,10 +170,6 @@ const LogicalTypeSpec &DeclTypeSpec::logicalTypeSpec() const {
 const CharacterTypeSpec &DeclTypeSpec::characterTypeSpec() const {
   CHECK(category_ == Character);
   return *typeSpec_.character;
-}
-DerivedTypeSpec &DeclTypeSpec::derivedTypeSpec() {
-  CHECK(category_ == TypeDerived || category_ == ClassDerived);
-  return *typeSpec_.derived;
 }
 const DerivedTypeSpec &DeclTypeSpec::derivedTypeSpec() const {
   CHECK(category_ == TypeDerived || category_ == ClassDerived);

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -85,8 +85,8 @@ private:
 // A type parameter value: integer expression or assumed or deferred.
 class ParamValue {
 public:
-  static const ParamValue Assumed() { return Category::Assumed; }
-  static const ParamValue Deferred() { return Category::Deferred; }
+  static ParamValue Assumed() { return Category::Assumed; }
+  static ParamValue Deferred() { return Category::Deferred; }
   explicit ParamValue(MaybeIntExpr &&expr);
   explicit ParamValue(std::int64_t);
   bool isExplicit() const { return category_ == Category::Explicit; }
@@ -242,7 +242,7 @@ public:
   // character
   DeclTypeSpec(CharacterTypeSpec &);
   // TYPE(derived-type-spec) or CLASS(derived-type-spec)
-  DeclTypeSpec(Category, DerivedTypeSpec &);
+  DeclTypeSpec(Category, const DerivedTypeSpec &);
   // TYPE(*) or CLASS(*)
   DeclTypeSpec(Category);
   DeclTypeSpec() = delete;
@@ -258,7 +258,6 @@ public:
   const LogicalTypeSpec &logicalTypeSpec() const;
   const CharacterTypeSpec &characterTypeSpec() const;
   const DerivedTypeSpec &derivedTypeSpec() const;
-  DerivedTypeSpec &derivedTypeSpec();
   void set_category(Category category) { category_ = category; }
 
 private:
@@ -267,12 +266,12 @@ private:
     TypeSpec() : derived{nullptr} {}
     TypeSpec(NumericTypeSpec numeric) : numeric{numeric} {}
     TypeSpec(LogicalTypeSpec logical) : logical{logical} {}
-    TypeSpec(CharacterTypeSpec *character) : character{character} {}
-    TypeSpec(DerivedTypeSpec *derived) : derived{derived} {}
+    TypeSpec(const CharacterTypeSpec *character) : character{character} {}
+    TypeSpec(const DerivedTypeSpec *derived) : derived{derived} {}
     NumericTypeSpec numeric;
     LogicalTypeSpec logical;
-    CharacterTypeSpec *character;
-    DerivedTypeSpec *derived;
+    const CharacterTypeSpec *character;
+    const DerivedTypeSpec *derived;
   } typeSpec_;
 };
 std::ostream &operator<<(std::ostream &, const DeclTypeSpec &);

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -63,6 +63,7 @@ set(ERROR_TESTS
   resolve36.f90
   resolve37.f90
   resolve38.f90
+  resolve39.f90
 )
 
 # These test files have expected symbols in the source
@@ -77,6 +78,7 @@ set(SYMBOL_TESTS
   symbol08.f90
   symbol09.f90
   symbol10.f90
+  symbol11.f90
 )
 
 # These test files have expected .mod file contents in the source

--- a/test/semantics/resolve39.f90
+++ b/test/semantics/resolve39.f90
@@ -1,0 +1,24 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+subroutine s1
+  implicit none
+  real(8) :: x = 2.0
+  !ERROR: The associate name 'a' is already used in this associate statement
+  associate(a => x, b => x+1, a => x+2)
+    x = b
+  end associate
+  !ERROR: No explicit type declared for 'b'
+  x = b
+end

--- a/test/semantics/symbol11.f90
+++ b/test/semantics/symbol11.f90
@@ -1,0 +1,95 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+!DEF: /s1 Subprogram
+subroutine s1
+ implicit none
+ !DEF: /s1/x ObjectEntity REAL(8)
+ real(kind=8) :: x = 2.0
+ !DEF: /s1/a ObjectEntity INTEGER(4)
+ integer a
+ !DEF: /s1/t DerivedType
+ type :: t
+ end type
+ !REF: /s1/t
+ !DEF: /s1/z ALLOCATABLE ObjectEntity CLASS(t)
+ class(t), allocatable :: z
+ !DEF: /s1/Block1/a AssocEntity REAL(8)
+ !REF: /s1/x
+ !DEF: /s1/Block1/b AssocEntity REAL(8)
+ !DEF: /s1/Block1/c AssocEntity CLASS(t)
+ !REF: /s1/z
+ associate (a => x, b => x+1, c => z)
+  !REF: /s1/x
+  !REF: /s1/Block1/a
+  x = a
+ end associate
+end subroutine
+
+!DEF: /s2 Subprogram
+subroutine s2
+ !DEF: /s2/x ObjectEntity CHARACTER(4_4,1)
+ !DEF: /s2/y ObjectEntity CHARACTER(4_4,1)
+ character(len=4) x, y
+ !DEF: /s2/Block1/z AssocEntity CHARACTER(4_4,1)
+ !REF: /s2/x
+ associate (z => x)
+  !REF: /s2/Block1/z
+  print *, "z:", z
+ end associate
+ !TODO: need correct length for z
+ !DEF: /s2/Block2/z AssocEntity CHARACTER(:,1)
+ !REF: /s2/x
+ !REF: /s2/y
+ associate (z => x//y)
+  !REF: /s2/Block2/z
+  print *, "z:", z
+ end associate
+end subroutine
+
+!DEF: /s3 Subprogram
+subroutine s3
+ !DEF: /s3/t1 DerivedType
+ type :: t1
+  !DEF: /s3/t1/a1 ObjectEntity INTEGER(4)
+  integer :: a1
+ end type
+ !REF: /s3/t1
+ !DEF: /s3/t2 DerivedType
+ type, extends(t1) :: t2
+  !DEF: /s3/t2/a2 ObjectEntity INTEGER(4)
+  integer :: a2
+ end type
+ !DEF: /s3/i ObjectEntity INTEGER(4)
+ integer i
+ !REF: /s3/t1
+ !DEF: /s3/x POINTER ObjectEntity CLASS(t1)
+ class(t1), pointer :: x
+ !REF: /s3/x
+ select type (y => x)
+  !REF: /s3/t2
+  class is (t2)
+   !REF: /s3/i
+   !DEF: /s3/Block1/y TARGET AssocEntity TYPE(t2)
+   !REF: /s3/t2/a2
+   i = y%a2
+   type is (integer(kind=8))
+    !REF: /s3/i
+    !DEF: /s3/Block2/y TARGET AssocEntity INTEGER(8)
+    i = y
+   class default
+    !DEF: /s3/Block3/y TARGET AssocEntity CLASS(t1)
+    print *, y
+ end select
+end subroutine

--- a/test/semantics/test_symbols.sh
+++ b/test/semantics/test_symbols.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ sed -e 's/!\([DR]EF:\)/KEEP \1/' \
 egrep -v '^ *!' $src1 > $src2  # strip out meaningful comments
 $CMD $src2 > $src3  # compile, inserting comments for symbols
 
-if diff -U999999 $src1 $src3 > $diffs; then
+if diff -w -U999999 $src1 $src3 > $diffs; then
   echo PASS
 else
   sed '1,/^\@\@/d' $diffs


### PR DESCRIPTION
Create `AssocEntityDetails` for symbols that represent entities
identified by the associate-name in ASSOCIATE and SELECT TYPE
constructs.

For ASSOCIATE, create a new scope for the associated entity.
For SELECT TYPE, create a new scope for each of type guard blocks.
Each one contains an associated entity with the appropriate type.

For SELECT TYPE, also create a place-holder symbol for the
associate-name in the SELECT TYPE statement. The real symbols
are in the new scopes and none of them is uniquely identified
with the associate-name.

Handling of `Selector` is common between these, with
`associate-name => expr | variable` recorded in
`ConstructVisitor::association_`.

When the selector is an expression, derive the type of the associated
entity from the type of the expression. This required some refactoring
of how `DeclTypeSpec`s are created. The `DerivedTypeSpec` that comes
from and expression is const so we can only create const `DeclTypeSpec`s
from it. But there were times during name resolution when we needed to
set type parameters in the current `DeclTypeSpec`. Now the non-const
`DerivedTypeSpec` is saved separately from the const `DeclTypeSpec`
while we are processing a declaration type spec. This makes it
unnecessary to save the derived type name.

Add a type alias for `common::Indirection` to reduce verbosity.