### PR TITLE
Simplify grammar for STOP/ERROR STOP.

### DIFF
--- a/lib/parser/grammar.h
+++ b/lib/parser/grammar.h
@@ -2324,8 +2324,9 @@ TYPE_CONTEXT_PARSER("STOP statement"_en_US,
         maybe(Parser<StopCode>{}), maybe(", QUIET =" >> scalarLogicalExpr)))
 
 // R1162 stop-code -> scalar-default-char-expr | scalar-int-expr
-TYPE_PARSER(construct<StopCode>(scalarDefaultCharExpr) ||
-    construct<StopCode>(scalarIntExpr))
+// The two alternatives for stop-code can't be distinguished at
+// parse time.
+TYPE_PARSER(construct<StopCode>(expr))
 
 // R1164 sync-all-stmt -> SYNC ALL [( [sync-stat-list] )]
 TYPE_CONTEXT_PARSER("SYNC ALL statement"_en_US,

--- a/lib/parser/grammar.h
+++ b/lib/parser/grammar.h
@@ -2326,7 +2326,7 @@ TYPE_CONTEXT_PARSER("STOP statement"_en_US,
 // R1162 stop-code -> scalar-default-char-expr | scalar-int-expr
 // The two alternatives for stop-code can't be distinguished at
 // parse time.
-TYPE_PARSER(construct<StopCode>(expr))
+TYPE_PARSER(construct<StopCode>(scalar(expr)))
 
 // R1164 sync-all-stmt -> SYNC ALL [( [sync-stat-list] )]
 TYPE_CONTEXT_PARSER("SYNC ALL statement"_en_US,

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -2391,10 +2391,10 @@ struct ComputedGotoStmt {
 };
 
 // R1162 stop-code -> scalar-default-char-expr | scalar-int-expr
-struct StopCode {
-  UNION_CLASS_BOILERPLATE(StopCode);
-  std::variant<ScalarDefaultCharExpr, ScalarIntExpr> u;
-};
+// We can't distinguish character expressions from integer
+// expressions until semantics, so we just parse an expr and
+// check its type later.
+WRAPPER_CLASS(StopCode, Expr);
 
 // R1160 stop-stmt -> STOP [stop-code] [, QUIET = scalar-logical-expr]
 // R1161 error-stop-stmt ->

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -2392,9 +2392,9 @@ struct ComputedGotoStmt {
 
 // R1162 stop-code -> scalar-default-char-expr | scalar-int-expr
 // We can't distinguish character expressions from integer
-// expressions until semantics, so we just parse an expr and
+// expressions during parsing, so we just parse an expr and
 // check its type later.
-WRAPPER_CLASS(StopCode, Expr);
+WRAPPER_CLASS(StopCode, Scalar<Expr>);
 
 // R1160 stop-stmt -> STOP [stop-code] [, QUIET = scalar-logical-expr]
 // R1161 error-stop-stmt ->


### PR DESCRIPTION
The f18 Fortran grammar transcribes prefixes from the Standard like "scalar" and "default-char" into constraint-checking nodes of the parse tree that lead to automatic checks in expression semantics.  In the case of the "stop-code" production, however, there's no point wrapping up the `expr` in these constraint checks (other than scalar) since the type of the expression can be either default character or default integer; the current parser is always parsing an expr and then decorating it with a default character constraint check.  So this change simplifies the grammar and parse tree to avoid confusion, and an explicit type check will have to be performed in statement semantics.