### PR TITLE
Add support for common blocks

### DIFF
--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -173,6 +173,15 @@ void ModFileWriter::PutSymbol(
             }
             decls_ << '\n';
           },
+          [&](const CommonBlockDetails &x) {
+            PutLower(decls_ << "common/", symbol);
+            char sep = '/';
+            for (const auto *object : x.objects()) {
+              PutLower(decls_ << sep, *object);
+              sep = ',';
+            }
+            decls_ << '\n';
+          },
           [&](const FinalProcDetails &) {
             PutLower(typeBindings << "final::", symbol) << '\n';
           },

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -153,6 +153,7 @@ std::string DetailsToString(const Details &details) {
           [](const ProcBindingDetails &) { return "ProcBinding"; },
           [](const GenericBindingDetails &) { return "GenericBinding"; },
           [](const NamelistDetails &) { return "Namelist"; },
+          [](const CommonBlockDetails &) { return "CommonBlockDetails"; },
           [](const FinalProcDetails &) { return "FinalProc"; },
           [](const TypeParamDetails &) { return "TypeParam"; },
           [](const MiscDetails &) { return "Misc"; },
@@ -383,6 +384,12 @@ std::ostream &operator<<(std::ostream &os, const Details &details) {
             }
           },
           [&](const NamelistDetails &x) {
+            os << ": ";
+            for (const auto *object : x.objects()) {
+              os << ' ' << object->name();
+            }
+          },
+          [&](const CommonBlockDetails &x) {
             os << ": ";
             for (const auto *object : x.objects()) {
               os << ' ' << object->name();

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -258,6 +258,15 @@ private:
   SymbolList objects_;
 };
 
+class CommonBlockDetails {
+public:
+  SymbolList objects() const { return objects_; }
+  void add_object(Symbol &object) { objects_.push_back(&object); }
+
+private:
+  SymbolList objects_;
+};
+
 class FinalProcDetails {};
 
 class MiscDetails {
@@ -366,7 +375,7 @@ using Details = std::variant<UnknownDetails, MainProgramDetails, ModuleDetails,
     ObjectEntityDetails, ProcEntityDetails, AssocEntityDetails,
     DerivedTypeDetails, UseDetails, UseErrorDetails, HostAssocDetails,
     GenericDetails, ProcBindingDetails, GenericBindingDetails, NamelistDetails,
-    FinalProcDetails, TypeParamDetails, MiscDetails>;
+    CommonBlockDetails, FinalProcDetails, TypeParamDetails, MiscDetails>;
 std::ostream &operator<<(std::ostream &, const Details &);
 std::string DetailsToString(const Details &);
 

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -194,6 +194,27 @@ std::ostream &operator<<(std::ostream &o, const ShapeSpec &x) {
   return o;
 }
 
+std::ostream &operator<<(std::ostream &os, const ArraySpec &arraySpec) {
+  char sep{'('};
+  for (auto &shape : arraySpec) {
+    os << sep << shape;
+    sep = ',';
+  }
+  if (sep == ',') {
+    os << ')';
+  }
+  return os;
+}
+
+bool IsExplicit(const ArraySpec &arraySpec) {
+  for (const auto &shapeSpec : arraySpec) {
+    if (!shapeSpec.isExplicit()) {
+      return false;
+    }
+  }
+  return true;
+}
+
 ParamValue::ParamValue(MaybeIntExpr &&expr) : expr_{std::move(expr)} {}
 ParamValue::ParamValue(SomeIntExpr &&expr) : expr_{std::move(expr)} {}
 ParamValue::ParamValue(std::int64_t value)

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -212,6 +212,7 @@ private:
 };
 
 using ArraySpec = std::list<ShapeSpec>;
+bool IsExplicit(const ArraySpec &);
 
 class DerivedTypeSpec {
 public:

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -67,6 +67,7 @@ set(ERROR_TESTS
   resolve39.f90
   resolve40.f90
   resolve41.f90
+  resolve42.f90
 )
 
 # These test files have expected symbols in the source
@@ -108,6 +109,7 @@ set(MODFILE_TESTS
   modfile18.f90
   modfile19.f90
   modfile20.f90
+  modfile21.f90
 )
 
 set(LABEL_TESTS

--- a/test/semantics/modfile21.f90
+++ b/test/semantics/modfile21.f90
@@ -1,0 +1,41 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+module m
+  logical b
+  common //t
+  common /cb/ x(2:10) /cb2/a,b,c
+  common /cb/ y,z
+  common w
+  common u,v
+  complex w
+  dimension b(4,4)
+end
+
+!Expect: m.mod
+!module m
+!  logical(4)::b(1_8:4_8,1_8:4_8)
+!  common//t,w,u,v
+!  real(4)::t
+!  common/cb/x,y,z
+!  real(4)::x(2_8:10_8)
+!  common/cb2/a,b,c
+!  real(4)::a
+!  real(4)::c
+!  real(4)::y
+!  real(4)::z
+!  complex(4)::w
+!  real(4)::u
+!  real(4)::v
+!end

--- a/test/semantics/resolve42.f90
+++ b/test/semantics/resolve42.f90
@@ -1,0 +1,119 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+subroutine s1
+  !ERROR: The shape of common block object 'z' must be explicit
+  common x, y(4), z(:)
+end
+
+subroutine s2
+  common /c1/ x, y, z
+  !ERROR: 'y' is already in a COMMON block
+  common y
+end
+
+subroutine s3
+  procedure(real) :: x
+  !ERROR: 'x' is already declared as a procedure
+  common x
+  common y
+  !ERROR: 'y' is already declared as an object
+  procedure(real) :: y
+end
+
+subroutine s4
+  integer x
+  !ERROR: 'x' is already declared in this scoping unit
+  common /x/ y
+  !ERROR: 's4' is already declared in this scoping unit
+  common /s4/ z
+end
+
+subroutine s5
+  integer x(2)
+  !ERROR: The dimensions of 'x' have already been declared
+  common x(4), y(4)
+  !ERROR: The dimensions of 'y' have already been declared
+  real y(2)
+end
+
+subroutine s6(x)
+  !ERROR: Dummy argument 'x' may not appear in a COMMON block
+  !ERROR: ALLOCATABLE object 'y' may not appear in a COMMON block
+  common x,y,z
+  allocatable y
+end
+
+module m7
+  !ERROR: Variable 'z' with BIND attribute may not appear in a COMMON block
+  common z
+  integer, bind(c) :: z
+end
+
+module m8
+  type t
+  end type
+  class(*), pointer :: x
+  !ERROR: Unlimited polymorphic pointer 'x' may not appear in a COMMON block
+  !ERROR: Unlimited polymorphic pointer 'y' may not appear in a COMMON block
+  common x, y
+  class(*), pointer :: y
+end
+
+module m9
+  integer x
+end
+subroutine s9
+  use m9
+  !ERROR: 'x' is use-associated from module 'm9' and cannot be re-declared
+  common x
+end
+
+module m10
+  type t
+  end type
+  type(t) :: x
+  !ERROR: Derived type 'x' in COMMON block must have the BIND or SEQUENCE attribute
+  common x
+end
+
+module m11
+  type t1
+    sequence
+    integer, allocatable :: a
+  end type
+  type t2
+    sequence
+    type(t1) :: b
+    integer:: c
+  end type
+  type(t2) :: x2
+  !ERROR: Derived type variable 'x2' may not appear in a COMMON block due to ALLOCATABLE component
+  common x2
+end
+
+module m12
+  type t1
+    sequence
+    integer :: a = 123
+  end type
+  type t2
+    sequence
+    type(t1) :: b
+    integer:: c
+  end type
+  type(t2) :: x2
+  !ERROR: Derived type variable 'x2' may not appear in a COMMON block due to component with default initialization
+  common x2
+end

--- a/test/semantics/test_errors.sh
+++ b/test/semantics/test_errors.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,7 +47,11 @@ fi
 # $actual has errors from the compiler; $expect has them from !ERROR comments in source
 # Format both as "<line>: <text>" so they can be diffed.
 sed -n 's=^[^:]*:\([^:]*\):[^:]*: error: =\1: =p' $log > $actual
-{ echo; cat $src; } | cat -n | sed -n 's=^ *\([0-9]*\). *\!ERROR: *=\1: =p' > $expect
+awk '
+  BEGIN { FS = "!ERROR: "; }
+  /^ *!ERROR: / { errors[nerrors++] = $2; next; }
+  { for (i = 0; i < nerrors; ++i) printf "%d: %s\n", NR, errors[i]; nerrors = 0; }
+' $src > $expect
 
 if diff -U0 $actual $expect > $diffs; then
   echo PASS


### PR DESCRIPTION
A symbol for a common block has `CommonBlockDetails` which contains
a list of the symbols that are in the common block.

The name of the symbol for the blank common block is the empty string.
That preserves the property that every symbol name is a substring of
the cooked source. We use the 0-length substring starting at the COMMON
statement so that when symbols are sorted by the location of the start
of the name it ends up in the right place.

Some of the checks on members of common blocks don't happen until the
end of the scope. They can't happen earlier because we don't necessarily
know the type and attributes.

Enhance `test_errors.sh` so that multiple errors can be expected for
a single line.