### PR TITLE
Simplify indirection.h, remove needless classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,9 +92,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
    endif()
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic")
-   set(CMAKE_CXX_FLAGS_RELEASE    "-O2 -DDEBUG")
+   set(CMAKE_CXX_FLAGS_RELEASE    "-O2")
    set(CMAKE_CXX_FLAGS_MINSIZEREL "-O2 '-DCHECK=(void)'")
-   set(CMAKE_CXX_FLAGS_DEBUG      "-g -DDEBUG")
+   set(CMAKE_CXX_FLAGS_DEBUG      "-g -DDEBUGF18")
 
    # Building shared libraries is death on performance with GCC by default
    # due to the need to preserve the right to override external entry points

--- a/documentation/C++style.md
+++ b/documentation/C++style.md
@@ -192,20 +192,17 @@ will be defined to return a reference.)
 wherever appropriate.
 * `std::unique_ptr<>`: A nullable pointer with ownership, null by default,
 not copyable, reassignable.
+F18 has a helpful `Deleter<>` class template that makes `unique_ptr<>`
+easier to use with forward-referenced data types.
 * `std::shared_ptr<>`: A nullable pointer with shared ownership via reference
 counting, null by default, shallowly copyable, reassignable, and slow.
-* `OwningPointer<>`: A nullable pointer with ownership, better suited
-for use with forward-defined types than `std::unique_ptr<>` is.
-Null by default, optionally copyable, reassignable.
-Does not have direct means for allocating data, and inconveniently requires
-the definition of an external destructor.
 * `Indirection<>`: A non-nullable pointer with ownership and
 optional deep copy semantics; reassignable.
 Often better than a reference (due to ownership) or `std::unique_ptr<>`
 (due to non-nullability and copyability).
 Can be wrapped in `std::optional<>` when nullability is required.
-* `ForwardReference<>`: A non-nullable `OwningPointer<>`, or a variant of
-`Indirection<>` that works with forward-declared content types; it's both.
+Usable with forward-referenced data types with some use of `extern template`
+in headers and explicit template instantiation in source files.
 * `CountedReference<>`: A nullable pointer with shared ownership via
 reference counting, null by default, shallowly copyable, reassignable.
 Safe to use *only* when the data are private to just one
@@ -219,11 +216,9 @@ A feature matrix:
 | -------              | -------- | ------------ | ------ | ------------ | --------          | ------------------ |
 | `*p`                 | yes      | no           | no     | yes          | shallowly         | yes                |
 | `&r`                 | no       | n/a          | no     | no           | shallowly         | yes                |
-| `unique_ptr<>`       | yes      | yes          | yes    | yes          | no                | no                 |
+| `unique_ptr<>`       | yes      | yes          | yes    | yes          | no                | yes, with work     |
 | `shared_ptr<>`       | yes      | yes          | yes    | yes          | shallowly         | no                 |
-| `OwningPointer<>`    | yes      | yes          | yes    | yes          | optionally deeply | yes                |
-| `Indirection<>`      | no       | n/a          | yes    | yes          | optionally deeply | no                 |
-| `ForwardReference<>` | no       | n/a          | yes    | yes          | optionally deeply | yes                |
+| `Indirection<>`      | no       | n/a          | yes    | yes          | optionally deeply | yes, with work     |
 | `CountedReference<>` | yes      | yes          | yes    | yes          | shallowly         | no                 |
 
 ### Overall design preferences

