### PR TITLE
Fix semantics test for "DO".

### DIFF
--- a/test/semantics/canondo04.f90
+++ b/test/semantics/canondo04.f90
@@ -13,7 +13,7 @@
 ! limitations under the License.
 
 ! RUN: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
-! CHECK-NOT: do *[1-9]
+! CHECK-NOT: do [1-9]
 
 ! Figure out how to also execute this test.
 


### PR DESCRIPTION
This test fails when the directory in which the tests are run contains a path that matches the pattern "do *[1-9]".  In my case, I had a directory called "do1".  The "*" is not necessary in the pattern.  Now the test passes unless the directory contains a " ".