### PR TITLE
Use IEEE-754 terminology better: subnormal, not denormal(ized)

### DIFF
--- a/lib/evaluate/common.h
+++ b/lib/evaluate/common.h
@@ -196,20 +196,20 @@ template<typename A> class Expr;
 struct FoldingContext {
   explicit FoldingContext(const parser::ContextualMessages &m,
       Rounding round = defaultRounding, bool flush = false)
-    : messages{m}, rounding{round}, flushDenormalsToZero{flush} {}
+    : messages{m}, rounding{round}, flushSubnormalsToZero{flush} {}
   FoldingContext(const FoldingContext &that)
     : messages{that.messages}, rounding{that.rounding},
-      flushDenormalsToZero{that.flushDenormalsToZero}, pdtInstance{
+      flushSubnormalsToZero{that.flushSubnormalsToZero}, pdtInstance{
                                                            that.pdtInstance} {}
   FoldingContext(
       const FoldingContext &that, const parser::ContextualMessages &m)
     : messages{m}, rounding{that.rounding},
-      flushDenormalsToZero{that.flushDenormalsToZero}, pdtInstance{
+      flushSubnormalsToZero{that.flushSubnormalsToZero}, pdtInstance{
                                                            that.pdtInstance} {}
 
   parser::ContextualMessages messages;
   Rounding rounding{defaultRounding};
-  bool flushDenormalsToZero{false};
+  bool flushSubnormalsToZero{false};
   bool bigEndian{false};
   const semantics::DerivedTypeSpec *pdtInstance{nullptr};
 };

--- a/lib/evaluate/complex.h
+++ b/lib/evaluate/complex.h
@@ -78,8 +78,8 @@ public:
   ValueWithRealFlags<Complex> Divide(
       const Complex &, Rounding rounding = defaultRounding) const;
 
-  constexpr Complex FlushDenormalToZero() const {
-    return {re_.FlushDenormalToZero(), im_.FlushDenormalToZero()};
+  constexpr Complex FlushSubnormalToZero() const {
+    return {re_.FlushSubnormalToZero(), im_.FlushSubnormalToZero()};
   }
 
   static constexpr Complex NotANumber() {

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -297,8 +297,8 @@ Expr<TO> FoldOperation(
                     "REAL(%d) to REAL(%d) conversion", Operand::kind, TO::kind);
                 RealFlagWarnings(context, converted.flags, buffer);
               }
-              if (context.flushDenormalsToZero) {
-                converted.value = converted.value.FlushDenormalToZero();
+              if (context.flushSubnormalsToZero) {
+                converted.value = converted.value.FlushSubnormalToZero();
               }
               return Expr<TO>{Constant<TO>{std::move(converted.value)}};
             }
@@ -398,8 +398,8 @@ Expr<T> FoldOperation(FoldingContext &context, Add<T> &&x) {
     } else {
       auto sum{folded->first.Add(folded->second, context.rounding)};
       RealFlagWarnings(context, sum.flags, "addition");
-      if (context.flushDenormalsToZero) {
-        sum.value = sum.value.FlushDenormalToZero();
+      if (context.flushSubnormalsToZero) {
+        sum.value = sum.value.FlushSubnormalToZero();
       }
       return Expr<T>{Constant<T>{sum.value}};
     }
@@ -420,8 +420,8 @@ Expr<T> FoldOperation(FoldingContext &context, Subtract<T> &&x) {
     } else {
       auto difference{folded->first.Subtract(folded->second, context.rounding)};
       RealFlagWarnings(context, difference.flags, "subtraction");
-      if (context.flushDenormalsToZero) {
-        difference.value = difference.value.FlushDenormalToZero();
+      if (context.flushSubnormalsToZero) {
+        difference.value = difference.value.FlushSubnormalToZero();
       }
       return Expr<T>{Constant<T>{difference.value}};
     }
@@ -442,8 +442,8 @@ Expr<T> FoldOperation(FoldingContext &context, Multiply<T> &&x) {
     } else {
       auto product{folded->first.Multiply(folded->second, context.rounding)};
       RealFlagWarnings(context, product.flags, "multiplication");
-      if (context.flushDenormalsToZero) {
-        product.value = product.value.FlushDenormalToZero();
+      if (context.flushSubnormalsToZero) {
+        product.value = product.value.FlushSubnormalToZero();
       }
       return Expr<T>{Constant<T>{product.value}};
     }
@@ -466,8 +466,8 @@ Expr<T> FoldOperation(FoldingContext &context, Divide<T> &&x) {
     } else {
       auto quotient{folded->first.Divide(folded->second, context.rounding)};
       RealFlagWarnings(context, quotient.flags, "division");
-      if (context.flushDenormalsToZero) {
-        quotient.value = quotient.value.FlushDenormalToZero();
+      if (context.flushSubnormalsToZero) {
+        quotient.value = quotient.value.FlushSubnormalToZero();
       }
       return Expr<T>{Constant<T>{quotient.value}};
     }
@@ -503,8 +503,8 @@ Expr<T> FoldOperation(FoldingContext &context, RealToIntPower<T> &&x) {
         if (auto folded{FoldOperands(context, x.left(), y)}) {
           auto power{evaluate::IntPower(folded->first, folded->second)};
           RealFlagWarnings(context, power.flags, "power with INTEGER exponent");
-          if (context.flushDenormalsToZero) {
-            power.value = power.value.FlushDenormalToZero();
+          if (context.flushSubnormalsToZero) {
+            power.value = power.value.FlushSubnormalToZero();
           }
           return Expr<T>{Constant<T>{power.value}};
         } else {

--- a/lib/evaluate/real.cc
+++ b/lib/evaluate/real.cc
@@ -116,7 +116,7 @@ ValueWithRealFlags<Real<W, P, IM>> Real<W, P, IM>::Add(
   Fraction yFraction{y.GetFraction()};
   int rshift = exponent - yExponent;
   if (exponent > 0 && yExponent == 0) {
-    --rshift;  // correct overshift when only y is denormal
+    --rshift;  // correct overshift when only y is subnormal
   }
   RoundingBits roundingBits{yFraction, rshift};
   yFraction = yFraction.SHIFTR(rshift);
@@ -236,7 +236,7 @@ ValueWithRealFlags<Real<W, P, IM>> Real<W, P, IM>::Divide(
       Fraction quotient;
       bool msb{false};
       if (!top.BTEST(top.bits - 1) || !divisor.BTEST(divisor.bits - 1)) {
-        // One or two denormals
+        // One or two subnormals
         int topLshift{top.LEADZ()};
         top = top.SHIFTL(topLshift);
         int divisorLshift{divisor.LEADZ()};

--- a/lib/evaluate/real.h
+++ b/lib/evaluate/real.h
@@ -86,7 +86,7 @@ public:
   constexpr bool IsZero() const {
     return Exponent() == 0 && GetSignificand().IsZero();
   }
-  constexpr bool IsDenormal() const {
+  constexpr bool IsSubnormal() const {
     return Exponent() == 0 && !GetSignificand().IsZero();
   }
 
@@ -119,7 +119,7 @@ public:
       return INT::HUGE();
     } else {
       int result{exponent - exponentBias};
-      if (IsDenormal()) {
+      if (IsSubnormal()) {
         ++result;
       }
       return {result};
@@ -132,8 +132,8 @@ public:
     return epsilon;
   }
 
-  constexpr Real FlushDenormalToZero() const {
-    if (IsDenormal()) {
+  constexpr Real FlushSubnormalToZero() const {
+    if (IsSubnormal()) {
       return Real{};
     }
     return *this;
@@ -319,7 +319,7 @@ public:
   constexpr int UnbiasedExponent() const {
     int exponent =
         word_.IBITS(significandBits, exponentBits).ToUInt64() - exponentBias;
-    if (IsDenormal()) {
+    if (IsSubnormal()) {
       ++exponent;
     }
     return exponent;

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -460,8 +460,8 @@ Constant<TYPE> ReadRealLiteral(
   CHECK(p == source.end());
   RealFlagWarnings(context, valWithFlags.flags, "conversion of REAL literal");
   auto value{valWithFlags.value};
-  if (context.flushDenormalsToZero) {
-    value = value.FlushDenormalToZero();
+  if (context.flushSubnormalsToZero) {
+    value = value.FlushSubnormalToZero();
   }
   return {value};
 }

--- a/test/evaluate/fp-testing.cc
+++ b/test/evaluate/fp-testing.cc
@@ -20,7 +20,7 @@
 using Fortran::evaluate::RealFlag;
 
 ScopedHostFloatingPointEnvironment::ScopedHostFloatingPointEnvironment(
-    bool treatDenormalOperandsAsZero, bool flushDenormalResultsToZero) {
+    bool treatSubnormalOperandsAsZero, bool flushSubnormalResultsToZero) {
   errno = 0;
   if (feholdexcept(&originalFenv_) != 0) {
     std::fprintf(stderr, "feholdexcept() failed: %s\n", std::strerror(errno));
@@ -31,12 +31,12 @@ ScopedHostFloatingPointEnvironment::ScopedHostFloatingPointEnvironment(
     std::abort();
   }
 #if __x86_64__
-  if (treatDenormalOperandsAsZero) {
+  if (treatSubnormalOperandsAsZero) {
     currentFenv_.__mxcsr |= 0x0040;
   } else {
     currentFenv_.__mxcsr &= ~0x0040;
   }
-  if (flushDenormalResultsToZero) {
+  if (flushSubnormalResultsToZero) {
     currentFenv_.__mxcsr |= 0x8000;
   } else {
     currentFenv_.__mxcsr &= ~0x8000;

--- a/test/evaluate/fp-testing.h
+++ b/test/evaluate/fp-testing.h
@@ -24,8 +24,8 @@ using Fortran::evaluate::RoundingMode;
 
 class ScopedHostFloatingPointEnvironment {
 public:
-  ScopedHostFloatingPointEnvironment(bool treatDenormalOperandsAsZero = false,
-      bool flushDenormalResultsToZero = false);
+  ScopedHostFloatingPointEnvironment(bool treatSubnormalOperandsAsZero = false,
+      bool flushSubnormalResultsToZero = false);
   ~ScopedHostFloatingPointEnvironment();
   void ClearFlags() const;
   static RealFlags CurrentFlags();


### PR DESCRIPTION
Replace "denormal" with "subnormal" wherever it appears so as to conform better with IEEE-754 and Fortran 2018 terminology.