### PR TITLE
Create framework for checking statement semantics

### DIFF
--- a/lib/semantics/assignment.h
+++ b/lib/semantics/assignment.h
@@ -15,6 +15,9 @@
 #ifndef FORTRAN_SEMANTICS_ASSIGNMENT_H_
 #define FORTRAN_SEMANTICS_ASSIGNMENT_H_
 
+#include "semantics.h"
+#include "../common/indirection.h"
+
 namespace Fortran::parser {
 template<typename> struct Statement;
 struct AssignmentStmt;
@@ -23,10 +26,27 @@ struct ForallStmt;
 struct PointerAssignmentStmt;
 struct Program;
 struct WhereStmt;
+struct WhereConstruct;
+struct ForallStmt;
+struct ForallConstruct;
 }
 
 namespace Fortran::semantics {
-class SemanticsContext;
+class AssignmentContext;
+
+class AssignmentChecker : public virtual BaseChecker {
+public:
+  explicit AssignmentChecker(SemanticsContext &);
+  void Enter(const parser::AssignmentStmt &);
+  void Enter(const parser::PointerAssignmentStmt &);
+  void Enter(const parser::WhereStmt &);
+  void Enter(const parser::WhereConstruct &);
+  void Enter(const parser::ForallStmt &);
+  void Enter(const parser::ForallConstruct &);
+
+private:
+  common::ForwardReference<AssignmentContext> context_;
+};
 
 // Semantic analysis of an assignment statement or WHERE/FORALL construct.
 void AnalyzeAssignment(
@@ -43,7 +63,5 @@ void AnalyzeAssignment(
 void AnalyzeConcurrentHeader(
     SemanticsContext &, const parser::ConcurrentHeader &);
 
-// Semantic analysis of all assignment statements and related constructs.
-void AnalyzeAssignments(parser::Program &, SemanticsContext &);
 }
 #endif  // FORTRAN_SEMANTICS_ASSIGNMENT_H_

--- a/lib/semantics/check-do-concurrent.h
+++ b/lib/semantics/check-do-concurrent.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,14 +15,24 @@
 #ifndef FORTRAN_SEMANTICS_CHECK_DO_CONCURRENT_H_
 #define FORTRAN_SEMANTICS_CHECK_DO_CONCURRENT_H_
 
+#include "semantics.h"
+#include "../common/indirection.h"
+
 namespace Fortran::parser {
-class Messages;
-struct Program;
+struct DoConstruct;
 }
 
 namespace Fortran::semantics {
+class DoConcurrentContext;
 
-void CheckDoConcurrentConstraints(
-    parser::Messages &messages, const parser::Program &program);
+class DoConcurrentChecker : public virtual BaseChecker {
+public:
+  explicit DoConcurrentChecker(SemanticsContext &);
+  void Leave(const parser::DoConstruct &);
+
+private:
+  common::ForwardReference<DoConcurrentContext> context_;
+};
+
 }
 #endif  // FORTRAN_SEMANTICS_CHECK_DO_CONCURRENT_H_

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -241,7 +241,8 @@ void ConformabilityCheck(
         left.Rank(), right.Rank());
   }
 }
-}
+
+}  // namespace Fortran::evaluate
 
 namespace Fortran::semantics {
 
@@ -253,13 +254,22 @@ std::optional<evaluate::Expr<evaluate::SomeType>> AnalyzeExpr(
   return AnalyzeExpr(exprContext, expr);
 }
 
-// Semantic analysis of all expressions in a parse tree, which is
-// decorated with typed representations for top-level expressions.
-void AnalyzeExpressions(parser::Program &, SemanticsContext &);
-
 // Semantic analysis of an intrinsic type's KIND parameter expression.
 evaluate::Expr<evaluate::SubscriptInteger> AnalyzeKindSelector(
-    SemanticsContext &, parser::CharBlock, common::TypeCategory,
+    SemanticsContext &, common::TypeCategory,
     const std::optional<parser::KindSelector> &);
-}
+
+// Semantic analysis of all expressions in a parse tree, which is
+// decorated with typed representations for top-level expressions.
+class ExprChecker : public virtual BaseChecker {
+public:
+  explicit ExprChecker(SemanticsContext &context) : context_{context} {}
+  void Enter(const parser::Expr &);
+
+private:
+  SemanticsContext &context_;
+};
+
+}  // namespace Fortran::semantics
+
 #endif  // FORTRAN_SEMANTICS_EXPRESSION_H_

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -24,12 +24,34 @@
 #include "scope.h"
 #include "symbol.h"
 #include "../common/default-kinds.h"
