### PR TITLE
Support coarrays in name resolution

### DIFF
--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -424,7 +424,7 @@ void PutEntity(std::ostream &os, const Symbol &symbol) {
 }
 
 void PutShapeSpec(std::ostream &os, const ShapeSpec &x) {
-  if (x.ubound().isAssumed()) {
+  if (x.lbound().isAssumed()) {
     CHECK(x.ubound().isAssumed());
     os << "..";
   } else {
@@ -437,9 +437,9 @@ void PutShapeSpec(std::ostream &os, const ShapeSpec &x) {
     }
   }
 }
-void PutShape(std::ostream &os, const ArraySpec &shape) {
+void PutShape(std::ostream &os, const ArraySpec &shape, char open, char close) {
   if (!shape.empty()) {
-    os << '(';
+    os << open;
     bool first{true};
     for (const auto &shapeSpec : shape) {
       if (first) {
@@ -449,7 +449,7 @@ void PutShape(std::ostream &os, const ArraySpec &shape) {
       }
       PutShapeSpec(os, shapeSpec);
     }
-    os << ')';
+    os << close;
   }
 }
 
@@ -460,7 +460,8 @@ void PutObjectEntity(std::ostream &os, const Symbol &symbol) {
     CHECK(type);
     PutLower(os, *type);
   });
-  PutShape(os, details.shape());
+  PutShape(os, details.shape(), '(', ')');
+  PutShape(os, details.coshape(), '[', ']');
   PutInit(os, details.init());
 }
 
@@ -813,6 +814,10 @@ void SubprogramSymbolCollector::DoSymbol(const Symbol &symbol) {
       common::visitors{
           [this](const ObjectEntityDetails &details) {
             for (const ShapeSpec &spec : details.shape()) {
+              DoBound(spec.lbound());
+              DoBound(spec.ubound());
+            }
+            for (const ShapeSpec &spec : details.coshape()) {
               DoBound(spec.lbound());
               DoBound(spec.ubound());
             }

--- a/lib/semantics/resolve-names-utils.h
+++ b/lib/semantics/resolve-names-utils.h
@@ -18,10 +18,13 @@
 // Utility functions and class for use in resolve-names.cc.
 
 #include "symbol.h"
+#include "type.h"
 #include "../parser/message.h"
 
 namespace Fortran::parser {
 class CharBlock;
+struct ArraySpec;
+struct CoarraySpec;
 struct DefinedOpName;
 struct GenericSpec;
 struct Name;
@@ -30,6 +33,7 @@ struct Name;
 namespace Fortran::semantics {
 
 using SourceName = parser::CharBlock;
+class SemanticsContext;
 
 // Record that a Name has been resolved to a Symbol
 Symbol &Resolve(const parser::Name &, Symbol &);
@@ -63,6 +67,12 @@ private:
   void Analyze(const parser::DefinedOpName &);
   void Analyze(const parser::GenericSpec &);
 };
+
+// Analyze a parser::ArraySpec or parser::CoarraySpec into the provide ArraySpec
+void AnalyzeArraySpec(
+    ArraySpec &, SemanticsContext &, const parser::ArraySpec &);
+void AnalyzeCoarraySpec(
+    ArraySpec &, SemanticsContext &, const parser::CoarraySpec &);
 
 }
 

--- a/lib/semantics/resolve-names-utils.h
+++ b/lib/semantics/resolve-names-utils.h
@@ -68,11 +68,10 @@ private:
   void Analyze(const parser::GenericSpec &);
 };
 
-// Analyze a parser::ArraySpec or parser::CoarraySpec into the provide ArraySpec
-void AnalyzeArraySpec(
-    ArraySpec &, SemanticsContext &, const parser::ArraySpec &);
-void AnalyzeCoarraySpec(
-    ArraySpec &, SemanticsContext &, const parser::CoarraySpec &);
+// Analyze a parser::ArraySpec or parser::CoarraySpec
+ArraySpec AnalyzeArraySpec(SemanticsContext &, const parser::ArraySpec &);
+ArraySpec AnalyzeCoarraySpec(
+    SemanticsContext &context, const parser::CoarraySpec &);
 
 }
 

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -1419,10 +1419,12 @@ bool ImplicitRulesVisitor::HandleImplicitNone(
 // ArraySpecVisitor implementation
 
 void ArraySpecVisitor::Post(const parser::ArraySpec &x) {
-  AnalyzeArraySpec(arraySpec_, context(), x);
+  CHECK(arraySpec_.empty());
+  arraySpec_ = AnalyzeArraySpec(context(), x);
 }
 void ArraySpecVisitor::Post(const parser::CoarraySpec &x) {
-  AnalyzeCoarraySpec(coarraySpec_, context(), x);
+  CHECK(coarraySpec_.empty());
+  coarraySpec_ = AnalyzeCoarraySpec(context(), x);
 }
 
 const ArraySpec &ArraySpecVisitor::arraySpec() {

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -134,6 +134,7 @@ set(MODFILE_TESTS
   modfile21.f90
   modfile22.f90
   modfile23.f90
+  modfile24.f90
 )
 
 set(LABEL_TESTS

--- a/test/semantics/modfile24.f90
+++ b/test/semantics/modfile24.f90
@@ -1,0 +1,88 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test declarations with coarray-spec
+
+! Different ways of declaring the same coarray.
+module m1
+  real :: a(1:5)[1:10,1:*]
+  real, dimension(5) :: b[1:10,1:*]
+  real, codimension[1:10,1:*] :: c(5)
+  real, codimension[1:10,1:*], dimension(5) :: d
+  codimension :: e[1:10,1:*]
+  dimension :: e(5)
+  real :: e
+end
+!Expect: m1.mod
+!module m1
+! real(4)::a(1_8:5_8)[1_8:10_8,1_8:*]
+! real(4)::b(1_8:5_8)[1_8:10_8,1_8:*]
+! real(4)::c(1_8:5_8)[1_8:10_8,1_8:*]
+! real(4)::d(1_8:5_8)[1_8:10_8,1_8:*]
+! real(4)::e(1_8:5_8)[1_8:10_8,1_8:*]
+!end
+
+! coarray-spec in codimension and target statements.
+module m2
+  codimension :: a[10,*], b[*]
+  target :: c[10,*], d[*]
+end
+!Expect: m2.mod
+!module m2
+! real(4)::a[1_8:10_8,1_8:*]
+! real(4)::b[1_8:*]
+! real(4),target::c[1_8:10_8,1_8:*]
+! real(4),target::d[1_8:*]
+!end
+
+! coarray-spec in components and with non-constants bounds
+module m3
+  type t
+    real :: c(1:5)[1:10,1:*]
+    complex, codimension[5,*] :: d
+  end type
+  real, allocatable :: e[:,:,:]
+contains
+  subroutine s(a, b, n)
+    integer(8) :: n
+    real :: a[1:n,2:*]
+    real, codimension[1:n,2:*] :: b
+  end
+end
+!Expect: m3.mod
+!module m3
+! type::t
+!  real(4)::c[1_8:10_8,1_8:*]
+!  complex(4)::d[1_8:5_8,1_8:*]
+! end type
+! real(4),allocatable::e[:,:,:]
+!contains
+! subroutine s(a,b,n)
+!  integer(8)::n
+!  real(4)::a[1_8:n,2_8:*]
+!  real(4)::b[1_8:n,2_8:*]
+! end
+!end
+
+! coarray-spec in both attributes and entity-decl
+module m4
+  real, codimension[2:*], dimension(2:5) :: a, b(4,4), c[10,*], d(4,4)[10,*]
+end
+!Expect: m4.mod
+!module m4
+! real(4)::a(2_8:5_8)[2_8:*]
+! real(4)::b(1_8:4_8,1_8:4_8)[2_8:*]
+! real(4)::c(2_8:5_8)[1_8:10_8,1_8:*]
+! real(4)::d(1_8:4_8,1_8:4_8)[1_8:10_8,1_8:*]
+!end

--- a/test/semantics/resolve07.f90
+++ b/test/semantics/resolve07.f90
@@ -16,18 +16,27 @@ subroutine s1
   integer :: x(2)
   !ERROR: The dimensions of 'x' have already been declared
   allocatable :: x(:)
+  real :: y[1:*]
+  !ERROR: The codimensions of 'y' have already been declared
+  allocatable :: y[:]
 end
 
 subroutine s2
   target :: x(1)
   !ERROR: The dimensions of 'x' have already been declared
   integer :: x(2)
+  target :: y[1:*]
+  !ERROR: The codimensions of 'y' have already been declared
+  integer :: y[2:*]
 end
 
 subroutine s3
-  dimension :: x(4), y(8)
+  dimension :: x(4), x2(8)
   !ERROR: The dimensions of 'x' have already been declared
   allocatable :: x(:)
+  codimension :: y[*], y2[1:2,2:*]
+  !ERROR: The codimensions of 'y' have already been declared
+  allocatable :: y[:]
 end
 
 subroutine s4


### PR DESCRIPTION
A coarray is represented as a `Symbol` with `ObjectEntityDetails` that
has a non-empty coshape. The coshape is represented using the same type
(`ArrayShape`) as the shape is, so the fact that it is a coshape is
determined from context.

Move code for analyzing shapes to `resolve-names-utils.cc` and
generalize it for coshapes.

In `symbol.cc` add dumping of coshapes. Simplify some of the functions
by adding some `Dump*` functions to handle common cases.

In `mod-file.cc` generalize the code for writing shapes to also write
coshapes. Fix a bug in `PutShapeSpec()`.