### PR TITLE
Add cmake option to link with FIR and LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@
 
 cmake_minimum_required(VERSION 3.9.0)
 
+option(LINK_WITH_FIR "Link driver with FIR and LLVM" OFF)
+
 # Pass -DGCC=... to cmake to use a specific gcc installation.
 if( GCC )
   set(CMAKE_CXX_COMPILER "${GCC}/bin/g++")
@@ -49,7 +51,7 @@ endif()
 message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}" )
 
 find_package(LLVM REQUIRED CONFIG)
-message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION} in ${LLVM_INSTALL_PREFIX}")
+message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION} in ${LLVM_DIR}")
 
 # Get names for the LLVM libraries
 #
@@ -70,8 +72,11 @@ message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION} in ${LLVM_INSTALL_PREFIX}")
 include_directories(${LLVM_INCLUDE_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 
-llvm_map_components_to_libnames(LLVM_COMMON_LIBS support)
-message(STATUS "LLVM libraries: ${LLVM_COMMON_LIBS}")
+if(LINK_WITH_FIR)
+  message(STATUS "Linking driver with FIR and LLVM")
+  llvm_map_components_to_libnames(LLVM_COMMON_LIBS support)
+  message(STATUS "LLVM libraries: ${LLVM_COMMON_LIBS}")
+endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/tools/f18/CMakeLists.txt
+++ b/tools/f18/CMakeLists.txt
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if(LINK_WITH_FIR)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DLINK_WITH_FIR")
+  set(FORTRAN_FIR_LIB "FortranFIR")
+endif()
+
 add_executable(f18
   f18.cc
   dump.cc
@@ -21,6 +26,6 @@ target_link_libraries(f18
   FortranParser
   FortranEvaluate
   FortranSemantics
-#  FortranFIR
-#  ${LLVM_COMMON_LIBS}
+  ${FORTRAN_FIR_LIB}
+  ${LLVM_COMMON_LIBS}
 )

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -14,7 +14,7 @@
 
 // Temporary Fortran front end driver main program for development scaffolding.
 
-#ifdef FIR
+#ifdef LINK_WITH_FIR
 #include "../../lib/FIR/afforestation.h"
 #include "../../lib/FIR/graph-writer.h"
 #endif
@@ -240,9 +240,9 @@ std::string CompileFortran(std::string path, Fortran::parser::Options options,
     }
   }
   if (driver.dumpGraph) {
-#ifdef FIR
-    auto *fir{Fortran::FIR::CreateFortranIR(parseTree,
-        semanticsContext, driver.debugLinearFIR)};
+#ifdef LINK_WITH_FIR
+    auto *fir{Fortran::FIR::CreateFortranIR(
+        parseTree, semanticsContext, driver.debugLinearFIR)};
     Fortran::FIR::GraphWriter::print(*fir);
 #endif
     return {};


### PR DESCRIPTION
The cmake option -DLINK_WITH_FIR=ON causes the f18 driver to be linked
against FIR and LLVM. When it is set to OFF (the default), the call into
FIR is #ifdef'd out.

The source in lib/FIR is always built; this option only affects linking.