+#include "../parser/parse-tree-visitor.h"
 #include <ostream>
 
 namespace Fortran::semantics {
 
 static void DoDumpSymbols(std::ostream &, const Scope &, int indent = 0);
 static void PutIndent(std::ostream &, int indent);
+
+// A parse tree visitor that calls Enter/Leave functions from each checker
+// class C supplied as template parameters. Enter is called before the node's
+// children are visited, Leave is called after. No two checkers may have the
+// same Enter or Leave function. Each checker must be constructible from
+// SemanticsContext and have BaseChecker as a virtual base class.
+template<typename... C> struct SemanticsVisitor : public virtual C... {
+  using C::Enter...;
+  using C::Leave...;
+  using BaseChecker::Enter;
+  using BaseChecker::Leave;
+  SemanticsVisitor(SemanticsContext &context) : C{context}... {}
+  template<typename N> bool Pre(const N &node) {
+    Enter(node);
+    return true;
+  }
+  template<typename N> void Post(const N &node) { Leave(node); }
+};
+
+using StatementSemantics =
+    SemanticsVisitor<ExprChecker, AssignmentChecker, DoConcurrentChecker>;
 
 SemanticsContext::SemanticsContext(
     const common::IntrinsicTypeDefaultKinds &defaultKinds)
@@ -80,9 +102,8 @@ bool Semantics::Perform() {
   if (AnyFatalError()) {
     return false;
   }
-  CheckDoConcurrentConstraints(context_.messages(), program_);
-  AnalyzeExpressions(program_, context_);
-  AnalyzeAssignments(program_, context_);
+  StatementSemantics visitor{context_};
+  parser::Walk(program_, visitor);
   if (AnyFatalError()) {
     return false;
   }
@@ -134,4 +155,5 @@ static void PutIndent(std::ostream &os, int indent) {
     os << "  ";
   }
 }
+
 }

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -41,6 +41,7 @@ public:
   const common::IntrinsicTypeDefaultKinds &defaultKinds() const {
     return defaultKinds_;
   }
+  const parser::CharBlock *location() const { return location_; }
   const std::vector<std::string> &searchDirectories() const {
     return searchDirectories_;
   }
@@ -52,6 +53,10 @@ public:
   parser::Messages &messages() { return messages_; }
   evaluate::FoldingContext &foldingContext() { return foldingContext_; }
 
+  SemanticsContext &set_location(const parser::CharBlock *location) {
+    location_ = location;
+    return *this;
+  }
   SemanticsContext &set_searchDirectories(const std::vector<std::string> &x) {
     searchDirectories_ = x;
     return *this;
@@ -81,6 +86,7 @@ public:
 
 private:
   const common::IntrinsicTypeDefaultKinds &defaultKinds_;
+  const parser::CharBlock *location_{nullptr};
   std::vector<std::string> searchDirectories_;
   std::string moduleDirectory_{"."s};
   bool warnOnNonstandardUsage_{false};
@@ -113,6 +119,12 @@ private:
   parser::Program &program_;
   const parser::CookedSource &cooked_;
 };
-}
 
+// Base class for semantics checkers.
+struct BaseChecker {
+  template<typename C> void Enter(const C &x) {}
+  template<typename C> void Leave(const C &x) {}
+};
+
+}
 #endif

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -122,8 +122,8 @@ private:
 
 // Base class for semantics checkers.
 struct BaseChecker {
-  template<typename C> void Enter(const C &x) {}
-  template<typename C> void Leave(const C &x) {}
+  template<typename N> void Enter(const N &) {}
+  template<typename N> void Leave(const N &) {}
 };
 
 }

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -75,6 +75,7 @@ set(ERROR_TESTS
   structconst01.f90
   structconst02.f90
   structconst03.f90
+  assign01.f90
 )
 
 # These test files have expected symbols in the source

--- a/test/semantics/assign01.f90
+++ b/test/semantics/assign01.f90
@@ -1,0 +1,28 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+integer :: a1(10), a2(10)
+logical :: m1(10), m2(5,5)
+m1 = .true.
+m2 = .false.
+a1 = [((i),i=1,10)]
+where (m1)
+  a2 = 1
+!ERROR: mask of ELSEWHERE statement is not conformable with the prior mask(s) in its WHERE construct
+elsewhere (m2)
+  a2 = 2
+elsewhere
+  a2 = 3
+end where
+end


### PR DESCRIPTION
Add `SemanticsVisitor` as the visitor class to perform statement
semantics checks. Its template parameters are "checker" classes
that perform the checks. They have `Enter` and `Leave` functions
that are called for the corresponding parse tree nodes (`Enter`
before the children, `Leave` after). Unlike `Pre` and `Post` in
visitors they cannot prevent the parse tree walker from visiting
child nodes.

Existing checks have been incorporated into this framework:
- `ExprChecker` replaces `AnalyzeExpressions()`
- `AssignmentChecker` replaces `AnalyzeAssignments()`
- `DoConcurrentChecker` replaces `CheckDoConcurrentConstraints()`

Adding a new checker requires:
- defining the checker class:
  - with BaseChecker as virtual base class
  - constructible from `SemanticsContext`
  - with Enter/Leave functions for nodes of interest
- add the checker class to the template parameters of `StatementSemantics`

Because these checkers and also `ResolveNamesVisitor` require tracking
the current statement source location, that has been moved into
`SemanticsContext`. `ResolveNamesVisitor` and `SemanticsVisitor`
update the location when `Statement` nodes are encountered, making it
available for error messages.

`AnalyzeKindSelector()` now has access to the current statement through
the context and so no longer needs to have it passed in.

Test `assign01.f90` was added to verify that `AssignmentChecker` is
actually doing something.