### PR TITLE
Shape analysis

### DIFF
--- a/lib/common/template.h
+++ b/lib/common/template.h
@@ -237,7 +237,7 @@ std::optional<std::tuple<A...>> AllElementsPresent(
 
 // std::vector<std::optional<A>> -> std::optional<std::vector<A>>
 // i.e., inverts a vector of optional values into an optional vector that
-// has a value of if all of the original elements were present.
+// will have a value only when all of the original elements are present.
 template<typename A>
 std::optional<std::vector<A>> AllElementsPresent(
     std::vector<std::optional<A>> &&v) {

--- a/lib/common/template.h
+++ b/lib/common/template.h
@@ -157,6 +157,21 @@ struct AreTypesDistinctHelper {
 template<typename... Ts>
 constexpr bool AreTypesDistinct{AreTypesDistinctHelper<Ts...>::value()};
 
+template<typename A, typename... Ts> struct AreSameTypeHelper {
+  using type = A;
+  static constexpr bool value() {
+    if constexpr (sizeof...(Ts) == 0) {
+      return true;
+    } else {
+      using Rest = AreSameTypeHelper<Ts...>;
+      return std::is_same_v<type, typename Rest::type> && Rest::value();
+    }
+  }
+};
+
+template<typename... Ts>
+constexpr bool AreSameType{AreSameTypeHelper<Ts...>::value()};
+
 template<typename> struct TupleToVariantHelper;
 template<typename... Ts> struct TupleToVariantHelper<std::tuple<Ts...>> {
   static_assert(AreTypesDistinct<Ts...> ||

--- a/lib/common/template.h
+++ b/lib/common/template.h
@@ -240,6 +240,10 @@ std::optional<R> MapOptional(
   }
   return std::nullopt;
 }
+template<typename R, typename... A>
+std::optional<R> MapOptional(R (*f)(A &&...), std::optional<A> &&... x) {
+  return MapOptional(std::function<R(A && ...)>{f}, std::move(x)...);
+}
 
 // Given a VISITOR class of the general form
 //   struct VISITOR {

--- a/lib/common/template.h
+++ b/lib/common/template.h
@@ -20,6 +20,7 @@
 #include <tuple>
 #include <type_traits>
 #include <variant>
+#include <vector>
 
 // Utility templates for metaprogramming and for composing the
 // std::optional<>, std::tuple<>, and std::variant<> containers.
@@ -232,6 +233,24 @@ std::optional<std::tuple<A...>> AllElementsPresent(
     std::tuple<std::optional<A>...> &&t) {
   return AllElementsPresentHelper(
       std::move(t), std::index_sequence_for<A...>{});
+}
+
+// std::vector<std::optional<A>> -> std::optional<std::vector<A>>
+// i.e., inverts a vector of optional values into an optional vector that
+// has a value of if all of the original elements were present.
+template<typename A>
+std::optional<std::vector<A>> AllElementsPresent(
+    std::vector<std::optional<A>> &&v) {
+  for (const auto &maybeA : v) {
+    if (!maybeA.has_value()) {
+      return std::nullopt;
+    }
+  }
+  std::vector<A> result;
+  for (auto &&maybeA : std::move(v)) {
+    result.emplace_back(std::move(*maybeA));
+  }
+  return result;
 }
 
 // (std::optional<>...) -> std::optional<std::tuple<...>>

--- a/lib/evaluate/CMakeLists.txt
+++ b/lib/evaluate/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(FortranEvaluate
   intrinsics-library.cc
   logical.cc
   real.cc
+  shape.cc
   static-data.cc
   tools.cc
   type.cc

--- a/lib/evaluate/call.cc
+++ b/lib/evaluate/call.cc
@@ -29,14 +29,6 @@ bool ActualArgument::operator==(const ActualArgument &that) const {
       isAlternateReturn == that.isAlternateReturn && value() == that.value();
 }
 
-std::optional<int> ActualArgument::VectorSize() const {
-  if (Rank() != 1) {
-    return std::nullopt;
-  }
-  // TODO: get shape vector of value, return its length
-  return std::nullopt;
-}
-
 bool SpecificIntrinsic::operator==(const SpecificIntrinsic &that) const {
   return name == that.name && type == that.type && rank == that.rank &&
       attrs == that.attrs;

--- a/lib/evaluate/call.h
+++ b/lib/evaluate/call.h
@@ -45,7 +45,6 @@ public:
   int Rank() const;
   bool operator==(const ActualArgument &) const;
   std::ostream &AsFortran(std::ostream &) const;
-  std::optional<int> VectorSize() const;
 
   std::optional<parser::CharBlock> keyword;
   bool isAlternateReturn{false};  // when true, "value" is a label number

--- a/lib/evaluate/common.h
+++ b/lib/evaluate/common.h
@@ -201,6 +201,7 @@ template<typename A> class Expr;
 
 class FoldingContext {
 public:
+  FoldingContext() = default;
   explicit FoldingContext(const parser::ContextualMessages &m,
       Rounding round = defaultRounding, bool flush = false)
     : messages_{m}, rounding_{round}, flushSubnormalsToZero_{flush} {}

--- a/lib/evaluate/constant.cc
+++ b/lib/evaluate/constant.cc
@@ -42,6 +42,12 @@ auto ConstantBase<RESULT, VALUE>::At(
   return values_.at(SubscriptsToOffset(index, shape_));
 }
 
+template<typename RESULT, typename VALUE>
+auto ConstantBase<RESULT, VALUE>::At(std::vector<std::int64_t> &&index) const
+    -> ScalarValue {
+  return values_.at(SubscriptsToOffset(index, shape_));
+}
+
 static Constant<SubscriptInteger> ShapeAsConstant(
     const std::vector<std::int64_t> &shape) {
   using IntType = Scalar<SubscriptInteger>;

--- a/lib/evaluate/constant.h
+++ b/lib/evaluate/constant.h
@@ -66,6 +66,7 @@ public:
 
   // Apply 1-based subscripts
   ScalarValue At(const std::vector<std::int64_t> &) const;
+  ScalarValue At(std::vector<std::int64_t> &&) const;
 
   Constant<SubscriptInteger> SHAPE() const;
   std::ostream &AsFortran(std::ostream &) const;

--- a/lib/evaluate/descender.h
+++ b/lib/evaluate/descender.h
@@ -210,23 +210,16 @@ public:
     Visit(aref.subscript());
   }
 
-  void Descend(const CoarrayRef::BasePartRef &part) {
-    Visit(*part.symbol);
-    Visit(part.subscript);
-  }
-  void Descend(CoarrayRef::BasePartRef &part) {
-    Visit(*part.symbol);
-    Visit(part.subscript);
-  }
-
   void Descend(const CoarrayRef &caref) {
-    Visit(caref.baseDataRef());
+    Visit(caref.base());
+    Visit(caref.subscript());
     Visit(caref.cosubscript());
     Visit(caref.stat());
     Visit(caref.team());
   }
   void Descend(CoarrayRef &caref) {
-    Visit(caref.baseDataRef());
+    Visit(caref.base());
+    Visit(caref.subscript());
     Visit(caref.cosubscript());
     Visit(caref.stat());
     Visit(caref.team());

--- a/lib/evaluate/descender.h
+++ b/lib/evaluate/descender.h
@@ -210,16 +210,23 @@ public:
     Visit(aref.subscript());
   }
 
+  void Descend(const CoarrayRef::BasePartRef &part) {
+    Visit(*part.symbol);
+    Visit(part.subscript);
+  }
+  void Descend(CoarrayRef::BasePartRef &part) {
+    Visit(*part.symbol);
+    Visit(part.subscript);
+  }
+
   void Descend(const CoarrayRef &caref) {
-    Visit(caref.base());
-    Visit(caref.subscript());
+    Visit(caref.baseDataRef());
     Visit(caref.cosubscript());
     Visit(caref.stat());
     Visit(caref.team());
   }
   void Descend(CoarrayRef &caref) {
-    Visit(caref.base());
-    Visit(caref.subscript());
+    Visit(caref.baseDataRef());
     Visit(caref.cosubscript());
     Visit(caref.stat());
     Visit(caref.team());

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -443,7 +443,7 @@ private:
 template<typename RESULT> struct ArrayConstructorValue {
   using Result = RESULT;
   EVALUATE_UNION_CLASS_BOILERPLATE(ArrayConstructorValue)
-  std::variant<common::CopyableIndirection<Expr<Result>>, ImpliedDo<Result>> u;
+  std::variant<Expr<Result>, ImpliedDo<Result>> u;
 };
 
 template<typename RESULT> class ArrayConstructorValues {

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -533,12 +533,15 @@ private:
       Power<Result>, Extremum<Result>>;
   using Indices = std::conditional_t<KIND == ImpliedDoIndex::Result::kind,
       std::tuple<ImpliedDoIndex>, std::tuple<>>;
+  using DescriptorInquiries =
+      std::conditional_t<KIND == DescriptorInquiry::Result::kind,
+          std::tuple<DescriptorInquiry>, std::tuple<>>;
   using Others = std::tuple<Constant<Result>, ArrayConstructor<Result>,
       TypeParamInquiry<KIND>, Designator<Result>, FunctionRef<Result>>;
 
 public:
-  common::TupleToVariant<
-      common::CombineTuples<Operations, Conversions, Indices, Others>>
+  common::TupleToVariant<common::CombineTuples<Operations, Conversions, Indices,
+      DescriptorInquiries, Others>>
       u;
 };
 

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -56,8 +56,18 @@ DataRef FoldOperation(FoldingContext &, DataRef &&);
 Substring FoldOperation(FoldingContext &, Substring &&);
 ComplexPart FoldOperation(FoldingContext &, ComplexPart &&);
 template<int KIND>
-Expr<Type<TypeCategory::Integer, KIND>> FoldOperation(FoldingContext &context,
-    FunctionRef<Type<TypeCategory::Integer, KIND>> &&funcRef);
+Expr<Type<TypeCategory::Integer, KIND>> FoldOperation(
+    FoldingContext &context, FunctionRef<Type<TypeCategory::Integer, KIND>> &&);
+template<int KIND>
+Expr<Type<TypeCategory::Real, KIND>> FoldOperation(
+    FoldingContext &context, FunctionRef<Type<TypeCategory::Real, KIND>> &&);
+template<int KIND>
+Expr<Type<TypeCategory::Complex, KIND>> FoldOperation(
+    FoldingContext &context, FunctionRef<Type<TypeCategory::Complex, KIND>> &&);
+// TODO: Character intrinsic function folding
+template<int KIND>
+Expr<Type<TypeCategory::Logical, KIND>> FoldOperation(
+    FoldingContext &context, FunctionRef<Type<TypeCategory::Logical, KIND>> &&);
 template<typename T> Expr<T> FoldOperation(FoldingContext &, Designator<T> &&);
 template<int KIND>
 Expr<Type<TypeCategory::Integer, KIND>> FoldOperation(
@@ -999,6 +1009,7 @@ Expr<TO> FoldOperation(
       [&](auto &kindExpr) -> Expr<TO> {
         kindExpr = Fold(context, std::move(kindExpr));
         using Operand = ResultType<decltype(kindExpr)>;
+        // TODO pmk: conversion of array constructors (constant or not)
         char buffer[64];
         if (auto value{GetScalarConstantValue<Operand>(kindExpr)}) {
           if constexpr (TO::category == TypeCategory::Integer) {

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -884,10 +884,19 @@ private:
     std::optional<std::int64_t> start{ToInt64(lower)}, end{ToInt64(upper)},
         step{ToInt64(stride)};
     if (start.has_value() && end.has_value() && step.has_value()) {
+      if (*step == 0) {
+        return false;
+      }
       bool result{true};
-      for (std::int64_t &j{context_.StartImpliedDo(iDo.name(), *start)};
-           j <= *end; j += *step) {
-        result &= FoldArray(iDo.values());
+      std::int64_t &j{context_.StartImpliedDo(iDo.name(), *start)};
+      if (*step > 0) {
+        for (; j <= *end; j += *step) {
+          result &= FoldArray(iDo.values());
+        }
+      } else {
+        for (; j >= *end; j += *step) {
+          result &= FoldArray(iDo.values());
+        }
       }
       context_.EndImpliedDo(iDo.name());
       return result;

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -113,16 +113,19 @@ ArrayRef FoldOperation(FoldingContext &context, ArrayRef &&arrayRef) {
 }
 
 CoarrayRef FoldOperation(FoldingContext &context, CoarrayRef &&coarrayRef) {
-  auto base{coarrayRef.base()};
-  std::vector<Expr<SubscriptInteger>> subscript, cosubscript;
-  for (Expr<SubscriptInteger> x : coarrayRef.subscript()) {
-    subscript.emplace_back(Fold(context, std::move(x)));
+  CoarrayRef::BaseDataRef baseDataRef;
+  for (auto &&part : std::move(coarrayRef.baseDataRef())) {
+    baseDataRef.emplace_back(*coarrayRef.baseDataRef().front().symbol);
+    for (auto &&subscript : std::move(part.subscript)) {
+      baseDataRef.back().subscript.emplace_back(
+          Fold(context, std::move(subscript)));
+    }
   }
+  std::vector<Expr<SubscriptInteger>> cosubscript;
   for (Expr<SubscriptInteger> x : coarrayRef.cosubscript()) {
     cosubscript.emplace_back(Fold(context, std::move(x)));
   }
-  CoarrayRef folded{
-      std::move(base), std::move(subscript), std::move(cosubscript)};
+  CoarrayRef folded{std::move(baseDataRef), std::move(cosubscript)};
   if (std::optional<Expr<SomeInteger>> stat{coarrayRef.stat()}) {
     folded.set_stat(Fold(context, std::move(*stat)));
   }

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -19,6 +19,7 @@
 #include "host.h"
 #include "int-power.h"
 #include "intrinsics-library-templates.h"
+#include "shape.h"
 #include "tools.h"
 #include "traversal.h"
 #include "type.h"
@@ -473,13 +474,17 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldOperation(FoldingContext &context,
       }
       return FoldElementalIntrinsic<T, T, T, T>(
           context, std::move(funcRef), &Scalar<T>::MERGE_BITS);
+    } else if (name == "rank") {
+      // TODO pmk: get rank
+    } else if (name == "shape") {
+      // TODO pmk: call GetShape on argument, massage result
     }
     // TODO:
     // ceiling, count, cshift, dot_product, eoshift,
     // findloc, floor, iachar, iall, iany, iparity, ibits, ichar, image_status,
     // index, ishftc, lbound, len_trim, matmul, max, maxloc, maxval, merge, min,
     // minloc, minval, mod, modulo, nint, not, pack, product, reduce, reshape,
-    // scan, selected_char_kind, selected_int_kind, selected_real_kind, shape,
+    // scan, selected_char_kind, selected_int_kind, selected_real_kind,
     // sign, size, spread, sum, transfer, transpose, ubound, unpack, verify
   }
   return Expr<T>{std::move(funcRef)};

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -478,6 +478,8 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldOperation(FoldingContext &context,
       // TODO pmk: get rank
     } else if (name == "shape") {
       // TODO pmk: call GetShape on argument, massage result
+    } else if (name == "size") {
+      // TODO pmk: call GetShape on argument, extract or compute result
     }
     // TODO:
     // ceiling, count, cshift, dot_product, eoshift,
@@ -485,7 +487,7 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldOperation(FoldingContext &context,
     // index, ishftc, lbound, len_trim, matmul, max, maxloc, maxval, merge, min,
     // minloc, minval, mod, modulo, nint, not, pack, product, reduce, reshape,
     // scan, selected_char_kind, selected_int_kind, selected_real_kind,
-    // sign, size, spread, sum, transfer, transpose, ubound, unpack, verify
+    // sign, spread, sum, transfer, transpose, ubound, unpack, verify
   }
   return Expr<T>{std::move(funcRef)};
 }

--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -298,9 +298,8 @@ template<int KIND> const char *LogicalOperation<KIND>::Infix() const {
 }
 
 template<typename T>
-std::ostream &EmitArray(
-    std::ostream &o, const common::CopyableIndirection<Expr<T>> &expr) {
-  return expr.value().AsFortran(o);
+std::ostream &EmitArray(std::ostream &o, const Expr<T> &expr) {
+  return expr.AsFortran(o);
 }
 
 template<typename T>

--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -511,23 +511,23 @@ std::ostream &ArrayRef::AsFortran(std::ostream &o) const {
 
 std::ostream &CoarrayRef::AsFortran(std::ostream &o) const {
   bool first{true};
-  for (const auto &part : baseDataRef_) {
+  for (const Symbol *part : base_) {
     if (first) {
       first = false;
     } else {
       o << '%';
     }
-    EmitVar(o, *part.symbol);
-    char ch{'('};
-    for (const auto &sscript : part.subscript) {
-      EmitVar(o << ch, sscript);
-      ch = ',';
-    }
-    if (ch == ',') {
-      o << ')';
-    }
+    EmitVar(o, *part);
   }
-  char separator{'['};
+  char separator{'('};
+  for (const auto &sscript : subscript_) {
+    EmitVar(o << separator, sscript);
+    separator = ',';
+  }
+  if (separator == ',') {
+    o << ')';
+  }
+  separator = '[';
   for (const auto &css : cosubscript_) {
     EmitVar(o << separator, css);
     separator = ',';

--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -575,8 +575,9 @@ std::ostream &Designator<T>::AsFortran(std::ostream &o) const {
 std::ostream &DescriptorInquiry::AsFortran(std::ostream &o) const {
   switch (field_) {
   case Field::LowerBound: o << "lbound("; break;
-  case Field::Extent: o << "%EXTENT("; break;
+  case Field::Extent: o << "size("; break;
   case Field::Stride: o << "%STRIDE("; break;
+  case Field::Rank: o << "rank("; break;
   }
   std::visit(
       common::visitors{
@@ -588,8 +589,8 @@ std::ostream &DescriptorInquiry::AsFortran(std::ostream &o) const {
           [&](const Component &comp) { EmitVar(o, comp); },
       },
       base_);
-  if (dimension_ > 0) {
-    o << ",dim=" << dimension_;
+  if (dimension_ >= 0) {
+    o << ",dim=" << (dimension_ + 1);
   }
   return o << ')';
 }

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -503,7 +503,7 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
     {"product",
         {{"array", SameNumeric, Rank::array}, OptionalDIM, OptionalMASK},
         SameNumeric, Rank::dimReduced},
-    // TODO pmk: "rank"
+    {"rank", {{"a", Anything, Rank::anyOrAssumedRank}}, DefaultInt},
     {"real", {{"a", AnyNumeric, Rank::elementalOrBOZ}, DefaultingKIND},
         KINDReal},
     {"reduce",
@@ -968,10 +968,10 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
         CHECK(!shapeArgSize.has_value());
         if (rank == 1) {
           if (auto shape{GetShape(*arg)}) {
-            CHECK(shape->size() == 1);
-            if (auto value{ToInt64(shape->at(0))}) {
-              shapeArgSize = *value;
-              argOk = *value >= 0;
+            if (auto constShape{AsConstantShape(*shape)}) {
+              shapeArgSize = (**constShape).ToInt64();
+              CHECK(shapeArgSize >= 0);
+              argOk = true;
             }
           }
         }

--- a/lib/evaluate/shape.cc
+++ b/lib/evaluate/shape.cc
@@ -40,10 +40,9 @@ std::optional<Shape> AsShape(ExtentExpr &&arrayExpr) {
   if (auto *constructor{UnwrapExpr<ArrayConstructor<ExtentType>>(arrayExpr)}) {
     Shape result;
     for (const auto &value : constructor->values()) {
-      if (const auto *expr{
-              std::get_if<common::CopyableIndirection<ExtentExpr>>(&value.u)}) {
-        if (expr->value().Rank() == 0) {
-          result.emplace_back(std::move(expr->value()));
+      if (const auto *expr{std::get_if<ExtentExpr>(&value.u)}) {
+        if (expr->Rank() == 0) {
+          result.emplace_back(std::move(*expr));
           continue;
         }
       }

--- a/lib/evaluate/shape.cc
+++ b/lib/evaluate/shape.cc
@@ -322,6 +322,10 @@ std::optional<Shape> GetShape(const ProcedureRef &call) {
           ExtentExpr{call.arguments().front().value().value().Rank()}}};
     } else if (intrinsic->name == "reshape") {
       if (call.arguments().size() >= 2 && call.arguments().at(1).has_value()) {
+        // SHAPE(RESHAPE(array,shape)) -> shape
+        const Expr<SomeType> &shapeExpr{call.arguments().at(1)->value()};
+        Expr<SomeInteger> shape{std::get<Expr<SomeInteger>>(shapeExpr.u)};
+        return AsShape(ConvertToType<ExtentType>(std::move(shape)));
       }
     } else {
       // TODO: shapes of other non-elemental intrinsic results

--- a/lib/evaluate/shape.cc
+++ b/lib/evaluate/shape.cc
@@ -1,0 +1,118 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "shape.h"
+#include "fold.h"
+#include "tools.h"
+#include "../common/idioms.h"
+#include "../semantics/symbol.h"
+
+namespace Fortran::evaluate {
+std::optional<Shape> GetShape(
+    const semantics::Symbol &symbol, const Component *component) {
+  if (const auto *details{symbol.detailsIf<semantics::ObjectEntityDetails>()}) {
+    Shape result;
+    int dimension{1};
+    for (const auto &shapeSpec : details->shape()) {
+      if (shapeSpec.isExplicit()) {
+        result.emplace_back(
+            common::Clone(shapeSpec.ubound().GetExplicit().value()) -
+            common::Clone(shapeSpec.lbound().GetExplicit().value()) +
+            Expr<SubscriptInteger>{1});
+      } else if (component != nullptr) {
+        result.emplace_back(Expr<SubscriptInteger>{DescriptorInquiry{
+            *component, DescriptorInquiry::Field::Extent, dimension}});
+      } else {
+        result.emplace_back(Expr<SubscriptInteger>{DescriptorInquiry{
+            symbol, DescriptorInquiry::Field::Extent, dimension}});
+      }
+      ++dimension;
+    }
+    return result;
+  } else {
+    return std::nullopt;
+  }
+}
+
+std::optional<Shape> GetShape(const Component &component) {
+  const Symbol &symbol{component.GetLastSymbol()};
+  if (symbol.Rank() > 0) {
+    return GetShape(symbol, &component);
+  } else {
+    return GetShape(component.base());
+  }
+}
+static Extent GetExtent(const Subscript &subscript) {
+  return std::visit(
+      common::visitors{
+          [](const Triplet &triplet) -> Extent {
+            if (auto lower{triplet.lower()}) {
+              if (auto lowerValue{ToInt64(*lower)}) {
+                if (auto upper{triplet.upper()}) {
+                  if (auto upperValue{ToInt64(*upper)}) {
+                    if (auto strideValue{ToInt64(triplet.stride())}) {
+                      if (*strideValue != 0) {
+                        std::int64_t extent{
+                            (*upperValue - *lowerValue + *strideValue) /
+                            *strideValue};
+                        return Expr<SubscriptInteger>{extent > 0 ? extent : 0};
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            return std::nullopt;
+          },
+          [](const IndirectSubscriptIntegerExpr &subs) -> Extent {
+            if (auto shape{GetShape(subs.value())}) {
+              if (shape->size() == 1) {
+                return std::move(shape->at(0));
+              }
+            }
+            return std::nullopt;
+          },
+      },
+      subscript.u);
+}
+std::optional<Shape> GetShape(const ArrayRef &arrayRef) {
+  int subscripts{arrayRef.size()};
+  Shape shape;
+  for (int j = 0; j < subscripts; ++j) {
+    const Subscript &subscript{arrayRef.at(j)};
+    if (subscript.Rank() > 0) {
+      shape.emplace_back(GetExtent(subscript));
+    }
+  }
+  if (shape.empty()) {
+    return GetShape(arrayRef.base());
+  } else {
+    return shape;
+  }
+}
+std::optional<Shape> GetShape(const CoarrayRef &);  // TODO pmk
+std::optional<Shape> GetShape(const DataRef &dataRef) {
+  return std::visit([](const auto &x) { return GetShape(x); }, dataRef.u);
+}
+std::optional<Shape> GetShape(const Substring &substring) {
+  if (const auto *dataRef{substring.GetParentIf<DataRef>()}) {
+    return GetShape(*dataRef);
+  } else {
+    return std::nullopt;
+  }
+}
+std::optional<Shape> GetShape(const ComplexPart &part) {
+  return GetShape(part.complex());
+}
+}

--- a/lib/evaluate/shape.cc
+++ b/lib/evaluate/shape.cc
@@ -87,12 +87,10 @@ static Extent GetExtent(const Subscript &subscript) {
       subscript.u);
 }
 std::optional<Shape> GetShape(const ArrayRef &arrayRef) {
-  int subscripts{arrayRef.size()};
   Shape shape;
-  for (int j = 0; j < subscripts; ++j) {
-    const Subscript &subscript{arrayRef.at(j)};
-    if (subscript.Rank() > 0) {
-      shape.emplace_back(GetExtent(subscript));
+  for (const Subscript &ss : arrayRef.subscript()) {
+    if (ss.Rank() > 0) {
+      shape.emplace_back(GetExtent(ss));
     }
   }
   if (shape.empty()) {
@@ -101,7 +99,19 @@ std::optional<Shape> GetShape(const ArrayRef &arrayRef) {
     return shape;
   }
 }
-std::optional<Shape> GetShape(const CoarrayRef &);  // TODO pmk
+std::optional<Shape> GetShape(const CoarrayRef &coarrayRef) {
+  Shape shape;
+  for (const Subscript &ss : coarrayRef.subscript()) {
+    if (ss.Rank() > 0) {
+      shape.emplace_back(GetExtent(ss));
+    }
+  }
+  if (shape.empty()) {
+    return GetShape(coarrayRef.GetLastSymbol());
+  } else {
+    return shape;
+  }
+}
 std::optional<Shape> GetShape(const DataRef &dataRef) {
   return std::visit([](const auto &x) { return GetShape(x); }, dataRef.u);
 }

--- a/lib/evaluate/shape.h
+++ b/lib/evaluate/shape.h
@@ -32,8 +32,9 @@ using ExtentExpr = Expr<ExtentType>;
 using MaybeExtent = std::optional<ExtentExpr>;
 using Shape = std::vector<MaybeExtent>;
 
-// Convert a constant shape to the expression form, and vice versa.
-Shape AsGeneralShape(const Constant<ExtentType> &);
+// Convert between various representations of shapes
+Shape AsShape(const Constant<ExtentType> &arrayConstant);
+std::optional<Shape> AsShape(ExtentExpr &&arrayExpr);
 std::optional<ExtentExpr> AsShapeArrayExpr(const Shape &);  // array constructor
 std::optional<Constant<ExtentType>> AsConstantShape(const Shape &);
 
@@ -79,7 +80,7 @@ std::optional<Shape> GetShape(const NullPointer &);
 
 template<typename T> std::optional<Shape> GetShape(const Constant<T> &c) {
   Constant<ExtentType> shape{c.SHAPE()};
-  return AsGeneralShape(shape);
+  return AsShape(shape);
 }
 
 template<typename T>

--- a/lib/evaluate/shape.h
+++ b/lib/evaluate/shape.h
@@ -1,0 +1,80 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// GetShape() analyzes an expression and determines its shape, if possible,
+// representing the result as a vector of scalar integer expressions.
+
+#ifndef FORTRAN_EVALUATE_SHAPE_H_
+#define FORTRAN_EVALUATE_SHAPE_H_
+
+#include "expression.h"
+#include "type.h"
+#include "../common/indirection.h"
+#include <optional>
+#include <variant>
+
+namespace Fortran::evaluate {
+
+using Extent = std::optional<Expr<SubscriptInteger>>;
+using Shape = std::vector<Extent>;
+
+template<typename A> std::optional<Shape> GetShape(const A &) {
+  return std::nullopt;
+}
+
+template<typename T> std::optional<Shape> GetShape(const Expr<T> &);
+
+template<typename A, bool COPY>
+std::optional<Shape> GetShape(const common::Indirection<A, COPY> &p) {
+  return GetShape(p.value());
+}
+
+template<typename A> std::optional<Shape> GetShape(const std::optional<A> &x) {
+  if (x.has_value()) {
+    return GetShape(*x);
+  } else {
+    return std::nullopt;
+  }
+}
+
+template<typename... A>
+std::optional<Shape> GetShape(const std::variant<A...> &u) {
+  return std::visit([](const auto &x) { return GetShape(x); }, u);
+}
+
+std::optional<Shape> GetShape(
+    const semantics::Symbol &, const Component * = nullptr);
+std::optional<Shape> GetShape(const DataRef &);
+std::optional<Shape> GetShape(const ComplexPart &);
+std::optional<Shape> GetShape(const Substring &);
+std::optional<Shape> GetShape(const Component &);
+std::optional<Shape> GetShape(const ArrayRef &);
+std::optional<Shape> GetShape(const CoarrayRef &);
+
+template<typename T>
+std::optional<Shape> GetShape(const Designator<T> &designator) {
+  return std::visit([](const auto &x) { return GetShape(x); }, designator.u);
+}
+
+template<typename T> std::optional<Shape> GetShape(const Expr<T> &expr) {
+  return std::visit(
+      common::visitors{
+          [](const BOZLiteralConstant &) { return Shape{}; },
+          [](const NullPointer &) { return std::nullopt; },
+          [](const auto &x) { return GetShape(x); },
+      },
+      expr.u);
+}
+}
+#endif  // FORTRAN_EVALUATE_SHAPE_H_

--- a/lib/evaluate/shape.h
+++ b/lib/evaluate/shape.h
@@ -117,7 +117,7 @@ template<typename T>
 MaybeExtent GetExtent(const ArrayConstructorValue<T> &value) {
   return std::visit(
       common::visitors{
-          [](const common::CopyableIndirection<Expr<T>> &x) -> MaybeExtent {
+          [](const Expr<T> &x) -> MaybeExtent {
             if (std::optional<Shape> xShape{GetShape(x)}) {
               // Array values in array constructors get linearized.
               return GetSize(std::move(*xShape));

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -385,8 +385,7 @@ template<typename T> struct Variable {
 class DescriptorInquiry {
 public:
   using Result = SubscriptInteger;
-  ENUM_CLASS(Field, LowerBound, Extent, Stride)
-  // TODO: Also type parameters and/or CHARACTER length?
+  ENUM_CLASS(Field, LowerBound, Extent, Stride, Rank)
 
   CLASS_BOILERPLATE(DescriptorInquiry)
   DescriptorInquiry(const Symbol &, Field, int);

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -142,7 +142,7 @@ public:
       std::optional<Expr<SubscriptInteger>> &&);
   std::optional<Expr<SubscriptInteger>> lower() const;
   std::optional<Expr<SubscriptInteger>> upper() const;
-  const Expr<SubscriptInteger> &stride() const;
+  Expr<SubscriptInteger> stride() const;
   bool operator==(const Triplet &) const;
   bool IsStrideOne() const;
   std::ostream &AsFortran(std::ostream &) const;
@@ -237,6 +237,7 @@ public:
   int Rank() const;
   const Symbol &GetFirstSymbol() const;
   const Symbol &GetLastSymbol() const;
+  SymbolOrComponent GetBaseSymbolOrComponent() const;
   Expr<SubscriptInteger> LEN() const;
   bool operator==(const CoarrayRef &) const;
   std::ostream &AsFortran(std::ostream &) const;
@@ -404,7 +405,7 @@ public:
 private:
   SymbolOrComponent base_{nullptr};
   Field field_;
-  int dimension_{0};
+  int dimension_{0};  // zero-based
 };
 
 #define INSTANTIATE_VARIABLE_TEMPLATES \

--- a/lib/parser/message.h
+++ b/lib/parser/message.h
@@ -241,6 +241,7 @@ private:
 
 class ContextualMessages {
 public:
+  ContextualMessages() = default;
   ContextualMessages(CharBlock at, Messages *m) : at_{at}, messages_{m} {}
   ContextualMessages(const ContextualMessages &that)
     : at_{that.at_}, messages_{that.messages_} {}

--- a/lib/semantics/check-do-concurrent.cc
+++ b/lib/semantics/check-do-concurrent.cc
@@ -382,11 +382,11 @@ static CS GatherReferencesFromExpression(const parser::Expr &expression) {
   // Use the new expression traversal framework if possible, for testing.
   if (expression.typedExpr) {
     struct CollectSymbols : public virtual evaluate::VisitorBase<CS> {
+      using Result = CS;
       explicit CollectSymbols(int) {}
       void Handle(const Symbol *symbol) { result().push_back(symbol); }
     };
-    return evaluate::Visitor<CS, CollectSymbols>{0}.Traverse(
-        *expression.typedExpr);
+    return evaluate::Visitor<CollectSymbols>{0}.Traverse(*expression.typedExpr);
   } else {
     GatherSymbols gatherSymbols;
     parser::Walk(expression, gatherSymbols);

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -87,12 +87,13 @@ private:
 
   using SymbolVector = std::vector<const Symbol *>;
   struct SymbolVisitor : public virtual evaluate::VisitorBase<SymbolVector> {
+    using Result = SymbolVector;
     explicit SymbolVisitor(int) {}
     void Handle(const Symbol *symbol) { result().push_back(symbol); }
   };
 
   template<typename T> void DoExpr(evaluate::Expr<T> expr) {
-    evaluate::Visitor<SymbolVector, SymbolVisitor> visitor{0};
+    evaluate::Visitor<SymbolVisitor> visitor{0};
     for (const Symbol *symbol : visitor.Traverse(expr)) {
       CHECK(symbol && "bad symbol from Traverse");
       DoSymbol(*symbol);

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -135,6 +135,7 @@ set(MODFILE_TESTS
   modfile22.f90
   modfile23.f90
   modfile24.f90
+  modfile25.f90
 )
 
 set(LABEL_TESTS

--- a/test/semantics/modfile25.f90
+++ b/test/semantics/modfile25.f90
@@ -1,0 +1,64 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test compile-time analysis of shapes.
+
+module m1
+  integer(8), parameter :: a0s(:) = shape(3.14159)
+  real :: a1(5,5,5)
+  integer(8), parameter :: a1s(:) = shape(a1)
+  integer(8), parameter :: a1ss(:) = shape(a1s)
+  integer(8), parameter :: a1sss(:) = shape(a1ss)
+  integer(8), parameter :: a1rs(:) = [rank(a1),rank(a1s),rank(a1ss),rank(a1sss)]
+  integer(8), parameter :: a1n(:) = [size(a1),size(a1,1),size(a1,2)]
+  integer(8), parameter :: a1sn(:) = [size(a1s),size(a1ss),size(a1sss)]
+  integer(8), parameter :: ac1s(:) = shape([1])
+  integer(8), parameter :: ac2s(:) = shape([1,2,3])
+  integer(8), parameter :: ac3s(:) = shape([(1,j=1,4)])
+  integer(8), parameter :: ac3bs(:) = shape([(1,j=4,1,-1)])
+  integer(8), parameter :: ac4s(:) = shape([((j,k,j*k,k=1,3),j=1,4)])
+  integer(8), parameter :: ac5s(:) = shape([((0,k=5,1,-2),j=9,2,-3)])
+ contains
+  subroutine subr(x,n1,n2)
+    real, intent(in) :: x(:,:)
+    integer, intent(in) :: n1(3), n2(:)
+    real :: a(:,:,:)
+    a = reshape(x,n1)
+    a = reshape(x,n2(10:30:9)) ! fails if we can't figure out triplet shape
+  end subroutine
+end module m1
+!Expect: m1.mod
+! !mod$ v1 sum:7a360903510189bc
+! module m1
+! integer(8),parameter::a0s(1_8:)=[Integer(8)::]
+! real(4)::a1(1_8:5_8,1_8:5_8,1_8:5_8)
+! integer(8),parameter::a1s(1_8:)=[Integer(8)::5_8,5_8,5_8]
+! integer(8),parameter::a1ss(1_8:)=[Integer(8)::3_8]
+! integer(8),parameter::a1sss(1_8:)=[Integer(8)::1_8]
+! integer(8),parameter::a1rs(1_8:)=[Integer(4)::3_4,1_4,1_4,1_4]
+! integer(8),parameter::a1n(1_8:)=[Integer(8)::125_8,5_8,5_8]
+! integer(8),parameter::a1sn(1_8:)=[Integer(8)::3_8,1_8,1_8]
+! integer(8),parameter::ac1s(1_8:)=[Integer(8)::1_8]
+! integer(8),parameter::ac2s(1_8:)=[Integer(8)::3_8]
+! integer(8),parameter::ac3s(1_8:)=[Integer(8)::4_8]
+! integer(8),parameter::ac3bs(1_8:)=[Integer(8)::4_8]
+! integer(8),parameter::ac4s(1_8:)=[Integer(8)::36_8]
+! integer(8),parameter::ac5s(1_8:)=[Integer(8)::9_8]
+! contains
+! subroutine subr(x,n1,n2)
+! real(4),intent(in)::x(1_8:,1_8:)
+! integer(4),intent(in)::n1(1_8:3_8)
+! integer(4),intent(in)::n2(1_8:)
+! end
+! end

--- a/test/semantics/modfile25.f90
+++ b/test/semantics/modfile25.f90
@@ -29,6 +29,7 @@ module m1
   integer(8), parameter :: ac3bs(:) = shape([(1,j=4,1,-1)])
   integer(8), parameter :: ac4s(:) = shape([((j,k,j*k,k=1,3),j=1,4)])
   integer(8), parameter :: ac5s(:) = shape([((0,k=5,1,-2),j=9,2,-3)])
+  integer(8), parameter :: rss(:) = shape(reshape([(0,j=1,90)], [10_8,9_8]))
  contains
   subroutine subr(x,n1,n2)
     real, intent(in) :: x(:,:)
@@ -54,6 +55,7 @@ end module m1
 ! integer(8),parameter::ac3bs(1_8:)=[Integer(8)::4_8]
 ! integer(8),parameter::ac4s(1_8:)=[Integer(8)::36_8]
 ! integer(8),parameter::ac5s(1_8:)=[Integer(8)::9_8]
+! integer(8),parameter::rss(1_8:)=[Integer(8)::10_8,9_8]
 ! contains
 ! subroutine subr(x,n1,n2)
 ! real(4),intent(in)::x(1_8:,1_8:)

--- a/test/semantics/modfile25.f90
+++ b/test/semantics/modfile25.f90
@@ -39,7 +39,6 @@ module m1
   end subroutine
 end module m1
 !Expect: m1.mod
-! !mod$ v1 sum:7a360903510189bc
 ! module m1
 ! integer(8),parameter::a0s(1_8:)=[Integer(8)::]
 ! real(4)::a1(1_8:5_8,1_8:5_8,1_8:5_8)


### PR DESCRIPTION
Implement analysis of array shapes (vector-valued integer expressions denoting the extents of the dimensions on an array object or expression).  Use these shapes to properly validate compilation-time constraints on the SHAPE= argument to the RESHAPE intrinsic, resolving a TODO that prevented a compilation of a test case noticed by Steve.  Represent references to fields in descriptors from expressions, which are needed to represent shapes of deferred- and assumed-shape objects.  Fix bugs encountered while testing.