--- a/lib/FIR/afforestation.cc
+++ b/lib/FIR/afforestation.cc
@@ -25,9 +25,9 @@
 
 namespace Fortran::FIR {
 namespace {
-Expression *ExprRef(const parser::Expr &a) { return &a.typedExpr.value(); }
+Expression *ExprRef(const parser::Expr &a) { return a.typedExpr.get(); }
 Expression *ExprRef(const common::Indirection<parser::Expr> &a) {
-  return &a.value().typedExpr.value();
+  return a.value().typedExpr.get();
 }
 
 struct LinearOp;
@@ -1296,9 +1296,9 @@ public:
       const std::vector<LinearLabelRef> &refs) {
     auto &cases{
         std::get<std::list<parser::CaseConstruct::Case>>(caseConstruct->t)};
-    SwitchCaseArguments result{
-        GetSwitchCaseSelector(caseConstruct), unspecifiedLabel,
-            populateSwitchValues(builder_, cases), std::move(refs)};
+    SwitchCaseArguments result{GetSwitchCaseSelector(caseConstruct),
+        unspecifiedLabel, populateSwitchValues(builder_, cases),
+        std::move(refs)};
     cleanupSwitchPairs<SwitchCaseStmt>(
         result.defLab, result.values, result.labels);
     return result;

--- a/lib/common/idioms.h
+++ b/lib/common/idioms.h
@@ -135,7 +135,6 @@ template<typename A> struct ListItemCount {
   }
 
 // Given a const reference to a value, return a copy of the value.
-
 template<typename A> A Clone(const A &x) { return x; }
 }
 #endif  // FORTRAN_COMMON_IDIOMS_H_

--- a/lib/common/unwrap.h
+++ b/lib/common/unwrap.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -70,10 +70,6 @@ template<typename A, typename... Bs>
 auto Unwrap(const std::variant<Bs...> &) -> std::add_const_t<A> *;
 template<typename A, typename B, bool COPY>
 auto Unwrap(const Indirection<B, COPY> &) -> Constify<A, B> *;
-template<typename A, typename B>
-auto Unwrap(const OwningPointer<B> &) -> Constify<A, B> *;
-template<typename A, typename B>
-auto Unwrap(const CountedReference<B> &) -> Constify<A, B> *;
 
 // Implementations of specializations
 template<typename A, typename B> auto Unwrap(B *p) -> Constify<A, B> * {
@@ -142,15 +138,6 @@ auto Unwrap(const std::variant<Bs...> &u) -> std::add_const_t<A> * {
 template<typename A, typename B, bool COPY>
 auto Unwrap(const Indirection<B, COPY> &p) -> Constify<A, B> * {
   return Unwrap<A>(*p);
-}
-
-template<typename A, typename B>
-auto Unwrap(const OwningPointer<B> &p) -> Constify<A, B> * {
-  if (p.get() != nullptr) {
-    return Unwrap<A>(*p);
-  } else {
-    return nullptr;
-  }
 }
 
 template<typename A, typename B>

--- a/lib/evaluate/call.h
+++ b/lib/evaluate/call.h
@@ -34,7 +34,7 @@ namespace Fortran::evaluate {
 class ActualArgument {
 public:
   explicit ActualArgument(Expr<SomeType> &&x) : value_{std::move(x)} {}
-  explicit ActualArgument(CopyableIndirection<Expr<SomeType>> &&v)
+  explicit ActualArgument(common::CopyableIndirection<Expr<SomeType>> &&v)
     : value_{std::move(v)} {}
 
   Expr<SomeType> &value() { return value_.value(); }
@@ -57,7 +57,7 @@ private:
   // e.g. between X and (X).  The parser attempts to parse each argument
   // first as a variable, then as an expression, and the distinction appears
   // in the parse tree.
-  CopyableIndirection<Expr<SomeType>> value_;
+  common::CopyableIndirection<Expr<SomeType>> value_;
 };
 
 using ActualArguments = std::vector<std::optional<ActualArgument>>;

--- a/lib/evaluate/characteristics.cc
+++ b/lib/evaluate/characteristics.cc
@@ -61,8 +61,8 @@ bool DummyProcedure::operator==(const DummyProcedure &that) const {
 
 std::ostream &DummyProcedure::Dump(std::ostream &o) const {
   attrs.Dump(o, EnumToString);
-  if (explicitProcedure.has_value()) {
-    explicitProcedure.value().Dump(o);
+  if (explicitProcedure) {
+    explicitProcedure->Dump(o);
   }
   return o;
 }
@@ -98,5 +98,6 @@ std::ostream &Procedure::Dump(std::ostream &o) const {
   }
   return o << (sep == '(' ? "()" : ")");
 }
+DEFINE_DEFAULT_CONSTRUCTORS_AND_ASSIGNMENTS(DummyProcedure)
 }
 DEFINE_DELETER(Fortran::evaluate::characteristics::Procedure)

--- a/lib/evaluate/characteristics.cc
+++ b/lib/evaluate/characteristics.cc
@@ -61,9 +61,7 @@ bool DummyProcedure::operator==(const DummyProcedure &that) const {
 
 std::ostream &DummyProcedure::Dump(std::ostream &o) const {
   attrs.Dump(o, EnumToString);
-  if (explicitProcedure) {
-    explicitProcedure->Dump(o);
-  }
+  explicitProcedure.value().Dump(o);
   return o;
 }
 

--- a/lib/evaluate/characteristics.cc
+++ b/lib/evaluate/characteristics.cc
@@ -99,7 +99,4 @@ std::ostream &Procedure::Dump(std::ostream &o) const {
   return o << (sep == '(' ? "()" : ")");
 }
 }
-
-// Define OwningPointer special member functions
-DEFINE_OWNING_SPECIAL_FUNCTIONS(
-    OwningPointer, evaluate::characteristics::Procedure)
+DEFINE_DELETER(Fortran::evaluate::characteristics::Procedure)

--- a/lib/evaluate/characteristics.h
+++ b/lib/evaluate/characteristics.h
@@ -54,7 +54,7 @@ struct DummyDataObject {
 struct DummyProcedure {
   ENUM_CLASS(Attr, Pointer, Optional)
   DEFAULT_CONSTRUCTORS_AND_ASSIGNMENTS(DummyProcedure)
-  common::OwningPointer<Procedure> explicitProcedure;
+  std::unique_ptr<Procedure, common::Deleter<Procedure>> explicitProcedure;
   common::EnumSet<Attr, 32> attrs;
   bool operator==(const DummyProcedure &) const;
   std::ostream &Dump(std::ostream &) const;

--- a/lib/evaluate/characteristics.h
+++ b/lib/evaluate/characteristics.h
@@ -53,7 +53,7 @@ struct DummyDataObject {
 // 15.3.2.3
 struct DummyProcedure {
   ENUM_CLASS(Attr, Pointer, Optional)
-  DEFAULT_CONSTRUCTORS_AND_ASSIGNMENTS(DummyProcedure)
+  DECLARE_CONSTRUCTORS_AND_ASSIGNMENTS(DummyProcedure)
   std::unique_ptr<Procedure, common::Deleter<Procedure>> explicitProcedure;
   common::EnumSet<Attr, 32> attrs;
   bool operator==(const DummyProcedure &) const;

--- a/lib/evaluate/characteristics.h
+++ b/lib/evaluate/characteristics.h
@@ -54,7 +54,7 @@ struct DummyDataObject {
 struct DummyProcedure {
   ENUM_CLASS(Attr, Pointer, Optional)
   DECLARE_CONSTRUCTORS_AND_ASSIGNMENTS(DummyProcedure)
-  std::unique_ptr<Procedure, common::Deleter<Procedure>> explicitProcedure;
+  common::CopyableIndirection<Procedure> explicitProcedure;
   common::EnumSet<Attr, 32> attrs;
   bool operator==(const DummyProcedure &) const;
   std::ostream &Dump(std::ostream &) const;

--- a/lib/evaluate/common.h
+++ b/lib/evaluate/common.h
@@ -166,11 +166,21 @@ using HostUnsignedInt =
 // - There are full copy and move semantics for construction and assignment.
 // - Discriminated unions have a std::variant<> member "u" and support
 //   explicit copy and move constructors as well as comparison for equality.
+#define DECLARE_CONSTRUCTORS_AND_ASSIGNMENTS(t) \
+  t(const t &); \
+  t(t &&); \
+  t &operator=(const t &); \
+  t &operator=(t &&);
 #define DEFAULT_CONSTRUCTORS_AND_ASSIGNMENTS(t) \
   t(const t &) = default; \
   t(t &&) = default; \
   t &operator=(const t &) = default; \
   t &operator=(t &&) = default;
+#define DEFINE_DEFAULT_CONSTRUCTORS_AND_ASSIGNMENTS(t) \
+  t::t(const t &) = default; \
+  t::t(t &&) = default; \
+  t &t::operator=(const t &) = default; \
+  t &t::operator=(t &&) = default;
 
 #define CLASS_BOILERPLATE(t) \
   t() = delete; \
@@ -183,9 +193,6 @@ using HostUnsignedInt =
   explicit t(std::enable_if_t<!std::is_reference_v<_A>, _A> &&x) \
     : u(std::move(x)) {} \
   bool operator==(const t &that) const { return u == that.u; }
-
-// Force availability of copy construction and assignment
-template<typename A> using CopyableIndirection = common::Indirection<A, true>;
 
 // Forward definition of Expr<> so that it can be indirectly used in its own
 // definition

--- a/lib/evaluate/constant.h
+++ b/lib/evaluate/constant.h
@@ -128,8 +128,8 @@ private:
   std::vector<std::int64_t> shape_;
 };
 
-using StructureConstructorValues =
-    std::map<const semantics::Symbol *, CopyableIndirection<Expr<SomeType>>>;
+using StructureConstructorValues = std::map<const semantics::Symbol *,
+    common::CopyableIndirection<Expr<SomeType>>>;
 
 template<>
 class Constant<SomeDerived>

--- a/lib/evaluate/descender.h
+++ b/lib/evaluate/descender.h
@@ -51,10 +51,12 @@ public:
     }
   }
 
-  template<typename X> void Descend(const CopyableIndirection<X> &p) {
+  template<typename X, bool COPY>
+  void Descend(const common::Indirection<X, COPY> &p) {
     Visit(p.value());
   }
-  template<typename X> void Descend(CopyableIndirection<X> &p) {
+  template<typename X, bool COPY>
+  void Descend(common::Indirection<X, COPY> &p) {
     Visit(p.value());
   }
 

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -250,7 +250,7 @@ public:
   }
 
 private:
-  bool FoldArray(const CopyableIndirection<Expr<T>> &expr) {
+  bool FoldArray(const common::CopyableIndirection<Expr<T>> &expr) {
     Expr<T> folded{Fold(context_, common::Clone(expr.value()))};
     if (auto *c{UnwrapExpr<Constant<T>>(folded)}) {
       // Copy elements in Fortran array element order

--- a/lib/evaluate/type.h
+++ b/lib/evaluate/type.h
@@ -195,7 +195,7 @@ using SameKind = Type<CATEGORY, std::decay_t<T>::kind>;
 // Many expressions, including subscripts, CHARACTER lengths, array bounds,
 // and effective type parameter values, are of a maximal kind of INTEGER.
 using IndirectSubscriptIntegerExpr =
-    CopyableIndirection<Expr<SubscriptInteger>>;
+    common::CopyableIndirection<Expr<SubscriptInteger>>;
 
 // A predicate that is true when a kind value is a kind that could possibly
 // be supported for an intrinsic type category on some target instruction

--- a/lib/evaluate/variable.cc
+++ b/lib/evaluate/variable.cc
@@ -258,8 +258,8 @@ std::ostream &Emit(
   return o;
 }
 
-template<typename A>
-std::ostream &Emit(std::ostream &o, const CopyableIndirection<A> &p,
+template<typename A, bool COPY>
+std::ostream &Emit(std::ostream &o, const common::Indirection<A, COPY> &p,
     const char *kw = nullptr) {
   if (kw != nullptr) {
     o << kw;

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -77,7 +77,7 @@ public:
   CLASS_BOILERPLATE(Component)
   Component(const DataRef &b, const Symbol &c) : base_{b}, symbol_{&c} {}
   Component(DataRef &&b, const Symbol &c) : base_{std::move(b)}, symbol_{&c} {}
-  Component(CopyableIndirection<DataRef> &&b, const Symbol &c)
+  Component(common::CopyableIndirection<DataRef> &&b, const Symbol &c)
     : base_{std::move(b)}, symbol_{&c} {}
 
   const DataRef &base() const { return base_.value(); }
@@ -90,7 +90,7 @@ public:
   std::ostream &AsFortran(std::ostream &) const;
 
 private:
-  CopyableIndirection<DataRef> base_;
+  common::CopyableIndirection<DataRef> base_;
   const Symbol *symbol_;
 };
 
@@ -238,7 +238,7 @@ public:
 private:
   std::vector<const Symbol *> base_;
   std::vector<Expr<SubscriptInteger>> subscript_, cosubscript_;
-  std::optional<CopyableIndirection<Expr<SomeInteger>>> stat_, team_;
+  std::optional<common::CopyableIndirection<Expr<SomeInteger>>> stat_, team_;
   bool teamIsTeamNumber_{false};  // false: TEAM=, true: TEAM_NUMBER=
 };
 

--- a/lib/parser/parse-tree.cc
+++ b/lib/parser/parse-tree.cc
@@ -18,6 +18,13 @@
 #include "../common/indirection.h"
 #include <algorithm>
 
+// So "delete Expr::typedExpr;" calls an external destructor.
+namespace Fortran::evaluate {
+struct GenericExprWrapper {
+  ~GenericExprWrapper();
+};
+}
+
 namespace Fortran::parser {
 
 // R867
@@ -171,3 +178,5 @@ std::ostream &operator<<(std::ostream &os, const CharBlock &x) {
   return os << x.ToString();
 }
 }
+
+template class std::unique_ptr<Fortran::evaluate::GenericExprWrapper>;

--- a/lib/parser/parse-tree.cc
+++ b/lib/parser/parse-tree.cc
@@ -18,7 +18,7 @@
 #include "../common/indirection.h"
 #include <algorithm>
 
-// So "delete Expr::typedExpr;" calls an external destructor.
+// So "delete Expr;" calls an external destructor for its typedExpr.
 namespace Fortran::evaluate {
 struct GenericExprWrapper {
   ~GenericExprWrapper();

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -549,7 +549,7 @@ WRAPPER_CLASS(NamedConstant, Name);
 // R1023 defined-binary-op -> . letter [letter]... .
 // R1414 local-defined-operator -> defined-unary-op | defined-binary-op
 // R1415 use-defined-operator -> defined-unary-op | defined-binary-op
-// The Name here is stored without the dots; e.g., FOO, not .FOO.
+// The Name here is stored with the dots; e.g., .FOO.
 WRAPPER_CLASS(DefinedOpName, Name);
 
 // R608 intrinsic-operator ->
@@ -2389,10 +2389,10 @@ struct ComputedGotoStmt {
 };
 
 // R1162 stop-code -> scalar-default-char-expr | scalar-int-expr
-struct StopCode {
-  UNION_CLASS_BOILERPLATE(StopCode);
-  std::variant<ScalarDefaultCharExpr, ScalarIntExpr> u;
-};
+// We can't distinguish character expressions from integer
+// expressions during parsing, so we just parse an expr and
+// check its type later.
+WRAPPER_CLASS(StopCode, Scalar<Expr>);
 
 // R1160 stop-stmt -> STOP [stop-code] [, QUIET = scalar-logical-expr]
 // R1161 error-stop-stmt ->
@@ -2879,6 +2879,7 @@ struct GenericSpec {
   EMPTY_CLASS(ReadUnformatted);
   EMPTY_CLASS(WriteFormatted);
   EMPTY_CLASS(WriteUnformatted);
+  CharBlock source;
   std::variant<Name, DefinedOperator, Assignment, ReadFormatted,
       ReadUnformatted, WriteFormatted, WriteUnformatted>
       u;

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -836,7 +836,7 @@ public:
     Walk(std::get<2>(x.t));  // right
   }
   void Unparse(const DefinedOpName &x) {  // R1003, R1023, R1414, & R1415
-    Put('.'), Walk(x.v), Put('.');
+    Walk(x.v);
   }
   void Unparse(const AssignmentStmt &x) {  // R1032
     Walk(x.t, " = ");

--- a/lib/semantics/assignment.cc
+++ b/lib/semantics/assignment.cc
@@ -132,7 +132,8 @@ private:
 
 }  // namespace Fortran::semantics
 
-DEFINE_OWNING_DESTRUCTOR(ForwardReference, semantics::AssignmentContext)
+template class Fortran::common::Indirection<
+    Fortran::semantics::AssignmentContext>;
 
 namespace Fortran::semantics {
 
@@ -297,6 +298,8 @@ void AnalyzeConcurrentHeader(
     SemanticsContext &context, const parser::ConcurrentHeader &header) {
   AssignmentContext{context}.Analyze(header);
 }
+
+AssignmentChecker::~AssignmentChecker() = default;
 
 AssignmentChecker::AssignmentChecker(SemanticsContext &context)
   : context_{new AssignmentContext{context}} {}

--- a/lib/semantics/assignment.h
+++ b/lib/semantics/assignment.h
@@ -17,6 +17,7 @@
 
 #include "semantics.h"
 #include "../common/indirection.h"
+#include "../evaluate/expression.h"
 
 namespace Fortran::parser {
 template<typename> struct Statement;
@@ -31,12 +32,23 @@ struct ForallStmt;
 struct ForallConstruct;
 }
 
+namespace Fortran::evaluate {
+void CheckPointerAssignment(parser::ContextualMessages &, const Symbol &,
+    const evaluate::Expr<evaluate::SomeType> &);
+}
+
 namespace Fortran::semantics {
 class AssignmentContext;
+}
 
+extern template class Fortran::common::Indirection<
+    Fortran::semantics::AssignmentContext>;
+
+namespace Fortran::semantics {
 class AssignmentChecker : public virtual BaseChecker {
 public:
   explicit AssignmentChecker(SemanticsContext &);
+  ~AssignmentChecker();
   void Enter(const parser::AssignmentStmt &);
   void Enter(const parser::PointerAssignmentStmt &);
   void Enter(const parser::WhereStmt &);
@@ -45,7 +57,7 @@ public:
   void Enter(const parser::ForallConstruct &);
 
 private:
-  common::ForwardReference<AssignmentContext> context_;
+  common::Indirection<AssignmentContext> context_;
 };
 
 // Semantic analysis of an assignment statement or WHERE/FORALL construct.
@@ -62,6 +74,5 @@ void AnalyzeAssignment(
 // well as in DO CONCURRENT loops.
 void AnalyzeConcurrentHeader(
     SemanticsContext &, const parser::ConcurrentHeader &);
-
 }
 #endif  // FORTRAN_SEMANTICS_ASSIGNMENT_H_

--- a/lib/semantics/check-do-concurrent.h
+++ b/lib/semantics/check-do-concurrent.h
@@ -21,17 +21,21 @@
 namespace Fortran::parser {
 struct DoConstruct;
 }
-
 namespace Fortran::semantics {
 class DoConcurrentContext;
+}
+extern template class Fortran::common::Indirection<
+    Fortran::semantics::DoConcurrentContext>;
 
+namespace Fortran::semantics {
 class DoConcurrentChecker : public virtual BaseChecker {
 public:
   explicit DoConcurrentChecker(SemanticsContext &);
+  ~DoConcurrentChecker();
   void Leave(const parser::DoConstruct &);
 
 private:
-  common::ForwardReference<DoConcurrentContext> context_;
+  common::Indirection<DoConcurrentContext> context_;
 };
 
 }

--- a/tools/f18/dump.cc
+++ b/tools/f18/dump.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 // Each is based on operator<< for that type. There are overloadings for
 // reference and pointer, and for dumping to a provided ostream or cerr.
 
-#ifdef DEBUG
+#ifdef DEBUGF18
 
 #include <iostream>
 

--- a/tools/f18/stub-evaluate.cc
+++ b/tools/f18/stub-evaluate.cc
@@ -14,14 +14,16 @@
 
 // The parse tree has slots in which pointers to typed expressions may be
 // placed.  When using the parser without the expression library, as here,
-// we need to stub out the dependence.
+// we need to stub out the dependence on the external destructor, which
+// will never actually be called.
 
 #include "../../lib/common/indirection.h"
 
 namespace Fortran::evaluate {
 struct GenericExprWrapper {
-  bool operator==(const GenericExprWrapper &) const { return false; }
+  ~GenericExprWrapper();
 };
+GenericExprWrapper::~GenericExprWrapper() = default;
 }
 
-DEFINE_OWNING_DESTRUCTOR(OwningPointer, evaluate::GenericExprWrapper)
+DEFINE_DELETER(Fortran::evaluate::GenericExprWrapper)


### PR DESCRIPTION
While working on development in another branch, I was able to simplify `lib/common/indirection.h` by removing the template classes `OwningPointer` and `ForwardReference` in favor of using other techniques to allow `std::unique_ptr<>` and `Indirection<>` on forward-referenced undefined types.  It would have been great if I had figured out these techniques earlier and avoided creating the needless template classes in the first place, but at least I'm cleaning them up now.

This PR extracts those simplifications from that development branch as a stand-alone change (pretty much).  Many more changes are coming, and they'll be easier to review without these in the way.

The documentation is also updated.