### PR TITLE
Simplify Semantics::Perform

### DIFF
--- a/lib/semantics/canonicalize-do.cc
+++ b/lib/semantics/canonicalize-do.cc
@@ -89,8 +89,10 @@ private:
   }
 };
 
-void CanonicalizeDo(Program &program) {
+bool CanonicalizeDo(Program &program) {
   CanonicalizationOfDoLoops canonicalizationOfDoLoops;
   Walk(program, canonicalizationOfDoLoops);
+  return true;
 }
+
 }

--- a/lib/semantics/canonicalize-do.h
+++ b/lib/semantics/canonicalize-do.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 // logically nested) into the more structured DoConstruct (explicitly nested)
 namespace Fortran::parser {
 struct Program;
-void CanonicalizeDo(Program &program);
+bool CanonicalizeDo(Program &program);
 }
 
 #endif  // FORTRAN_SEMANTICS_CANONICALIZE_DO_H_

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -59,7 +59,10 @@ static bool FileContentsMatch(
 static std::string GetHeader(const std::string &);
 static std::size_t GetFileSize(const std::string &);
 
-void ModFileWriter::WriteAll() { WriteAll(context_.globalScope()); }
+bool ModFileWriter::WriteAll() {
+  WriteAll(context_.globalScope());
+  return !context_.AnyFatalError();
+}
 
 void ModFileWriter::WriteAll(const Scope &scope) {
   for (const auto &child : scope.children()) {

--- a/lib/semantics/mod-file.h
+++ b/lib/semantics/mod-file.h
@@ -37,7 +37,7 @@ class SemanticsContext;
 class ModFileWriter {
 public:
   ModFileWriter(SemanticsContext &context) : context_{context} {}
-  void WriteAll();
+  bool WriteAll();
 
 private:
   SemanticsContext &context_;

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -4637,8 +4637,9 @@ void ResolveNamesVisitor::Post(const parser::Program &) {
   CHECK(!GetDeclTypeSpec());
 }
 
-void ResolveNames(SemanticsContext &context, const parser::Program &program) {
+bool ResolveNames(SemanticsContext &context, const parser::Program &program) {
   ResolveNamesVisitor{context}.Walk(program);
+  return !context.AnyFatalError();
 }
 
 // Get the Name out of a GenericSpec, or nullptr if none.

--- a/lib/semantics/resolve-names.h
+++ b/lib/semantics/resolve-names.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,8 +27,9 @@ namespace Fortran::semantics {
 
 class SemanticsContext;
 
-void ResolveNames(SemanticsContext &, const parser::Program &);
+bool ResolveNames(SemanticsContext &, const parser::Program &);
 void DumpSymbols(std::ostream &);
+
 }
 
 #endif  // FORTRAN_SEMANTICS_RESOLVE_NAMES_H_

--- a/lib/semantics/rewrite-parse-tree.cc
+++ b/lib/semantics/rewrite-parse-tree.cc
@@ -120,8 +120,10 @@ bool RewriteMutator::Pre(parser::ExecutionPart &x) {
   return true;
 }
 
-void RewriteParseTree(SemanticsContext &context, parser::Program &program) {
+bool RewriteParseTree(SemanticsContext &context, parser::Program &program) {
   RewriteMutator mutator{context.messages()};
   parser::Walk(program, mutator);
+  return !context.AnyFatalError();
 }
+
 }

--- a/lib/semantics/rewrite-parse-tree.h
+++ b/lib/semantics/rewrite-parse-tree.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ class SemanticsContext;
 }
 
 namespace Fortran::semantics {
-void RewriteParseTree(SemanticsContext &, parser::Program &);
+bool RewriteParseTree(SemanticsContext &, parser::Program &);
 }
 
 #endif  // FORTRAN_SEMANTICS_REWRITE_PARSE_TREE_H_


### PR DESCRIPTION
`Semantics::Perform` is mostly a series of calls followed by a check
for fatal errors. There is more error checking logic than real code.

To make it clearer, change each of the phases it calls to return true
on success so that `Perform` can just call them one after the other.