### PR TITLE
Name resolution for defined operators

### DIFF
--- a/lib/parser/grammar.h
+++ b/lib/parser/grammar.h
@@ -3187,8 +3187,8 @@ TYPE_PARSER(construct<ProcedureStmt>("MODULE PROCEDURE"_sptok >>
 // R1509 defined-io-generic-spec ->
 //         READ ( FORMATTED ) | READ ( UNFORMATTED ) |
 //         WRITE ( FORMATTED ) | WRITE ( UNFORMATTED )
-TYPE_PARSER(first(construct<GenericSpec>(
-                      "OPERATOR" >> parenthesized(Parser<DefinedOperator>{})),
+TYPE_PARSER(sourced(first(construct<GenericSpec>("OPERATOR" >>
+                              parenthesized(Parser<DefinedOperator>{})),
     construct<GenericSpec>(
         construct<GenericSpec::Assignment>("ASSIGNMENT ( = )"_tok)),
     construct<GenericSpec>(
@@ -3199,7 +3199,7 @@ TYPE_PARSER(first(construct<GenericSpec>(
         construct<GenericSpec::WriteFormatted>("WRITE ( FORMATTED )"_tok)),
     construct<GenericSpec>(
         construct<GenericSpec::WriteUnformatted>("WRITE ( UNFORMATTED )"_tok)),
-    construct<GenericSpec>(name)))
+    construct<GenericSpec>(name))))
 
 // R1510 generic-stmt ->
 //         GENERIC [, access-spec] :: generic-spec => specific-procedure-list

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -553,7 +553,7 @@ WRAPPER_CLASS(NamedConstant, Name);
 // R1023 defined-binary-op -> . letter [letter]... .
 // R1414 local-defined-operator -> defined-unary-op | defined-binary-op
 // R1415 use-defined-operator -> defined-unary-op | defined-binary-op
-// The Name here is stored without the dots; e.g., FOO, not .FOO.
+// The Name here is stored with the dots; e.g., .FOO.
 WRAPPER_CLASS(DefinedOpName, Name);
 
 // R608 intrinsic-operator ->
@@ -2881,6 +2881,7 @@ struct GenericSpec {
   EMPTY_CLASS(ReadUnformatted);
   EMPTY_CLASS(WriteFormatted);
   EMPTY_CLASS(WriteUnformatted);
+  CharBlock source;
   std::variant<Name, DefinedOperator, Assignment, ReadFormatted,
       ReadUnformatted, WriteFormatted, WriteUnformatted>
       u;

--- a/lib/parser/token-parsers.h
+++ b/lib/parser/token-parsers.h
@@ -720,12 +720,11 @@ constexpr auto logicalFALSE{
 // C1003 A defined operator must be distinct from logical literal constants
 // and intrinsic operator names; this is handled by attempting their parses
 // first, and by name resolution on their definitions, for best errors.
-// N.B. The name of the operator is captured without the periods around it.
+// N.B. The name of the operator is captured with the dots around it.
 constexpr auto definedOpNameChar{
     letter || extension<LanguageFeature::PunctuationInNames>("$@"_ch)};
-TYPE_PARSER(space >> "."_ch >>
-    construct<DefinedOpName>(
-        sourced(some(definedOpNameChar) >> construct<Name>())) /
-        "."_ch)
+TYPE_PARSER(
+    space >> construct<DefinedOpName>(sourced("."_ch >>
+                 some(definedOpNameChar) >> construct<Name>() / "."_ch)))
 }
 #endif  // FORTRAN_PARSER_TOKEN_PARSERS_H_

--- a/lib/semantics/CMakeLists.txt
+++ b/lib/semantics/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(FortranSemantics
   mod-file.cc
   resolve-labels.cc
   resolve-names.cc
+  resolve-names-utils.cc
   rewrite-parse-tree.cc
   scope.cc
   semantics.cc

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -277,8 +277,13 @@ void ModFileWriter::PutSubprogram(const Symbol &symbol) {
 void ModFileWriter::PutGeneric(const Symbol &symbol) {
   auto &details{symbol.get<GenericDetails>()};
   decls_ << "generic";
-  PutAttrs(decls_, symbol.attrs());
-  PutLower(decls_ << "::", symbol) << "=>";
+  PutAttrs(decls_, symbol.attrs()) << "::";
+  if (details.kind() == GenericKind::DefinedOp) {
+    PutLower(decls_ << "operator(", symbol) << ')';
+  } else {
+    PutLower(decls_, symbol);
+  }
+  decls_ << "=>";
   int n = 0;
   for (auto *specific : details.specificProcs()) {
     if (n++ > 0) decls_ << ',';

--- a/lib/semantics/resolve-names-utils.cc
+++ b/lib/semantics/resolve-names-utils.cc
@@ -1,0 +1,166 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "resolve-names-utils.h"
+#include "semantics.h"
+#include "symbol.h"
+#include "type.h"
+#include "../common/idioms.h"
+#include "../parser/char-block.h"
+#include "../parser/features.h"
+#include "../parser/parse-tree.h"
+#include <ostream>
+#include <variant>
+
+namespace Fortran::semantics {
+
+using IntrinsicOperator = parser::DefinedOperator::IntrinsicOperator;
+
+static GenericKind MapIntrinsicOperator(IntrinsicOperator);
+
+Symbol *Resolve(const parser::Name &name, Symbol *symbol) {
+  if (symbol && !name.symbol) {
+    name.symbol = symbol;
+  }
+  return symbol;
+}
+Symbol &Resolve(const parser::Name &name, Symbol &symbol) {
+  return *Resolve(name, &symbol);
+}
+
+parser::MessageFixedText WithIsFatal(
+    const parser::MessageFixedText &msg, bool isFatal) {
+  return parser::MessageFixedText{
+      msg.text().begin(), msg.text().size(), isFatal};
+}
+
+bool IsDefinedOperator(const SourceName &name) {
+  const char *begin{name.begin()};
+  const char *end{name.end()};
+  return begin != end && begin[0] == '.' && end[-1] == '.';
+}
+
+bool IsInstrinsicOperator(
+    const SemanticsContext &context, const SourceName &name) {
+  std::string str{name.ToString()};
+  std::set<std::string> intrinsics{".and.", ".eq.", ".eqv.", ".ge.", ".gt.",
+      ".le.", ".lt.", ".ne.", ".neqv.", ".not.", ".or."};
+  if (intrinsics.count(str) > 0) {
+    return true;
+  }
+  if (context.IsEnabled(parser::LanguageFeature::XOROperator) &&
+      str == ".xor.") {
+    return true;
+  }
+  if (context.IsEnabled(parser::LanguageFeature::LogicalAbbreviations) &&
+      (str == ".n." || str == ".a" || str == ".o." || str == ".x.")) {
+    return true;
+  }
+  return false;
+}
+
+bool IsLogicalConstant(
+    const SemanticsContext &context, const SourceName &name) {
+  std::string str{name.ToString()};
+  return str == ".true." || str == ".false." ||
+      (context.IsEnabled(parser::LanguageFeature::LogicalAbbreviations) &&
+          (str == ".t" || str == ".f."));
+}
+
+void GenericSpecInfo::Resolve(Symbol *symbol) {
+  if (symbol) {
+    if (auto *details{symbol->detailsIf<GenericDetails>()}) {
+      details->set_kind(kind_);
+    } else if (auto *details{symbol->detailsIf<GenericBindingDetails>()}) {
+      details->set_kind(kind_);
+    }
+    if (parseName_) {
+      semantics::Resolve(*parseName_, symbol);
+    }
+  }
+}
+
+void GenericSpecInfo::Analyze(const parser::DefinedOpName &name) {
+  kind_ = GenericKind::DefinedOp;
+  parseName_ = &name.v;
+  symbolName_ = &name.v.source;
+}
+
+void GenericSpecInfo::Analyze(const parser::GenericSpec &x) {
+  symbolName_ = &x.source;
+  kind_ = std::visit(
+      common::visitors{
+          [&](const parser::Name &y) {
+            parseName_ = &y;
+            symbolName_ = &y.source;
+            return GenericKind::Name;
+          },
+          [&](const parser::DefinedOperator &y) {
+            return std::visit(
+                common::visitors{
+                    [&](const parser::DefinedOpName &z) {
+                      Analyze(z);
+                      return GenericKind::DefinedOp;
+                    },
+                    [&](const IntrinsicOperator &z) {
+                      return MapIntrinsicOperator(z);
+                    },
+                },
+                y.u);
+          },
+          [&](const parser::GenericSpec::Assignment &y) {
+            return GenericKind::Assignment;
+          },
+          [&](const parser::GenericSpec::ReadFormatted &y) {
+            return GenericKind::ReadFormatted;
+          },
+          [&](const parser::GenericSpec::ReadUnformatted &y) {
+            return GenericKind::ReadUnformatted;
+          },
+          [&](const parser::GenericSpec::WriteFormatted &y) {
+            return GenericKind::WriteFormatted;
+          },
+          [&](const parser::GenericSpec::WriteUnformatted &y) {
+            return GenericKind::WriteUnformatted;
+          },
+      },
+      x.u);
+}
+
+// parser::DefinedOperator::IntrinsicOperator -> GenericKind
+static GenericKind MapIntrinsicOperator(IntrinsicOperator op) {
+  switch (op) {
+  case IntrinsicOperator::Power: return GenericKind::OpPower;
+  case IntrinsicOperator::Multiply: return GenericKind::OpMultiply;
+  case IntrinsicOperator::Divide: return GenericKind::OpDivide;
+  case IntrinsicOperator::Add: return GenericKind::OpAdd;
+  case IntrinsicOperator::Subtract: return GenericKind::OpSubtract;
+  case IntrinsicOperator::Concat: return GenericKind::OpConcat;
+  case IntrinsicOperator::LT: return GenericKind::OpLT;
+  case IntrinsicOperator::LE: return GenericKind::OpLE;
+  case IntrinsicOperator::EQ: return GenericKind::OpEQ;
+  case IntrinsicOperator::NE: return GenericKind::OpNE;
+  case IntrinsicOperator::GE: return GenericKind::OpGE;
+  case IntrinsicOperator::GT: return GenericKind::OpGT;
+  case IntrinsicOperator::NOT: return GenericKind::OpNOT;
+  case IntrinsicOperator::AND: return GenericKind::OpAND;
+  case IntrinsicOperator::OR: return GenericKind::OpOR;
+  case IntrinsicOperator::XOR: return GenericKind::OpXOR;
+  case IntrinsicOperator::EQV: return GenericKind::OpEQV;
+  case IntrinsicOperator::NEQV: return GenericKind::OpNEQV;
+  default: CRASH_NO_CASE;
+  }
+}
+
+}

--- a/lib/semantics/resolve-names-utils.h
+++ b/lib/semantics/resolve-names-utils.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_SEMANTICS_RESOLVE_NAMES_UTILS_H_
+#define FORTRAN_SEMANTICS_RESOLVE_NAMES_UTILS_H_
+
+// Utility functions and class for use in resolve-names.cc.
+
+#include "symbol.h"
+#include "../parser/message.h"
+
+namespace Fortran::parser {
+struct CharBlock;
+struct DefinedOpName;
+struct GenericSpec;
+struct Name;
+}
+
+namespace Fortran::semantics {
+
+using SourceName = parser::CharBlock;
+
+// Record that a Name has been resolved to a Symbol
+Symbol &Resolve(const parser::Name &, Symbol &);
+Symbol *Resolve(const parser::Name &, Symbol *);
+
+// Create a copy of msg with a new isFatal value.
+parser::MessageFixedText WithIsFatal(
+    const parser::MessageFixedText &msg, bool isFatal);
+
+// Is this the name of a defined operator, e.g. ".foo."
+bool IsDefinedOperator(const SourceName &);
+bool IsInstrinsicOperator(const SemanticsContext &, const SourceName &);
+bool IsLogicalConstant(const SemanticsContext &, const SourceName &);
+
+// Analyze a generic-spec and generate a symbol name and GenericKind for it.
+class GenericSpecInfo {
+public:
+  GenericSpecInfo(const parser::DefinedOpName &x) { Analyze(x); }
+  GenericSpecInfo(const parser::GenericSpec &x) { Analyze(x); }
+
+  const SourceName &symbolName() const { return *symbolName_; }
+  // Set the GenericKind in this symbol and resolve the corresponding
+  // name if there is one
+  void Resolve(Symbol *);
+
+private:
+  GenericKind kind_;
+  const parser::Name *parseName_{nullptr};
+  const SourceName *symbolName_{nullptr};
+
+  void Analyze(const parser::DefinedOpName &);
+  void Analyze(const parser::GenericSpec &);
+};
+
+}
+
+#endif  // FORTRAN_SEMANTICS_RESOLVE_NAMES_H_

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -63,12 +63,20 @@ using StatementSemanticsPass1 = SemanticsVisitor<ExprChecker>;
 using StatementSemanticsPass2 =
     SemanticsVisitor<AssignmentChecker, DoConcurrentChecker>;
 
-SemanticsContext::SemanticsContext(
-    const common::IntrinsicTypeDefaultKinds &defaultKinds)
-  : defaultKinds_{defaultKinds},
+SemanticsContext::SemanticsContext(const common::IntrinsicTypeDefaultKinds
+        &defaultKinds, const parser::LanguageFeatureControl &languageFeatures)
+  : defaultKinds_{defaultKinds}, languageFeatures_{languageFeatures},
     intrinsics_{evaluate::IntrinsicProcTable::Configure(defaultKinds)},
     foldingContext_{evaluate::FoldingContext{
         parser::ContextualMessages{parser::CharBlock{}, &messages_}}} {}
+
+bool SemanticsContext::IsEnabled(parser::LanguageFeature feature) const {
+  return languageFeatures_.IsEnabled(feature);
+}
+
+bool SemanticsContext::ShouldWarn(parser::LanguageFeature feature) const {
+  return languageFeatures_.ShouldWarn(feature);
+}
 
 const DeclTypeSpec &SemanticsContext::MakeNumericType(
     TypeCategory category, int kind) {

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -19,6 +19,7 @@
 #include "../evaluate/common.h"
 #include "../evaluate/intrinsics.h"
 #include "../parser/message.h"
+#include "../parser/features.h"
 #include <iosfwd>
 #include <string>
 #include <vector>
@@ -36,11 +37,14 @@ namespace Fortran::semantics {
 
 class SemanticsContext {
 public:
-  SemanticsContext(const common::IntrinsicTypeDefaultKinds &);
+  SemanticsContext(const common::IntrinsicTypeDefaultKinds &,
+      const parser::LanguageFeatureControl &);
 
   const common::IntrinsicTypeDefaultKinds &defaultKinds() const {
     return defaultKinds_;
   }
+  bool IsEnabled(parser::LanguageFeature) const;
+  bool ShouldWarn(parser::LanguageFeature) const;
   const parser::CharBlock *location() const { return location_; }
   const std::vector<std::string> &searchDirectories() const {
     return searchDirectories_;
@@ -86,6 +90,7 @@ public:
 
 private:
   const common::IntrinsicTypeDefaultKinds &defaultKinds_;
+  const parser::LanguageFeatureControl &languageFeatures_;
   const parser::CharBlock *location_{nullptr};
   std::vector<std::string> searchDirectories_;
   std::string moduleDirectory_{"."s};

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -394,6 +394,7 @@ std::ostream &operator<<(std::ostream &os, const Details &details) {
           },
           [](const HostAssocDetails &) {},
           [&](const GenericDetails &x) {
+            os << ' ' << EnumToString(x.kind());
             for (const auto *proc : x.specificProcs()) {
               os << ' ' << proc->name();
             }

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -252,9 +252,18 @@ private:
   std::optional<SourceName> passName_;  // name in PASS attribute
 };
 
+ENUM_CLASS(GenericKind, // Kinds of generic-spec
+    Name, DefinedOp,  // these have a Name associated with them
+    Assignment,  // user-defined assignment
+    OpPower, OpMultiply, OpDivide, OpAdd, OpSubtract, OpConcat, OpLT, OpLE,
+    OpEQ, OpNE, OpGE, OpGT, OpNOT, OpAND, OpOR, OpXOR, OpEQV, OpNEQV,
+    ReadFormatted, ReadUnformatted, WriteFormatted, WriteUnformatted)
+
 class GenericBindingDetails {
 public:
   GenericBindingDetails() {}
+  GenericKind kind() const { return kind_; }
+  void set_kind(GenericKind kind) { kind_ = kind; }
   const SymbolList &specificProcs() const { return specificProcs_; }
   void add_specificProc(const Symbol &proc) { specificProcs_.push_back(&proc); }
   void add_specificProcs(const SymbolList &procs) {
@@ -262,6 +271,7 @@ public:
   }
 
 private:
+  GenericKind kind_{GenericKind::Name};
   SymbolList specificProcs_;
 };
 
@@ -366,8 +376,10 @@ public:
   GenericDetails(const SymbolList &specificProcs);
   GenericDetails(Symbol *specific) : specific_{specific} {}
 
-  const SymbolList specificProcs() const { return specificProcs_; }
+  GenericKind kind() const { return kind_; }
+  void set_kind(GenericKind kind) { kind_ = kind; }
 
+  const SymbolList specificProcs() const { return specificProcs_; }
   void add_specificProc(const Symbol &proc) { specificProcs_.push_back(&proc); }
 
   Symbol *specific() { return specific_; }
@@ -384,6 +396,7 @@ public:
   const Symbol *CheckSpecific() const;
 
 private:
+  GenericKind kind_{GenericKind::Name};
   // all of the specific procedures for this generic
   SymbolList specificProcs_;
   // a specific procedure with the same name as this generic, if any
@@ -468,7 +481,6 @@ public:
     return const_cast<DeclTypeSpec *>(
         const_cast<const Symbol *>(this)->GetType());
   }
-
   const DeclTypeSpec *GetType() const {
     return std::visit(
         common::visitors{

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -72,6 +72,7 @@ set(ERROR_TESTS
   resolve44.f90
   resolve45.f90
   resolve46.f90
+  resolve47.f90
   structconst01.f90
   structconst02.f90
   structconst03.f90

--- a/test/semantics/modfile07.f90
+++ b/test/semantics/modfile07.f90
@@ -15,26 +15,33 @@
 ! Check modfile generation for generic interfaces
 module m
   interface foo
-    subroutine s1(x)
-      real x
-    end subroutine
-    subroutine s2(x)
-      complex x
-    end subroutine
+    real function s1(x,y)
+      real x,y
+    end function
+    complex function s2(x,y)
+      complex x,y
+    end function
   end interface
+  generic :: operator(+)=> s1, s2
   interface bar
     procedure :: s1
     procedure :: s2
     procedure :: s3
     procedure :: s4
   end interface
+  interface operator(.bar.)
+    procedure :: s1
+    procedure :: s2
+    procedure :: s3
+    procedure :: s4
+  end interface
 contains
-  subroutine s3(x)
-    logical x
-  end
-  subroutine s4(x)
-    integer x
-  end
+  logical function s3(x,y)
+    logical x,y
+  end function
+  integer function s4(x,y)
+    integer x,y
+  end function
 end
 
 module m2
@@ -54,22 +61,32 @@ end
 !module m
 ! generic::foo=>s1,s2
 ! interface
-!  subroutine s1(x)
+!  function s1(x,y)
+!   real(4)::s1
 !   real(4)::x
+!   real(4)::y
 !  end
 ! end interface
 ! interface
-!  subroutine s2(x)
+!  function s2(x,y)
+!   complex(4)::s2
 !   complex(4)::x
+!   complex(4)::y
 !  end
 ! end interface
+! generic::operator(+)=>s1,s2
 ! generic::bar=>s1,s2,s3,s4
+! generic::operator(.bar.)=>s1,s2,s3,s4
 !contains
-! subroutine s3(x)
+! function s3(x,y)
+!  logical(4)::s3
 !  logical(4)::x
+!  logical(4)::y
 ! end
-! subroutine s4(x)
+! function s4(x,y)
+!  integer(4)::s4
 !  integer(4)::x
+!  integer(4)::y
 ! end
 !end
 

--- a/test/semantics/modfile14.f90
+++ b/test/semantics/modfile14.f90
@@ -17,7 +17,9 @@ module m
   contains
     procedure, nopass :: s2
     procedure, nopass :: s3
+    procedure :: r
     generic :: foo => s2
+    generic :: read(formatted)=> r
   end type
   type, extends(t1) :: t2
   contains
@@ -33,7 +35,15 @@ contains
   subroutine s4(z)
     complex :: z
   end
-end module
+  subroutine r(dtv, unit, iotype, v_list, iostat, iomsg)
+    class(t1), intent(inout) :: dtv
+    integer, intent(in) :: unit
+    character (len=*), intent(in) :: iotype
+    integer, intent(in) :: v_list(:)
+    integer, intent(out) :: iostat
+    character (len=*), intent(inout) :: iomsg
+  end
+end
 
 !Expect: m.mod
 !module m
@@ -41,7 +51,9 @@ end module
 !  contains
 !    procedure,nopass::s2
 !    procedure,nopass::s3
+!    procedure::r
 !    generic::foo=>s2
+!    generic::read(formatted)=>r
 !  end type
 !  type,extends(t1)::t2
 !  contains
@@ -59,5 +71,13 @@ end module
 !  end
 !  subroutine s4(z)
 !    complex(4)::z
+!  end
+!  subroutine r(dtv,unit,iotype,v_list,iostat,iomsg)
+!    class(t1),intent(inout)::dtv
+!    integer(4),intent(in)::unit
+!    character(*,1),intent(in)::iotype
+!    integer(4),intent(in)::v_list(1_8:)
+!    integer(4),intent(out)::iostat
+!    character(*,1),intent(inout)::iomsg
 !  end
 !end

--- a/test/semantics/resolve11.f90
+++ b/test/semantics/resolve11.f90
@@ -20,3 +20,22 @@ module m
   !The accessibility of 'j' has already been specified as PRIVATE
   private j
 end
+
+module m2
+  interface operator(.foo.)
+    module procedure ifoo
+  end interface
+  public :: operator(.foo.)
+  !ERROR: The accessibility of operator '.foo.' has already been specified as PUBLIC
+  private :: operator(.foo.)
+  interface operator(+)
+    module procedure ifoo
+  end interface
+  public :: operator(+)
+  !ERROR: The accessibility of 'operator(+)' has already been specified as PUBLIC
+  private :: operator(+)
+contains
+  integer function ifoo(x, y)
+    integer, intent(in) :: x, y
+  end
+end module

--- a/test/semantics/resolve13.f90
+++ b/test/semantics/resolve13.f90
@@ -15,6 +15,23 @@
 module m1
   integer :: x
   integer, private :: y
+  interface operator(.foo.)
+    module procedure ifoo
+  end interface
+  interface operator(-)
+    module procedure ifoo
+  end interface
+  interface operator(.priv.)
+    module procedure ifoo
+  end interface
+  interface operator(*)
+    module procedure ifoo
+  end interface
+  private :: operator(.priv.), operator(*)
+contains
+  integer function ifoo(x, y)
+    integer, intent(in) :: x, y
+  end
 end
 
 use m1, local_x => x
@@ -22,12 +39,25 @@ use m1, local_x => x
 use m1, local_y => y
 !ERROR: 'z' not found in module 'm1'
 use m1, local_z => z
+use m1, operator(.localfoo.) => operator(.foo.)
+!ERROR: Operator '.bar.' not found in module 'm1'
+use m1, operator(.localbar.) => operator(.bar.)
 
 !ERROR: 'y' is PRIVATE in 'm1'
 use m1, only: y
+!ERROR: Operator '.priv.' is PRIVATE in 'm1'
+use m1, only: operator(.priv.)
+!ERROR: 'operator(*)' is PRIVATE in 'm1'
+use m1, only: operator(*)
 !ERROR: 'z' not found in module 'm1'
 use m1, only: z
 !ERROR: 'z' not found in module 'm1'
 use m1, only: my_x => z
+use m1, only: operator(.foo.)
+!ERROR: Operator '.bar.' not found in module 'm1'
+use m1, only: operator(.bar.)
+use m1, only: operator(-)
+!ERROR: 'operator(+)' not found in module 'm1'
+use m1, only: operator(+)
 
 end

--- a/test/semantics/resolve15.f90
+++ b/test/semantics/resolve15.f90
@@ -20,6 +20,12 @@ module m
     !ERROR: Procedure 'bad' not found
     procedure :: bad
   end interface
+  interface operator(.foo.)
+    !ERROR: 'var' is not a subprogram
+    procedure :: sub, var
+    !ERROR: Procedure 'bad' not found
+    procedure :: bad
+  end interface
 contains
   subroutine sub
   end
@@ -27,6 +33,10 @@ end
 
 subroutine s
   interface i
+    !ERROR: 'sub' is not a module procedure
+    module procedure :: sub
+  end interface
+  interface assignment(=)
     !ERROR: 'sub' is not a module procedure
     module procedure :: sub
   end interface

--- a/test/semantics/resolve25.f90
+++ b/test/semantics/resolve25.f90
@@ -25,15 +25,31 @@ module m
     procedure s1
   end interface
   interface
-    subroutine s4(x)
-      real x
+    subroutine s4(x,y)
+      real x,y
     end subroutine
-    subroutine s2(x)
-      complex x
+    subroutine s2(x,y)
+      complex x,y
     end subroutine
   end interface
   generic :: bar => s4
   generic :: bar => s2
   !ERROR: Procedure 's4' is already specified in generic 'bar'
   generic :: bar => s4
+
+  generic :: operator(.foo.)=> s4
+  generic :: operator(.foo.)=> s2
+  !ERROR: Procedure 's4' is already specified in generic operator '.foo.'
+  generic :: operator(.foo.)=> s4
 end module
+
+module m2
+  interface
+    integer function f(x, y)
+      integer, intent(in) :: x, y
+    end function
+  end interface
+  generic :: operator(+)=> f
+  !ERROR: Procedure 'f' is already specified in generic 'operator(+)'
+  generic :: operator(+)=> f
+end

--- a/test/semantics/resolve47.f90
+++ b/test/semantics/resolve47.f90
@@ -1,0 +1,50 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+module m1
+  !ERROR: Logical constant '.true.' may not be used as a defined operator
+  interface operator(.TRUE.)
+  end interface
+  !ERROR: Logical constant '.false.' may not be used as a defined operator
+  generic :: operator(.false.) => bar
+end
+
+module m2
+  interface operator(+)
+    module procedure foo
+  end interface
+  interface operator(.foo.)
+    module procedure foo
+  end interface
+  interface operator(.ge.)
+    module procedure bar
+  end interface
+contains
+  integer function foo(x, y)
+    logical, intent(in) :: x, y
+    foo = 0
+  end
+  logical function bar(x, y)
+    complex, intent(in) :: x, y
+    bar = .false.
+  end
+end
+
+!ERROR: Intrinsic operator '.le.' may not be used as a defined operator
+use m2, only: operator(.le.) => operator(.ge.)
+!ERROR: Intrinsic operator '.not.' may not be used as a defined operator
+use m2, only: operator(.not.) => operator(.foo.)
+!ERROR: Logical constant '.true.' may not be used as a defined operator
+use m2, only: operator(.true.) => operator(.foo.)
+end

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -511,7 +511,8 @@ int main(int argc, char *const argv[]) {
     driver.pgf90Args.push_back("-Mbackslash");
   }
 
-  Fortran::semantics::SemanticsContext semanticsContext{defaultKinds};
+  Fortran::semantics::SemanticsContext semanticsContext{
+      defaultKinds, options.features};
   semanticsContext.set_moduleDirectory(driver.moduleDirectory)
       .set_searchDirectories(driver.searchDirectories)
       .set_warnOnNonstandardUsage(driver.warnOnNonstandardUsage)


### PR DESCRIPTION
Instead of tracking just genericName_ while in a generic interface
block or generic statement, now we immediately create a symbol for it.
A parser::Name isn't good enough because a defined-operator or
defined-io-generic-spec doesn't have a name.

Change the parse tree to add a source field to GenericSpec. Use these
as names for symbols for defined-operator and defined-io-generic-spec
(e.g. "operator(+)" or "read(formatted)").

Change the source for defined-op-name to include the dots so that they
can be distinguished from normal symbols with the same name (e.g. you
can have both ".foo." and "foo"). These symbols have names in the symbol
table like ".foo.", not "operator(.foo.)", because references to them
have that form.

Add GenericKind enum to GenericDetails and GenericBindingDetails.
This allows us to know a symbol is "assignment(=)", for example,
without having to do a string comparison.

Add GenericSpecInfo to handle analyzing the various kinds of
generic-spec and generating symbol names and GenericKind for them.

Add reference to LanguageFeatureControl to SemanticsContext so that
they can be checked during semantics. For this change, if
LogicalAbbreviations is enabled, report an error if the user tries
to define an operator named ".T." or ".F.".

Add resolve-name-utils.cc to hold utility functions and classes that
don't have to be in the ResolveNamesVisitor class hierarchy. The goal
is to reduce the size of resolve-names.cc where possible.