### PR TITLE
Avoid capturing trailing space with parentheses

### DIFF
--- a/documentation/ParserCombinators.md
+++ b/documentation/ParserCombinators.md
@@ -143,7 +143,9 @@ is built.  All of the following parsers consume characters acquired from
   the combinator `/`.
 * `"..."_sptok` is a string match in which the spaces are required in
    free form source.
-* `parenthesized(p)` is shorthand for `"(" >> p / ")"`.
+* `"..."_nosptok` is like `"..."_tok` except that trailing spaces are
+  not skipped.
+* `parenthesized(p)` is shorthand for `"(" >> p / ")"_nosptok`.
 * `bracketed(p)` is shorthand for `"[" >> p / "]"`.
 * `nonEmptyList(p)` matches a comma-separated list of one or more
   instances of p.

--- a/lib/parser/grammar.h
+++ b/lib/parser/grammar.h
@@ -3190,15 +3190,15 @@ TYPE_PARSER(construct<ProcedureStmt>("MODULE PROCEDURE"_sptok >>
 TYPE_PARSER(sourced(first(construct<GenericSpec>("OPERATOR" >>
                               parenthesized(Parser<DefinedOperator>{})),
     construct<GenericSpec>(
-        construct<GenericSpec::Assignment>("ASSIGNMENT ( = )"_tok)),
+        construct<GenericSpec::Assignment>("ASSIGNMENT ( = )"_nosptok)),
     construct<GenericSpec>(
-        construct<GenericSpec::ReadFormatted>("READ ( FORMATTED )"_tok)),
+        construct<GenericSpec::ReadFormatted>("READ ( FORMATTED )"_nosptok)),
+    construct<GenericSpec>(construct<GenericSpec::ReadUnformatted>(
+        "READ ( UNFORMATTED )"_nosptok)),
     construct<GenericSpec>(
-        construct<GenericSpec::ReadUnformatted>("READ ( UNFORMATTED )"_tok)),
-    construct<GenericSpec>(
-        construct<GenericSpec::WriteFormatted>("WRITE ( FORMATTED )"_tok)),
-    construct<GenericSpec>(
-        construct<GenericSpec::WriteUnformatted>("WRITE ( UNFORMATTED )"_tok)),
+        construct<GenericSpec::WriteFormatted>("WRITE ( FORMATTED )"_nosptok)),
+    construct<GenericSpec>(construct<GenericSpec::WriteUnformatted>(
+        "WRITE ( UNFORMATTED )"_nosptok)),
     construct<GenericSpec>(name))))
 
 // R1510 generic-stmt ->

--- a/lib/semantics/resolve-names-utils.h
+++ b/lib/semantics/resolve-names-utils.h
@@ -21,7 +21,7 @@
 #include "../parser/message.h"
 
 namespace Fortran::parser {
-struct CharBlock;
+class CharBlock;
 struct DefinedOpName;
 struct GenericSpec;
 struct Name;

--- a/test/semantics/modfile07.f90
+++ b/test/semantics/modfile07.f90
@@ -22,14 +22,14 @@ module m
       complex x,y
     end function
   end interface
-  generic :: operator(+)=> s1, s2
+  generic :: operator ( + ) => s1, s2
   interface bar
     procedure :: s1
     procedure :: s2
     procedure :: s3
     procedure :: s4
   end interface
-  interface operator(.bar.)
+  interface operator( .bar.)
     procedure :: s1
     procedure :: s2
     procedure :: s3

--- a/test/semantics/resolve11.f90
+++ b/test/semantics/resolve11.f90
@@ -33,7 +33,7 @@ module m2
   end interface
   public :: operator(+)
   !ERROR: The accessibility of 'operator(+)' has already been specified as PUBLIC
-  private :: operator(+)
+  private :: operator(+) , ifoo
 contains
   integer function ifoo(x, y)
     integer, intent(in) :: x, y

--- a/test/semantics/resolve13.f90
+++ b/test/semantics/resolve13.f90
@@ -56,7 +56,7 @@ use m1, only: my_x => z
 use m1, only: operator(.foo.)
 !ERROR: Operator '.bar.' not found in module 'm1'
 use m1, only: operator(.bar.)
-use m1, only: operator(-)
+use m1, only: operator(-) , ifoo
 !ERROR: 'operator(+)' not found in module 'm1'
 use m1, only: operator(+)
 


### PR DESCRIPTION
When we have cooked source like `generic :: operator(+) => ...`
the name of the symbol we want to create is "operator(+)" but the
parser includes the following space in the `CharBlock` it captures
for that generic spec.

The fix has two parts:
1. Define another user-defined string token matcherm `""_nosptok`.
   It works like `""_tok` except it does not skip trailing spaces.
2. Make use of it in closing parenthesis of the `parenthesized()`
   token matcher and the various `GenericSpec` matchers.