### PR TITLE
Fix bugs #376, #377

### DIFF
--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -207,20 +207,6 @@ template<TypeCategory CAT>
 static constexpr Precedence GetPrecedence(const Expr<SomeKind<CAT>> &expr) {
   return std::visit([](const auto &x) { return GetPrecedence(x); }, expr.u);
 }
-static constexpr Precedence GetPrecedence(const Expr<SomeDerived> &expr) {
-  return std::visit(
-      [](const auto &x) { return ToPrecedence<std::decay_t<decltype(x)>>; },
-      expr.u);
-}
-static constexpr Precedence GetPrecedence(const BOZLiteralConstant &) {
-  return Precedence::Primary;
-}
-static constexpr Precedence GetPrecedence(const NullPointer &) {
-  return Precedence::Primary;
-}
-static constexpr Precedence GetPrecedence(const Expr<SomeType> &expr) {
-  return std::visit([](const auto &x) { return GetPrecedence(x); }, expr.u);
-}
 
 template<typename T> static bool IsNegatedScalarConstant(const Expr<T> &expr) {
   static constexpr TypeCategory cat{T::category};

--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -212,14 +212,14 @@ static constexpr Precedence GetPrecedence(const Expr<SomeDerived> &expr) {
       [](const auto &x) { return ToPrecedence<std::decay_t<decltype(x)>>; },
       expr.u);
 }
+static constexpr Precedence GetPrecedence(const BOZLiteralConstant &) {
+  return Precedence::Primary;
+}
+static constexpr Precedence GetPrecedence(const NullPointer &) {
+  return Precedence::Primary;
+}
 static constexpr Precedence GetPrecedence(const Expr<SomeType> &expr) {
-  return std::visit(
-      common::visitors{
-          [](const BOZLiteralConstant &) { return Precedence::Primary; },
-          [](const NullPointer &) { return Precedence::Primary; },
-          [](const auto &x) { return GetPrecedence(x); },
-      },
-      expr.u);
+  return std::visit([](const auto &x) { return GetPrecedence(x); }, expr.u);
 }
 
 template<typename T> static bool IsNegatedScalarConstant(const Expr<T> &expr) {

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -98,7 +98,6 @@ private:
       DoSymbol(*symbol);
     }
   }
