### PR TITLE
More structure constructor semantics checking

### DIFF
--- a/lib/common/indirection.h
+++ b/lib/common/indirection.h
@@ -65,10 +65,6 @@ public:
 
   A &value() { return *p_; }
   const A &value() const { return *p_; }
-  A &operator*() { return *p_; }
-  const A &operator*() const { return *p_; }
-  A *operator->() { return p_; }
-  const A *operator->() const { return p_; }
 
   bool operator==(const A &x) const { return *p_ == x; }
   bool operator==(const Indirection &that) const { return *p_ == *that.p_; }
@@ -120,10 +116,6 @@ public:
 
   A &value() { return *p_; }
   const A &value() const { return *p_; }
-  A &operator*() { return *p_; }
-  const A &operator*() const { return *p_; }
-  A *operator->() { return p_; }
-  const A *operator->() const { return p_; }
 
   bool operator==(const A &x) const { return *p_ == x; }
   bool operator==(const Indirection &that) const { return *p_ == *that.p_; }
@@ -168,12 +160,15 @@ public:
     return *this = OwningPointer(std::move(p));
   }
 
-  A &operator*() { return *p_; }
-  const A &operator*() const { return *p_; }
-  A *operator->() { return p_; }
-  const A *operator->() const { return p_; }
-
-  A *get() const { return p_; }
+  bool has_value() const { return p_ != nullptr; }
+  A &value() {
+    CHECK(p_ != nullptr);
+    return *p_;
+  }
+  const A &value() const {
+    CHECK(p_ != nullptr);
+    return *p_;
+  }
 
   bool operator==(const A &x) const { return p_ != nullptr && *p_ == x; }
   bool operator==(const OwningPointer &that) const {
@@ -223,11 +218,6 @@ public:
   ForwardReference &operator=(A *&&p) {
     return *this = ForwardReference(std::move(p));
   }
-
-  A &operator*() { return *p_; }
-  const A &operator*() const { return *p_; }
-  A *operator->() { return p_; }
-  const A *operator->() const { return p_; }
 
   A &value() { return *p_; }
   const A &value() const { return *p_; }

--- a/lib/evaluate/call.cc
+++ b/lib/evaluate/call.cc
@@ -19,14 +19,14 @@
 namespace Fortran::evaluate {
 
 std::optional<DynamicType> ActualArgument::GetType() const {
-  return value->GetType();
+  return value().GetType();
 }
 
-int ActualArgument::Rank() const { return value->Rank(); }
+int ActualArgument::Rank() const { return value().Rank(); }
 
 bool ActualArgument::operator==(const ActualArgument &that) const {
   return keyword == that.keyword &&
-      isAlternateReturn == that.isAlternateReturn && value == that.value;
+      isAlternateReturn == that.isAlternateReturn && value() == that.value();
 }
 
 std::ostream &ActualArgument::AsFortran(std::ostream &o) const {
@@ -36,7 +36,7 @@ std::ostream &ActualArgument::AsFortran(std::ostream &o) const {
   if (isAlternateReturn) {
     o << '*';
   }
-  return value->AsFortran(o);
+  return value().AsFortran(o);
 }
 
 std::optional<int> ActualArgument::VectorSize() const {

--- a/lib/evaluate/call.h
+++ b/lib/evaluate/call.h
@@ -75,7 +75,7 @@ struct SpecificIntrinsic {
 
   IntrinsicProcedure name;
   bool isRestrictedSpecific{false};  // if true, can only call it
-  std::optional<DynamicType> type;  // absent if and only if subroutine call
+  std::optional<DynamicType> type;  // absent if subroutine call or NULL()
   int rank{0};
   semantics::Attrs attrs;  // ELEMENTAL, POINTER
 };

--- a/lib/evaluate/call.h
+++ b/lib/evaluate/call.h
@@ -31,10 +31,14 @@ class Symbol;
 
 namespace Fortran::evaluate {
 
-struct ActualArgument {
-  explicit ActualArgument(Expr<SomeType> &&x) : value{std::move(x)} {}
+class ActualArgument {
+public:
+  explicit ActualArgument(Expr<SomeType> &&x) : value_{std::move(x)} {}
   explicit ActualArgument(CopyableIndirection<Expr<SomeType>> &&v)
-    : value{std::move(v)} {}
+    : value_{std::move(v)} {}
+
+  Expr<SomeType> &value() { return value_.value(); }
+  const Expr<SomeType> &value() const { return value_.value(); }
 
   std::optional<DynamicType> GetType() const;
   int Rank() const;
@@ -47,12 +51,13 @@ struct ActualArgument {
 
   // TODO: Mark legacy %VAL and %REF arguments
 
+private:
   // Subtlety: There is a distinction that must be maintained here between an
   // actual argument expression that is a variable and one that is not,
   // e.g. between X and (X).  The parser attempts to parse each argument
   // first as a variable, then as an expression, and the distinction appears
   // in the parse tree.
-  CopyableIndirection<Expr<SomeType>> value;
+  CopyableIndirection<Expr<SomeType>> value_;
 };
 
 using ActualArguments = std::vector<std::optional<ActualArgument>>;

--- a/lib/evaluate/characteristics.cc
+++ b/lib/evaluate/characteristics.cc
@@ -61,8 +61,8 @@ bool DummyProcedure::operator==(const DummyProcedure &that) const {
 
 std::ostream &DummyProcedure::Dump(std::ostream &o) const {
   attrs.Dump(o, EnumToString);
-  if (explicitProcedure.get() != nullptr) {
-    explicitProcedure->Dump(o);
+  if (explicitProcedure.has_value()) {
+    explicitProcedure.value().Dump(o);
   }
   return o;
 }

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -298,7 +298,7 @@ std::ostream &StructureConstructor::AsFortran(std::ostream &o) const {
 
 std::ostream &DerivedTypeSpecAsFortran(
     std::ostream &o, const semantics::DerivedTypeSpec &spec) {
-  o << "TYPE("s << spec.typeSymbol().name().ToString();
+  o << spec.typeSymbol().name().ToString();
   if (!spec.parameters().empty()) {
     char ch{'('};
     for (const auto &[name, value] : spec.parameters()) {

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -177,6 +177,7 @@ Expr<SubscriptInteger> Expr<Type<TypeCategory::Character, KIND>>::LEN() const {
           },
           [](const Designator<Result> &dr) { return dr.LEN(); },
           [](const FunctionRef<Result> &fr) { return fr.LEN(); },
+          [](const SetLength<KIND> &x) { return x.right(); },
       },
       u);
 }

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -204,12 +204,11 @@ std::optional<DynamicType> ExpressionBase<A>::GetType() const {
     return std::visit(
         [](const auto &x) -> std::optional<DynamicType> {
           using Ty = std::decay_t<decltype(x)>;
-          if constexpr (std::is_same_v<Ty, BOZLiteralConstant> ||
-              std::is_same_v<Ty, NullPointer>) {
-            return std::nullopt;  // typeless really means "no type"
-          } else {
+          if constexpr (!std::is_same_v<Ty, BOZLiteralConstant> &&
+              !std::is_same_v<Ty, NullPointer>) {
             return x.GetType();
           }
+          return std::nullopt;  // typeless really means "no type"
         },
         derived().u);
   }

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -98,12 +98,6 @@ public:
   static Derived Rewrite(FoldingContext &, Derived &&);
 };
 
-// BOZ literal "typeless" constants must be wide enough to hold a numeric
-// value of any supported kind of INTEGER or REAL.  They must also be
-// distinguishable from other integer constants, since they are permitted
-// to be used in only a few situations.
-using BOZLiteralConstant = typename LargestReal::Scalar::Word;
-
 // Operations always have specific Fortran result types (i.e., with known
 // intrinsic type category and kind parameter value).  The classes that
 // represent the operations all inherit from this Operation<> base class
@@ -725,6 +719,18 @@ public:
   common::MapTemplate<Expr, CategoryTypes<CAT>> u;
 };
 
+// BOZ literal "typeless" constants must be wide enough to hold a numeric
+// value of any supported kind of INTEGER or REAL.  They must also be
+// distinguishable from other integer constants, since they are permitted
+// to be used in only a few situations.
+using BOZLiteralConstant = typename LargestReal::Scalar::Word;
+
+// Null pointers without MOLD= arguments are typed by context.
+struct NullPointer {
+  constexpr bool operator==(const NullPointer &) const { return true; }
+  constexpr int Rank() const { return 0; }
+};
+
 // A completely generic expression, polymorphic across all of the intrinsic type
 // categories and each of their kinds.
 template<> class Expr<SomeType> : public ExpressionBase<SomeType> {
@@ -757,7 +763,7 @@ public:
   }
 
 private:
-  using Others = std::variant<BOZLiteralConstant>;
+  using Others = std::variant<BOZLiteralConstant, NullPointer>;
   using Categories = common::MapTemplate<Expr, SomeCategory>;
 
 public:

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -212,7 +212,7 @@ private:
 
 // Conversions to specific types from expressions of known category and
 // dynamic kind.
-template<typename TO, TypeCategory FROMCAT>
+template<typename TO, TypeCategory FROMCAT = TO::category>
 struct Convert : public Operation<Convert<TO, FROMCAT>, TO, SomeKind<FROMCAT>> {
   // Fortran doesn't have conversions between kinds of CHARACTER apart from
   // assignments, and in those the data must be convertible to/from 7-bit ASCII.
@@ -221,6 +221,8 @@ struct Convert : public Operation<Convert<TO, FROMCAT>, TO, SomeKind<FROMCAT>> {
                      TO::category == TypeCategory::Real) &&
                     (FROMCAT == TypeCategory::Integer ||
                         FROMCAT == TypeCategory::Real)) ||
+      (TO::category == TypeCategory::Character &&
+          FROMCAT == TypeCategory::Character) ||
       (TO::category == TypeCategory::Logical &&
           FROMCAT == TypeCategory::Logical));
   using Result = TO;
@@ -572,7 +574,8 @@ public:
   Expr<SubscriptInteger> LEN() const;
 
   std::variant<Constant<Result>, ArrayConstructor<Result>, Designator<Result>,
-      FunctionRef<Result>, Parentheses<Result>, Concat<KIND>, Extremum<Result>>
+      FunctionRef<Result>, Parentheses<Result>, Convert<Result>, Concat<KIND>,
+      Extremum<Result>>
       u;
 };
 
@@ -641,8 +644,8 @@ public:
   explicit Expr(bool x) : u{Constant<Result>{x}} {}
 
 private:
-  using Operations = std::tuple<Convert<Result, TypeCategory::Logical>,
-      Parentheses<Result>, Not<KIND>, LogicalOperation<KIND>>;
+  using Operations = std::tuple<Convert<Result>, Parentheses<Result>, Not<KIND>,
+      LogicalOperation<KIND>>;
   using Relations = std::conditional_t<KIND == LogicalResult::kind,
       std::tuple<Relational<SomeType>>, std::tuple<>>;
   using Others = std::tuple<Constant<Result>, ArrayConstructor<Result>,

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -272,6 +272,22 @@ struct Not : public Operation<Not<KIND>, Type<TypeCategory::Logical, KIND>,
   static std::ostream &Prefix(std::ostream &o) { return o << "(.NOT."; }
 };
 
+// Character lengths are determined by context in Fortran and do not
+// have explicit syntax for changing them.  Expressions represent
+// changes of length (e.g., for assignments and structure constructors)
+// with this operation.
+template<int KIND>
+struct SetLength
+  : public Operation<SetLength<KIND>, Type<TypeCategory::Character, KIND>,
+        Type<TypeCategory::Character, KIND>, SubscriptInteger> {
+  using Result = Type<TypeCategory::Character, KIND>;
+  using CharacterOperand = Result;
+  using LengthOperand = SubscriptInteger;
+  using Base = Operation<SetLength, Result, CharacterOperand, LengthOperand>;
+  using Base::Base;
+  static std::ostream &Prefix(std::ostream &o) { return o << "%SET_LENGTH("; }
+};
+
 // Binary operations
 
 template<typename A> struct Add : public Operation<Add<A>, A, A, A> {
@@ -569,7 +585,7 @@ public:
 
   std::variant<Constant<Result>, ArrayConstructor<Result>, Designator<Result>,
       FunctionRef<Result>, Parentheses<Result>, Convert<Result>, Concat<KIND>,
-      Extremum<Result>>
+      Extremum<Result>, SetLength<KIND>>
       u;
 };
 

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -702,6 +702,24 @@ Expr<Type<TypeCategory::Character, KIND>> FoldOperation(
   return Expr<Result>{std::move(x)};
 }
 
+template<int KIND>
+Expr<Type<TypeCategory::Character, KIND>> FoldOperation(
+    FoldingContext &context, SetLength<KIND> &&x) {
+  using Result = Type<TypeCategory::Character, KIND>;
+  if (auto folded{FoldOperands(context, x.left(), x.right())}) {
+    auto oldLength{static_cast<std::int64_t>(folded->first.size())};
+    auto newLength{folded->second.ToInt64()};
+    if (newLength < oldLength) {
+      folded->first.erase(newLength);
+    } else {
+      folded->first.append(newLength - oldLength, ' ');
+    }
+    CHECK(static_cast<std::int64_t>(folded->first.size()) == newLength);
+    return Expr<Result>{Constant<Result>{std::move(folded->first)}};
+  }
+  return Expr<Result>{std::move(x)};
+}
+
 template<typename T>
 Expr<LogicalResult> FoldOperation(
     FoldingContext &context, Relational<T> &&relation) {

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -944,7 +944,7 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
   for (std::size_t j{0}; j < dummies; ++j) {
     const IntrinsicDummyArgument &d{dummy[std::min(j, dummyArgPatterns - 1)]};
     if (const ActualArgument * arg{actualForDummy[j]}) {
-      if (IsAssumedRank(*arg->value) && d.rank != Rank::anyOrAssumedRank) {
+      if (IsAssumedRank(arg->value()) && d.rank != Rank::anyOrAssumedRank) {
         messages.Say("assumed-rank array cannot be forwarded to "
                      "'%s=' argument"_err_en_US,
             d.keyword);
@@ -1069,7 +1069,7 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
       CHECK(kindDummyArg != nullptr);
       CHECK(result.categorySet == CategorySet{resultType->category});
       if (kindArg != nullptr) {
-        auto &expr{*kindArg->value};
+        auto &expr{kindArg->value()};
         CHECK(expr.Rank() == 0);
         if (auto code{ToInt64(expr)}) {
           if (IsValidKindOfIntrinsicType(resultType->category, *code)) {
@@ -1263,7 +1263,7 @@ std::optional<SpecificCall> IntrinsicProcTable::Implementation::Probe(
       genericErrors.Say("unknown argument '%s' to NULL()"_err_en_US,
           arguments[0]->keyword->ToString().data());
     } else {
-      Expr<SomeType> &mold{*arguments[0]->value};
+      Expr<SomeType> &mold{arguments[0]->value()};
       if (IsPointerOrAllocatable(mold)) {
         return std::make_optional<SpecificCall>(
             SpecificIntrinsic{"null"s, mold.GetType(), mold.Rank(),

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -1256,7 +1256,6 @@ std::optional<SpecificCall> IntrinsicProcTable::Implementation::Probe(
     if (arguments.size() == 0) {
       return std::make_optional<SpecificCall>(
           SpecificIntrinsic{"null"s}, std::move(arguments));
-      // TODO pmk work in progress - fold into NullPointer (where?)
     } else if (arguments.size() > 1) {
       genericErrors.Say("too many arguments to NULL()"_err_en_US);
     } else if (arguments[0].has_value() && arguments[0]->keyword.has_value() &&

--- a/lib/evaluate/tools.cc
+++ b/lib/evaluate/tools.cc
@@ -347,6 +347,10 @@ std::optional<Expr<SomeType>> Negation(
             messages.Say("BOZ literal cannot be negated"_err_en_US);
             return NoExpr();
           },
+          [&](NullPointer &&) {
+            messages.Say("NULL() cannot be negated"_err_en_US);
+            return NoExpr();
+          },
           [&](Expr<SomeInteger> &&x) { return Package(-std::move(x)); },
           [&](Expr<SomeReal> &&x) { return Package(-std::move(x)); },
           [&](Expr<SomeComplex> &&x) { return Package(-std::move(x)); },
@@ -501,7 +505,8 @@ std::optional<Expr<SomeType>> ConvertToNumeric(int kind, Expr<SomeType> &&x) {
   return std::visit(
       [=](auto &&cx) -> std::optional<Expr<SomeType>> {
         using cxType = std::decay_t<decltype(cx)>;
-        if constexpr (!std::is_same_v<cxType, BOZLiteralConstant>) {
+        if constexpr (!std::is_same_v<cxType, BOZLiteralConstant> &&
+            !std::is_same_v<cxType, NullPointer>) {
           if constexpr (IsNumericTypeCategory(ResultType<cxType>::category)) {
             return std::make_optional(
                 Expr<SomeType>{ConvertToKind<TO>(kind, std::move(cx))});

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -227,6 +227,8 @@ std::optional<Expr<SomeType>> ConvertToType(
     const DynamicType &, Expr<SomeType> &&);
 std::optional<Expr<SomeType>> ConvertToType(
     const DynamicType &, std::optional<Expr<SomeType>> &&);
+std::optional<Expr<SomeType>> ConvertToType(
+    const semantics::Symbol &, Expr<SomeType> &&);
 
 // Conversions to the type of another expression
 template<TypeCategory TC, int TK, typename FROM>
@@ -339,7 +341,7 @@ template<typename A> Expr<TypeOf<A>> ScalarConstantToExpr(const A &x) {
   using Ty = TypeOf<A>;
   static_assert(
       std::is_same_v<Scalar<Ty>, std::decay_t<A>> || !"TypeOf<> is broken");
-  return {Constant<Ty>{x}};
+  return Expr<TypeOf<A>>{Constant<Ty>{x}};
 }
 
 // Combine two expressions of the same specific numeric type with an operation

--- a/lib/evaluate/type.cc
+++ b/lib/evaluate/type.cc
@@ -89,9 +89,14 @@ bool IsDescriptor(const Symbol &symbol) {
 
 namespace Fortran::evaluate {
 
+template<typename A> bool PointeeComparison(const A *x, const A *y) {
+  return x == y || (x != nullptr && y != nullptr && *x == *y);
+}
+
 bool DynamicType::operator==(const DynamicType &that) const {
   return category == that.category && kind == that.kind &&
-      charLength == that.charLength && derived == that.derived;
+      PointeeComparison(charLength, that.charLength) &&
+      PointeeComparison(derived, that.derived);
 }
 
 std::optional<DynamicType> GetSymbolType(const semantics::Symbol *symbol) {
@@ -115,6 +120,14 @@ std::optional<DynamicType> GetSymbolType(const semantics::Symbol *symbol) {
     }
   }
   return std::nullopt;
+}
+
+std::optional<DynamicType> GetSymbolType(const semantics::Symbol *symbol) {
+  if (symbol != nullptr) {
+    return GetSymbolType(*symbol);
+  } else {
+    return std::nullopt;
+  }
 }
 
 std::string DynamicType::AsFortran() const {
@@ -191,7 +204,7 @@ DynamicType DynamicType::ResultTypeForMultiply(const DynamicType &that) const {
 
 bool SomeKind<TypeCategory::Derived>::operator==(
     const SomeKind<TypeCategory::Derived> &that) const {
-  return spec_ == that.spec_;
+  return PointeeComparison(spec_, that.spec_);
 }
 
 std::string SomeDerived::AsFortran() const {

--- a/lib/evaluate/type.cc
+++ b/lib/evaluate/type.cc
@@ -99,24 +99,22 @@ bool DynamicType::operator==(const DynamicType &that) const {
       PointeeComparison(derived, that.derived);
 }
 
-std::optional<DynamicType> GetSymbolType(const semantics::Symbol *symbol) {
-  if (symbol != nullptr) {
-    if (const auto *type{symbol->GetType()}) {
-      if (const auto *intrinsic{type->AsIntrinsic()}) {
-        if (auto kind{ToInt64(intrinsic->kind())}) {
-          TypeCategory category{intrinsic->category()};
-          if (IsValidKindOfIntrinsicType(category, *kind)) {
-            if (category == TypeCategory::Character) {
-              const auto &charType{type->characterTypeSpec()};
-              return DynamicType{static_cast<int>(*kind), charType.length()};
-            } else {
-              return DynamicType{category, static_cast<int>(*kind)};
-            }
+std::optional<DynamicType> GetSymbolType(const semantics::Symbol &symbol) {
+  if (const auto *type{symbol.GetType()}) {
+    if (const auto *intrinsic{type->AsIntrinsic()}) {
+      if (auto kind{ToInt64(intrinsic->kind())}) {
+        TypeCategory category{intrinsic->category()};
+        if (IsValidKindOfIntrinsicType(category, *kind)) {
+          if (category == TypeCategory::Character) {
+            const auto &charType{type->characterTypeSpec()};
+            return DynamicType{static_cast<int>(*kind), charType.length()};
+          } else {
+            return DynamicType{category, static_cast<int>(*kind)};
           }
         }
-      } else if (const auto *derived{type->AsDerived()}) {
-        return DynamicType{*derived};
       }
+    } else if (const auto *derived{type->AsDerived()}) {
+      return DynamicType{*derived};
     }
   }
   return std::nullopt;

--- a/lib/evaluate/type.cc
+++ b/lib/evaluate/type.cc
@@ -207,7 +207,7 @@ bool SomeKind<TypeCategory::Derived>::operator==(
 
 std::string SomeDerived::AsFortran() const {
   std::stringstream out;
-  DerivedTypeSpecAsFortran(out, spec());
+  DerivedTypeSpecAsFortran(out << "TYPE(", spec()) << ')';
   return out.str();
 }
 }

--- a/lib/evaluate/type.h
+++ b/lib/evaluate/type.h
@@ -84,6 +84,7 @@ struct DynamicType {
 
 // Result will be missing when a symbol is absent or
 // has an erroneous type, e.g., REAL(KIND=666).
+std::optional<DynamicType> GetSymbolType(const semantics::Symbol &);
 std::optional<DynamicType> GetSymbolType(const semantics::Symbol *);
 
 template<TypeCategory CATEGORY, int KIND = 0> struct TypeBase {

--- a/lib/evaluate/variable.cc
+++ b/lib/evaluate/variable.cc
@@ -638,10 +638,8 @@ template<typename T> const Symbol *Designator<T>::GetLastSymbol() const {
 template<typename T> std::optional<DynamicType> Designator<T>::GetType() const {
   if constexpr (IsLengthlessIntrinsicType<Result>) {
     return {Result::GetType()};
-  } else if (const Symbol * symbol{GetLastSymbol()}) {
-    return GetSymbolType(symbol);
   } else {
-    return std::nullopt;
+    return GetSymbolType(GetLastSymbol());
   }
 }
 

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -55,6 +55,13 @@ struct BaseObject {
   Expr<SubscriptInteger> LEN() const;
   bool operator==(const BaseObject &) const;
   std::ostream &AsFortran(std::ostream &) const;
+  const Symbol *symbol() const {
+    if (const auto *result{std::get_if<const Symbol *>(&u)}) {
+      return *result;
+    } else {
+      return nullptr;
+    }
+  }
   std::variant<const Symbol *, StaticDataObject::Pointer> u;
 };
 

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -80,8 +80,8 @@ public:
   Component(CopyableIndirection<DataRef> &&b, const Symbol &c)
     : base_{std::move(b)}, symbol_{&c} {}
 
-  const DataRef &base() const { return *base_; }
-  DataRef &base() { return *base_; }
+  const DataRef &base() const { return base_.value(); }
+  DataRef &base() { return base_.value(); }
   int Rank() const;
   const Symbol &GetFirstSymbol() const;
   const Symbol &GetLastSymbol() const { return *symbol_; }

--- a/lib/parser/parse-tree-visitor.h
+++ b/lib/parser/parse-tree-visitor.h
@@ -221,11 +221,11 @@ std::enable_if_t<WrapperTrait<A>> Walk(A &x, M &mutator) {
 
 template<typename T, typename V>
 void Walk(const common::Indirection<T> &x, V &visitor) {
-  Walk(*x, visitor);
+  Walk(x.value(), visitor);
 }
 template<typename T, typename M>
 void Walk(common::Indirection<T> &x, M &mutator) {
-  Walk(*x, mutator);
+  Walk(x.value(), mutator);
 }
 
 // Walk a class with a single field 'thing'.

--- a/lib/parser/parse-tree.cc
+++ b/lib/parser/parse-tree.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -96,19 +96,19 @@ Designator FunctionReference::ConvertToArrayElementRef() {
     std::visit(
         common::visitors{
             [&](common::Indirection<Expr> &y) {
-              args.push_back(std::move(*y));
+              args.push_back(std::move(y.value()));
             },
             [&](common::Indirection<Variable> &y) {
               args.push_back(std::visit(
                   common::visitors{
                       [&](common::Indirection<Designator> &z) {
-                        return Expr{std::move(*z)};
+                        return Expr{std::move(z.value())};
                       },
                       [&](common::Indirection<FunctionReference> &z) {
-                        return Expr{std::move(*z)};
+                        return Expr{std::move(z.value())};
                       },
                   },
-                  y->u));
+                  y.value().u));
             },
             [&](auto &) { CHECK(!"unexpected kind of ActualArg"); },
         },

--- a/lib/parser/user-state.cc
+++ b/lib/parser/user-state.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ std::optional<CapturedLabelDoStmt::resultType> CapturedLabelDoStmt::Parse(
   auto result{parser.Parse(state)};
   if (result) {
     if (auto *ustate{state.userState()}) {
-      ustate->NewDoLabel(std::get<Label>(result->statement->t));
+      ustate->NewDoLabel(std::get<Label>(result->statement.value().t));
     }
   }
   return result;

--- a/lib/semantics/CMakeLists.txt
+++ b/lib/semantics/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(FortranSemantics
   scope.cc
   semantics.cc
   symbol.cc
+  tools.cc
   type.cc
   unparse-with-symbols.cc
 )

--- a/lib/semantics/assignment.cc
+++ b/lib/semantics/assignment.cc
@@ -103,7 +103,7 @@ public:
     nested.Analyze(stmt.statement);
   }
   template<typename A> void Analyze(const common::Indirection<A> &x) {
-    Analyze(*x);
+    Analyze(x.value());
   }
   template<typename... As> void Analyze(const std::variant<As...> &u) {
     std::visit([&](const auto &x) { Analyze(x); }, u);

--- a/lib/semantics/canonicalize-do.cc
+++ b/lib/semantics/canonicalize-do.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public:
             common::visitors{
                 [](auto &) {},
                 [&](Statement<common::Indirection<LabelDoStmt>> &labelDoStmt) {
-                  auto &label{std::get<Label>(labelDoStmt.statement->t)};
+                  auto &label{std::get<Label>(labelDoStmt.statement.value().t)};
                   stack.push_back(LabelInfo{i, label});
                 },
                 [&](Statement<common::Indirection<EndDoStmt>> &endDoStmt) {
@@ -74,7 +74,8 @@ private:
                 std::move(std::get<std::optional<LoopControl>>(
                     std::get<Statement<common::Indirection<LabelDoStmt>>>(
                         std::get<ExecutableConstruct>(doLoop->u).u)
-                        .statement->t)))}};
+                        .statement.value()
+                        .t)))}};
         nonLabelDoStmt.source = originalSource;
         std::get<ExecutableConstruct>(doLoop->u).u =
             common::Indirection<DoConstruct>{

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1496,7 +1496,8 @@ static MaybeExpr AnalyzeExpr(ExpressionAnalysisContext &context,
             result.Add(*symbol, std::move(*converted));
           } else {
             if (auto *msg{context.Say(expr.source,
-                    "Structure constructor value is incompatible with component"_err_en_US)}) {
+                    "Structure constructor value is incompatible with component '%s'"_err_en_US,
+                    symbol->name().ToString().data())}) {
               msg->Attach(symbol->name(), "Component declaration"_en_US);
             }
           }

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -96,6 +96,7 @@ static std::optional<DataRef> ExtractDataRef(Expr<SomeType> &&expr) {
           [](BOZLiteralConstant &&) -> std::optional<DataRef> {
             return std::nullopt;
           },
+          [](NullPointer &&) -> std::optional<DataRef> { return std::nullopt; },
           [](auto &&catExpr) { return ExtractDataRef(std::move(catExpr)); },
       },
       std::move(expr.u));
@@ -1644,6 +1645,9 @@ static MaybeExpr AnalyzeExpr(
             [&](BOZLiteralConstant &&boz) {
               return operand;  // ignore parentheses around typeless constants
             },
+            [&](NullPointer &&boz) {
+              return operand;  // ignore parentheses around NULL()
+            },
             [&](Expr<SomeDerived> &&) {
               // TODO: parenthesized derived type variable
               return operand;
@@ -1669,6 +1673,9 @@ static MaybeExpr AnalyzeExpr(
     std::visit(
         common::visitors{
             [](const BOZLiteralConstant &) {},  // allow +Z'1', it's harmless
+            [&](const NullPointer &) {
+              context.Say("+NULL() is not allowed"_err_en_US);
+            },
             [&](const auto &catExpr) {
               TypeCategory cat{ResultType<decltype(catExpr)>::category};
               if (cat != TypeCategory::Integer && cat != TypeCategory::Real &&

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -152,7 +152,7 @@ std::optional<Expr<SomeType>> AnalyzeExpr(
 template<typename A>
 std::optional<Expr<SomeType>> AnalyzeExpr(
     ExpressionAnalysisContext &context, const common::Indirection<A> &x) {
-  return AnalyzeExpr(context, *x);
+  return AnalyzeExpr(context, x.value());
 }
 
 // These specializations implement constraint checking.

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -682,7 +682,8 @@ static const SourceName *GetSubmoduleParent(const parser::Program &program) {
   CHECK(program.v.size() == 1);
   auto &unit{program.v.front()};
   auto &submod{std::get<common::Indirection<parser::Submodule>>(unit.u)};
-  auto &stmt{std::get<parser::Statement<parser::SubmoduleStmt>>(submod->t)};
+  auto &stmt{
+      std::get<parser::Statement<parser::SubmoduleStmt>>(submod.value().t)};
   auto &parentId{std::get<parser::ParentIdentifier>(stmt.statement.t)};
   if (auto &parent{std::get<std::optional<parser::Name>>(parentId.t)}) {
     return &parent->source;

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -3291,6 +3291,7 @@ void DeclarationVisitor::Post(const parser::AllocateStmt &) {
 bool DeclarationVisitor::Pre(const parser::StructureConstructor &x) {
   auto &parsedType{std::get<parser::DerivedTypeSpec>(x.t)};
   const DeclTypeSpec *type{ProcessTypeSpec(parsedType)};
+
   if (type == nullptr) {
     return false;
   }

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -1762,7 +1762,7 @@ bool ModuleVisitor::Pre(const parser::Only &x) {
                     [&](const parser::Name &name) { AddUse(name); },
                     [](const auto &) { common::die("TODO: GenericSpec"); },
                 },
-                generic->u);
+                generic.value().u);
           },
           [&](const parser::Name &name) { AddUse(name); },
           [&](const parser::Rename &rename) {
@@ -3241,7 +3241,7 @@ bool DeclarationVisitor::Pre(const parser::TypeBoundGenericStmt &x) {
       specificProcs.push_back(symbol);
     }
   }
-  const auto *genericName{GetGenericSpecName(*genericSpec)};
+  const auto *genericName{GetGenericSpecName(genericSpec.value())};
   if (!genericName) {
     return false;
   }
@@ -3906,7 +3906,9 @@ bool ConstructVisitor::Pre(const parser::DataImpliedDo &x) {
 bool ConstructVisitor::Pre(const parser::DataStmtObject &x) {
   std::visit(
       common::visitors{
-          [&](const common::Indirection<parser::Variable> &y) { Walk(*y); },
+          [&](const common::Indirection<parser::Variable> &y) {
+            Walk(y.value());
+          },
           [&](const parser::DataImpliedDo &y) {
             PushScope(Scope::Kind::ImpliedDos, nullptr);
             Walk(y);
@@ -3992,7 +3994,8 @@ void ConstructVisitor::Post(const parser::Selector &x) {
           [&](const parser::Variable &y) {
             if (const auto *des{
                     std::get_if<Indirection<parser::Designator>>(&y.u)}) {
-              if (const auto *dr{std::get_if<parser::DataRef>(&(*des)->u)}) {
+              if (const auto *dr{
+                      std::get_if<parser::DataRef>(&des->value().u)}) {
                 variable = std::get_if<parser::Name>(&dr->u);
                 if (variable && !FindSymbol(*variable)) {
                   variable = nullptr;
@@ -4236,13 +4239,13 @@ const parser::Name *ResolveNamesVisitor::ResolveDataRef(
       common::visitors{
           [=](const parser::Name &y) { return ResolveName(y); },
           [=](const Indirection<parser::StructureComponent> &y) {
-            return ResolveStructureComponent(*y);
+            return ResolveStructureComponent(y.value());
           },
           [=](const Indirection<parser::ArrayElement> &y) {
-            return ResolveArrayElement(*y);
+            return ResolveArrayElement(y.value());
           },
           [=](const Indirection<parser::CoindexedNamedObject> &y) {
-            return ResolveCoindexedNamedObject(*y);
+            return ResolveCoindexedNamedObject(y.value());
           },
       },
       x.u);
@@ -4447,7 +4450,7 @@ bool ModuleVisitor::Pre(const parser::AccessStmt &x) {
                         },
                         [](const auto &) { common::die("TODO: GenericSpec"); },
                     },
-                    y->u);
+                    y.value().u);
               },
           },
           accessId.u);
@@ -4594,7 +4597,7 @@ bool ResolveNamesVisitor::Pre(const parser::PointerAssignmentStmt &x) {
                 },
                 [](const auto &) -> const parser::Name * { return nullptr; },
             },
-            (*designator)->u)}) {
+            designator->value().u)}) {
       return !NameIsKnownOrIntrinsic(*name);
     }
   }

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -120,14 +120,6 @@ const DeclTypeSpec &Scope::MakeDerivedType(
   return MakeDerivedType(std::move(spec), category);
 }
 
-const DeclTypeSpec &Scope::MakeDerivedType(DeclTypeSpec::Category category,
-    DerivedTypeSpec &&instance, SemanticsContext &semanticsContext) {
-  DeclTypeSpec &type{declTypeSpecs_.emplace_back(
-      category, DerivedTypeSpec{std::move(instance)})};
-  type.derivedTypeSpec().Instantiate(*this, semanticsContext);
-  return type;
-}
-
 DeclTypeSpec &Scope::MakeDerivedType(const Symbol &typeSymbol) {
   CHECK(typeSymbol.has<DerivedTypeDetails>());
   CHECK(typeSymbol.scope() != nullptr);
@@ -250,7 +242,10 @@ const DeclTypeSpec *Scope::FindInstantiatedDerivedType(
   if (typeIter != declTypeSpecs_.end()) {
     return &*typeIter;
   }
-  return nullptr;
+  if (&parent_ == this) {
+    return nullptr;
+  }
+  return parent_.FindInstantiatedDerivedType(spec, category);
 }
 
 const DeclTypeSpec &Scope::FindOrInstantiateDerivedType(DerivedTypeSpec &&spec,

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -144,8 +144,6 @@ public:
       ParamValue &&length, KindExpr &&kind = KindExpr{0});
   const DeclTypeSpec &MakeDerivedType(
       DeclTypeSpec::Category, DerivedTypeSpec &&);
-  const DeclTypeSpec &MakeDerivedType(
-      DeclTypeSpec::Category, DerivedTypeSpec &&, SemanticsContext &);
   DeclTypeSpec &MakeDerivedType(const Symbol &);
   DeclTypeSpec &MakeDerivedType(DerivedTypeSpec &&, DeclTypeSpec::Category);
   const DeclTypeSpec &MakeTypeStarType();

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -57,6 +57,15 @@ bool SemanticsContext::AnyFatalError() const {
       (warningsAreErrors_ || messages_.AnyFatalError());
 }
 
+const Scope &SemanticsContext::FindScope(
+    const parser::CharBlock &source) const {
+  if (const auto *scope{globalScope_.FindScope(source)}) {
+    return *scope;
+  } else {
+    common::die("invalid source location");
+  }
+}
+
 bool Semantics::Perform() {
   ValidateLabels(context_.messages(), program_);
   if (AnyFatalError()) {
@@ -80,14 +89,6 @@ bool Semantics::Perform() {
   ModFileWriter writer{context_};
   writer.WriteAll();
   return !AnyFatalError();
-}
-
-const Scope &Semantics::FindScope(const parser::CharBlock &source) const {
-  if (const auto *scope{context_.globalScope().FindScope(source)}) {
-    return *scope;
-  } else {
-    common::die("invalid source location");
-  }
 }
 
 void Semantics::EmitMessages(std::ostream &os) const {

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -77,6 +77,8 @@ public:
     return messages_.Say(std::forward<A>(args)...);
   }
 
+  const Scope &FindScope(const parser::CharBlock &) const;
+
 private:
   const common::IntrinsicTypeDefaultKinds &defaultKinds_;
   std::vector<std::string> searchDirectories_;
@@ -99,7 +101,9 @@ public:
 
   SemanticsContext &context() const { return context_; }
   bool Perform();
-  const Scope &FindScope(const parser::CharBlock &) const;
+  const Scope &FindScope(const parser::CharBlock &where) const {
+    return context_.FindScope(where);
+  }
   bool AnyFatalError() const { return context_.AnyFatalError(); }
   void EmitMessages(std::ostream &) const;
   void DumpSymbols(std::ostream &);

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -591,6 +591,7 @@ Symbol &Symbol::Instantiate(
           },
           [&](const ProcBindingDetails &that) { symbol.details_ = that; },
           [&](const GenericBindingDetails &that) { symbol.details_ = that; },
+          [&](const ProcEntityDetails &that) { symbol.details_ = that; },
           [&](const TypeParamDetails &that) {
             // LEN type parameter, or error recovery on a KIND type parameter
             // with no corresponding actual argument or default

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -87,22 +87,25 @@ bool IsUseAssociated(const Symbol &symbol, const Scope &scope) {
       owner != FindProgramUnitContaining(scope);
 }
 
-bool IsAncestor(const Scope *maybeAncestor, const Scope &maybeDescendent) {
-  if (maybeAncestor == nullptr) {
-    return false;
-  }
-  const Scope *scope{&maybeDescendent};
-  while (scope->kind() != Scope::Kind::Global) {
-    scope = &scope->parent();
-    if (scope == maybeAncestor) {
-      return true;
+bool DoesScopeContain(const Scope *maybeAncestor, const Scope &maybeDescendent) {
+  if (maybeAncestor != nullptr) {
+    const Scope *scope{&maybeDescendent};
+    while (scope->kind() != Scope::Kind::Global) {
+      scope = &scope->parent();
+      if (scope == maybeAncestor) {
+        return true;
+      }
     }
   }
   return false;
 }
 
+bool DoesScopeContain(const Scope *maybeAncestor, const Symbol &symbol) {
+  return DoesScopeContain(maybeAncestor, symbol.owner());
+}
+
 bool IsHostAssociated(const Symbol &symbol, const Scope &scope) {
-  return IsAncestor(FindProgramUnitContaining(symbol), scope);
+  return DoesScopeContain(FindProgramUnitContaining(symbol), scope);
 }
 
 bool IsDummy(const Symbol &symbol) {

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -1,0 +1,212 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tools.h"
+#include "scope.h"
+#include "../evaluate/variable.h"
+#include <algorithm>
+#include <set>
+#include <variant>
+
+namespace Fortran::semantics {
+
+static const Symbol *FindCommonBlockInScope(
+    const Scope &scope, const Symbol &object) {
+  for (const auto &pair : scope.commonBlocks()) {
+    const Symbol &block{*pair.second};
+    if (IsCommonBlockContaining(block, object)) {
+      return &block;
+    }
+  }
+  return nullptr;
+}
+
+const Symbol *FindCommonBlockContaining(const Symbol &object) {
+  for (const Scope *scope{&object.owner()};
+       scope->kind() != Scope::Kind::Global; scope = &scope->parent()) {
+    if (const Symbol * block{FindCommonBlockInScope(*scope, object)}) {
+      return block;
+    }
+  }
+  return nullptr;
+}
+
+const Scope *FindProgramUnitContaining(const Scope &start) {
+  const Scope *scope{&start};
+  while (scope != nullptr) {
+    switch (scope->kind()) {
+    case Scope::Kind::Module:
+    case Scope::Kind::MainProgram:
+    case Scope::Kind::Subprogram: return scope;
+    case Scope::Kind::Global:
+    case Scope::Kind::System: return nullptr;
+    case Scope::Kind::DerivedType:
+    case Scope::Kind::Block:
+    case Scope::Kind::Forall:
+    case Scope::Kind::ImpliedDos: scope = &scope->parent();
+    }
+  }
+  return nullptr;
+}
+
+const Scope *FindProgramUnitContaining(const Symbol &symbol) {
+  return FindProgramUnitContaining(symbol.owner());
+}
+
+const Scope *FindPureFunctionContaining(const Scope *scope) {
+  scope = FindProgramUnitContaining(*scope);
+  while (scope != nullptr) {
+    if (IsPureFunction(*scope)) {
+      return scope;
+    }
+    scope = FindProgramUnitContaining(scope->parent());
+  }
+  return nullptr;
+}
+
+bool IsCommonBlockContaining(const Symbol &block, const Symbol &object) {
+  const auto &objects{block.get<CommonBlockDetails>().objects()};
+  auto found{std::find(objects.begin(), objects.end(), &object)};
+  return found != objects.end();
+}
+
+bool IsUseAssociated(const Symbol &symbol, const Scope &scope) {
+  const Scope *owner{FindProgramUnitContaining(symbol.GetUltimate().owner())};
+  return owner != nullptr && owner->kind() == Scope::Kind::Module &&
+      owner != FindProgramUnitContaining(scope);
+}
+
+bool IsAncestor(const Scope *maybeAncestor, const Scope &maybeDescendent) {
+  if (maybeAncestor == nullptr) {
+    return false;
+  }
+  const Scope *scope{&maybeDescendent};
+  while (scope->kind() != Scope::Kind::Global) {
+    scope = &scope->parent();
+    if (scope == maybeAncestor) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool IsHostAssociated(const Symbol &symbol, const Scope &scope) {
+  return IsAncestor(FindProgramUnitContaining(symbol), scope);
+}
+
+bool IsDummy(const Symbol &symbol) {
+  if (const auto *details{symbol.detailsIf<ObjectEntityDetails>()}) {
+    return details->isDummy();
+  } else if (const auto *details{symbol.detailsIf<ProcEntityDetails>()}) {
+    return details->isDummy();
+  } else {
+    return false;
+  }
+}
+
+bool IsPointerDummy(const Symbol &symbol) {
+  return symbol.attrs().test(Attr::POINTER) && IsDummy(symbol);
+}
+
+bool IsFunction(const Symbol &symbol) {
+  if (const auto *procDetails{symbol.detailsIf<ProcEntityDetails>()}) {
+    return procDetails->interface().type() != nullptr ||
+        (procDetails->interface().symbol() != nullptr &&
+            IsFunction(*procDetails->interface().symbol()));
+  } else if (const auto *subprogram{symbol.detailsIf<SubprogramDetails>()}) {
+    return subprogram->isFunction();
+  } else {
+    return false;
+  }
+}
+
+bool IsPureFunction(const Symbol &symbol) {
+  return symbol.attrs().test(Attr::PURE) && IsFunction(symbol);
+}
+
+bool IsPureFunction(const Scope &scope) {
+  if (const Symbol * symbol{scope.GetSymbol()}) {
+    return IsPureFunction(*symbol);
+  } else {
+    return false;
+  }
+}
+
+static bool HasPointerComponent(
+    const Scope &scope, std::set<const Scope *> &visited) {
+  if (scope.kind() != Scope::Kind::DerivedType) {
+    return false;
+  }
+  if (!visited.insert(&scope).second) {
+    return false;
+  }
+  for (const auto &pair : scope) {
+    const Symbol &symbol{*pair.second};
+    if (symbol.attrs().test(Attr::POINTER)) {
+      return true;
+    }
+    if (const auto *details{symbol.detailsIf<ObjectEntityDetails>()}) {
+      if (const DeclTypeSpec * type{details->type()}) {
+        if (const DerivedTypeSpec * derived{type->AsDerived()}) {
+          if (const Scope * nested{derived->scope()}) {
+            if (HasPointerComponent(*nested, visited)) {
+              return true;
+            }
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
+bool HasPointerComponent(const Scope &scope) {
+  std::set<const Scope *> visited;
+  return HasPointerComponent(scope, visited);
+}
+
+bool HasPointerComponent(const DerivedTypeSpec &derived) {
+  if (const Scope * scope{derived.scope()}) {
+    return HasPointerComponent(*scope);
+  } else {
+    return false;
+  }
+}
+
+bool HasPointerComponent(const DeclTypeSpec &type) {
+  if (const DerivedTypeSpec * derived{type.AsDerived()}) {
+    return HasPointerComponent(*derived);
+  } else {
+    return false;
+  }
+}
+
+bool HasPointerComponent(const DeclTypeSpec *type) {
+  return type != nullptr && HasPointerComponent(*type);
+}
+
+bool IsOrHasPointerComponent(const Symbol &symbol) {
+  return symbol.attrs().test(Attr::POINTER) ||
+      HasPointerComponent(symbol.GetType());
+}
+
+// C1594 specifies several ways by which an object might be globally visible.
+bool IsExternallyVisibleObject(const Symbol &object, const Scope &scope) {
+  return IsUseAssociated(object, scope) || IsHostAssociated(object, scope) ||
+      (IsPureFunction(scope) && IsPointerDummy(object)) ||
+      (object.attrs().test(Attr::INTENT_IN) && IsDummy(object)) ||
+      FindCommonBlockContaining(object) != nullptr;
+  // TODO: Storage association with any object for which this predicate holds
+}
+}

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -1,0 +1,74 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_SEMANTICS_TOOLS_H_
+#define FORTRAN_SEMANTICS_TOOLS_H_
+
+// Simple predicates and look-up functions that are best defined
+// canonically for use in semantic checking.
+
+#include "scope.h"
+#include "symbol.h"
+#include "type.h"
+#include "../evaluate/variable.h"
+
+namespace Fortran::semantics {
+
+const Symbol *FindCommonBlockContaining(const Symbol &object);
+const Scope *FindProgramUnitContaining(const Scope &);
+const Scope *FindProgramUnitContaining(const Symbol &);
+const Scope *FindPureFunctionContaining(const Scope *);
+
+bool IsCommonBlockContaining(const Symbol &block, const Symbol &object);
+bool IsAncestor(const Scope *maybeAncestor, const Scope &maybeDescendent);
+bool IsUseAssociated(const Symbol *, const Scope &);
+bool IsHostAssociated(const Symbol &, const Scope &);
+bool IsDummy(const Symbol &);
+bool IsPointerDummy(const Symbol &);
+bool IsFunction(const Symbol &);
+bool IsPureFunction(const Symbol &);
+bool IsPureFunction(const Scope &);
+bool HasPointerComponent(const Scope &);
+bool HasPointerComponent(const DerivedTypeSpec &);
+bool HasPointerComponent(const DeclTypeSpec &);
+bool IsOrHasPointerComponent(const Symbol &);
+
+// Determines whether an object might be visible outside a
+// PURE function (C1594)
+bool IsExternallyVisibleObject(const Symbol &, const Scope &);
+
+template<typename A> bool IsExternallyVisibleObject(const A &, const Scope &) {
+  return false;  // default base case
+}
+
+template<typename T>
+bool IsExternallyVisibleObject(
+    const evaluate::Designator<T> &designator, const Scope &scope) {
+  if (const Symbol * symbol{designator.GetBaseObject().symbol()}) {
+    return IsExternallyVisibleObject(*symbol, scope);
+  } else {
+    // Coindexed values are visible even if their image-local objects are not.
+    return std::holds_alternative<evaluate::CoarrayRef>(designator.u);
+  }
+}
+
+template<typename T>
+bool IsExternallyVisibleObject(
+    const evaluate::Expr<T> &expr, const Scope &scope) {
+  return std::visit(
+      [&](const auto &x) { return IsExternallyVisibleObject(x, scope); },
+      expr.u);
+}
+}
+#endif  // FORTRAN_SEMANTICS_TOOLS_H_

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -35,7 +35,8 @@ const Symbol *FindPointerComponent(const DeclTypeSpec &);
 const Symbol *FindPointerComponent(const Symbol &);
 
 bool IsCommonBlockContaining(const Symbol &block, const Symbol &object);
-bool IsAncestor(const Scope *maybeAncestor, const Scope &maybeDescendent);
+bool DoesScopeContain(const Scope *maybeAncestor, const Scope &maybeDescendent);
+bool DoesScopeContain(const Scope *, const Symbol &);
 bool IsUseAssociated(const Symbol *, const Scope &);
 bool IsHostAssociated(const Symbol &, const Scope &);
 bool IsDummy(const Symbol &);

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -42,10 +42,6 @@ void DerivedTypeSpec::set_scope(const Scope &scope) {
   scope_ = &scope;
 }
 
-bool DerivedTypeSpec::operator==(const DerivedTypeSpec &that) const {
-  return &typeSymbol_ == &that.typeSymbol_ && parameters_ == that.parameters_;
-}
-
 ParamValue &DerivedTypeSpec::AddParamValue(
     SourceName name, ParamValue &&value) {
   auto pair{parameters_.insert(std::make_pair(name, std::move(value)))};
@@ -225,10 +221,6 @@ ParamValue::ParamValue(std::int64_t value)
 void ParamValue::SetExplicit(SomeIntExpr &&x) {
   category_ = Category::Explicit;
   expr_ = std::move(x);
-}
-
-bool ParamValue::operator==(const ParamValue &that) const {
-  return category_ == that.category_ && expr_ == that.expr_;
 }
 
 std::ostream &operator<<(std::ostream &o, const ParamValue &x) {

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -101,7 +101,9 @@ public:
   bool isDeferred() const { return category_ == Category::Deferred; }
   const MaybeIntExpr &GetExplicit() const { return expr_; }
   void SetExplicit(SomeIntExpr &&);
-  bool operator==(const ParamValue &) const;
+  bool operator==(const ParamValue &that) const {
+    return category_ == that.category_ && expr_ == that.expr_;
+  }
 
 private:
   enum class Category { Explicit, Deferred, Assumed };
@@ -240,7 +242,9 @@ public:
   }
   void FoldParameterExpressions(evaluate::FoldingContext &);
   void Instantiate(Scope &, SemanticsContext &);
-  bool operator==(const DerivedTypeSpec &) const;  // for std::find()
+  bool operator==(const DerivedTypeSpec &that) const {
+    return &typeSymbol_ == &that.typeSymbol_ && parameters_ == that.parameters_;
+  }
 
 private:
   const Symbol &typeSymbol_;

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -117,6 +117,7 @@ set(MODFILE_TESTS
   modfile19.f90
   modfile20.f90
   modfile21.f90
+  modfile22.f90
 )
 
 set(LABEL_TESTS

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -74,6 +74,7 @@ set(ERROR_TESTS
   resolve46.f90
   structconst01.f90
   structconst02.f90
+  structconst03.f90
 )
 
 # These test files have expected symbols in the source

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -73,6 +73,7 @@ set(ERROR_TESTS
   resolve45.f90
   resolve46.f90
   structconst01.f90
+  structconst02.f90
 )
 
 # These test files have expected symbols in the source

--- a/test/semantics/modfile22.f90
+++ b/test/semantics/modfile22.f90
@@ -1,0 +1,36 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test character length conversions in constructors
+
+module m
+type :: t(k)
+  integer, kind :: k = 1
+  character(kind=k,len=1) :: a
+  character(kind=k,len=3) :: b
+end type t
+type(t), parameter :: p = t(k=1)(a='xx',b='xx')
+character(len=2), parameter :: c2(3) = [character(len=2) :: 'x', 'xx', 'xxx']
+end module m
+
+!Expect: m.mod
+!module m
+!type::t(k)
+!integer(4),kind::k=1_4
+!character(1_4,int(k,kind=8))::a
+!character(3_4,int(k,kind=8))::b
+!end type
+!type(t),parameter::p=t(k=1_4)(a=1_"x",b=1_"xx ")
+!character(2_4,1),parameter::c2(1_8:3_8)=[CHARACTER(KIND=1,LEN=2)::"x ","xx","xx"]
+!end

--- a/test/semantics/structconst02.f90
+++ b/test/semantics/structconst02.f90
@@ -1,0 +1,52 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Error tests for structure constructors: per-component type
+! (in)compatibility.
+
+module module1
+  interface
+    real function realfunc(x)
+      real, value :: x
+    end function realfunc
+  end interface
+  type :: scalar(ik,rk,zk,ck,lk,len)
+    integer, kind :: ik = 4, rk = 4, zk = 4, ck = 1, lk = 1
+    integer, len :: len = 1
+    integer(kind=ik) :: ix = 0
+    real(kind=rk) :: rx = 0.
+    complex(kind=zk) :: zx = (0.,0.)
+    character(kind=ck,len=len) :: cx = ' '
+    logical(kind=lk) :: lx = .false.
+    real(kind=rk), pointer :: rp = NULL()
+    procedure(realfunc), pointer :: rfp1 => NULL()
+    procedure(real), pointer :: rfp2 => NULL()
+  end type scalar
+ contains
+  subroutine scalararg(x)
+    type(scalar), intent(in) :: x
+  end subroutine scalararg
+  subroutine errors
+    call scalararg(scalar(4)(ix=1,rx=2.,zx=(3.,4.),cx='a',lx=.true.))
+    call scalararg(scalar(4)(1,2.,(3.,4.),'a',.true.))
+!    call scalararg(scalar(4)(ix=5.,rx=6,zx=(7._8,8._2),cx=4_'b',lx=.true._4))
+!    call scalararg(scalar(4)(5.,6,(7._8,8._2),4_'b',.true._4))
+    call scalararg(scalar(4)(ix=5.,rx=6,zx=(7._8,8._2),cx=4_'b',lx=.true.))
+    call scalararg(scalar(4)(5.,6,(7._8,8._2),4_'b',.true.))
+    call scalararg(scalar(4)(ix='a'))
+    call scalararg(scalar(4)(ix=.false.))
+    call scalararg(scalar(4)(ix=[1]))
+    !TODO more!
+  end subroutine errors
+end module module1

--- a/test/semantics/structconst02.f90
+++ b/test/semantics/structconst02.f90
@@ -44,8 +44,11 @@ module module1
 !    call scalararg(scalar(4)(5.,6,(7._8,8._2),4_'b',.true._4))
     call scalararg(scalar(4)(ix=5.,rx=6,zx=(7._8,8._2),cx=4_'b',lx=.true.))
     call scalararg(scalar(4)(5.,6,(7._8,8._2),4_'b',.true.))
+    !ERROR: Structure constructor value is incompatible with component 'ix'
     call scalararg(scalar(4)(ix='a'))
+    !ERROR: Structure constructor value is incompatible with component 'ix'
     call scalararg(scalar(4)(ix=.false.))
+    !ERROR: Structure constructor value is incompatible with component 'ix'
     call scalararg(scalar(4)(ix=[1]))
     !TODO more!
   end subroutine errors

--- a/test/semantics/structconst03.f90
+++ b/test/semantics/structconst03.f90
@@ -1,0 +1,178 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Error tests for structure constructors: C1594 violations
+! from assigning globally-visible data to POINTER components.
+
+module usefrom
+  real :: usedfrom1
+end module usefrom
+
+module module1
+  use usefrom
+  implicit none
+  type :: has_pointer1
+    real, pointer :: p
+    type(has_pointer1), allocatable :: link1
+  end type has_pointer1
+  type :: has_pointer2
+    type(has_pointer1) :: p
+    type(has_pointer2), allocatable :: link2
+  end type has_pointer2
+  type, extends(has_pointer2) :: has_pointer3
+    type(has_pointer3), allocatable :: link3
+  end type has_pointer3
+  type :: t1(k)
+    integer, kind :: k
+    real, pointer :: p
+    type(t1(k)), allocatable :: link
+  end type t1
+  type :: t2(k)
+    integer, kind :: k
+    type(has_pointer1) :: hp1
+    type(t2(k)), allocatable :: link
+  end type t2
+  type :: t3(k)
+    integer, kind :: k
+    type(has_pointer2) :: hp2
+    type(t3(k)), allocatable :: link
+  end type t3
+  type :: t4(k)
+    integer, kind :: k
+    type(has_pointer3) :: hp3
+    type(t4(k)), allocatable :: link
+  end type t4
+  real :: modulevar1
+  real :: commonvar1
+  type(has_pointer1) :: modulevar2, commonvar2
+  type(has_pointer2) :: modulevar3, commonvar3
+  type(has_pointer3) :: modulevar4, commonvar4
+  common /cblock/ commonvar1
+
+ contains
+
+  pure real function pf1(dummy1, dummy2, dummy3, dummy4)
+    real :: local1
+    type(t1(0)) :: x1
+    type(t2(0)) :: x2
+    type(t3(0)) :: x3
+    type(t4(0)) :: x4
+    real, intent(in) :: dummy1
+    real, intent(inout) :: dummy2
+    real, pointer :: dummy3
+    real, intent(inout) :: dummy4[*]
+    pf1 = 0.
+    x1 = t1(0)(local1)
+    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+    x1 = t1(0)(usedfrom1)
+    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+    x1 = t1(0)(modulevar1)
+    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+    x1 = t1(0)(commonvar1)
+    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+    x1 = t1(0)(dummy1)
+    x1 = t1(0)(dummy2)
+    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+    x1 = t1(0)(dummy3)
+! TODO when semantics handles coindexing:
+! TODO !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+! TODO x1 = t1(0)(dummy4[0])
+    x1 = t1(0)(dummy4)
+    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+    x2 = t2(0)(modulevar2)
+    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+    x2 = t2(0)(commonvar2)
+    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+    x3 = t3(0)(modulevar3)
+    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+    x3 = t3(0)(commonvar3)
+    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+    x4 = t4(0)(modulevar4)
+    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+    x4 = t4(0)(commonvar4)
+   contains
+    subroutine subr(dummy1a, dummy2a, dummy3a, dummy4a)
+      real :: local1a
+      type(t1(0)) :: x1a
+      type(t2(0)) :: x2a
+      type(t3(0)) :: x3a
+      type(t4(0)) :: x4a
+      real, intent(in) :: dummy1a
+      real, intent(inout) :: dummy2a
+      real, pointer :: dummy3a
+      real, intent(inout) :: dummy4a[*]
+      x1a = t1(0)(local1a)
+      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      x1a = t1(0)(usedfrom1)
+      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      x1a = t1(0)(modulevar1)
+      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      x1a = t1(0)(commonvar1)
+      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      x1a = t1(0)(dummy1)
+      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      x1a = t1(0)(dummy1a)
+      x1a = t1(0)(dummy2a)
+      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      x1a = t1(0)(dummy3)
+      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      x1a = t1(0)(dummy3a)
+! TODO when semantics handles coindexing:
+! TODO !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+! TODO x1a = t1(0)(dummy4a[0])
+      x1a = t1(0)(dummy4a)
+      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      x2a = t2(0)(modulevar2)
+      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      x2a = t2(0)(commonvar2)
+      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      x3a = t3(0)(modulevar3)
+      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      x3a = t3(0)(commonvar3)
+      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      x4a = t4(0)(modulevar4)
+      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      x4a = t4(0)(commonvar4)
+    end subroutine subr
+  end function pf1
+
+  impure real function ipf1(dummy1, dummy2, dummy3, dummy4)
+    real :: local1
+    type(t1(0)) :: x1
+    type(t2(0)) :: x2
+    type(t3(0)) :: x3
+    type(t4(0)) :: x4
+    real, intent(in) :: dummy1
+    real, intent(inout) :: dummy2
+    real, pointer :: dummy3
+    real, intent(inout) :: dummy4[*]
+    ipf1 = 0.
+    x1 = t1(0)(local1)
+    x1 = t1(0)(usedfrom1)
+    x1 = t1(0)(modulevar1)
+    x1 = t1(0)(commonvar1)
+    x1 = t1(0)(dummy1)
+    x1 = t1(0)(dummy2)
+    x1 = t1(0)(dummy3)
+! TODO when semantics handles coindexing:
+! TODO x1 = t1(0)(dummy4[0])
+    x1 = t1(0)(dummy4)
+    x2 = t2(0)(modulevar2)
+    x2 = t2(0)(commonvar2)
+    x3 = t3(0)(modulevar3)
+    x3 = t3(0)(commonvar3)
+    x4 = t4(0)(modulevar4)
+    x4 = t4(0)(commonvar4)
+  end function ipf1
+end module module1

--- a/test/semantics/structconst03.f90
+++ b/test/semantics/structconst03.f90
@@ -23,11 +23,11 @@ module module1
   use usefrom
   implicit none
   type :: has_pointer1
-    real, pointer :: p
-    type(has_pointer1), allocatable :: link1
+    real, pointer :: ptop
+    type(has_pointer1), allocatable :: link1 ! don't loop during analysis
   end type has_pointer1
   type :: has_pointer2
-    type(has_pointer1) :: p
+    type(has_pointer1) :: pnested
     type(has_pointer2), allocatable :: link2
   end type has_pointer2
   type, extends(has_pointer2) :: has_pointer3
@@ -35,7 +35,7 @@ module module1
   end type has_pointer3
   type :: t1(k)
     integer, kind :: k
-    real, pointer :: p
+    real, pointer :: pt1
     type(t1(k)), allocatable :: link
   end type t1
   type :: t2(k)
@@ -54,11 +54,9 @@ module module1
     type(t4(k)), allocatable :: link
   end type t4
   real :: modulevar1
-  real :: commonvar1
-  type(has_pointer1) :: modulevar2, commonvar2
-  type(has_pointer2) :: modulevar3, commonvar3
-  type(has_pointer3) :: modulevar4, commonvar4
-  common /cblock/ commonvar1
+  type(has_pointer1) :: modulevar2
+  type(has_pointer2) :: modulevar3
+  type(has_pointer3) :: modulevar4
 
  contains
 
@@ -72,35 +70,31 @@ module module1
     real, intent(inout) :: dummy2
     real, pointer :: dummy3
     real, intent(inout) :: dummy4[*]
+    real :: commonvar1
+    common /cblock/ commonvar1
     pf1 = 0.
     x1 = t1(0)(local1)
-    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+    !ERROR: Externally visible object 'usedfrom1' must not be associated with pointer component 'pt1' in a PURE function
     x1 = t1(0)(usedfrom1)
-    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+    !ERROR: Externally visible object 'modulevar1' must not be associated with pointer component 'pt1' in a PURE function
     x1 = t1(0)(modulevar1)
-    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+    !ERROR: Externally visible object 'cblock' must not be associated with pointer component 'pt1' in a PURE function
     x1 = t1(0)(commonvar1)
-    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+    !ERROR: Externally visible object 'dummy1' must not be associated with pointer component 'pt1' in a PURE function
     x1 = t1(0)(dummy1)
     x1 = t1(0)(dummy2)
-    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+    !ERROR: Externally visible object 'dummy3' must not be associated with pointer component 'pt1' in a PURE function
     x1 = t1(0)(dummy3)
 ! TODO when semantics handles coindexing:
 ! TODO !ERROR: Externally visible object must not be associated with a pointer in a PURE function
 ! TODO x1 = t1(0)(dummy4[0])
     x1 = t1(0)(dummy4)
-    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+    !ERROR: Externally visible object 'modulevar2' must not be associated with pointer component 'ptop' in a PURE function
     x2 = t2(0)(modulevar2)
-    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
-    x2 = t2(0)(commonvar2)
-    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+    !ERROR: Externally visible object 'modulevar3' must not be associated with pointer component 'ptop' in a PURE function
     x3 = t3(0)(modulevar3)
-    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
-    x3 = t3(0)(commonvar3)
-    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+    !ERROR: Externally visible object 'modulevar4' must not be associated with pointer component 'ptop' in a PURE function
     x4 = t4(0)(modulevar4)
-    !ERROR: Externally visible object must not be associated with a pointer in a PURE function
-    x4 = t4(0)(commonvar4)
    contains
     subroutine subr(dummy1a, dummy2a, dummy3a, dummy4a)
       real :: local1a
@@ -113,37 +107,31 @@ module module1
       real, pointer :: dummy3a
       real, intent(inout) :: dummy4a[*]
       x1a = t1(0)(local1a)
-      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      !ERROR: Externally visible object 'usedfrom1' must not be associated with pointer component 'pt1' in a PURE function
       x1a = t1(0)(usedfrom1)
-      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      !ERROR: Externally visible object 'modulevar1' must not be associated with pointer component 'pt1' in a PURE function
       x1a = t1(0)(modulevar1)
-      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      !ERROR: Externally visible object 'cblock' must not be associated with pointer component 'pt1' in a PURE function
       x1a = t1(0)(commonvar1)
-      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      !ERROR: Externally visible object 'dummy1' must not be associated with pointer component 'pt1' in a PURE function
       x1a = t1(0)(dummy1)
-      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      !ERROR: Externally visible object 'dummy1a' must not be associated with pointer component 'pt1' in a PURE function
       x1a = t1(0)(dummy1a)
       x1a = t1(0)(dummy2a)
-      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      !ERROR: Externally visible object 'dummy3' must not be associated with pointer component 'pt1' in a PURE function
       x1a = t1(0)(dummy3)
-      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      !ERROR: Externally visible object 'dummy3a' must not be associated with pointer component 'pt1' in a PURE function
       x1a = t1(0)(dummy3a)
 ! TODO when semantics handles coindexing:
 ! TODO !ERROR: Externally visible object must not be associated with a pointer in a PURE function
 ! TODO x1a = t1(0)(dummy4a[0])
       x1a = t1(0)(dummy4a)
-      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      !ERROR: Externally visible object 'modulevar2' must not be associated with pointer component 'ptop' in a PURE function
       x2a = t2(0)(modulevar2)
-      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
-      x2a = t2(0)(commonvar2)
-      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      !ERROR: Externally visible object 'modulevar3' must not be associated with pointer component 'ptop' in a PURE function
       x3a = t3(0)(modulevar3)
-      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
-      x3a = t3(0)(commonvar3)
-      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+      !ERROR: Externally visible object 'modulevar4' must not be associated with pointer component 'ptop' in a PURE function
       x4a = t4(0)(modulevar4)
-      !ERROR: Externally visible object must not be associated with a pointer in a PURE function
-      x4a = t4(0)(commonvar4)
     end subroutine subr
   end function pf1
 
@@ -157,6 +145,8 @@ module module1
     real, intent(inout) :: dummy2
     real, pointer :: dummy3
     real, intent(inout) :: dummy4[*]
+    real :: commonvar1
+    common /cblock/ commonvar1
     ipf1 = 0.
     x1 = t1(0)(local1)
     x1 = t1(0)(usedfrom1)
@@ -169,10 +159,7 @@ module module1
 ! TODO x1 = t1(0)(dummy4[0])
     x1 = t1(0)(dummy4)
     x2 = t2(0)(modulevar2)
-    x2 = t2(0)(commonvar2)
     x3 = t3(0)(modulevar3)
-    x3 = t3(0)(commonvar3)
     x4 = t4(0)(modulevar4)
-    x4 = t4(0)(commonvar4)
   end function ipf1
 end module module1


### PR DESCRIPTION
Structure constructor semantics remain incomplete, but here's another step, and I'm sending it out for review before continuing.  I needed a bunch of utility routines to implement some complicated rules and I packaged them into their own new module in lib/semantics/tools.{h,cc} because they looked likely to be useful in other situations.