### PR TITLE
Add CMake rules to install static and shared libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,8 +37,7 @@ endif()
 set(CMAKE_SKIP_BUILD_RPATH false)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH false)
 
-# Don't use the installation RPATH when building
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib" "${CMAKE_INSTALL_RPATH}")
 
 # Reminder: Setting CMAKE_CXX_COMPILER must be done before calling project()
 
@@ -100,7 +99,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
    # due to the need to preserve the right to override external entry points
    # at dynamic link time.  -fno-semantic-interposition waives that right and
    # recovers a little bit of that performance.
-   if (BUILD_SHARED_LIBS)
+   if (BUILD_SHARED_LIBS AND NOT (CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
      set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fno-semantic-interposition")
    endif()
 endif()

--- a/lib/FIR/CMakeLists.txt
+++ b/lib/FIR/CMakeLists.txt
@@ -28,3 +28,9 @@ add_library(FortranFIR
 target_link_libraries(FortranFIR
   FortranCommon
 )
+
+install (TARGETS FortranFIR
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)

--- a/lib/common/CMakeLists.txt
+++ b/lib/common/CMakeLists.txt
@@ -16,3 +16,9 @@ add_library(FortranCommon
   default-kinds.cc
   idioms.cc
 )
+
+install (TARGETS FortranCommon
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)

--- a/lib/evaluate/CMakeLists.txt
+++ b/lib/evaluate/CMakeLists.txt
@@ -39,6 +39,12 @@ target_link_libraries(FortranEvaluate
   m
 )
 
+install (TARGETS FortranEvaluate
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
 if (LIBPGMATH_DIR)
   # If pgmath library is found, it can be used for constant folding.
   find_library(LIBPGMATH pgmath PATHS ${LIBPGMATH_DIR})

--- a/lib/parser/CMakeLists.txt
+++ b/lib/parser/CMakeLists.txt
@@ -33,3 +33,9 @@ add_library(FortranParser
 target_link_libraries(FortranParser
   FortranCommon
 )
+
+install (TARGETS FortranParser
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)

--- a/lib/semantics/CMakeLists.txt
+++ b/lib/semantics/CMakeLists.txt
@@ -39,3 +39,9 @@ target_link_libraries(FortranSemantics
   FortranCommon
   FortranEvaluate
 )
+
+install (TARGETS FortranSemantics
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)

--- a/tools/f18/CMakeLists.txt
+++ b/tools/f18/CMakeLists.txt
@@ -38,3 +38,5 @@ add_executable(f18-parse-demo
 target_link_libraries(f18-parse-demo
   FortranParser
 )
+
+install(TARGETS f18 f18-parse-demo DESTINATION bin)


### PR DESCRIPTION
Libraries are installed to the default install directory or to the directory specified with CMAKE_INSTALL_PREFIX.  Fixes #359.