### PR TITLE
Add `ForwardReference<>` class template

### DIFF
--- a/documentation/C++style.md
+++ b/documentation/C++style.md
@@ -199,6 +199,7 @@ for use with forward-defined types than `std::unique_ptr<>` is.
 Null by default, optionally copyable, reassignable.
 Does not have direct means for allocating data, and inconveniently requires
 the definition of an external destructor.
+* `OwningReference<>`: A non-nullable `OwningPointer<>`.
 * `Indirection<>`: A non-nullable pointer with ownership and
 optional deep copy semantics; reassignable.
 Often better than a reference (due to ownership) or `std::unique_ptr<>`
@@ -220,6 +221,7 @@ A feature matrix:
 | `unique_ptr<>`       | yes      | yes          | yes    | yes          | no                | no                 |
 | `shared_ptr<>`       | yes      | yes          | yes    | yes          | shallowly         | no                 |
 | `OwningPointer<>`    | yes      | yes          | yes    | yes          | optionally deeply | yes                |
+| `OwningReference<>`  | no       | yes          | yes    | yes          | optionally deeply | yes                |
 | `Indirection<>`      | no       | n/a          | yes    | yes          | optionally deeply | no                 |
 | `CountedReference<>` | yes      | yes          | yes    | yes          | shallowly         | no                 |
 

--- a/documentation/C++style.md
+++ b/documentation/C++style.md
@@ -199,12 +199,13 @@ for use with forward-defined types than `std::unique_ptr<>` is.
 Null by default, optionally copyable, reassignable.
 Does not have direct means for allocating data, and inconveniently requires
 the definition of an external destructor.
-* `OwningReference<>`: A non-nullable `OwningPointer<>`.
 * `Indirection<>`: A non-nullable pointer with ownership and
 optional deep copy semantics; reassignable.
 Often better than a reference (due to ownership) or `std::unique_ptr<>`
 (due to non-nullability and copyability).
 Can be wrapped in `std::optional<>` when nullability is required.
+* `ForwardReference<>`: A non-nullable `OwningPointer<>`, or a variant of
+`Indirection<>` that works with forward-declared content types; it's both.
 * `CountedReference<>`: A nullable pointer with shared ownership via
 reference counting, null by default, shallowly copyable, reassignable.
 Safe to use *only* when the data are private to just one
@@ -221,8 +222,8 @@ A feature matrix:
 | `unique_ptr<>`       | yes      | yes          | yes    | yes          | no                | no                 |
 | `shared_ptr<>`       | yes      | yes          | yes    | yes          | shallowly         | no                 |
 | `OwningPointer<>`    | yes      | yes          | yes    | yes          | optionally deeply | yes                |
-| `OwningReference<>`  | no       | yes          | yes    | yes          | optionally deeply | yes                |
 | `Indirection<>`      | no       | n/a          | yes    | yes          | optionally deeply | no                 |
+| `ForwardReference<>` | no       | n/a          | yes    | yes          | optionally deeply | yes                |
 | `CountedReference<>` | yes      | yes          | yes    | yes          | shallowly         | no                 |
 
 ### Overall design preferences

--- a/lib/common/indirection.h
+++ b/lib/common/indirection.h
@@ -53,6 +53,9 @@ public:
     that.p_ = tmp;
     return *this;
   }
+
+  A &value() { return *p_; }
+  const A &value() const { return *p_; }
   A &operator*() { return *p_; }
   const A &operator*() const { return *p_; }
   A *operator->() { return p_; }
@@ -103,6 +106,9 @@ public:
     that.p_ = tmp;
     return *this;
   }
+
+  A &value() { return *p_; }
+  const A &value() const { return *p_; }
   A &operator*() { return *p_; }
   const A &operator*() const { return *p_; }
   A *operator->() { return p_; }
@@ -208,7 +214,6 @@ private:
     return *this; \
   } \
   }
-}
 
 #define DEFINE_OWNING_POINTER_COPY_FUNCTIONS(A) \
   DEFINE_OWNING_POINTER_COPY_CONSTRUCTORS(A) \
@@ -216,5 +221,5 @@ private:
 #define DEFINE_OWNING_POINTER_SPECIAL_FUNCTIONS(A) \
   DEFINE_OWNING_POINTER_DESTRUCTOR(A) \
   DEFINE_OWNING_POINTER_COPY_FUNCTIONS(A)
-
+}
 #endif  // FORTRAN_COMMON_INDIRECTION_H_

--- a/lib/evaluate/characteristics.cc
+++ b/lib/evaluate/characteristics.cc
@@ -101,4 +101,5 @@ std::ostream &Procedure::Dump(std::ostream &o) const {
 }
 
 // Define OwningPointer special member functions
-DEFINE_OWNING_POINTER_SPECIAL_FUNCTIONS(evaluate::characteristics::Procedure)
+DEFINE_OWNING_SPECIAL_FUNCTIONS(
+    OwningPointer, evaluate::characteristics::Procedure)

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -321,4 +321,4 @@ FOR_EACH_INTRINSIC_KIND(template class ArrayConstructor)
 // been embedded in the parse tree.  This destructor appears here, where
 // definitions for all the necessary types are available, to obviate a
 // need to include lib/evaluate/*.h headers in the parser proper.
-DEFINE_OWNING_POINTER_SPECIAL_FUNCTIONS(evaluate::GenericExprWrapper)
+DEFINE_OWNING_SPECIAL_FUNCTIONS(OwningPointer, evaluate::GenericExprWrapper)

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -2032,8 +2032,7 @@ public:
 #if PMKDEBUG
 //        checked->AsFortran(std::cout << "checked expression: ") << '\n';
 #endif
-        expr.typedExpr.reset(
-            new evaluate::GenericExprWrapper{std::move(*checked)});
+        expr.typedExpr = new evaluate::GenericExprWrapper{std::move(*checked)};
       } else {
 #if PMKDEBUG
         std::cout << "TODO: expression analysis failed for this expression: ";


### PR DESCRIPTION
After a suggestion from Tim that a non-nullable variation on `OwningPointer<>` would be handy (basically an `Indirection<>` that copes with forward-declared content types) for executable statement semantics, I've defined one here, and also straightened out the documentation and commentary a bit.