### PR TITLE
Fixes and extensions to get WRF to parse

### DIFF
--- a/documentation/Extensions.md
+++ b/documentation/Extensions.md
@@ -56,6 +56,8 @@ Extensions, deletions, and legacy features supported by default
 * Character literals as elements of an array constructor without an explicit
   type specifier need not have the same length; the longest literal determines
   the length parameter of the implicit type, not the first.
+* Outside a character literal, a comment after a continuation marker (&)
+  need not begin with a comment marker (!).
 
 Extensions supported when enabled by options
 --------------------------------------------

--- a/lib/parser/features.h
+++ b/lib/parser/features.h
@@ -29,7 +29,8 @@ ENUM_CLASS(LanguageFeature, BackslashEscapes, OldDebugLines,
     OldStyleParameter, ComplexConstructor, PercentLOC, SignedPrimary, FileName,
     Convert, Dispose, IOListLeadingComma, AbbreviatedEditDescriptor,
     ProgramParentheses, PercentRefAndVal, OmitFunctionDummies, CrayPointer,
-    Hollerith, ArithmeticIF, Assign, AssignedGOTO, Pause, OpenMP)
+    Hollerith, ArithmeticIF, Assign, AssignedGOTO, Pause, OpenMP,
+    CruftAfterAmpersand)
 
 using LanguageFeatures =
     common::EnumSet<LanguageFeature, LanguageFeature_enumSize>;

--- a/lib/parser/grammar.h
+++ b/lib/parser/grammar.h
@@ -3396,16 +3396,16 @@ TYPE_CONTEXT_PARSER("statement function definition"_en_US,
         name, parenthesized(optionalList(name)), "=" >> scalar(expr)))
 
 // Directives, extensions, and deprecated statements
-// !DIR$ IVDEP
 // !DIR$ IGNORE_TKR [ [(tkr...)] name ]...
+// !DIR$ name...
 constexpr auto beginDirective{skipStuffBeforeStatement >> "!"_ch};
 constexpr auto endDirective{space >> endOfLine};
-constexpr auto ivdep{construct<CompilerDirective::IVDEP>("DIR$ IVDEP"_tok)};
 constexpr auto ignore_tkr{
     "DIR$ IGNORE_TKR" >> optionalList(construct<CompilerDirective::IgnoreTKR>(
                              defaulted(parenthesized(some("tkr"_ch))), name))};
-TYPE_PARSER(beginDirective >> sourced(construct<CompilerDirective>(ivdep) ||
-                                  construct<CompilerDirective>(ignore_tkr)) /
+TYPE_PARSER(
+    beginDirective >> sourced(construct<CompilerDirective>(ignore_tkr) ||
+                          construct<CompilerDirective>("DIR$" >> many(name))) /
         endDirective)
 
 TYPE_PARSER(extension<LanguageFeature::CrayPointer>(

--- a/lib/parser/grammar.h
+++ b/lib/parser/grammar.h
@@ -3092,7 +3092,8 @@ TYPE_PARSER(construct<UseStmt>("USE" >> optionalBeforeColons(moduleNature),
                 name, ", ONLY :" >> optionalList(Parser<Only>{})) ||
     construct<UseStmt>("USE" >> optionalBeforeColons(moduleNature), name,
         defaulted("," >>
-            nonemptyList("expected renamings"_err_en_US, Parser<Rename>{}))))
+            nonemptyList("expected renamings"_err_en_US, Parser<Rename>{})) /
+            lookAhead(endOfStmt)))
 
 // R1411 rename ->
 //         local-name => use-name |

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -3154,17 +3154,16 @@ struct StmtFunctionStmt {
 };
 
 // Compiler directives
-// !DIR$ IVDEP
 // !DIR$ IGNORE_TKR [ [(tkr...)] name ]...
+// !DIR$ name...
 struct CompilerDirective {
   UNION_CLASS_BOILERPLATE(CompilerDirective);
   struct IgnoreTKR {
     TUPLE_CLASS_BOILERPLATE(IgnoreTKR);
     std::tuple<std::list<const char *>, Name> t;
   };
-  EMPTY_CLASS(IVDEP);
   CharBlock source;
-  std::variant<std::list<IgnoreTKR>, IVDEP> u;
+  std::variant<std::list<IgnoreTKR>, std::list<Name>> u;
 };
 
 // Legacy extensions