-
 };
 
 bool ModFileWriter::WriteAll() {
@@ -391,7 +390,6 @@ std::vector<const Symbol *> CollectSymbols(const Scope &scope) {
   }
   for (const auto &pair : scope.commonBlocks()) {
     const Symbol *symbol{pair.second};
-    SourceName name{pair.first};
     if (symbols.insert(symbol).second) {
       common.push_back(symbol);
     }

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -185,12 +185,17 @@ bool Scope::CanImport(const SourceName &name) const {
   }
 }
 
-const Scope *Scope::FindScope(const parser::CharBlock &source) const {
+const Scope *Scope::FindScope(parser::CharBlock source) const {
+  return const_cast<const Scope *>(
+      const_cast<Scope *>(this)->FindScope(source));
+}
+
+Scope *Scope::FindScope(parser::CharBlock source) {
   if (!sourceRange_.Contains(source)) {
     return nullptr;
   }
-  for (const auto &child : children_) {
-    if (const auto *scope{child.FindScope(source)}) {
+  for (auto &child : children_) {
+    if (auto *scope{child.FindScope(source)}) {
       return scope;
     }
   }

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -249,7 +249,7 @@ const DeclTypeSpec *Scope::FindInstantiatedDerivedType(
 }
 
 const DeclTypeSpec &Scope::FindOrInstantiateDerivedType(DerivedTypeSpec &&spec,
-    DeclTypeSpec::Category category, SemanticsContext &semanticsContext) {
+    SemanticsContext &semanticsContext, DeclTypeSpec::Category category) {
   spec.FoldParameterExpressions(semanticsContext.foldingContext());
   if (const DeclTypeSpec * type{FindInstantiatedDerivedType(spec, category)}) {
     return *type;

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -186,8 +186,7 @@ bool Scope::CanImport(const SourceName &name) const {
 }
 
 const Scope *Scope::FindScope(parser::CharBlock source) const {
-  return const_cast<const Scope *>(
-      const_cast<Scope *>(this)->FindScope(source));
+  return const_cast<Scope *>(this)->FindScope(source);
 }
 
 Scope *Scope::FindScope(parser::CharBlock source) {

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -172,7 +172,8 @@ public:
   const parser::CharBlock &sourceRange() const { return sourceRange_; }
   void AddSourceRange(const parser::CharBlock &);
   // Find the smallest scope under this one that contains source
-  const Scope *FindScope(const parser::CharBlock &) const;
+  const Scope *FindScope(parser::CharBlock) const;
+  Scope *FindScope(parser::CharBlock);
 
   // Attempts to find a match for a derived type instance
   const DeclTypeSpec *FindInstantiatedDerivedType(const DerivedTypeSpec &,

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -180,8 +180,8 @@ public:
 
   // Returns a matching derived type instance if one exists, otherwise
   // creates one
-  const DeclTypeSpec &FindOrInstantiateDerivedType(
-      DerivedTypeSpec &&, DeclTypeSpec::Category, SemanticsContext &);
+  const DeclTypeSpec &FindOrInstantiateDerivedType(DerivedTypeSpec &&,
+      SemanticsContext &, DeclTypeSpec::Category = DeclTypeSpec::TypeDerived);
 
   // Clones a DerivedType scope into a new derived type instance's scope.
   void InstantiateDerivedType(Scope &, SemanticsContext &) const;

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -115,9 +115,13 @@ bool SemanticsContext::AnyFatalError() const {
       (warningsAreErrors_ || messages_.AnyFatalError());
 }
 
-const Scope &SemanticsContext::FindScope(
-    const parser::CharBlock &source) const {
-  if (const auto *scope{globalScope_.FindScope(source)}) {
+const Scope &SemanticsContext::FindScope(parser::CharBlock source) const {
+  return const_cast<const Scope &>(
+      const_cast<SemanticsContext *>(this)->FindScope(source));
+}
+
+Scope &SemanticsContext::FindScope(parser::CharBlock source) {
+  if (auto *scope{globalScope_.FindScope(source)}) {
     return *scope;
   } else {
     common::die("invalid source location");

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -116,8 +116,7 @@ bool SemanticsContext::AnyFatalError() const {
 }
 
 const Scope &SemanticsContext::FindScope(parser::CharBlock source) const {
-  return const_cast<const Scope &>(
-      const_cast<SemanticsContext *>(this)->FindScope(source));
+  return const_cast<SemanticsContext *>(this)->FindScope(source);
 }
 
 Scope &SemanticsContext::FindScope(parser::CharBlock source) {

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -95,7 +95,8 @@ public:
     return messages_.Say(std::move(msg));
   }
 
-  const Scope &FindScope(const parser::CharBlock &) const;
+  const Scope &FindScope(parser::CharBlock) const;
+  Scope &FindScope(parser::CharBlock);
 
 private:
   const common::IntrinsicTypeDefaultKinds &defaultKinds_;

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -569,7 +569,7 @@ Symbol &Symbol::Instantiate(
                 }
                 details.ReplaceType(
                     scope.FindOrInstantiateDerivedType(std::move(newSpec),
-                        origType->category(), semanticsContext));
+                        semanticsContext, origType->category()));
               } else if (origType->AsIntrinsic() != nullptr) {
                 const DeclTypeSpec &newType{scope.InstantiateIntrinsicType(
                     *origType, semanticsContext)};


### PR DESCRIPTION
Extracts and improves some development code to avoid an internal error in expression semantics when rewriting a misparsed function call as a structure constructor (now that it's clear that's what it is), and tweaks some new code from yesterday to dodge a bogus compilation error from gcc 7.2.0.