### PR TITLE
Fix two ambiguous parsing cases by patching parse tree in expression semantics

### DIFF
--- a/lib/parser/parse-tree.cc
+++ b/lib/parser/parse-tree.cc
@@ -136,6 +136,17 @@ StructureConstructor FunctionReference::ConvertToStructureConstructor(
   return StructureConstructor{std::move(spec), std::move(components)};
 }
 
+Substring ArrayElement::ConvertToSubstring() {
+  auto iter{subscripts.begin()};
+  CHECK(iter != subscripts.end());
+  auto &triplet{std::get<SubscriptTriplet>(iter->u)};
+  SubstringRange range{
+      std::move(std::get<0>(triplet.t)), std::move(std::get<1>(triplet.t))};
+  CHECK(!std::get<2>(triplet.t).has_value());
+  CHECK(++iter == subscripts.end());
+  return Substring{std::move(base), std::move(range)};
+}
+
 // R1544 stmt-function-stmt
 // Convert this stmt-function-stmt to an array element assignment statement.
 Statement<ActionStmt> StmtFunctionStmt::ConvertToAssignment() {

--- a/lib/parser/parse-tree.cc
+++ b/lib/parser/parse-tree.cc
@@ -89,32 +89,48 @@ static Designator MakeArrayElementRef(Name &name, std::list<Expr> &subscripts) {
   return Designator{DataRef{common::Indirection{std::move(arrayElement)}}};
 }
 
+static std::optional<Expr> ActualArgToExpr(ActualArgSpec &arg) {
+  return std::visit(
+      common::visitors{
+          [&](common::Indirection<Expr> &y) {
+            return std::make_optional<Expr>(std::move(y.value()));
+          },
+          [&](common::Indirection<Variable> &y) {
+            return std::visit(
+                [&](auto &indirection) {
+                  return std::make_optional<Expr>(
+                      std::move(indirection.value()));
+                },
+                y.value().u);
+          },
+          [&](auto &) -> std::optional<Expr> { return std::nullopt; },
+      },
+      std::get<ActualArg>(arg.t).u);
+}
+
 Designator FunctionReference::ConvertToArrayElementRef() {
   auto &name{std::get<parser::Name>(std::get<ProcedureDesignator>(v.t).u)};
   std::list<Expr> args;
   for (auto &arg : std::get<std::list<ActualArgSpec>>(v.t)) {
-    std::visit(
-        common::visitors{
-            [&](common::Indirection<Expr> &y) {
-              args.push_back(std::move(y.value()));
-            },
-            [&](common::Indirection<Variable> &y) {
-              args.push_back(std::visit(
-                  common::visitors{
-                      [&](common::Indirection<Designator> &z) {
-                        return Expr{std::move(z.value())};
-                      },
-                      [&](common::Indirection<FunctionReference> &z) {
-                        return Expr{std::move(z.value())};
-                      },
-                  },
-                  y.value().u));
-            },
-            [&](auto &) { CHECK(!"unexpected kind of ActualArg"); },
-        },
-        std::get<ActualArg>(arg.t).u);
+    args.emplace_back(std::move(ActualArgToExpr(arg).value()));
   }
   return MakeArrayElementRef(name, args);
+}
+
+StructureConstructor FunctionReference::ConvertToStructureConstructor() {
+  Name name{std::get<parser::Name>(std::get<ProcedureDesignator>(v.t).u)};
+  std::list<ComponentSpec> components;
+  for (auto &arg : std::get<std::list<ActualArgSpec>>(v.t)) {
+    std::optional<Keyword> keyword;
+    if (auto &kw{std::get<std::optional<Keyword>>(arg.t)}) {
+      keyword.emplace(Keyword{Name{kw->v}});
+    }
+    components.emplace_back(
+        std::move(keyword), ComponentDataSource{ActualArgToExpr(arg).value()});
+  }
+  return StructureConstructor{
+      DerivedTypeSpec{std::move(name), std::list<TypeParamSpec>{}},
+      std::move(components)};
 }
 
 // R1544 stmt-function-stmt

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -538,8 +538,6 @@ WRAPPER_CLASS(Program, std::list<ProgramUnit>);
 
 // R603 name -> letter [alphanumeric-character]...
 struct Name {
-  Name() {}
-  COPY_AND_ASSIGN_BOILERPLATE(Name);
   std::string ToString() const { return source.ToString(); }
   CharBlock source;
   mutable semantics::Symbol *symbol{nullptr};  // filled in during semantics
@@ -3094,6 +3092,7 @@ struct Call {
 struct FunctionReference {
   WRAPPER_CLASS_BOILERPLATE(FunctionReference, Call);
   Designator ConvertToArrayElementRef();
+  StructureConstructor ConvertToStructureConstructor();
 };
 
 // R1521 call-stmt -> CALL procedure-designator [( [actual-arg-spec-list] )]

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -1810,6 +1810,7 @@ struct ArrayElement {
   BOILERPLATE(ArrayElement);
   ArrayElement(DataRef &&dr, std::list<SectionSubscript> &&ss)
     : base{std::move(dr)}, subscripts(std::move(ss)) {}
+  Substring ConvertToSubstring();
   DataRef base;
   std::list<SectionSubscript> subscripts;
 };

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -3092,7 +3092,8 @@ struct Call {
 struct FunctionReference {
   WRAPPER_CLASS_BOILERPLATE(FunctionReference, Call);
   Designator ConvertToArrayElementRef();
-  StructureConstructor ConvertToStructureConstructor();
+  StructureConstructor ConvertToStructureConstructor(
+      const semantics::DerivedTypeSpec &);
 };
 
 // R1521 call-stmt -> CALL procedure-designator [( [actual-arg-spec-list] )]

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -322,16 +322,13 @@ static void FixMisparsedSubstring(const parser::Designator &d) {
                     },
                     arrElement.base.u)}) {
               const Symbol &ultimate{symbol->GetUltimate()};
-              if (const auto *details{
-                      ultimate.detailsIf<semantics::ObjectEntityDetails>()}) {
-                if (const semantics::DeclTypeSpec * type{details->type()}) {
-                  if (!details->IsArray() &&
-                      type->category() == semantics::DeclTypeSpec::Character) {
-                    // The ambiguous S(j:k) was parsed as an array section
-                    // reference, but it's now clear that it's a substring.
-                    // Fix the parse tree in situ.
-                    mutate.u = arrElement.ConvertToSubstring();
-                  }
+              if (const semantics::DeclTypeSpec *type{ultimate.GetType()}) {
+                if (!ultimate.IsObjectArray() &&
+                    type->category() == semantics::DeclTypeSpec::Character) {
+                  // The ambiguous S(j:k) was parsed as an array section
+                  // reference, but it's now clear that it's a substring.
+                  // Fix the parse tree in situ.
+                  mutate.u = arrElement.ConvertToSubstring();
                 }
               }
             }

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -297,6 +297,7 @@ class ExprChecker : public virtual BaseChecker {
 public:
   explicit ExprChecker(SemanticsContext &context) : context_{context} {}
   void Enter(const parser::Expr &);
+  void Enter(const parser::Variable &);
 
 private:
   SemanticsContext &context_;

--- a/lib/semantics/rewrite-parse-tree.cc
+++ b/lib/semantics/rewrite-parse-tree.cc
@@ -37,8 +37,6 @@ public:
   void Post(parser::Name &);
   void Post(parser::SpecificationPart &);
   bool Pre(parser::ExecutionPart &);
-  void Post(parser::Variable &x) { ConvertFunctionRef(x); }
-  void Post(parser::Expr &x) { ConvertFunctionRef(x); }
 
   // Name resolution yet implemented:
   bool Pre(parser::EquivalenceStmt &) { return false; }
@@ -62,24 +60,6 @@ private:
   bool errorOnUnresolvedName_{true};
   parser::Messages &messages_;
   std::list<stmtFuncType> stmtFuncsToConvert_;
-
-  // For T = Variable or Expr, if x has a function reference that really
-  // should be an array element reference (i.e. the name occurs in an
-  // entity declaration, convert it.
-  template<typename T> void ConvertFunctionRef(T &x) {
-    auto *funcRef{
-        std::get_if<common::Indirection<parser::FunctionReference>>(&x.u)};
-    if (!funcRef) {
-      return;
-    }
-    parser::Name *name{std::get_if<parser::Name>(
-        &std::get<parser::ProcedureDesignator>(funcRef->value().v.t).u)};
-    if (!name || !name->symbol ||
-        !name->symbol->GetUltimate().has<ObjectEntityDetails>()) {
-      return;
-    }
-    x.u = common::Indirection{funcRef->value().ConvertToArrayElementRef()};
-  }
 };
 
 // Check that name has been resolved to a symbol

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -175,8 +175,8 @@ public:
   const Scope *FindScope(const parser::CharBlock &) const;
 
   // Attempts to find a match for a derived type instance
-  const DeclTypeSpec *FindInstantiatedDerivedType(
-      const DerivedTypeSpec &, DeclTypeSpec::Category) const;
+  const DeclTypeSpec *FindInstantiatedDerivedType(const DerivedTypeSpec &,
+      DeclTypeSpec::Category = DeclTypeSpec::TypeDerived) const;
 
   // Returns a matching derived type instance if one exists, otherwise
   // creates one

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -75,6 +75,7 @@ set(ERROR_TESTS
   structconst01.f90
   structconst02.f90
   structconst03.f90
+  structconst04.f90
   assign01.f90
 )
 

--- a/test/semantics/structconst04.f90
+++ b/test/semantics/structconst04.f90
@@ -14,8 +14,7 @@
 
 ! Error tests for structure constructors: C1594 violations
 ! from assigning globally-visible data to POINTER components.
-! test/semantics/structconst04.f90 is this same test without type
-! parameters.
+! This test is structconst03.f90 with the type parameters removed.
 
 module usefrom
   real :: usedfrom1
@@ -35,25 +34,21 @@ module module1
   type, extends(has_pointer2) :: has_pointer3
     type(has_pointer3), allocatable :: link3
   end type has_pointer3
-  type :: t1(k)
-    integer, kind :: k
+  type :: t1
     real, pointer :: pt1
-    type(t1(k)), allocatable :: link
+    type(t1), allocatable :: link
   end type t1
-  type :: t2(k)
-    integer, kind :: k
+  type :: t2
     type(has_pointer1) :: hp1
-    type(t2(k)), allocatable :: link
+    type(t2), allocatable :: link
   end type t2
-  type :: t3(k)
-    integer, kind :: k
+  type :: t3
     type(has_pointer2) :: hp2
-    type(t3(k)), allocatable :: link
+    type(t3), allocatable :: link
   end type t3
-  type :: t4(k)
-    integer, kind :: k
+  type :: t4
     type(has_pointer3) :: hp3
-    type(t4(k)), allocatable :: link
+    type(t4), allocatable :: link
   end type t4
   real :: modulevar1
   type(has_pointer1) :: modulevar2
@@ -64,10 +59,10 @@ module module1
 
   pure real function pf1(dummy1, dummy2, dummy3, dummy4)
     real :: local1
-    type(t1(0)) :: x1
-    type(t2(0)) :: x2
-    type(t3(0)) :: x3
-    type(t4(0)) :: x4
+    type(t1) :: x1
+    type(t2) :: x2
+    type(t3) :: x3
+    type(t4) :: x4
     real, intent(in) :: dummy1
     real, intent(inout) :: dummy2
     real, pointer :: dummy3
@@ -75,74 +70,74 @@ module module1
     real :: commonvar1
     common /cblock/ commonvar1
     pf1 = 0.
-    x1 = t1(0)(local1)
+    x1 = t1(local1)
     !ERROR: Externally visible object 'usedfrom1' must not be associated with pointer component 'pt1' in a PURE function
-    x1 = t1(0)(usedfrom1)
+    x1 = t1(usedfrom1)
     !ERROR: Externally visible object 'modulevar1' must not be associated with pointer component 'pt1' in a PURE function
-    x1 = t1(0)(modulevar1)
+    x1 = t1(modulevar1)
     !ERROR: Externally visible object 'cblock' must not be associated with pointer component 'pt1' in a PURE function
-    x1 = t1(0)(commonvar1)
+    x1 = t1(commonvar1)
     !ERROR: Externally visible object 'dummy1' must not be associated with pointer component 'pt1' in a PURE function
-    x1 = t1(0)(dummy1)
-    x1 = t1(0)(dummy2)
+    x1 = t1(dummy1)
+    x1 = t1(dummy2)
     !ERROR: Externally visible object 'dummy3' must not be associated with pointer component 'pt1' in a PURE function
-    x1 = t1(0)(dummy3)
+    x1 = t1(dummy3)
 ! TODO when semantics handles coindexing:
 ! TODO !ERROR: Externally visible object must not be associated with a pointer in a PURE function
-! TODO x1 = t1(0)(dummy4[0])
-    x1 = t1(0)(dummy4)
+! TODO x1 = t1(dummy4[0])
+    x1 = t1(dummy4)
     !ERROR: Externally visible object 'modulevar2' must not be associated with pointer component 'ptop' in a PURE function
-    x2 = t2(0)(modulevar2)
+    x2 = t2(modulevar2)
     !ERROR: Externally visible object 'modulevar3' must not be associated with pointer component 'ptop' in a PURE function
-    x3 = t3(0)(modulevar3)
+    x3 = t3(modulevar3)
     !ERROR: Externally visible object 'modulevar4' must not be associated with pointer component 'ptop' in a PURE function
-    x4 = t4(0)(modulevar4)
+    x4 = t4(modulevar4)
    contains
     subroutine subr(dummy1a, dummy2a, dummy3a, dummy4a)
       real :: local1a
-      type(t1(0)) :: x1a
-      type(t2(0)) :: x2a
-      type(t3(0)) :: x3a
-      type(t4(0)) :: x4a
+      type(t1) :: x1a
+      type(t2) :: x2a
+      type(t3) :: x3a
+      type(t4) :: x4a
       real, intent(in) :: dummy1a
       real, intent(inout) :: dummy2a
       real, pointer :: dummy3a
       real, intent(inout) :: dummy4a[*]
-      x1a = t1(0)(local1a)
+      x1a = t1(local1a)
       !ERROR: Externally visible object 'usedfrom1' must not be associated with pointer component 'pt1' in a PURE function
-      x1a = t1(0)(usedfrom1)
+      x1a = t1(usedfrom1)
       !ERROR: Externally visible object 'modulevar1' must not be associated with pointer component 'pt1' in a PURE function
-      x1a = t1(0)(modulevar1)
+      x1a = t1(modulevar1)
       !ERROR: Externally visible object 'cblock' must not be associated with pointer component 'pt1' in a PURE function
-      x1a = t1(0)(commonvar1)
+      x1a = t1(commonvar1)
       !ERROR: Externally visible object 'dummy1' must not be associated with pointer component 'pt1' in a PURE function
-      x1a = t1(0)(dummy1)
+      x1a = t1(dummy1)
       !ERROR: Externally visible object 'dummy1a' must not be associated with pointer component 'pt1' in a PURE function
-      x1a = t1(0)(dummy1a)
-      x1a = t1(0)(dummy2a)
+      x1a = t1(dummy1a)
+      x1a = t1(dummy2a)
       !ERROR: Externally visible object 'dummy3' must not be associated with pointer component 'pt1' in a PURE function
-      x1a = t1(0)(dummy3)
+      x1a = t1(dummy3)
       !ERROR: Externally visible object 'dummy3a' must not be associated with pointer component 'pt1' in a PURE function
-      x1a = t1(0)(dummy3a)
+      x1a = t1(dummy3a)
 ! TODO when semantics handles coindexing:
 ! TODO !ERROR: Externally visible object must not be associated with a pointer in a PURE function
-! TODO x1a = t1(0)(dummy4a[0])
-      x1a = t1(0)(dummy4a)
+! TODO x1a = t1(dummy4a[0])
+      x1a = t1(dummy4a)
       !ERROR: Externally visible object 'modulevar2' must not be associated with pointer component 'ptop' in a PURE function
-      x2a = t2(0)(modulevar2)
+      x2a = t2(modulevar2)
       !ERROR: Externally visible object 'modulevar3' must not be associated with pointer component 'ptop' in a PURE function
-      x3a = t3(0)(modulevar3)
+      x3a = t3(modulevar3)
       !ERROR: Externally visible object 'modulevar4' must not be associated with pointer component 'ptop' in a PURE function
-      x4a = t4(0)(modulevar4)
+      x4a = t4(modulevar4)
     end subroutine subr
   end function pf1
 
   impure real function ipf1(dummy1, dummy2, dummy3, dummy4)
     real :: local1
-    type(t1(0)) :: x1
-    type(t2(0)) :: x2
-    type(t3(0)) :: x3
-    type(t4(0)) :: x4
+    type(t1) :: x1
+    type(t2) :: x2
+    type(t3) :: x3
+    type(t4) :: x4
     real, intent(in) :: dummy1
     real, intent(inout) :: dummy2
     real, pointer :: dummy3
@@ -150,18 +145,18 @@ module module1
     real :: commonvar1
     common /cblock/ commonvar1
     ipf1 = 0.
-    x1 = t1(0)(local1)
-    x1 = t1(0)(usedfrom1)
-    x1 = t1(0)(modulevar1)
-    x1 = t1(0)(commonvar1)
-    x1 = t1(0)(dummy1)
-    x1 = t1(0)(dummy2)
-    x1 = t1(0)(dummy3)
+    x1 = t1(local1)
+    x1 = t1(usedfrom1)
+    x1 = t1(modulevar1)
+    x1 = t1(commonvar1)
+    x1 = t1(dummy1)
+    x1 = t1(dummy2)
+    x1 = t1(dummy3)
 ! TODO when semantics handles coindexing:
-! TODO x1 = t1(0)(dummy4[0])
-    x1 = t1(0)(dummy4)
-    x2 = t2(0)(modulevar2)
-    x3 = t3(0)(modulevar3)
-    x4 = t4(0)(modulevar4)
+! TODO x1 = t1(dummy4[0])
+    x1 = t1(dummy4)
+    x2 = t2(modulevar2)
+    x3 = t3(modulevar3)
+    x4 = t4(modulevar4)
   end function ipf1
 end module module1


### PR DESCRIPTION
The ambiguous `A(1,2)` might be a function call, array element, or structure constructor.  The parser will parse it as a function call.  This patch adds code to expression semantics to detect when it should be replaced (prior to semantic analysis).  The replacement takes place in the parse tree so that any tools can benefit from a corrected parse.

Prior to this change, the only way I could test structure constructors was to force their parses through the use of no-op type parameters (e.g., `T(0)(1, 2)`).  Now that "bare" structure constructors can be parsed as such, they're tested by a new test that copies an earlier one and removes the no-op type parameters.

While I'm at it, replace the code that fixed a misparsed `A(1:2)` array section when it's meant to be a substring; similarly, the corrected parse is left in the parse tree.
