### PR TITLE
Enable shared library build without dependence cycle between binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ cmake_minimum_required(VERSION 3.9.0)
 if( GCC )
   set(CMAKE_CXX_COMPILER "${GCC}/bin/g++")
   set(CMAKE_CC_COMPILER "${GCC}/bin/gcc")
+  set(CMAKE_BUILD_RPATH "${GCC}/lib64")
   set(CMAKE_INSTALL_RPATH "${GCC}/lib64")
-  set(CMAKE_BUILD_WITH_INSTALL_RPATH true)
 endif()
 if(BUILD_WITH_CLANG)
   set(CMAKE_CXX_COMPILER "${BUILD_WITH_CLANG}/bin/clang")
@@ -28,6 +28,15 @@ if(BUILD_WITH_CLANG)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --gcc-toolchain=${GCC}")
   endif()
 endif()
+
+# Set RPATH in every executable (overriding default setting)
+# If you set this first variable back to true (the default),
+# also set the second one.
+set(CMAKE_SKIP_BUILD_RPATH false)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH false)
+
+# Don't use the installation RPATH when building
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
 
 # Reminder: Setting CMAKE_CXX_COMPILER must be done before calling project()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ if(BUILD_WITH_CLANG)
   endif()
 endif()
 
-# Set RPATH in every executable (overriding default setting)
+# Set RPATH in every executable, overriding the default setting.
 # If you set this first variable back to true (the default),
 # also set the second one.
 set(CMAKE_SKIP_BUILD_RPATH false)
