### PR TITLE
Fix parse of .TRUE._8

### DIFF
--- a/lib/parser/token-parsers.h
+++ b/lib/parser/token-parsers.h
@@ -704,10 +704,22 @@ constexpr auto rawName{nonDigitIdChar >> many(nonDigitIdChar || digit)};
 TYPE_PARSER(space >> sourced(rawName >> construct<Name>()))
 constexpr auto keyword{construct<Keyword>(name)};
 
+constexpr auto logicalTRUE{
+    (".TRUE."_tok ||
+        extension<LanguageFeature::LogicalAbbreviations>(".T."_tok)) >>
+    pure(true)};
+constexpr auto logicalFALSE{
+    (".FALSE."_tok ||
+        extension<LanguageFeature::LogicalAbbreviations>(".F."_tok)) >>
+    pure(false)};
+
 // R1003 defined-unary-op -> . letter [letter]... .
 // R1023 defined-binary-op -> . letter [letter]... .
 // R1414 local-defined-operator -> defined-unary-op | defined-binary-op
 // R1415 use-defined-operator -> defined-unary-op | defined-binary-op
+// C1003 A defined operator must be distinct from logical literal constants
+// and intrinsic operator names; this is handled by attempting their parses
+// first, and by name resolution on their definitions, for best errors.
 // N.B. The name of the operator is captured without the periods around it.
 constexpr auto definedOpNameChar{
     letter || extension<LanguageFeature::PunctuationInNames>("$@"_ch)};

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -279,7 +279,7 @@ MaybeExpr ExpressionAnalyzer::TopLevelChecks(DataRef &&dataRef) {
     if (componentRank > 0) {
       int baseRank{component->base().Rank()};
       if (baseRank > 0) {
-        Say("reference to whole rank-%d component '%%%s' of "
+        Say("Reference to whole rank-%d component '%%%s' of "
             "rank-%d array of derived type is not allowed"_err_en_US,
             componentRank, symbol.name().ToString().data(), baseRank);
       } else {


### PR DESCRIPTION
Since we allow leading underscores on names as an extension, the parser was misparsing `.TRUE._8` as the application of a user-defined operator named `.TRUE.` to an object named `_8`.  User-defined operators must be distinct from logical literal constants and intrinsic operators.  Resolve the problem by attempting parses of primaries before parses of unary user-defined operators in the grammar.