### PR TITLE
Silence clang warning related to ISO_Fortran_binding.h usage in C++

### DIFF
--- a/include/flang/ISO_Fortran_binding.h
+++ b/include/flang/ISO_Fortran_binding.h
@@ -28,8 +28,6 @@
 namespace Fortran {
 namespace ISO {
 inline namespace Fortran_2018 {
-#else
-#define CFI_ISO_FORTRAN_BINDING_FLEXIBLE_ARRAY
 #endif
 
 /* 18.5.4 */

--- a/include/flang/ISO_Fortran_binding.h
+++ b/include/flang/ISO_Fortran_binding.h
@@ -108,16 +108,18 @@ typedef struct CFI_dim_t {
 } CFI_dim_t;
 
 #ifdef __cplusplus
+namespace cfi_internal {
 // C++ does not support flexible array.
-// The below structure emulate a flexible array. This structure does not take
+// The below structure emulates a flexible array. This structure does not take
 // care of getting the memory storage. Note that it already contains one element
 // because a struct cannot be empty.
-struct CFI_dim_t_cpp_flexible_array : CFI_dim_t {
-  CFI_dim_t &operator[](int index) { return *(this + index); }
-  const CFI_dim_t &operator[](int index) const { return *(this + index); }
-  operator CFI_dim_t *() { return this; }
-  operator const CFI_dim_t *() const { return this; }
+template<typename T> struct FlexibleArray : T {
+  T &operator[](int index) { return *(this + index); }
+  const T &operator[](int index) const { return *(this + index); }
+  operator T *() { return this; }
+  operator const T *() const { return this; }
 };
+}
 #endif
 
 /* 18.5.3 generic data descriptor */
@@ -131,7 +133,7 @@ typedef struct CFI_cdesc_t {
   CFI_attribute_t attribute;
   unsigned char f18Addendum;
 #ifdef __cplusplus
-  CFI_dim_t_cpp_flexible_array dim;
+  cfi_internal::FlexibleArray<CFI_dim_t> dim;
 #else
   CFI_dim_t dim[]; /* must appear last */
 #endif


### PR DESCRIPTION
This PR silences warnings that clang was emitting while compiling  `test/evaluate/ISO-Fortran-binding.cc`.
The warnings were of the form: "array index xx is past the end of the array".
This came from access to elements of the dim array member of `CFI_cdesc_t` struct.

The issue is that `CFI_cdesc_t` last member must be a flexible array according to the Fortran standard, but this is not possible in C++. The standard does not mandate that ISO_Fortran_binding.h should work in C++, but F18 ISO_Fortran_binding.h is trying to be C++ compatible on top of C.
The solution so far was to have a one element array `dim` in C++ at the end of the `CFI_cdesc_t` struct and to over-allocate space for `CFI_cdesc_t` to get a bigger array in practice.
However, clang++ does not like this because it is doing array bound checking when it can and complains every time the index to access the array is bigger than zero.
This PR fixes this by replacing, for C++ only, the array by a struct that defines `[]` operators and array conversions using pointer arithmetic. This was suggested in [a comment in the previous PR](https://github.com/flang-compiler/f18/pull/222#discussion_r231662013). This prevent C++ compilers from doing any kind of static array bound checking which are meaningless in case of CFI_cdesc_t.


