### PR TITLE
Elemental Intrinsic Function Reference Folding Draft

### DIFF
--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -15,6 +15,7 @@
 #include "fold.h"
 #include "common.h"
 #include "expression.h"
+#include "host.h"
 #include "int-power.h"
 #include "tools.h"
 #include "type.h"
@@ -24,6 +25,8 @@
 #include "../parser/message.h"
 #include "../semantics/scope.h"
 #include "../semantics/symbol.h"
+#include <cmath>
+#include <complex>
 #include <cstdio>
 #include <optional>
 #include <set>
@@ -49,7 +52,9 @@ CoarrayRef FoldOperation(FoldingContext &, CoarrayRef &&);
 DataRef FoldOperation(FoldingContext &, DataRef &&);
 Substring FoldOperation(FoldingContext &, Substring &&);
 ComplexPart FoldOperation(FoldingContext &, ComplexPart &&);
-template<typename T> Expr<T> FoldOperation(FoldingContext &, FunctionRef<T> &&);
+template<int KIND>
+Expr<Type<TypeCategory::Integer, KIND>> FoldOperation(FoldingContext &context,
+    FunctionRef<Type<TypeCategory::Integer, KIND>> &&funcRef);
 template<typename T> Expr<T> FoldOperation(FoldingContext &, Designator<T> &&);
 template<int KIND>
 Expr<Type<TypeCategory::Integer, KIND>> FoldOperation(
@@ -152,35 +157,486 @@ ComplexPart FoldOperation(FoldingContext &context, ComplexPart &&complexPart) {
       FoldOperation(context, std::move(complex)), complexPart.part()};
 }
 
