### PR TITLE
Some tweaks to preprocess & parse all Fortran in SPEC CPUv6

### DIFF
--- a/documentation/Extensions.md
+++ b/documentation/Extensions.md
@@ -58,6 +58,8 @@ Extensions, deletions, and legacy features supported by default
   the length parameter of the implicit type, not the first.
 * Outside a character literal, a comment after a continuation marker (&)
   need not begin with a comment marker (!).
+* Classic C-style /*comments*/ are skipped, so multi-language header
+  files are easier to write and use.
 
 Extensions supported when enabled by options
 --------------------------------------------

--- a/lib/parser/features.h
+++ b/lib/parser/features.h
@@ -30,7 +30,7 @@ ENUM_CLASS(LanguageFeature, BackslashEscapes, OldDebugLines,
     Convert, Dispose, IOListLeadingComma, AbbreviatedEditDescriptor,
     ProgramParentheses, PercentRefAndVal, OmitFunctionDummies, CrayPointer,
     Hollerith, ArithmeticIF, Assign, AssignedGOTO, Pause, OpenMP,
-    CruftAfterAmpersand)
+    CruftAfterAmpersand, ClassicCComments)
 
 using LanguageFeatures =
     common::EnumSet<LanguageFeature, LanguageFeature_enumSize>;

--- a/lib/parser/preprocessor.cc
+++ b/lib/parser/preprocessor.cc
@@ -461,11 +461,9 @@ void Preprocessor::Directive(const TokenSequence &dir, Prescanner *prescanner) {
   } else if (dirName == "ifdef" || dirName == "ifndef") {
     bool doThen{false};
     if (nameToken.empty()) {
-      // Warning, not error, in PGI.
-      // This misusage appears in WRF & other SPEC codes (might be a local mod).
       prescanner->Say(
           dir.GetIntervalProvenanceRange(dirOffset, tokens - dirOffset),
-          "#%s: missing name"_en_US, dirName.data());
+          "#%s: missing name"_err_en_US, dirName.data());
     } else {
       j = dir.SkipBlanks(j + 1);
       if (j != tokens) {

--- a/lib/parser/prescan.h
+++ b/lib/parser/prescan.h
@@ -140,11 +140,21 @@ private:
     return inFixedForm_ && !inPreprocessorDirective_ && !InCompilerDirective();
   }
 
+  bool IsCComment(const char *p) const {
+    return p[0] == '/' && p[1] == '*' &&
+        (inPreprocessorDirective_ ||
+            (!inCharLiteral_ &&
+                features_.IsEnabled(LanguageFeature::ClassicCComments)));
+  }
+
   void LabelField(TokenSequence &, int outCol = 1);
   void SkipToEndOfLine();
   void NextChar();
+  void SkipCComments();
   void SkipSpaces();
   static const char *SkipWhiteSpace(const char *);
+  const char *SkipWhiteSpaceAndCComments(const char *) const;
+  const char *SkipCComment(const char *) const;
   bool NextToken(TokenSequence &);
   bool ExponentAndKind(TokenSequence &);
   void QuotedCharacterLiteral(TokenSequence &);
@@ -152,7 +162,7 @@ private:
   bool PadOutCharacterLiteral(TokenSequence &);
   bool SkipCommentLine(bool afterAmpersand);
   bool IsFixedFormCommentLine(const char *) const;
-  bool IsFreeFormComment(const char *) const;
+  const char *IsFreeFormComment(const char *) const;
   std::optional<std::size_t> IsIncludeLine(const char *) const;
   void FortranInclude(const char *quote);
   const char *IsPreprocessorDirectiveLine(const char *) const;

--- a/tools/f18/CMakeLists.txt
+++ b/tools/f18/CMakeLists.txt
@@ -32,9 +32,9 @@ target_link_libraries(f18
 
 add_executable(f18-parse-demo
   f18-parse-demo.cc
+  stub-evaluate.cc
 )
 
 target_link_libraries(f18-parse-demo
   FortranParser
-  FortranEvaluate
 )

--- a/tools/f18/f18-parse-demo.cc
+++ b/tools/f18/f18-parse-demo.cc
@@ -70,7 +70,8 @@ void CleanUpAtExit() {
   }
 }
 
-#if _POSIX_C_SOURCE >= 199309L && defined CLOCK_PROCESS_CPUTIME_ID
+#if _POSIX_C_SOURCE >= 199309L && _POSIX_TIMERS > 0 && _POSIX_CPUTIME && \
+    defined CLOCK_PROCESS_CPUTIME_ID
 static constexpr bool canTime{true};
 double CPUseconds() {
   struct timespec tspec;

--- a/tools/f18/stub-evaluate.cc
+++ b/tools/f18/stub-evaluate.cc
@@ -1,0 +1,27 @@
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The parse tree has slots in which pointers to typed expressions may be
+// placed.  When using the parser without the expression library, as here,
+// we need to stub out the dependence.
+
+#include "../../lib/common/indirection.h"
+
+namespace Fortran::evaluate {
+struct GenericExprWrapper {
+  bool operator==(const GenericExprWrapper &) const { return false; }
+};
+}
+
+DEFINE_OWNING_DESTRUCTOR(OwningPointer, evaluate::GenericExprWrapper)


### PR DESCRIPTION
1.55M lines of fixed and free-form Fortran run through `f18-parse-demo -fparse-only` in less than a minute.

The one significant change is coping with classic C-style `/* comments */`, which appear in some header files.  They're unambiguous, and easy to recognize and skip, so that seems like the right thing to do.

Also resolves some review comments from yesterday's PR and fixes a build bug in really old Linux systems without `clock_gettime`.