### PR TITLE
Update documentation to reflect current intrinsic procedure support in f18

### DIFF
--- a/documentation/Intrinsics.md
+++ b/documentation/Intrinsics.md
@@ -733,13 +733,13 @@ listed below are folded using host independent implementations.
 | LOGICAL | BGE, BGT, BLE, BLT |
 
 ### Intrinsic Functions with Host Dependent Folding Support
-Implementations using the host runtime may not be available for all f18 supported
-type kind depending on the host hardware types and the libraries available on the host.
+Implementations using the host runtime may not be available for all supported
+f18 types depending on the host hardware types and the libraries available on the host.
 The actual support on a host depends on what the host hardware types are.
 The list below gives the functions that are folded using host runtime and the related C/C++ types.
 F18 automatically detects if these types match an f18 scalar type. If so,
 folding of the intrinsic functions will be possible for the related f18 scalar type,
-else an error message will be produced by f18 when attempting to fold related intrinsic functions.
+otherwise an error message will be produced by f18 when attempting to fold related intrinsic functions.
 
 | C/C++ Host Type | Intrinsic Functions with Host Standard C++ Library Based Folding Support |
 | --- | --- |

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -475,7 +475,7 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldOperation(FoldingContext &context,
           context, std::move(funcRef), &Scalar<T>::MERGE_BITS);
     }
     // TODO:
-    // ceiling, command_argument_count, count, cshift, dot_product, eoshift,
+    // ceiling, count, cshift, dot_product, eoshift,
     // findloc, floor, iachar, iall, iany, iparity, ibits, ichar, image_status,
     // index, ishftc, lbound, len_trim, matmul, max, maxloc, maxval, merge, min,
     // minloc, minval, mod, modulo, nint, not, pack, product, reduce, reshape,

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -394,7 +394,6 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldOperation(FoldingContext &context,
               return Fold(context, ConvertToType<T>(std::move(x)));
             }
             common::die("int() argument type not valid");
-            return Expr<T>{std::move(funcRef)};  // unreachable
           },
           std::move(args[0].value().value().u));
     } else if (name == "kind") {
@@ -621,7 +620,6 @@ Expr<Type<TypeCategory::Real, KIND>> FoldOperation(FoldingContext &context,
               return Fold(context, ConvertToType<T>(std::move(x)));
             }
             common::die("real() argument type not valid");
-            return Expr<T>{std::move(funcRef)};  // unreachable
           },
           std::move(args[0].value().value().u));
     }

--- a/lib/evaluate/intrinsics-library-templates.h
+++ b/lib/evaluate/intrinsics-library-templates.h
@@ -73,9 +73,8 @@ template<typename TR, typename... ArgInfo> struct CallableHostWrapper {
       hostFPE.CheckAndRestoreFloatingPointEnvironment(context);
       return host::CastHostToFortran<TR>(res);
     } else {
-      common::die("Internal error: Host does not supports this function types."
+      common::die("Internal error: Host does not supports this function type."
                   "This should not have been called for folding");
-      return Scalar<TR>{};  // unreachable
     }
   }
   static constexpr inline auto MakeScalarCallable() { return &scalarCallable; }


### PR DESCRIPTION
As per the title plus a minor code change to remove 3 useless return statements that Eric pointed out (After re-testing, removing them is not producing any warnings).