### PR TITLE
Implement semantics for computed GOTO

### DIFF
--- a/lib/semantics/CMakeLists.txt
+++ b/lib/semantics/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(FortranSemantics
   attr.cc
   canonicalize-do.cc
   check-arithmeticif.cc
+  check-computed-goto.cc
   check-do-concurrent.cc
   check-if-construct.cc
   check-if-stmt.cc

--- a/lib/semantics/check-arithmeticif.cc
+++ b/lib/semantics/check-arithmeticif.cc
@@ -13,13 +13,7 @@
 // limitations under the License.
 
 #include "check-arithmeticif.h"
-#include "attr.h"
-#include "scope.h"
-#include "semantics.h"
-#include "symbol.h"
 #include "tools.h"
-#include "type.h"
-#include "../evaluate/traversal.h"
 #include "../parser/message.h"
 #include "../parser/parse-tree.h"
 

--- a/lib/semantics/check-computed-goto.cc
+++ b/lib/semantics/check-computed-goto.cc
@@ -1,0 +1,44 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "check-computed-goto.h"
+#include "attr.h"
+#include "scope.h"
+#include "semantics.h"
+#include "symbol.h"
+#include "tools.h"
+#include "type.h"
+#include "../evaluate/traversal.h"
+#include "../parser/message.h"
+#include "../parser/parse-tree.h"
+
+namespace Fortran::semantics {
+
+void ComputedGotoStmtChecker::Leave(
+    const parser::ComputedGotoStmt &computedGotoStmt) {
+  // C1169 Labels will have already been check
+  // R1158 Check for scalar-int-expr
+  auto &expr{
+      std::get<parser::ScalarIntExpr>(computedGotoStmt.t).thing.thing.value()};
+  if (expr.typedExpr->v.Rank() > 0) {
+    context_.messages().Say(expr.source,
+        "Computed GOTO expression must be a scalar expression"_err_en_US);
+  } else if (!ExprHasTypeCategory(
+                 *expr.typedExpr, common::TypeCategory::Integer)) {
+    context_.messages().Say(expr.source,
+        "Computed GOTO expression must be an integer expression"_err_en_US);
+  }
+}
+
+}  // namespace Fortran::semantics

--- a/lib/semantics/check-computed-goto.cc
+++ b/lib/semantics/check-computed-goto.cc
@@ -27,7 +27,7 @@ namespace Fortran::semantics {
 
 void ComputedGotoStmtChecker::Leave(
     const parser::ComputedGotoStmt &computedGotoStmt) {
-  // C1169 Labels will have already been check
+  // C1169 Labels have already been checked
   // R1158 Check for scalar-int-expr
   auto &expr{
       std::get<parser::ScalarIntExpr>(computedGotoStmt.t).thing.thing.value()};

--- a/lib/semantics/check-computed-goto.cc
+++ b/lib/semantics/check-computed-goto.cc
@@ -13,13 +13,7 @@
 // limitations under the License.
 
 #include "check-computed-goto.h"
-#include "attr.h"
-#include "scope.h"
-#include "semantics.h"
-#include "symbol.h"
 #include "tools.h"
-#include "type.h"
-#include "../evaluate/traversal.h"
 #include "../parser/message.h"
 #include "../parser/parse-tree.h"
 

--- a/lib/semantics/check-computed-goto.h
+++ b/lib/semantics/check-computed-goto.h
@@ -1,0 +1,35 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_SEMANTICS_CHECK_COMPUTED_GOTO_STMT_H_
+#define FORTRAN_SEMANTICS_CHECK_COMPUTED_GOTO_STMT_H_
+
+#include "semantics.h"
+
+namespace Fortran::parser {
+struct ComputedGotoStmt;
+}
+
+namespace Fortran::semantics {
+class ComputedGotoStmtChecker : public virtual BaseChecker {
+public:
+  inline ComputedGotoStmtChecker(SemanticsContext &context)
+    : context_{context} {}
+  void Leave(const parser::ComputedGotoStmt &);
+
+private:
+  SemanticsContext &context_;
+};
+}
+#endif  // FORTRAN_SEMANTICS_CHECK_COMPUTED_GOTO_STMT_H_

--- a/lib/semantics/check-if-construct.cc
+++ b/lib/semantics/check-if-construct.cc
@@ -13,13 +13,7 @@
 // limitations under the License.
 
 #include "check-if-construct.h"
-#include "attr.h"
-#include "scope.h"
-#include "semantics.h"
-#include "symbol.h"
 #include "tools.h"
-#include "type.h"
-#include "../evaluate/traversal.h"
 #include "../parser/message.h"
 #include "../parser/parse-tree.h"
 

--- a/lib/semantics/check-if-stmt.cc
+++ b/lib/semantics/check-if-stmt.cc
@@ -13,13 +13,7 @@
 // limitations under the License.
 
 #include "check-if-stmt.h"
-#include "attr.h"
-#include "scope.h"
-#include "semantics.h"
-#include "symbol.h"
 #include "tools.h"
-#include "type.h"
-#include "../evaluate/traversal.h"
 #include "../parser/message.h"
 #include "../parser/parse-tree.h"
 

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -16,6 +16,7 @@
 #include "assignment.h"
 #include "canonicalize-do.h"
 #include "check-arithmeticif.h"
+#include "check-computed-goto.h"
 #include "check-do-concurrent.h"
 #include "check-if-construct.h"
 #include "check-if-stmt.h"
@@ -64,7 +65,8 @@ private:
 
 using StatementSemanticsPass1 = SemanticsVisitor<ExprChecker>;
 using StatementSemanticsPass2 = SemanticsVisitor<ArithmeticIfStmtChecker,
-    AssignmentChecker, DoConcurrentChecker, IfConstructChecker, IfStmtChecker>;
+    AssignmentChecker, ComputedGotoStmtChecker, DoConcurrentChecker,
+    IfConstructChecker, IfStmtChecker>;
 
 SemanticsContext::SemanticsContext(
     const common::IntrinsicTypeDefaultKinds &defaultKinds,

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -84,6 +84,8 @@ set(ERROR_TESTS
   if_construct02.f90
   if_stmt02.f90
   if_stmt03.f90
+  computed-goto01.f90
+  computed-goto02.f90
 )
 
 # These test files have expected symbols in the source

--- a/test/semantics/computed-goto01.f90
+++ b/test/semantics/computed-goto01.f90
@@ -1,0 +1,37 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check that a basic computed goto compiles
+
+INTEGER, DIMENSION (2) :: B
+
+GOTO (100) 1
+GOTO (100) I
+GOTO (100) I+J
+GOTO (100) B(1)
+
+GOTO (100, 200) 1
+GOTO (100, 200) I
+GOTO (100, 200) I+J
+GOTO (100, 200) B(1)
+
+GOTO (100, 200, 300) 1
+GOTO (100, 200, 300) I
+GOTO (100, 200, 300) I+J
+GOTO (100, 200, 300) B(1)
+
+100 CONTINUE
+200 CONTINUE
+300 CONTINUE
+END

--- a/test/semantics/computed-goto02.f90
+++ b/test/semantics/computed-goto02.f90
@@ -1,0 +1,36 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check that computed goto express must be a scalar integer expression
+! TODO: PGI, for example, accepts a float & converts the value to int.
+
+REAL R
+COMPLEX Z
+LOGICAL L
+INTEGER, DIMENSION (2) :: B
+
+!ERROR: Computed GOTO expression must be an integer expression
+GOTO (100) 1.5
+!ERROR: Computed GOTO expression must be an integer expression
+GOTO (100) .TRUE.
+!ERROR: Computed GOTO expression must be an integer expression
+GOTO (100) R
+!ERROR: Computed GOTO expression must be an integer expression
+GOTO (100) Z
+!ERROR: Computed GOTO expression must be a scalar expression
+GOTO (100) B
+
+100 CONTINUE
+
+END


### PR DESCRIPTION
Note that a PGI extension will implicitly convert a float to integer (and issue a warning).  This commit does not implement that extension.