### PR TITLE
Fix F18 scalar integer power algorithm

### DIFF
--- a/lib/evaluate/integer.h
+++ b/lib/evaluate/integer.h
@@ -953,9 +953,9 @@ public:
           result.overflow |= product.SignedMultiplicationOverflowed();
         }
         if (j + 1 < nbits) {
-          ValueWithOverflow doubled{shifted.AddSigned(shifted)};
-          result.overflow |= doubled.overflow;
-          shifted = doubled.value;
+          Product squared{shifted.MultiplySigned(shifted)};
+          result.overflow |= squared.SignedMultiplicationOverflowed();
+          shifted = squared.lower;
         }
       }
     }

--- a/test/evaluate/folding01.f90
+++ b/test/evaluate/folding01.f90
@@ -95,5 +95,9 @@ module m
   logical, parameter :: test_divide_i3 = ((-7)/2).EQ.(-3)
   logical, parameter :: test_divide_i4 = (0/127).EQ.(0)
 
+  logical, parameter :: test_pow1 = (2**0).EQ.(1)
+  logical, parameter :: test_pow2 = (1**100).EQ.(1)
+  logical, parameter :: test_pow3 = (2**4).EQ.(16)
+  logical, parameter :: test_pow4 = (7**5).EQ.(16807)
 
 end module


### PR DESCRIPTION
Fix `Integer::Power(const Integer &exponent)` algorithm.
Currently `2**5` was returning `16` instead of the expected `32`.
The algorithm was doubling the base value every power of 2 instead of squaring it.
Add related short test.