### PR TITLE
Make x86 fp flag edge case behavior emulation conditional.

### DIFF
--- a/lib/evaluate/common.h
+++ b/lib/evaluate/common.h
@@ -118,9 +118,22 @@ template<typename A> struct ValueWithRealFlags {
   RealFlags flags;
 };
 
-ENUM_CLASS(Rounding, TiesToEven, ToZero, Down, Up, TiesAwayFromZero)
+ENUM_CLASS(RoundingMode, TiesToEven, ToZero, Down, Up, TiesAwayFromZero)
 
-static constexpr Rounding defaultRounding{Rounding::TiesToEven};
+struct Rounding {
+  RoundingMode mode{RoundingMode::TiesToEven};
+  // When set, emulate status flag behavior peculiar to x86
+  // (viz., fail to set the Underflow flag when an inexact product of a
+  // multiplication is rounded up to a normal number from a subnormal
+  // in some rounding modes)
+#if __x86_64__
+  bool x86CompatibleBehavior{true};
+#else
+  bool x86CompatibleBehavior{false};
+#endif
+};
+
+static constexpr Rounding defaultRounding;
 
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 constexpr bool IsHostLittleEndian{false};

--- a/lib/evaluate/rounding-bits.h
+++ b/lib/evaluate/rounding-bits.h
@@ -83,14 +83,14 @@ public:
   constexpr bool MustRound(
       Rounding rounding, bool isNegative, bool isOdd) const {
     bool round{false};  // to dodge bogus g++ warning about missing return
-    switch (rounding) {
-    case Rounding::TiesToEven:
+    switch (rounding.mode) {
+    case RoundingMode::TiesToEven:
       round = guard_ && (round_ | sticky_ | isOdd);
       break;
-    case Rounding::ToZero: break;
-    case Rounding::Down: round = isNegative && !empty(); break;
-    case Rounding::Up: round = !isNegative && !empty(); break;
-    case Rounding::TiesAwayFromZero: round = guard_; break;
+    case RoundingMode::ToZero: break;
+    case RoundingMode::Down: round = isNegative && !empty(); break;
+    case RoundingMode::Up: round = !isNegative && !empty(); break;
+    case RoundingMode::TiesAwayFromZero: round = guard_; break;
     }
     return round;
   }

--- a/test/evaluate/fp-testing.cc
+++ b/test/evaluate/fp-testing.cc
@@ -30,7 +30,7 @@ ScopedHostFloatingPointEnvironment::ScopedHostFloatingPointEnvironment(
     std::fprintf(stderr, "fegetenv() failed: %s\n", std::strerror(errno));
     std::abort();
   }
-#if defined __x86_64__
+#if __x86_64__
   if (treatDenormalOperandsAsZero) {
     currentFenv_.__mxcsr |= 0x0040;
   } else {
@@ -85,12 +85,12 @@ RealFlags ScopedHostFloatingPointEnvironment::CurrentFlags() {
 }
 
 void ScopedHostFloatingPointEnvironment::SetRounding(Rounding rounding) {
-  switch (rounding) {
-  case Rounding::TiesToEven: fesetround(FE_TONEAREST); break;
-  case Rounding::ToZero: fesetround(FE_TOWARDZERO); break;
-  case Rounding::Up: fesetround(FE_UPWARD); break;
-  case Rounding::Down: fesetround(FE_DOWNWARD); break;
-  case Rounding::TiesAwayFromZero:
+  switch (rounding.mode) {
+  case RoundingMode::TiesToEven: fesetround(FE_TONEAREST); break;
+  case RoundingMode::ToZero: fesetround(FE_TOWARDZERO); break;
+  case RoundingMode::Up: fesetround(FE_UPWARD); break;
+  case RoundingMode::Down: fesetround(FE_DOWNWARD); break;
+  case RoundingMode::TiesAwayFromZero:
     std::fprintf(stderr, "SetRounding: TiesAwayFromZero not available");
     std::abort();
     break;

--- a/test/evaluate/fp-testing.h
+++ b/test/evaluate/fp-testing.h
@@ -20,6 +20,7 @@
 
 using Fortran::evaluate::RealFlags;
 using Fortran::evaluate::Rounding;
+using Fortran::evaluate::RoundingMode;
 
 class ScopedHostFloatingPointEnvironment {
 public:

--- a/test/evaluate/real.cc
+++ b/test/evaluate/real.cc
@@ -532,10 +532,10 @@ int main() {
     // Use 8192 or 16384 for more exhaustive testing.
     opds = std::atol(p);
   }
-  roundTest(0, Rounding::TiesToEven, opds);
-  roundTest(1, Rounding::ToZero, opds);
-  roundTest(2, Rounding::Up, opds);
-  roundTest(3, Rounding::Down, opds);
+  roundTest(0, Rounding{RoundingMode::TiesToEven}, opds);
+  roundTest(1, Rounding{RoundingMode::ToZero}, opds);
+  roundTest(2, Rounding{RoundingMode::Up}, opds);
+  roundTest(3, Rounding{RoundingMode::Down}, opds);
   // TODO: how to test Rounding::TiesAwayFromZero on x86?
   return testing::Complete();
 }


### PR DESCRIPTION
Fixes issue #211 and probably #148 (but that's unconfirmed).

Some code in the floating-point evaluation library unconditionally emulates an x86 edge case behavior in which the Underflow flag isn't always set when an inexact product of a multiply rounds an subnormal up to a normal number.  This PR makes that behavior conditional on a new "x86 behavior emulation" flag in an expanded `Rounding` struct.  All tests now pass on OpenPower and maybe this fix is sufficient for ARM.