### PR TITLE
Emergency temporary patch to fix build

### DIFF
--- a/tools/f18/CMakeLists.txt
+++ b/tools/f18/CMakeLists.txt
@@ -21,6 +21,6 @@ target_link_libraries(f18
   FortranParser
   FortranEvaluate
   FortranSemantics
-  FortranFIR
-  ${LLVM_COMMON_LIBS}
+#  FortranFIR
+#  ${LLVM_COMMON_LIBS}
 )

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -14,8 +14,10 @@
 
 // Temporary Fortran front end driver main program for development scaffolding.
 
+#ifdef FIR
 #include "../../lib/FIR/afforestation.h"
 #include "../../lib/FIR/graph-writer.h"
+#endif
 #include "../../lib/common/default-kinds.h"
 #include "../../lib/parser/characters.h"
 #include "../../lib/parser/features.h"
@@ -238,9 +240,11 @@ std::string CompileFortran(std::string path, Fortran::parser::Options options,
     }
   }
   if (driver.dumpGraph) {
+#ifdef FIR
     auto *fir{Fortran::FIR::CreateFortranIR(parseTree,
         semanticsContext, driver.debugLinearFIR)};
     Fortran::FIR::GraphWriter::print(*fir);
+#endif
     return {};
   }
   if (driver.dumpParseTree) {


### PR DESCRIPTION
Tweak f18.cc build to not link to LLVM libraries until we figure out a new build/test environment so that other work can make progress.  Specifically, FIR still gets built but it isn't linked into the throwaway f18 driver.  This patch restores buildability with the previous gcc and clang configuations that we use in-house.