--- a/lib/parser/prescan.cc
+++ b/lib/parser/prescan.cc
@@ -853,8 +853,9 @@ bool Prescanner::FreeFormContinuation() {
   if (*p != '\n') {
     if (inCharLiteral_) {
       return false;
-    } else if (*p != '!') {
-      Say(GetProvenance(p), "treated as comment after &"_en_US);
+    } else if (*p != '!' &&
+        features_.ShouldWarn(LanguageFeature::CruftAfterAmpersand)) {
+      Say(GetProvenance(p), "missing ! before comment after &"_en_US);
     }
   }
   do {

--- a/lib/parser/prescan.h
+++ b/lib/parser/prescan.h
@@ -82,8 +82,9 @@ private:
     enum class Kind {
       Comment,
       ConditionalCompilationDirective,
+      IncludeDirective,  // #include
       PreprocessorDirective,
-      Include,
+      IncludeLine,  // Fortran INCLUDE
       CompilerDirective,
       Source
     };
@@ -149,7 +150,7 @@ private:
   void QuotedCharacterLiteral(TokenSequence &);
   void Hollerith(TokenSequence &, int count, const char *start);
   bool PadOutCharacterLiteral(TokenSequence &);
-  bool SkipCommentLine();
+  bool SkipCommentLine(bool afterAmpersand);
   bool IsFixedFormCommentLine(const char *) const;
   bool IsFreeFormComment(const char *) const;
   std::optional<std::size_t> IsIncludeLine(const char *) const;
@@ -197,6 +198,13 @@ private:
   // is necessary to treat the line break as a space character by
   // setting this flag, which is cleared by EmitChar().
   bool insertASpace_{false};
+
+  // When a free form continuation marker (&) appears at the end of a line
+  // before a INCLUDE or #include, we delete it and omit the newline, so
+  // that the first line of the included file is truly a continuation of
+  // the line before.  Also used when the & appears at the end of the last
+  // line in an include file.
+  bool omitNewline_{false};
 
   const Provenance spaceProvenance_{
       cooked_.allSources().CompilerInsertionProvenance(' ')};

--- a/lib/parser/prescan.h
+++ b/lib/parser/prescan.h
@@ -205,6 +205,7 @@ private:
   // the line before.  Also used when the & appears at the end of the last
   // line in an include file.
   bool omitNewline_{false};
+  bool skipLeadingAmpersand_{false};
 
   const Provenance spaceProvenance_{
       cooked_.allSources().CompilerInsertionProvenance(' ')};

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -1746,10 +1746,10 @@ public:
     std::visit(
         common::visitors{
             [&](const std::list<CompilerDirective::IgnoreTKR> &tkr) {
-              Word("!DIR$ IGNORE_TKR");
+              Word("!DIR$ IGNORE_TKR");  // emitted even if tkr list is empty
               Walk(" ", tkr, ", ");
             },
-            [&](const CompilerDirective::IVDEP &) { Word("!DIR$ IVDEP\n"); },
+            [&](const std::list<Name> &names) { Walk("!DIR$ ", names, " "); },
         },
         x.u);
     Put('\n');

--- a/lib/semantics/dump-parse-tree.h
+++ b/lib/semantics/dump-parse-tree.h
@@ -139,7 +139,6 @@ public:
   NODE(parser, CommonStmt)
   NODE(parser::CommonStmt, Block)
   NODE(parser, CompilerDirective)
-  NODE(parser::CompilerDirective, IVDEP)
   NODE(parser::CompilerDirective, IgnoreTKR)
   NODE(parser, ComplexLiteralConstant)
   NODE(parser, ComplexPart)

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -190,6 +190,7 @@ std::string CompileFortran(std::string path, Fortran::parser::Options options,
     return {};
   }
   if (driver.dumpCookedChars) {
+    parsing.messages().Emit(std::cerr, parsing.cooked());
     parsing.DumpCookedChars(std::cout);
     return {};
   }
@@ -219,8 +220,8 @@ std::string CompileFortran(std::string path, Fortran::parser::Options options,
   }
   // TODO: Change this predicate to just "if (!driver.debugNoSemantics)"
   if (driver.debugSemantics || driver.debugResolveNames || driver.dumpSymbols ||
-      driver.dumpUnparseWithSymbols ||
-      driver.debugLinearFIR || driver.dumpGraph) {
+      driver.dumpUnparseWithSymbols || driver.debugLinearFIR ||
+      driver.dumpGraph) {
     Fortran::semantics::Semantics semantics{
         semanticsContext, parseTree, parsing.cooked()};
     semantics.Perform();


### PR DESCRIPTION
The SPEC CPU kit 96 version of WRF now parses with f18.  Fixed a preprocessing expression evaluation bug, resolved an ambiguous parse, and now support the use of `#include` after `&` to include a file in the middle of a statement.  Also allow `& comment...` without `!` as a warnable nonstandard usage.