### PR TITLE
Fix link error from last integration

### DIFF
--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1413,6 +1413,9 @@ MaybeExpr ExpressionAnalysisContext::Analyze(const parser::Expr &expr) {
     return AnalyzeExpr(*this, expr.u);
   }
 }
+MaybeExpr ExpressionAnalysisContext::Analyze(const parser::Variable &variable) {
+  return AnalyzeExpr(*this, variable.u);
+}
 
 int ExpressionAnalysisContext::Analyze(TypeCategory category,
     const std::optional<parser::KindSelector> &selector) {

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -91,6 +91,7 @@ public:
   }
 
   std::optional<Expr<SomeType>> Analyze(const parser::Expr &);
+  std::optional<Expr<SomeType>> Analyze(const parser::Variable &);
   int Analyze(common::TypeCategory category,
       const std::optional<parser::KindSelector> &);
 
@@ -108,6 +109,10 @@ std::optional<Expr<SomeType>> AnalyzeExpr(
 inline std::optional<Expr<SomeType>> AnalyzeExpr(
     ExpressionAnalysisContext &context, const parser::Expr &expr) {
   return context.Analyze(expr);
+}
+inline std::optional<Expr<SomeType>> AnalyzeExpr(
+    ExpressionAnalysisContext &context, const parser::Variable &variable) {
+  return context.Analyze(variable);
 }
 
 // Forward declarations of exposed specializations

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -3138,8 +3138,7 @@ void ConstructVisitor::Post(const parser::Selector &x) {
                 }
               }
             }
-            return std::visit(
-                [&](const auto &z) { return EvaluateExpr(*z); }, y.u);
+            return EvaluateExpr(y);
           },
       },
       x.u)};


### PR DESCRIPTION
We need to be able to analyze the `Variable` in a `Selector` and an
expression. That worked in a previous iteration of `expression.h` by
analyzing each variant of `Variable`.

This fix adds an explicit public function to analyze a `Variable` and
return a `MaybeExpr`.