### PR TITLE
Fix bug#348

### DIFF
--- a/lib/parser/prescan.cc
+++ b/lib/parser/prescan.cc
@@ -424,7 +424,7 @@ bool Prescanner::NextToken(TokenSequence &tokens) {
   }
   const char *start{at_};
   if (*at_ == '\'' || *at_ == '"') {
-    QuotedCharacterLiteral(tokens);
+    QuotedCharacterLiteral(tokens, start);
     preventHollerith_ = false;
   } else if (IsDecimalDigit(*at_)) {
     int n{0}, digits{0};
@@ -458,7 +458,7 @@ bool Prescanner::NextToken(TokenSequence &tokens) {
       EmitCharAndAdvance(tokens, *at_);
     } else if (at_[0] == '_' && (at_[1] == '\'' || at_[1] == '"')) {
       EmitCharAndAdvance(tokens, *at_);
-      QuotedCharacterLiteral(tokens);
+      QuotedCharacterLiteral(tokens, start);
     }
     preventHollerith_ = false;
   } else if (*at_ == '.') {
@@ -475,7 +475,7 @@ bool Prescanner::NextToken(TokenSequence &tokens) {
     while (IsLegalInIdentifier(EmitCharAndAdvance(tokens, *at_))) {
     }
     if (*at_ == '\'' || *at_ == '"') {
-      QuotedCharacterLiteral(tokens);
+      QuotedCharacterLiteral(tokens, start);
       preventHollerith_ = false;
     } else {
       // Subtle: Don't misrecognize labeled DO statement label as Hollerith
@@ -535,12 +535,8 @@ bool Prescanner::ExponentAndKind(TokenSequence &tokens) {
   return true;
 }
 
-void Prescanner::QuotedCharacterLiteral(TokenSequence &tokens) {
-  const char *start{at_};
-  if (!tokens.empty()) {
-    // If there's a kind prefix, include it in error messages.
-    start = tokens.TokenAt(tokens.SizeInTokens() - 1).begin();
-  }
+void Prescanner::QuotedCharacterLiteral(
+    TokenSequence &tokens, const char *start) {
   char quote{*at_};
   const char *end{at_ + 1};
   inCharLiteral_ = true;

--- a/lib/parser/prescan.h
+++ b/lib/parser/prescan.h
@@ -157,7 +157,7 @@ private:
   const char *SkipCComment(const char *) const;
   bool NextToken(TokenSequence &);
   bool ExponentAndKind(TokenSequence &);
-  void QuotedCharacterLiteral(TokenSequence &);
+  void QuotedCharacterLiteral(TokenSequence &, const char *start);
   void Hollerith(TokenSequence &, int count, const char *start);
   bool PadOutCharacterLiteral(TokenSequence &);
   bool SkipCommentLine(bool afterAmpersand);

--- a/lib/parser/token-sequence.cc
+++ b/lib/parser/token-sequence.cc
@@ -135,9 +135,12 @@ TokenSequence &TokenSequence::ToLowerCase() {
       while (p < limit && IsDecimalDigit(*p)) {
         ++p;
       }
-      if (p < limit && (*p == 'h' || *p == 'H')) {
+      if (p >= limit) {
+      } else if (*p == 'h' || *p == 'H') {
         // Hollerith
         *p = 'h';
+      } else if (*p == '_') {
+        // kind-prefixed character literal (e.g., 1_"ABC")
       } else {
         // exponent
         for (; p < limit; ++p) {
@@ -153,7 +156,8 @@ TokenSequence &TokenSequence::ToLowerCase() {
           *p = ToLowerCaseLetter(*p);
         }
       } else {
-        // Kanji NC'...' character literal or literal with kind-param prefix.
+        // Kanji NC'...' character literal or literal with kind-param prefix
+        // name (e.g., K_"ABC").
         for (; *p != limit[-1]; ++p) {
           *p = ToLowerCaseLetter(*p);
         }


### PR DESCRIPTION
Tokenization in the prescanner was treating `1_"ABC"` as two preprocessing tokens, not one.  This would usually be benign, except that the logic for converting a token to miniscule letters was triggered.  Fixed, and also improved the error message locations for prefixed character literals to include the kind prefix.