### PR TITLE
Remove build dependency on clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,11 +48,8 @@ endif()
 
 message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}" )
 
-find_package(Clang REQUIRED CONFIG)
-include_directories(${CLANG_INSTALL_PREFIX/include})
-message(STATUS "Found Clang in ${CLANG_INSTALL_PREFIX}")
-message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+find_package(LLVM REQUIRED CONFIG)
+message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION} in ${LLVM_INSTALL_PREFIX}")
 
 # Get names for the LLVM libraries
 #
@@ -73,7 +70,8 @@ message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 include_directories(${LLVM_INCLUDE_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 
-llvm_map_components_to_libnames(LLVM_COMMON_LIBS support target option)
+llvm_map_components_to_libnames(LLVM_COMMON_LIBS support)
+message(STATUS "LLVM libraries: ${LLVM_COMMON_LIBS}")
 
 if(CMAKE_COMPILER_IS_GNUCXX OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/lib/semantics/CMakeLists.txt
+++ b/lib/semantics/CMakeLists.txt
@@ -33,5 +33,4 @@ add_library(FortranSemantics
 target_link_libraries(FortranSemantics
   FortranCommon
   FortranEvaluate
-  clangBasic
 )

--- a/tools/f18/CMakeLists.txt
+++ b/tools/f18/CMakeLists.txt
@@ -21,4 +21,5 @@ target_link_libraries(f18
   FortranParser
   FortranEvaluate
   FortranSemantics
+  ${LLVM_COMMON_LIBS}
 )


### PR DESCRIPTION
For now all we need to depend on is LLVM.
Use llvm_map_components_to_libnames to find libraries to link against.