+// Scalar conversion
+// Conversion Helper to be used to avoid instantiating ScalarConvert when
+// it would be undefined.
+template<TypeCategory TOCAT, TypeCategory FROMCAT>
+static constexpr inline bool IsAllowedBasicConversion() {
+  if constexpr (TOCAT == TypeCategory::Integer || TOCAT == TypeCategory::Real) {
+    return FROMCAT == TypeCategory::Real || FROMCAT == TypeCategory::Integer;
+  } else if constexpr (TOCAT == TypeCategory::Logical) {
+    return FROMCAT == TypeCategory::Logical;
+  }
+  return false;
+}
+
+template<typename TO, typename Operand>
+Scalar<TO> ScalarConvert(
+    FoldingContext &context, const Scalar<Operand> &value) {
+  static_assert(IsAllowedBasicConversion<TO::category, Operand::category>());
+  if constexpr (TO::category == TypeCategory::Integer) {
+    if constexpr (Operand::category == TypeCategory::Integer) {
+      auto converted{Scalar<TO>::ConvertSigned(value)};
+      if (converted.overflow) {
+        context.messages.Say(
+            "INTEGER(%d) to INTEGER(%d) conversion overflowed"_en_US,
+            Operand::kind, TO::kind);
+      }
+      return std::move(converted.value);
+    } else if constexpr (Operand::category == TypeCategory::Real) {
+      auto converted{value.template ToInteger<Scalar<TO>>()};
+      if (converted.flags.test(RealFlag::InvalidArgument)) {
+        context.messages.Say(
+            "REAL(%d) to INTEGER(%d) conversion: invalid argument"_en_US,
+            Operand::kind, TO::kind);
+      } else if (converted.flags.test(RealFlag::Overflow)) {
+        context.messages.Say(
+            "REAL(%d) to INTEGER(%d) conversion overflowed"_en_US,
+            Operand::kind, TO::kind);
+      }
+      return std::move(converted.value);
+    }
+  } else if constexpr (TO::category == TypeCategory::Real) {
+    char buffer[64];
+    if constexpr (Operand::category == TypeCategory::Integer) {
+      auto converted{Scalar<TO>::FromInteger(value)};
+      if (!converted.flags.empty()) {
+        std::snprintf(buffer, sizeof buffer,
+            "INTEGER(%d) to REAL(%d) conversion", Operand::kind, TO::kind);
+        RealFlagWarnings(context, converted.flags, buffer);
+      }
+      return std::move(converted.value);
+    } else if constexpr (Operand::category == TypeCategory::Real) {
+      auto converted{Scalar<TO>::Convert(value)};
+      if (!converted.flags.empty()) {
+        std::snprintf(buffer, sizeof buffer, "REAL(%d) to REAL(%d) conversion",
+            Operand::kind, TO::kind);
+        RealFlagWarnings(context, converted.flags, buffer);
+      }
+      if (context.flushSubnormalsToZero) {
+        converted.value = converted.value.FlushSubnormalToZero();
+      }
+      return std::move(converted.value);
+    }
+  } else if constexpr (TO::category == TypeCategory::Logical &&
+      Operand::category == TypeCategory::Logical) {
+    return value.IsTrue();
+  }
+}
+
+// helpers to fold intrinsic function references
+namespace intrinsicHelper {
+// helper to produce hash of intrinsic names based the first 3 letters. All
+// intrinsic names are longer than 3 letters
+static constexpr inline std::int32_t CommonHash(const char *s, std::size_t n) {
+  if (n < 3) {
+    return 0;
+  }
+  return (((static_cast<std::int32_t>(s[0]) << 8) + s[1]) << 8) + s[2];
+}
+
+static constexpr std::int32_t operator"" _hash(const char *s, std::size_t n) {
+  return CommonHash(s, n);
+}
+
+static std::int32_t DynamicHash(const std::string &s) {
+  return CommonHash(s.data(), s.size());
+}
+
+// Define function pointer and callable types used in a common utility that
+// takes care of array and cast/conversion aspects for elemental intrinsics Note:
+// math complex functions from <complex> are passing arg as const ref
+template<typename TR, typename... TA> using FuncPointer = TR (*)(TA...);
+
+template<typename TR, typename... TA>
+using HostFuncPointer = FuncPointer<Host::HostType<TR>,
+    std::conditional_t<TA::category == TypeCategory::Complex,
+        const Host::HostType<TA> &, Host::HostType<TA>>...>;
+
+template<typename TR, typename... TA>
+using BiggerOrSameHostFuncPointer = FuncPointer<Host::BiggerOrSameHostType<TR>,
+    std::conditional_t<TA::category == TypeCategory::Complex,
+        const Host::BiggerOrSameHostType<TA> &,
+        Host::BiggerOrSameHostType<TA>>...>;
+
+template<typename TR, typename... TArgs>
+using ScalarFunc = std::function<Scalar<TR>(const Scalar<TArgs> &...)>;
+
+// Helper that build std::function operating on Scalar types from host runtime
+// function. There is version that only works if the scalar has a matching host
+// type and one that allow conversions of scalar types toward "bigger" host
+// types. By "bigger", it is meant that all the scalar types can be converted to
+// and from this host type without any precision loss. The purpose of this is
+// mainly to allow folding of 16 bits float intrinsic function with the host
+// runtime for 32bit floats when it is acceptable (e.g acos).
+template<typename TR, typename... TA>
+static constexpr inline ScalarFunc<TR, TA...> HostFuncWrap(
+    HostFuncPointer<TR, TA...> func) {
+  return [=](const Scalar<TA> &... x) -> Scalar<TR> {
+    // TODO fp-exception
+    return Host::CastHostToFortran<TR>(func(Host::CastFortranToHost<TA>(x)...));
+  };
+}
+
+template<typename TO, typename Operand>
+static inline Scalar<TO> ScalarConvertWithComplexSupport(
+    FoldingContext &context, const Scalar<Operand> &value) {
+  if constexpr (TO::category == TypeCategory::Complex &&
+      Operand::category == TypeCategory::Complex) {
+    using ToPart = typename TO::Part;
+    using FromPart = typename Operand::Part;
+    return Scalar<TO>{ScalarConvert<ToPart, FromPart>(context, value.REAL()),
+        ScalarConvert<ToPart, FromPart>(context, value.AIMAG())};
+  } else {
+    return ScalarConvert<TO, Operand>(context, value);
+  }
+}
+
 template<typename T>
-Expr<T> FoldOperation(FoldingContext &context, FunctionRef<T> &&funcRef) {
-  ActualArguments args{std::move(funcRef.arguments())};
-  for (std::optional<ActualArgument> &arg : args) {
+using Bigger = Host::BiggerOrSameFortanTypeSupportedOnHost<T>;
+template<typename TR, typename... TA>
+static constexpr inline ScalarFunc<TR, TA...> BiggerOrSameHostFuncWrap(
+    FoldingContext &context, BiggerOrSameHostFuncPointer<TR, TA...> func) {
+  if constexpr (Host::HostTypeExists<TR>() &&
+      (... && Host::HostTypeExists<TA>())) {
+    return HostFuncWrap<TR, TA...>(func);
+  } else {
+    return [=, &context](const Scalar<TA> &... x) -> Scalar<TR> {
+      // TODO fp-exception
+      return ScalarConvertWithComplexSupport<TR, Bigger<TR>>(context,
+          Host::CastHostToFortran<Bigger<TR>>(
+              func(Host::CastFortranToHost<Bigger<TA>>(
+                  ScalarConvertWithComplexSupport<Bigger<TA>, TA>(
+                      context, x))...)));
+    };
+  }
+}
+
+// A utility that applies a scalar function over arrays or scalar for elemental
+// intrinsics.
+template<typename TR, typename... TA, std::size_t... I>
+static inline Expr<TR> FoldElementalIntrinsicHelper(FunctionRef<TR> &&funcRef,
+    ScalarFunc<TR, TA...> scalarFunc, std::index_sequence<I...>) {
+  static_assert(
+      (... && IsSpecificIntrinsicType<TA>));  // TODO derived types for MERGE?
+  std::tuple<const Scalar<TA> *...> scalars{
+      GetScalarConstantValue<TA>(*funcRef.arguments()[I]->value)...};
+  if ((... && (std::get<I>(scalars) != nullptr))) {
+    return Expr<TR>{Constant<TR>{scalarFunc(*std::get<I>(scalars)...)}};
+  }
+  // TODO: handle arrays when Constant<T> can represent them
+  return Expr<TR>{std::move(funcRef)};
+}
+
+template<typename TR, typename... TA>
+static Expr<TR> FoldElementalIntrinsic(
+    FunctionRef<TR> &&funcRef, ScalarFunc<TR, TA...> scalarFunc) {
+  return FoldElementalIntrinsicHelper<TR, TA...>(
+      std::move(funcRef), scalarFunc, std::index_sequence_for<TA...>{});
+}
+}
+
+template<int KIND>
+Expr<Type<TypeCategory::Integer, KIND>> FoldOperation(FoldingContext &context,
+    FunctionRef<Type<TypeCategory::Integer, KIND>> &&funcRef) {
+  using namespace intrinsicHelper;
+  using T = Type<TypeCategory::Integer, KIND>;
+  for (std::optional<ActualArgument> &arg : funcRef.arguments()) {
     if (arg.has_value()) {
       *arg->value = FoldOperation(context, std::move(*arg->value));
     }
   }
   if (auto *intrinsic{std::get_if<SpecificIntrinsic>(&funcRef.proc().u)}) {
     std::string name{intrinsic->name};
-    if (name == "kind") {
-      if constexpr (common::HasMember<T, IntegerTypes>) {
-        return Expr<T>{args[0]->value->GetType()->kind};
-      } else {
-        common::die("kind() result not integral");
-      }
-    } else if (name == "len") {
-      if constexpr (std::is_same_v<T, SubscriptInteger>) {
-        if (auto *charExpr{UnwrapExpr<Expr<SomeCharacter>>(*args[0]->value)}) {
-          return std::visit([](auto &kx) { return kx.LEN(); }, charExpr->u);
+    switch (DynamicHash(name)) {
+    case "kin"_hash:
+      if (name == "kind") {
+        if constexpr (common::HasMember<T, IntegerTypes>) {
+          return Expr<T>{funcRef.arguments()[0]->value->GetType()->kind};
+        } else {
+          common::die("kind() result not integral");
         }
-      } else {
-        common::die("len() result not SubscriptInteger");
       }
-    } else {
+      break;
+    case "len"_hash:
+      if (name == "len") {
+        if constexpr (std::is_same_v<T, SubscriptInteger>) {
+          if (auto *charExpr{UnwrapExpr<Expr<SomeCharacter>>(
+                  *funcRef.arguments()[0]->value)}) {
+            return std::visit([](auto &kx) { return kx.LEN(); }, charExpr->u);
+          }
+        } else {
+          common::die("len() result not SubscriptInteger");
+        }
+      }
+      break;
+    case "ian"_hash:
+      if (name == "iand") {
+        if (auto *x{std::get_if<BOZLiteralConstant>(
+                &funcRef.arguments()[0]->value->u)}) {
+          *funcRef.arguments()[0]->value =
+              Fold(context, ConvertToType<T>(std::move(*x)));
+        }
+        if (auto *x{std::get_if<BOZLiteralConstant>(
+                &funcRef.arguments()[1]->value->u)}) {
+          *funcRef.arguments()[1]->value =
+              Fold(context, ConvertToType<T>(std::move(*x)));
+        }
+        return FoldElementalIntrinsic<T, T, T>(
+            std::move(funcRef), ScalarFunc<T, T, T>(&Scalar<T>::IAND));
+      }
+      break;
+    case "int"_hash:
+      if (name == "int") {
+        return std::visit(
+            [&](auto &&x) -> Expr<T> {
+              using From = std::decay_t<decltype(x)>;
+              if constexpr (std::is_same_v<From, BOZLiteralConstant> ||
+                  std::is_same_v<From, Expr<SomeReal>> ||
+                  std::is_same_v<From, Expr<SomeInteger>> ||
+                  std::is_same_v<From, Expr<SomeComplex>>) {
+                return Fold(context, ConvertToType<T>(std::move(x)));
+              } else {
+                common::die("int() argument type not valid");
+                return Expr<T>{std::move(funcRef)};  // unreachable
+              }
+            },
+            std::move(funcRef.arguments()[0]->value->u));
+      }
+      break;
+    default:
       // TODO: many more intrinsic functions
+      break;
     }
   }
-  return Expr<T>{FunctionRef<T>{std::move(funcRef.proc()), std::move(args)}};
+  return Expr<T>{std::move(funcRef)};
+}
+
+template<int KIND>
+Expr<Type<TypeCategory::Real, KIND>> FoldOperation(FoldingContext &context,
+    FunctionRef<Type<TypeCategory::Real, KIND>> &&funcRef) {
+  using namespace intrinsicHelper;
+  using T = Type<TypeCategory::Real, KIND>;
+  for (std::optional<ActualArgument> &arg : funcRef.arguments()) {
+    if (arg.has_value()) {
+      *arg->value = FoldOperation(context, std::move(*arg->value));
+    }
+  }
+  if (auto *intrinsic{std::get_if<SpecificIntrinsic>(&funcRef.proc().u)}) {
+    std::string name{intrinsic->name};
+    switch (DynamicHash(name)) {
+    case "aco"_hash:
+      if (name == "acos") {
+        if constexpr (Host::BiggerOrSameHostTypeExists<T>()) {
+          return FoldElementalIntrinsic<T, T>(std::move(funcRef),
+              BiggerOrSameHostFuncWrap<T, T>(
+                  context, BiggerOrSameHostFuncPointer<T, T>{std::acos}));
+        } else {
+          context.messages.Say(
+              "acos(real(kind=%d)) cannot be folded on host"_en_US, KIND);
+        }
+      } else if (name == "acosh") {
+        if constexpr (Host::BiggerOrSameHostTypeExists<T>()) {
+          return FoldElementalIntrinsic<T, T>(std::move(funcRef),
+              BiggerOrSameHostFuncWrap<T, T>(
+                  context, BiggerOrSameHostFuncPointer<T, T>{std::acosh}));
+        } else {
+          context.messages.Say(
+              "acosh(real(kind=%d)) cannot be folded on host"_en_US, KIND);
+        }
+      }
+    case "bes"_hash:
+      if (name == "bessel_jn" || name == "bessel_yn") {
+        if (funcRef.arguments().size() == 2) {  // elemental
+          if constexpr (Host::BiggerOrSameHostTypeExists<T>()) {
+            // TODO mapping to <cmath> function to be tested.<cmath> func takes
+            // real arg for n
+            if (auto *n{std::get_if<Expr<SomeInteger>>(
+                    &funcRef.arguments()[0]->value->u)}) {
+              *funcRef.arguments()[0]->value =
+                  Fold(context, ConvertToType<T>(std::move(*n)));
+            }
+            auto hostFunc{name == "bessel_jn"
+                    ? BiggerOrSameHostFuncPointer<T, T, T>{std::cyl_bessel_j}
+                    : BiggerOrSameHostFuncPointer<T, T, T>{std::cyl_neumann}};
+            return FoldElementalIntrinsic<T, T, T>(std::move(funcRef),
+                BiggerOrSameHostFuncWrap<T, T, T>(context, hostFunc));
+          }
+        }
+      }
+      break;
+    case "dpr"_hash:
+      if (name == "dprod") {
+        if (auto *x{std::get_if<Expr<SomeReal>>(
+                &funcRef.arguments()[0]->value->u)}) {
+          if (auto *y{std::get_if<Expr<SomeReal>>(
+                  &funcRef.arguments()[1]->value->u)}) {
+            return Fold(context,
+                Expr<T>{Multiply<T>{ConvertToType<T>(std::move(*x)),
+                    ConvertToType<T>(std::move(*y))}});
+          }
+        }
+        common::die("Wrong argument type in dprod()");
+        break;
+      }
+      break;
+    case "rea"_hash:
+      if (name == "real") {
+        return std::visit(
+            [&](auto &&x) -> Expr<T> {
+              using From = std::decay_t<decltype(x)>;
+              if constexpr (std::is_same_v<From, BOZLiteralConstant>) {
+                typename T::Scalar::Word::ValueWithOverflow result{
+                    T::Scalar::Word::ConvertUnsigned(x)};
+                if (result.overflow) {  // C1601
+                  context.messages.Say(
+                      "Non null truncated bits of boz literal constant in REAL intrinsic"_en_US);
+                }
+                return Expr<T>{Constant<T>{Scalar<T>(std::move(result.value))}};
+              } else if constexpr (std::is_same_v<From, Expr<SomeReal>> ||
+                  std::is_same_v<From, Expr<SomeInteger>> ||
+                  std::is_same_v<From, Expr<SomeComplex>>) {
+                return Fold(context, ConvertToType<T>(std::move(x)));
+              } else {
+                common::die("real() argument type not valid");
+                return Expr<T>{std::move(funcRef)};  // unreachable
+              }
+            },
+            std::move(funcRef.arguments()[0]->value->u));
+      }
+      break;
+    default:
+      // TODO: many more intrinsic functions
+      break;
+    }
+  }
+  return Expr<T>{std::move(funcRef)};
+}
+
+template<int KIND>
+Expr<Type<TypeCategory::Complex, KIND>> FoldOperation(FoldingContext &context,
+    FunctionRef<Type<TypeCategory::Complex, KIND>> &&funcRef) {
+  using namespace intrinsicHelper;
+  using T = Type<TypeCategory::Complex, KIND>;
+  for (std::optional<ActualArgument> &arg : funcRef.arguments()) {
+    if (arg.has_value()) {
+      *arg->value = FoldOperation(context, std::move(*arg->value));
+    }
+  }
+  if (auto *intrinsic{std::get_if<SpecificIntrinsic>(&funcRef.proc().u)}) {
+    std::string name{intrinsic->name};
+    switch (DynamicHash(name)) {
+    case "aco"_hash:
+      if (name == "acos") {
+        if constexpr (Host::BiggerOrSameHostTypeExists<T>()) {
+          return FoldElementalIntrinsic<T, T>(std::move(funcRef),
+              BiggerOrSameHostFuncWrap<T, T>(
+                  context, BiggerOrSameHostFuncPointer<T, T>{std::acos}));
+        } else {
+          context.messages.Say(
+              "acos(complex(kind=%d)) cannot be folded on host"_en_US, KIND);
+        }
+      } else if (name == "acosh") {
+        if constexpr (Host::BiggerOrSameHostTypeExists<T>()) {
+          return FoldElementalIntrinsic<T, T>(std::move(funcRef),
+              BiggerOrSameHostFuncWrap<T, T>(
+                  context, BiggerOrSameHostFuncPointer<T, T>{std::acosh}));
+        } else {
+          context.messages.Say(
+              "acosh(complex(kind=%d)) cannot be folded on host"_en_US, KIND);
+        }
+      }
+    case "cmp"_hash:
+      if (name == "cmplx") {
+        if (funcRef.arguments().size() == 2) {
+          if (auto *x{std::get_if<Expr<SomeComplex>>(
+                  &funcRef.arguments()[0]->value->u)}) {
+            return Fold(context, ConvertToType<T>(std::move(*x)));
+          } else {
+            common::die("x must be complex in cmplx(x[, kind])");
+          }
+        } else {
+          CHECK(funcRef.arguments().size() == 3);
+          using Part = typename T::Part;
+          Expr<SomeType> im{funcRef.arguments()[1].has_value()
+                  ? std::move(*funcRef.arguments()[1]->value)
+                  : AsGenericExpr(Constant<Part>{Scalar<Part>{}})};
+          Expr<SomeType> re{std::move(*funcRef.arguments()[0]->value)};
+          int reRank{re.Rank()};
+          int imRank{im.Rank()};
+          semantics::Attrs attrs;
+          attrs.set(semantics::Attr::ELEMENTAL);
+          auto reReal{
+              FunctionRef<Part>{ProcedureDesignator{SpecificIntrinsic{
+                                    "real", Part::GetType(), reRank, attrs}},
+                  ActualArguments{ActualArgument{std::move(re)}}}};
+          auto imReal{
+              FunctionRef<Part>{ProcedureDesignator{SpecificIntrinsic{
+                                    "real", Part::GetType(), imRank, attrs}},
+                  ActualArguments{ActualArgument{std::move(im)}}}};
+          return Fold(context,
+              Expr<T>{ComplexConstructor<T::kind>{Expr<Part>{std::move(reReal)},
+                  Expr<Part>{std::move(imReal)}}});
+        }
+      }
+      break;
+    default:
+      // TODO: many more intrinsic functions
+      break;
+    }
+  }
+  return Expr<T>{std::move(funcRef)};
+}
+
+template<int KIND>
+Expr<Type<TypeCategory::Logical, KIND>> FoldOperation(FoldingContext &context,
+    FunctionRef<Type<TypeCategory::Logical, KIND>> &&funcRef) {
+  using namespace intrinsicHelper;
+  using T = Type<TypeCategory::Logical, KIND>;
+  for (std::optional<ActualArgument> &arg : funcRef.arguments()) {
+    if (arg.has_value()) {
+      *arg->value = FoldOperation(context, std::move(*arg->value));
+    }
+  }
+  if (auto *intrinsic{std::get_if<SpecificIntrinsic>(&funcRef.proc().u)}) {
+    std::string name{intrinsic->name};
+    switch (DynamicHash(name)) {
+    case "bge"_hash:
+      if (name == "bge") {
+        using LargestInt = Type<TypeCategory::Integer, 16>;
+        static_assert(std::is_same_v<Scalar<LargestInt>, BOZLiteralConstant>);
+        if (auto *x{std::get_if<Expr<SomeInteger>>(
+                &funcRef.arguments()[0]->value->u)}) {
+          *funcRef.arguments()[0]->value =
+              Fold(context, ConvertToType<LargestInt>(std::move(*x)));
+        } else if (auto *x{std::get_if<BOZLiteralConstant>(
+                       &funcRef.arguments()[0]->value->u)}) {
+          *funcRef.arguments()[0]->value =
+              AsGenericExpr(Constant<LargestInt>{std::move(*x)});
+        }
+        if (auto *x{std::get_if<Expr<SomeInteger>>(
+                &funcRef.arguments()[1]->value->u)}) {
+          *funcRef.arguments()[1]->value =
+              Fold(context, ConvertToType<LargestInt>(std::move(*x)));
+        } else if (auto *x{std::get_if<BOZLiteralConstant>(
+                       &funcRef.arguments()[1]->value->u)}) {
+          *funcRef.arguments()[1]->value =
+              AsGenericExpr(Constant<LargestInt>{std::move(*x)});
+        }
+        return FoldElementalIntrinsic<T, LargestInt, LargestInt>(
+            std::move(funcRef),
+            ScalarFunc<T, LargestInt, LargestInt>(
+                [](const Scalar<LargestInt> &i, const Scalar<LargestInt> &j) {
+                  return Scalar<T>{i.BGE(j)};
+                }));
+      }
+      break;
+    default:
+      // TODO: many more intrinsic functions
+      break;
+    }
+  }
+  return Expr<T>{std::move(funcRef)};
 }
 
 template<typename T>
@@ -256,55 +712,10 @@ Expr<TO> FoldOperation(
       [&](auto &kindExpr) -> Expr<TO> {
         kindExpr = Fold(context, std::move(kindExpr));
         using Operand = ResultType<decltype(kindExpr)>;
-        char buffer[64];
         if (const auto *value{GetScalarConstantValue<Operand>(kindExpr)}) {
-          if constexpr (TO::category == TypeCategory::Integer) {
-            if constexpr (Operand::category == TypeCategory::Integer) {
-              auto converted{Scalar<TO>::ConvertSigned(*value)};
-              if (converted.overflow) {
-                context.messages.Say(
-                    "INTEGER(%d) to INTEGER(%d) conversion overflowed"_en_US,
-                    Operand::kind, TO::kind);
-              }
-              return Expr<TO>{Constant<TO>{std::move(converted.value)}};
-            } else if constexpr (Operand::category == TypeCategory::Real) {
-              auto converted{value->template ToInteger<Scalar<TO>>()};
-              if (converted.flags.test(RealFlag::InvalidArgument)) {
-                context.messages.Say(
-                    "REAL(%d) to INTEGER(%d) conversion: invalid argument"_en_US,
-                    Operand::kind, TO::kind);
-              } else if (converted.flags.test(RealFlag::Overflow)) {
-                context.messages.Say(
-                    "REAL(%d) to INTEGER(%d) conversion overflowed"_en_US,
-                    Operand::kind, TO::kind);
-              }
-              return Expr<TO>{Constant<TO>{std::move(converted.value)}};
-            }
-          } else if constexpr (TO::category == TypeCategory::Real) {
-            if constexpr (Operand::category == TypeCategory::Integer) {
-              auto converted{Scalar<TO>::FromInteger(*value)};
-              if (!converted.flags.empty()) {
-                std::snprintf(buffer, sizeof buffer,
-                    "INTEGER(%d) to REAL(%d) conversion", Operand::kind,
-                    TO::kind);
-                RealFlagWarnings(context, converted.flags, buffer);
-              }
-              return Expr<TO>{Constant<TO>{std::move(converted.value)}};
-            } else if constexpr (Operand::category == TypeCategory::Real) {
-              auto converted{Scalar<TO>::Convert(*value)};
-              if (!converted.flags.empty()) {
-                std::snprintf(buffer, sizeof buffer,
-                    "REAL(%d) to REAL(%d) conversion", Operand::kind, TO::kind);
-                RealFlagWarnings(context, converted.flags, buffer);
-              }
-              if (context.flushSubnormalsToZero) {
-                converted.value = converted.value.FlushSubnormalToZero();
-              }
-              return Expr<TO>{Constant<TO>{std::move(converted.value)}};
-            }
-          } else if constexpr (TO::category == TypeCategory::Logical &&
-              Operand::category == TypeCategory::Logical) {
-            return Expr<TO>{Constant<TO>{value->IsTrue()}};
+          if constexpr (IsAllowedBasicConversion<TO::category, FROMCAT>()) {
+            return Expr<TO>{
+                Constant<TO>{ScalarConvert<TO, Operand>(context, *value)}};
           }
         }
         return Expr<TO>{std::move(convert)};

--- a/lib/evaluate/host.h
+++ b/lib/evaluate/host.h
@@ -1,0 +1,196 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#ifndef FORTRAN_EVALUATE_HOST_H_
+#define FORTRAN_EVALUATE_HOST_H_
+
+// Define a compile-time mapping between Fortran intrinsic types and host
+// hardware types if possible. The purpose is to avoid having to do any kind of
+// assumption on whether a "float" matches the Scalar<Type<TypeCategory::Real,
+// 4>> outside of this header. The main tools are HostTypeExists<T> and
+// HostType<T>. HostTypeExists<T>() will return true if and only if a host
+// hardware type maps to Fortran intrinsic type T. Then HostType<T> can be used
+// to safely refer to this hardware type.
+
+#include "type.h"
+#include <complex>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <type_traits>
+
+namespace Fortran::evaluate {
+namespace Host {
+
+struct UnsupportedType {};
+
+template<typename FTN_T> struct HostTypeHelper {
+  using Type = UnsupportedType;
+};
+template<typename FTN_T> using HostType = typename HostTypeHelper<FTN_T>::Type;
+
+template<typename... T> constexpr inline bool HostTypeExists() {
+  return (... && (!std::is_same_v<HostType<T>, UnsupportedType>));
+}
+
+template<typename FTN_T>
+inline constexpr Scalar<FTN_T> CastHostToFortran(const HostType<FTN_T> &x) {
+  if constexpr (FTN_T::category == TypeCategory::Complex &&
+      sizeof(Scalar<FTN_T>) != sizeof(HostType<FTN_T>)) {
+    // X87 is usually padded to 12 or 16bytes. Need to cast piecewise for
+    // complex
+    return Scalar<FTN_T>{CastHostToFortran<typename FTN_T::Part>(std::real(x)),
+        CastHostToFortran<typename FTN_T::Part>(std::imag(x))};
+  } else {
+    return *reinterpret_cast<const Scalar<FTN_T> *>(&x);
+  }
+}
+
+template<typename FTN_T>
+inline constexpr HostType<FTN_T> CastFortranToHost(const Scalar<FTN_T> &x) {
+  if constexpr (FTN_T::category == TypeCategory::Complex &&
+      sizeof(Scalar<FTN_T>) != sizeof(HostType<FTN_T>)) {
+    // X87 is usually padded to 12 or 16bytes. Need to cast piecewise for
+    // complex
+    return HostType<FTN_T>{CastFortranToHost<typename FTN_T::Part>(x.REAL()),
+        CastFortranToHost<typename FTN_T::Part>(x.AIMAG())};
+  } else {
+    return *reinterpret_cast<const HostType<FTN_T> *>(&x);
+  }
+}
+
+template<typename T> struct BiggerOrSameHostTypeHelper {
+  using Type =
+      std::conditional_t<HostTypeExists<T>(), HostType<T>, UnsupportedType>;
+  using FortranType = T;
+};
+
+template<typename FTN_T>
+using BiggerOrSameHostType = typename BiggerOrSameHostTypeHelper<FTN_T>::Type;
+template<typename FTN_T>
+using BiggerOrSameFortanTypeSupportedOnHost =
+    typename BiggerOrSameHostTypeHelper<FTN_T>::FortranType;
+
+template<typename... T> constexpr inline bool BiggerOrSameHostTypeExists() {
+  return (... && (!std::is_same_v<BiggerOrSameHostType<T>, UnsupportedType>));
+}
+
+// Defining the actual mapping
+template<> struct HostTypeHelper<Type<TypeCategory::Integer, 1>> {
+  using Type = std::int8_t;
+};
+
+template<> struct HostTypeHelper<Type<TypeCategory::Integer, 2>> {
+  using Type = std::int16_t;
+};
+
+template<> struct HostTypeHelper<Type<TypeCategory::Integer, 4>> {
+  using Type = std::int32_t;
+};
+
+template<> struct HostTypeHelper<Type<TypeCategory::Integer, 8>> {
+  using Type = std::int64_t;
+};
+
+// no int 128bit
+
+// no float 16bits
+
+template<> struct HostTypeHelper<Type<TypeCategory::Real, 4>> {
+  // IEE 754 64bits
+  using Type = std::conditional_t<sizeof(float) == 4 &&
+          std::numeric_limits<float>::is_iec559,
+      float, UnsupportedType>;
+};
+
+template<> struct HostTypeHelper<Type<TypeCategory::Real, 8>> {
+  // IEE 754 64bits
+  using Type = std::conditional_t<sizeof(double) == 8 &&
+          std::numeric_limits<double>::is_iec559,
+      double, UnsupportedType>;
+};
+
+template<> struct HostTypeHelper<Type<TypeCategory::Real, 10>> {
+  // X87 80bits
+  using Type = std::conditional_t<sizeof(long double) >= 10 &&
+          std::numeric_limits<long double>::digits == 64 &&
+          std::numeric_limits<long double>::max_exponent == 16384,
+      long double, UnsupportedType>;
+};
+
+template<> struct HostTypeHelper<Type<TypeCategory::Real, 16>> {
+  // IEE 754 128bits
+  using Type = std::conditional_t<sizeof(long double) == 16 &&
+          std::numeric_limits<long double>::digits == 113 &&
+          std::numeric_limits<long double>::max_exponent == 16384,
+      long double, UnsupportedType>;
+};
+
+template<int KIND> struct HostTypeHelper<Type<TypeCategory::Complex, KIND>> {
+  using RealT = Fortran::evaluate::Type<TypeCategory::Real, KIND>;
+  using Type = std::conditional_t<HostTypeExists<RealT>(),
+      std::complex<HostType<RealT>>, UnsupportedType>;
+};
+
+template<int KIND> struct HostTypeHelper<Type<TypeCategory::Character, KIND>> {
+  using Type = std::conditional_t<KIND <= 8, std::uint8_t, UnsupportedType>;
+};
+
+template<> struct HostTypeHelper<Type<TypeCategory::Character, 1>> {
+  using Type = std::string;
+};
+
+template<> struct HostTypeHelper<Type<TypeCategory::Character, 2>> {
+  using Type = std::u16string;
+};
+
+// Utility to find "bigger" types that exist on host. By bigger, it is meant
+// that the bigger type can represent all the values of the smaller types without
+// information loss.
+template<TypeCategory cat, int KIND> struct NextBiggerReal {
+  using Type = void;
+};
+template<TypeCategory cat> struct NextBiggerReal<cat, 2> {
+  using Type = Fortran::evaluate::Type<cat, 3>;
+};
+template<TypeCategory cat> struct NextBiggerReal<cat, 3> {
+  using Type = Fortran::evaluate::Type<cat, 4>;
+};
+template<TypeCategory cat> struct NextBiggerReal<cat, 4> {
+  using Type = Fortran::evaluate::Type<cat, 8>;
+};
+
+template<int KIND>
+struct BiggerOrSameHostTypeHelper<Type<TypeCategory::Real, KIND>> {
+  using T = Fortran::evaluate::Type<TypeCategory::Real, KIND>;
+  using NextT = typename NextBiggerReal<TypeCategory::Real, KIND>::Type;
+  using Type = std::conditional_t<HostTypeExists<T>(), HostType<T>,
+      typename BiggerOrSameHostTypeHelper<NextT>::Type>;
+  using FortranType = std::conditional_t<HostTypeExists<T>(), T,
+      typename BiggerOrSameHostTypeHelper<NextT>::FortranType>;
+};
+
+template<int KIND>
+struct BiggerOrSameHostTypeHelper<Type<TypeCategory::Complex, KIND>> {
+  using T = Fortran::evaluate::Type<TypeCategory::Complex, KIND>;
+  using NextT = typename NextBiggerReal<TypeCategory::Complex, KIND>::Type;
+  using Type = std::conditional_t<HostTypeExists<T>(), HostType<T>,
+      typename BiggerOrSameHostTypeHelper<NextT>::Type>;
+  using FortranType = std::conditional_t<HostTypeExists<T>(), T,
+      typename BiggerOrSameHostTypeHelper<NextT>::FortranType>;
+};
+}
+}
+
+#endif  // FORTRAN_EVALUATE_HOST_H_

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -164,6 +164,16 @@ Expr<TO> ConvertToType(Expr<SomeKind<FROMCAT>> &&x) {
       Scalar<Part> zero;
       return Expr<TO>{ComplexConstructor<TO::kind>{
           ConvertToType<Part>(std::move(x)), Expr<Part>{Constant<Part>{zero}}}};
+    } else if constexpr (FROMCAT == TypeCategory::Complex) {
+      return Expr<TO>{std::visit(
+        [](auto &&z) {
+          using FromType = ResultType<decltype(z)>;
+          using FromPart = typename FromType::Part;
+          using FromGeneric = SomeKind<TypeCategory::Real>;
+          return Convert<TO, TypeCategory::Real>{Expr<FromGeneric>{
+              Expr<FromPart>{ComplexComponent<FromType::kind>{false, std::move(z)}}}};
+        },
+        std::move(x.u))};
     } else {
       return Expr<TO>{Convert<TO, FROMCAT>{std::move(x)}};
     }

--- a/test/evaluate/folding.cc
+++ b/test/evaluate/folding.cc
@@ -13,10 +13,20 @@
 // limitations under the License.
 
 #include "testing.h"
+#include "../../lib/evaluate/call.h"
 #include "../../lib/evaluate/expression.h"
 #include "../../lib/evaluate/fold.h"
+#include "../../lib/evaluate/host.h"
 #include "../../lib/evaluate/type.h"
+#include "../../lib/evaluate/variable.h"
+#include <cmath>
+#include <complex>
+#include <iostream>
 #include <tuple>
+// below headers needed to create a context
+#include "../../lib/evaluate/common.h"
+#include "../../lib/parser/char-block.h"
+#include "../../lib/parser/message.h"
 
 using namespace Fortran::evaluate;
 
@@ -27,6 +37,14 @@ struct RunOnTypes<Test, std::tuple<T...>> {
   static void Run() { (..., Test::template Run<T>()); }
 };
 
+// helper to get an empty context to give to fold
+FoldingContext getTestFoldingContext(Fortran::parser::Messages &m) {
+  Fortran::parser::CharBlock at{};
+  Fortran::parser::ContextualMessages cm{at, &m};
+  return Fortran::evaluate::FoldingContext(cm);
+}
+
+// test for fold.h GetScalarConstantValue function
 struct TestGetScalarConstantValue {
   template<typename T> static void Run() {
     Expr<T> exprFullyTyped{Constant<T>{Scalar<T>{}}};
@@ -38,8 +56,84 @@ struct TestGetScalarConstantValue {
   }
 };
 
+// test for fold.h Fold function
+template<typename TR, typename TA> struct ElementalIntrinsic {
+  ElementalIntrinsic(
+      std::string name, Host::HostType<TR> hr, Host::HostType<TA> hx)
+    : intrinsic{name}, expectedResult{Host::CastHostToFortran<TR>(hr)},
+      arg{Host::CastHostToFortran<TA>(hx)} {};
+  ElementalIntrinsic(std::string name, Scalar<TR> sr, Scalar<TA> sx)
+    : intrinsic{name}, expectedResult{sr}, arg{sx} {};
+  SpecificIntrinsic intrinsic;
+  Scalar<TR> expectedResult;
+  Scalar<TA> arg;
+};
+
+template<typename TR, typename TA>
+void TestElementalIntrinsicFold(ElementalIntrinsic<TR, TA> &call) {
+  Fortran::parser::Messages m;
+  FoldingContext context{getTestFoldingContext(m)};
+  std::optional<ActualArgument> x{Expr<SomeType>{
+      Expr<SomeKind<TA::category>>{Expr<TA>{Constant<TA>{call.arg}}}}};
+  Expr<TR> expr{Fold(context,
+      Expr<TR>{FunctionRef<TR>{
+          ProcedureDesignator{call.intrinsic}, ActualArguments{x}}})};
+  auto *res{GetScalarConstantValue(expr)};
+  if constexpr (TR::category == TypeCategory::Real) {
+    std::cout << "REAL" << std::endl;
+    auto *res2{GetScalarConstantValue(expr)};
+    std::cout << res2 << std::endl;
+    if (res) {
+      std::cout << "res not null" << std::endl;
+      res->AsFortran(std::cout, TR::kind) << std::endl;
+    }
+  }
+  TEST((res && (*res == call.expectedResult)));
+}
+
+void TestIntrinsicFolding() {
+  using Int4 = Type<TypeCategory::Integer, 4>;
+  using Int8 = Type<TypeCategory::Integer, 8>;
+  using Real3 = Type<TypeCategory::Real, 3>;
+  using Complex8 = Type<TypeCategory::Complex, 8>;
+  using Real4 = Type<TypeCategory::Real, 4>;
+  //  using Real8 = Type<TypeCategory::Real, 8>;
+  using Char1 = Type<TypeCategory::Character, 1>;
+
+  ElementalIntrinsic<Int4, Int4> kind{"kind", 4, 0};
+  TestElementalIntrinsicFold(kind);
+
+  std::string s{"a-test-string"};
+  // TODO Fill a bug against len implementation. It should accept any return
+  // kind
+  // ElementalIntrinsic<Int4, Char1> len{"len", static_cast<int>(s.length()),
+  // s};
+  ElementalIntrinsic<Int8, Char1> len{"len", static_cast<int>(s.length()), s};
+
+  ElementalIntrinsic<Real4, Real4> acos{"acos", std::acos(0.5f), 0.5f};
+  TestElementalIntrinsicFold(acos);
+
+  auto x16{Scalar<Real3>::Convert(Host::CastHostToFortran<Real4>(1.5f)).value};
+  x16.AsFortran(std::cout << "x16: ", 3) << std::endl;
+  auto x4{Scalar<Real4>::Convert(x16).value};
+  x4.AsFortran(std::cout << "x4: ", 4) << std::endl;
+  auto res16{Scalar<Real3>::Convert(Host::CastHostToFortran<Real4>(std::acosh(
+                                        Host::CastFortranToHost<Real4>(x4))))
+                 .value};
+
+  ElementalIntrinsic<Real3, Real3> acosh{"acosh", res16, x16};
+  TestElementalIntrinsicFold(acosh);
+
+  ElementalIntrinsic<Real4, Real4> acosh4{"acosh", std::acosh(1.5f), 1.5f};
+  TestElementalIntrinsicFold(acosh4);
+
+  std::complex<double> cx{-0.5, 0.5};
+  ElementalIntrinsic<Complex8, Complex8> acoshC8{"acosh", std::acosh(cx), cx};
+  TestElementalIntrinsicFold(acoshC8);
+}
+
 int main() {
-  using TestTypes = AllIntrinsicTypes;
-  RunOnTypes<TestGetScalarConstantValue, TestTypes>::Run();
+  RunOnTypes<TestGetScalarConstantValue, AllIntrinsicTypes>::Run();
+  TestIntrinsicFolding();
   return testing::Complete();
 }


### PR DESCRIPTION
Here is a draft of elemental function folding. Only a subset of elemental is part of this PR because this is only a draft for review.  This should be sufficient to review the concepts and patterns that will be repeated for most elemental intrinsic.

The main concepts are the following:
- When possible, convert to a tree of Operations and call Fold
- Else, use a common utility that takes a scalar function and applies it on all the elements (to be extended when PR #271 is merged).  This utility takes a std::function that can be built from lambdas, from Fortran intrinsic types member functions, or from host run-time functions. A factory function is provided to build such std::function from host run-time function. It uses a set of indirection templates from `host.h` to interact with host types without making any direct assumptions on what is under a `float` or `double` or ...

Host run-time function are used only if it would be a too big an risky task to implement the function on Fortran types. To provide as much flexibility as possible, small types that do not have native host support are folded with run-time function for bigger supported types. Scalar conversions are automatically added if needed when using the "BiggerOrSame..." templates (better ideas for the names are welcomed).

The only modification that have been made outside of function folding are:
- Convert<> folding, where the part of the code working on scalars was outlined. This is so that it can be used for type conversions when using host run-time of a bigger types without having to re-wrap and un-wrap with expressions.
- ConvertToType type in tools.h where it seems a case was missing for conversion from complex towards other types.  

 NB1: the tests in this PR are not extensive, but all the elemental for which code was added were successfully tested using f18 -fdebug-semantics -fdebug-dump-parse-tree. Better tests need to be added.