@@ -87,6 +87,14 @@ if(CMAKE_COMPILER_IS_GNUCXX OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
    set(CMAKE_CXX_FLAGS_RELEASE    "-O2 -DDEBUG")
    set(CMAKE_CXX_FLAGS_MINSIZEREL "-O2 '-DCHECK=(void)'")
    set(CMAKE_CXX_FLAGS_DEBUG      "-g -DDEBUG")
+
+   # Building shared libraries is death on performance with GCC by default
+   # due to the need to preserve the right to override external entry points
+   # at dynamic link time.  -fno-semantic-interposition waives that right and
+   # recovers a little bit of that performance.
+   if (BUILD_SHARED_LIBS)
+     set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-semantic-interposition")
+   endif()
 endif()
 
 set(FLANG_VERSION_MAJOR      "0")

--- a/lib/common/CMakeLists.txt
+++ b/lib/common/CMakeLists.txt
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(FortranCommon SHARED
+add_library(FortranCommon
   default-kinds.cc
   idioms.cc
 )
-

--- a/lib/common/CMakeLists.txt
+++ b/lib/common/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(FortranCommon
+add_library(FortranCommon SHARED
   default-kinds.cc
   idioms.cc
 )

--- a/lib/common/CMakeLists.txt
+++ b/lib/common/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 add_library(FortranCommon
+  default-kinds.cc
   idioms.cc
 )
 

--- a/lib/common/default-kinds.cc
+++ b/lib/common/default-kinds.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "default-kinds.h"
-#include "../common/idioms.h"
+#include "idioms.h"
 
-namespace Fortran::semantics {
+namespace Fortran::common {
 
 IntrinsicTypeDefaultKinds::IntrinsicTypeDefaultKinds() {
 #if __x86_64__

--- a/lib/common/default-kinds.h
+++ b/lib/common/default-kinds.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef FORTRAN_DEFAULT_KINDS_H_
-#define FORTRAN_DEFAULT_KINDS_H_
+#ifndef FORTRAN_COMMON_DEFAULT_KINDS_H_
+#define FORTRAN_COMMON_DEFAULT_KINDS_H_
 
 #include "../common/fortran.h"
 
 // Represent the default values of the kind parameters of the
 // various intrinsic types.  These can be configured by means of
 // the compiler command line.
-namespace Fortran::semantics {
-
-using Fortran::common::TypeCategory;
+namespace Fortran::common {
 
 class IntrinsicTypeDefaultKinds {
 public:
@@ -56,4 +54,4 @@ private:
   int defaultLogicalKind_{defaultIntegerKind_};
 };
 }
-#endif  // FORTRAN_DEFAULT_KINDS_H_
+#endif  // FORTRAN_COMMON_DEFAULT_KINDS_H_

--- a/lib/evaluate/CMakeLists.txt
+++ b/lib/evaluate/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(FortranEvaluate
+add_library(FortranEvaluate SHARED
   call.cc
   common.cc
   complex.cc

--- a/lib/evaluate/CMakeLists.txt
+++ b/lib/evaluate/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,5 +31,5 @@ add_library(FortranEvaluate
 
 target_link_libraries(FortranEvaluate
   FortranCommon
-  FortranSemantics
+  FortranParser
 )

--- a/lib/evaluate/CMakeLists.txt
+++ b/lib/evaluate/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(FortranEvaluate SHARED
+add_library(FortranEvaluate
   call.cc
   common.cc
   complex.cc

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -20,7 +20,6 @@
 #include "../common/enum-set.h"
 #include "../common/fortran.h"
 #include "../common/idioms.h"
-#include "../semantics/default-kinds.h"
 #include <algorithm>
 #include <map>
 #include <ostream>
@@ -206,7 +205,7 @@ struct IntrinsicInterface {
   TypePattern result;
   Rank rank{Rank::elemental};
   std::optional<SpecificCall> Match(const CallCharacteristics &,
-      const semantics::IntrinsicTypeDefaultKinds &, ActualArguments &,
+      const common::IntrinsicTypeDefaultKinds &, ActualArguments &,
       parser::ContextualMessages &messages) const;
   std::ostream &Dump(std::ostream &) const;
 };
@@ -757,7 +756,7 @@ static const SpecificIntrinsicInterface specificIntrinsicFunction[]{
 // procedure reference.
 std::optional<SpecificCall> IntrinsicInterface::Match(
     const CallCharacteristics &call,
-    const semantics::IntrinsicTypeDefaultKinds &defaults,
+    const common::IntrinsicTypeDefaultKinds &defaults,
     ActualArguments &arguments, parser::ContextualMessages &messages) const {
   // Attempt to construct a 1-1 correspondence between the dummy arguments in
   // a particular intrinsic procedure's generic interface and the actual
@@ -1158,7 +1157,7 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
 }
 
 struct IntrinsicProcTable::Implementation {
-  explicit Implementation(const semantics::IntrinsicTypeDefaultKinds &dfts)
+  explicit Implementation(const common::IntrinsicTypeDefaultKinds &dfts)
     : defaults{dfts} {
     for (const IntrinsicInterface &f : genericIntrinsicFunction) {
       genericFuncs.insert(std::make_pair(std::string{f.name}, &f));
@@ -1171,7 +1170,7 @@ struct IntrinsicProcTable::Implementation {
   std::optional<SpecificCall> Probe(const CallCharacteristics &,
       ActualArguments &, parser::ContextualMessages *) const;
 
-  semantics::IntrinsicTypeDefaultKinds defaults;
+  common::IntrinsicTypeDefaultKinds defaults;
   std::multimap<std::string, const IntrinsicInterface *> genericFuncs;
   std::multimap<std::string, const SpecificIntrinsicInterface *> specificFuncs;
   std::ostream &Dump(std::ostream &) const;
@@ -1253,7 +1252,7 @@ IntrinsicProcTable::~IntrinsicProcTable() {
 }
 
 IntrinsicProcTable IntrinsicProcTable::Configure(
-    const semantics::IntrinsicTypeDefaultKinds &defaults) {
+    const common::IntrinsicTypeDefaultKinds &defaults) {
   IntrinsicProcTable result;
   result.impl_ = new IntrinsicProcTable::Implementation(defaults);
   return result;

--- a/lib/evaluate/intrinsics.h
+++ b/lib/evaluate/intrinsics.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@
 #define FORTRAN_EVALUATE_INTRINSICS_H_
 
 #include "call.h"
+#include "../common/default-kinds.h"
 #include "../parser/char-block.h"
 #include "../parser/message.h"
-#include "../semantics/default-kinds.h"
 #include <optional>
 #include <ostream>
 
@@ -43,7 +43,7 @@ private:
 public:
   ~IntrinsicProcTable();
   static IntrinsicProcTable Configure(
-      const semantics::IntrinsicTypeDefaultKinds &);
+      const common::IntrinsicTypeDefaultKinds &);
 
   // Probe the intrinsics for a match against a specific call.
   // On success, the actual arguments are transferred to the result

--- a/lib/parser/CMakeLists.txt
+++ b/lib/parser/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(FortranParser SHARED
+add_library(FortranParser
   char-buffer.cc
   char-set.cc
   characters.cc

--- a/lib/parser/CMakeLists.txt
+++ b/lib/parser/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(FortranParser
+add_library(FortranParser SHARED
   char-buffer.cc
   char-set.cc
   characters.cc

--- a/lib/semantics/CMakeLists.txt
+++ b/lib/semantics/CMakeLists.txt
@@ -32,5 +32,6 @@ add_library(FortranSemantics
 
 target_link_libraries(FortranSemantics
   FortranCommon
+  FortranEvaluate
   clangBasic
 )

--- a/lib/semantics/CMakeLists.txt
+++ b/lib/semantics/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ add_library(FortranSemantics
   attr.cc
   canonicalize-do.cc
   check-do-concurrent.cc
-  default-kinds.cc
   expression.cc
   mod-file.cc
   resolve-labels.cc

--- a/lib/semantics/CMakeLists.txt
+++ b/lib/semantics/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(FortranSemantics SHARED
+add_library(FortranSemantics
   assignment.cc
   attr.cc
   canonicalize-do.cc

--- a/lib/semantics/CMakeLists.txt
+++ b/lib/semantics/CMakeLists.txt
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-add_library(FortranSemantics
+add_library(FortranSemantics SHARED
   assignment.cc
   attr.cc
   canonicalize-do.cc

--- a/lib/semantics/mod-file.h
+++ b/lib/semantics/mod-file.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 #define FORTRAN_SEMANTICS_MOD_FILE_H_
 
 #include "attr.h"
-#include "default-kinds.h"
 #include "resolve-names.h"
 #include "../parser/message.h"
 #include <set>

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -14,7 +14,6 @@
 
 #include "resolve-names.h"
 #include "attr.h"
-#include "default-kinds.h"
 #include "expression.h"
 #include "mod-file.h"
 #include "rewrite-parse-tree.h"
@@ -22,6 +21,7 @@
 #include "semantics.h"
 #include "symbol.h"
 #include "type.h"
+#include "../common/default-kinds.h"
 #include "../common/fortran.h"
 #include "../common/indirection.h"
 #include "../evaluate/common.h"

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -35,9 +35,6 @@ Scope &Scope::MakeScope(Kind kind, Symbol *symbol) {
 Scope::iterator Scope::find(const SourceName &name) {
   return symbols_.find(name);
 }
-Scope::const_iterator Scope::find(const SourceName &name) const {
-  return symbols_.find(name);
-}
 Scope::size_type Scope::erase(const SourceName &name) {
   auto it{symbols_.find(name)};
   if (it != end()) {

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -91,7 +91,9 @@ public:
   const_iterator cend() const { return symbols_.cend(); }
 
   iterator find(const SourceName &name);
-  const_iterator find(const SourceName &name) const;
+  const_iterator find(const SourceName &name) const {
+    return symbols_.find(name);
+  }
   size_type erase(const SourceName &);
   size_type size() const { return symbols_.size(); }
   bool empty() const { return symbols_.empty(); }

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -16,7 +16,6 @@
 #include "assignment.h"
 #include "canonicalize-do.h"
 #include "check-do-concurrent.h"
-#include "default-kinds.h"
 #include "expression.h"
 #include "mod-file.h"
 #include "resolve-labels.h"
@@ -24,6 +23,7 @@
 #include "rewrite-parse-tree.h"
 #include "scope.h"
 #include "symbol.h"
+#include "../common/default-kinds.h"
 #include <ostream>
 
 namespace Fortran::semantics {
@@ -32,7 +32,7 @@ static void DoDumpSymbols(std::ostream &, const Scope &, int indent = 0);
 static void PutIndent(std::ostream &, int indent);
 
 SemanticsContext::SemanticsContext(
-    const IntrinsicTypeDefaultKinds &defaultKinds)
+    const common::IntrinsicTypeDefaultKinds &defaultKinds)
   : defaultKinds_{defaultKinds},
     intrinsics_{evaluate::IntrinsicProcTable::Configure(defaultKinds)},
     foldingContext_{evaluate::FoldingContext{

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -23,6 +23,10 @@
 #include <string>
 #include <vector>
 
+namespace Fortran::common {
+class IntrinsicTypeDefaultKinds;
+}
+
 namespace Fortran::parser {
 struct Program;
 class CookedSource;
@@ -30,13 +34,11 @@ class CookedSource;
 
 namespace Fortran::semantics {
 
-class IntrinsicTypeDefaultKinds;
-
 class SemanticsContext {
 public:
-  SemanticsContext(const IntrinsicTypeDefaultKinds &);
+  SemanticsContext(const common::IntrinsicTypeDefaultKinds &);
 
-  const IntrinsicTypeDefaultKinds &defaultKinds() const {
+  const common::IntrinsicTypeDefaultKinds &defaultKinds() const {
     return defaultKinds_;
   }
   const std::vector<std::string> &searchDirectories() const {
@@ -76,7 +78,7 @@ public:
   }
 
 private:
-  const IntrinsicTypeDefaultKinds &defaultKinds_;
+  const common::IntrinsicTypeDefaultKinds &defaultKinds_;
   std::vector<std::string> searchDirectories_;
   std::string moduleDirectory_{"."s};
   bool warningsAreErrors_{false};

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -50,21 +50,8 @@ ParamValue &DerivedTypeSpec::AddParamValue(
 }
 
 ParamValue *DerivedTypeSpec::FindParameter(SourceName target) {
-  auto iter{parameters_.find(target)};
-  if (iter != parameters_.end()) {
-    return &iter->second;
-  } else {
-    return nullptr;
-  }
-}
-
-const ParamValue *DerivedTypeSpec::FindParameter(SourceName target) const {
-  auto iter{parameters_.find(target)};
-  if (iter != parameters_.end()) {
-    return &iter->second;
-  } else {
-    return nullptr;
-  }
+  return const_cast<ParamValue *>(
+      const_cast<const DerivedTypeSpec *>(this)->FindParameter(target));
 }
 
 void DerivedTypeSpec::FoldParameterExpressions(
@@ -278,27 +265,8 @@ bool DeclTypeSpec::IsNumeric(TypeCategory tc) const {
   return category_ == Numeric && numericTypeSpec().category() == tc;
 }
 IntrinsicTypeSpec *DeclTypeSpec::AsIntrinsic() {
-  switch (category_) {
-  case Numeric: return &std::get<NumericTypeSpec>(typeSpec_);
-  case Logical: return &std::get<LogicalTypeSpec>(typeSpec_);
-  case Character: return &std::get<CharacterTypeSpec>(typeSpec_);
-  default: return nullptr;
-  }
-}
-const IntrinsicTypeSpec *DeclTypeSpec::AsIntrinsic() const {
-  switch (category_) {
-  case Numeric: return &std::get<NumericTypeSpec>(typeSpec_);
-  case Logical: return &std::get<LogicalTypeSpec>(typeSpec_);
-  case Character: return &std::get<CharacterTypeSpec>(typeSpec_);
-  default: return nullptr;
-  }
-}
-const DerivedTypeSpec *DeclTypeSpec::AsDerived() const {
-  switch (category_) {
-  case TypeDerived:
-  case ClassDerived: return &std::get<DerivedTypeSpec>(typeSpec_);
-  default: return nullptr;
-  }
+  return const_cast<IntrinsicTypeSpec *>(
+      const_cast<const DeclTypeSpec *>(this)->AsIntrinsic());
 }
 const NumericTypeSpec &DeclTypeSpec::numericTypeSpec() const {
   CHECK(category_ == Numeric);

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -229,7 +229,14 @@ public:
   bool HasActualParameters() const { return !parameters_.empty(); }
   ParamValue &AddParamValue(SourceName, ParamValue &&);
   ParamValue *FindParameter(SourceName);
-  const ParamValue *FindParameter(SourceName) const;
+  const ParamValue *FindParameter(SourceName target) const {
+    auto iter{parameters_.find(target)};
+    if (iter != parameters_.end()) {
+      return &iter->second;
+    } else {
+      return nullptr;
+    }
+  }
   void FoldParameterExpressions(evaluate::FoldingContext &);
   void Instantiate(Scope &, evaluate::FoldingContext &);
   bool operator==(const DerivedTypeSpec &) const;  // for std::find()
@@ -271,14 +278,29 @@ public:
   Category category() const { return category_; }
   void set_category(Category category) { category_ = category; }
   bool IsNumeric(TypeCategory) const;
-  IntrinsicTypeSpec *AsIntrinsic();
-  const IntrinsicTypeSpec *AsIntrinsic() const;
-  const DerivedTypeSpec *AsDerived() const;
   const NumericTypeSpec &numericTypeSpec() const;
   const LogicalTypeSpec &logicalTypeSpec() const;
   const CharacterTypeSpec &characterTypeSpec() const;
   const DerivedTypeSpec &derivedTypeSpec() const;
   DerivedTypeSpec &derivedTypeSpec();
+
+  IntrinsicTypeSpec *AsIntrinsic();
+  const IntrinsicTypeSpec *AsIntrinsic() const {
+    switch (category_) {
+    case Numeric: return &std::get<NumericTypeSpec>(typeSpec_);
+    case Logical: return &std::get<LogicalTypeSpec>(typeSpec_);
+    case Character: return &std::get<CharacterTypeSpec>(typeSpec_);
+    default: return nullptr;
+    }
+  }
+
+  const DerivedTypeSpec *AsDerived() const {
+    switch (category_) {
+    case TypeDerived:
+    case ClassDerived: return &std::get<DerivedTypeSpec>(typeSpec_);
+    default: return nullptr;
+    }
+  }
 
 private:
   Category category_;

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(FortranRuntime
+add_library(FortranRuntime SHARED
   ISO_Fortran_binding.cc
   derived-type.cc
   descriptor.cc

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(FortranRuntime SHARED
+add_library(FortranRuntime
   ISO_Fortran_binding.cc
   derived-type.cc
   descriptor.cc

--- a/test/evaluate/CMakeLists.txt
+++ b/test/evaluate/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ add_executable(leading-zero-bit-count-test
 )
 
 target_link_libraries(leading-zero-bit-count-test
-  FortranEvaluate
   FortranEvaluateTesting
+  FortranEvaluate
 )
 
 add_executable(bit-population-count-test
@@ -31,8 +31,8 @@ add_executable(bit-population-count-test
 )
 
 target_link_libraries(bit-population-count-test
-  FortranEvaluate
   FortranEvaluateTesting
+  FortranEvaluate
 )
 
 add_executable(expression-test
@@ -41,10 +41,9 @@ add_executable(expression-test
 
 target_link_libraries(expression-test
   FortranEvaluateTesting
-  FortranEvaluate
-  FortranParser
   FortranSemantics
   FortranEvaluate
+  FortranParser
 )
 
 add_executable(integer-test
@@ -52,8 +51,8 @@ add_executable(integer-test
 )
 
 target_link_libraries(integer-test
-  FortranEvaluate
   FortranEvaluateTesting
+  FortranEvaluate
 )
 
 add_executable(intrinsics-test
@@ -62,9 +61,9 @@ add_executable(intrinsics-test
 
 target_link_libraries(intrinsics-test
   FortranEvaluateTesting
+  FortranSemantics
   FortranEvaluate
   FortranParser
-  FortranSemantics
   FortranRuntime
 )
 
@@ -73,8 +72,8 @@ add_executable(logical-test
 )
 
 target_link_libraries(logical-test
-  FortranEvaluate
   FortranEvaluateTesting
+  FortranEvaluate
 )
 
 add_executable(real-test
@@ -82,8 +81,8 @@ add_executable(real-test
 )
 
 target_link_libraries(real-test
-  FortranEvaluate
   FortranEvaluateTesting
+  FortranEvaluate
   m
 )
 
@@ -92,9 +91,9 @@ add_executable(reshape-test
 )
 
 target_link_libraries(reshape-test
+  FortranEvaluateTesting
   FortranSemantics
   FortranEvaluate
-  FortranEvaluateTesting
   FortranRuntime
 )
 
@@ -103,17 +102,17 @@ add_executable(ISO-Fortran-binding-test
 )
 
 target_link_libraries(ISO-Fortran-binding-test
-  FortranEvaluate
   FortranEvaluateTesting
+  FortranEvaluate
   FortranRuntime
 )
 
-add_test(NAME Expression COMMAND expression-test)
-add_test(NAME Leadz COMMAND leading-zero-bit-count-test)
-add_test(NAME PopPar COMMAND bit-population-count-test)
-add_test(NAME Integer COMMAND integer-test)
-add_test(NAME Intrinsics COMMAND intrinsics-test)
-add_test(NAME Logical COMMAND logical-test)
-add_test(NAME Real COMMAND real-test)
-add_test(NAME RESHAPE COMMAND reshape-test)
-add_test(NAME ISO-Fortran-binding COMMAND ISO-Fortran-binding-test)
+add_test(Expression expression-test)
+add_test(Leadz leading-zero-bit-count-test)
+add_test(PopPar bit-population-count-test)
+add_test(Integer integer-test)
+add_test(Intrinsics intrinsics-test)
+add_test(Logical logical-test)
+add_test(Real real-test)
+add_test(RESHAPE reshape-test)
+add_test(ISO-binding ISO-Fortran-binding-test)

--- a/test/evaluate/intrinsics.cc
+++ b/test/evaluate/intrinsics.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -135,7 +135,7 @@ struct TestCall {
 };
 
 void TestIntrinsics() {
-  semantics::IntrinsicTypeDefaultKinds defaults;
+  common::IntrinsicTypeDefaultKinds defaults;
   MATCH(4, defaults.GetDefaultKind(TypeCategory::Integer));
   MATCH(4, defaults.GetDefaultKind(TypeCategory::Real));
   IntrinsicProcTable table{IntrinsicProcTable::Configure(defaults)};

--- a/tools/f18/CMakeLists.txt
+++ b/tools/f18/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,6 @@ add_executable(f18
 
 target_link_libraries(f18
   FortranParser
-  FortranSemantics
   FortranEvaluate
+  FortranSemantics
 )

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 // Temporary Fortran front end driver main program for development scaffolding.
 
+#include "../../lib/common/default-kinds.h"
 #include "../../lib/parser/characters.h"
 #include "../../lib/parser/features.h"
 #include "../../lib/parser/message.h"
@@ -22,7 +23,6 @@
 #include "../../lib/parser/parsing.h"
 #include "../../lib/parser/provenance.h"
 #include "../../lib/parser/unparse.h"
-#include "../../lib/semantics/default-kinds.h"
 #include "../../lib/semantics/dump-parse-tree.h"
 #include "../../lib/semantics/expression.h"
 #include "../../lib/semantics/semantics.h"
@@ -319,7 +319,7 @@ int main(int argc, char *const argv[]) {
   options.predefinitions.emplace_back("__F18_MINOR__", "1");
   options.predefinitions.emplace_back("__F18_PATCHLEVEL__", "1");
 
-  Fortran::semantics::IntrinsicTypeDefaultKinds defaultKinds;
+  Fortran::common::IntrinsicTypeDefaultKinds defaultKinds;
 
   std::vector<std::string> fortranSources, otherSources, relocatables;
   bool anyFiles{false};


### PR DESCRIPTION
Rearrange some code so that the f18 library binaries are no longer mutually dependent.  Some code moves from semantics to common, some code moves from semantics to evaluate, and some moves into headers.  Tweak CMakeLists.txt files.  This PR will resolve at least one open "issue" about shared libraries and dependences.