### PR TITLE
Track current statement location in SemanticsVisitor

### DIFF
--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -680,7 +680,7 @@ std::optional<std::string> ModFileReader::FindModFile(
           : "Cannot find module file for submodule '%s' of module '%s'"_err_en_US,
       name.ToString().data(), ancestor.data()}};
   attachments.AttachTo(error);
-  context_.Say(error);
+  context_.Say(std::move(error));
   return std::nullopt;
 }
 

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -1063,7 +1063,7 @@ void ImplicitRules::SetType(const DeclTypeSpec &type, parser::Location lo,
   for (char ch = *lo; ch; ch = ImplicitRules::Incr(ch)) {
     auto res{map_.emplace(ch, &type)};
     if (!res.second && !isDefault) {
-      context_->Say(lo,
+      context_->messages().Say(lo,
           "More than one implicit type specified for '%s'"_err_en_US,
           std::string(1, ch).c_str());
     }

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -45,11 +45,23 @@ public:
   using BaseChecker::Leave;
   SemanticsVisitor(SemanticsContext &context)
     : C{context}..., context_{context} {}
+
   template<typename N> bool Pre(const N &node) {
     Enter(node);
     return true;
   }
   template<typename N> void Post(const N &node) { Leave(node); }
+
+  template<typename T> bool Pre(const parser::Statement<T> &node) {
+    context_.set_location(&node.source);
+    Enter(node);
+    return true;
+  }
+  template<typename T> void Post(const parser::Statement<T> &node) {
+    Leave(node);
+    context_.set_location(nullptr);
+  }
+
   bool Walk(const parser::Program &program) {
     parser::Walk(program, *this);
     return !context_.AnyFatalError();

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -18,8 +18,8 @@
 #include "scope.h"
 #include "../evaluate/common.h"
 #include "../evaluate/intrinsics.h"
-#include "../parser/message.h"
 #include "../parser/features.h"
+#include "../parser/message.h"
 #include <iosfwd>
 #include <string>
 #include <vector>
@@ -82,8 +82,17 @@ public:
   const DeclTypeSpec &MakeLogicalType(int kind = 0);
 
   bool AnyFatalError() const;
-  template<typename... A> parser::Message &Say(A... args) {
-    return messages_.Say(std::forward<A>(args)...);
+
+  template<typename... A>
+  parser::Message &Say(const parser::CharBlock &at, A &&... args) {
+    return messages_.Say(at, std::forward<A>(args)...);
+  }
+  template<typename... A> parser::Message &Say(A &&... args) {
+    CHECK(location_);
+    return messages_.Say(*location_, std::forward<A>(args)...);
+  }
+  parser::Message &Say(parser::Message &&msg) {
+    return messages_.Say(std::move(msg));
   }
 
   const Scope &FindScope(const parser::CharBlock &) const;


### PR DESCRIPTION
Change `SemanticsVisitor` to track the location of the current
statement, if any, so that it's available through
`SemanticsContext::location()`.

Add overloading of `SemanticsContext::Say()` that reports the
message at the location of the current statement if a `CharBlock`
is not provided.