### PR TITLE
Update the grammar with team-value

### DIFF
--- a/documentation/f2018-grammar.txt
+++ b/documentation/f2018-grammar.txt
@@ -342,7 +342,7 @@ R924 image-selector ->
        lbracket cosubscript-list [, image-selector-spec-list] rbracket
 R925 cosubscript -> scalar-int-expr
 R926 image-selector-spec ->
-       STAT = stat-variable | TEAM = team-variable |
+       STAT = stat-variable | TEAM = team-value |
        TEAM_NUMBER = scalar-int-expr
 R927 allocate-stmt ->
        ALLOCATE ( [type-spec ::] allocation-list [, alloc-opt-list] )
@@ -457,12 +457,12 @@ R1109 block-specification-part ->
 R1110 end-block-stmt -> END BLOCK [block-construct-name]
 R1111 change-team-construct -> change-team-stmt block end-change-team-stmt
 R1112 change-team-stmt ->
-        [team-construct-name :] CHANGE TEAM ( team-variable
+        [team-construct-name :] CHANGE TEAM ( team-value
         [, coarray-association-list] [, sync-stat-list] )
 R1113 coarray-association -> codimension-decl => selector
 R1114 end-change-team-stmt ->
         END TEAM [( [sync-stat-list] )] [team-construct-name]
-R1115 team-variable -> scalar-variable
+R1115 team-value -> scalar-expr
 R1116 critical-construct -> critical-stmt block end-critical-stmt
 R1117 critical-stmt ->
         [critical-construct-name :] CRITICAL [( [sync-stat-list] )]
@@ -538,7 +538,7 @@ R1165 sync-stat -> STAT = stat-variable | ERRMSG = errmsg-variable
 R1166 sync-images-stmt -> SYNC IMAGES ( image-set [, sync-stat-list] )
 R1167 image-set -> int-expr | *
 R1168 sync-memory-stmt -> SYNC MEMORY [( [sync-stat-list] )]
-R1169 sync-team-stmt -> SYNC TEAM ( team-variable [, sync-stat-list] )
+R1169 sync-team-stmt -> SYNC TEAM ( team-value [, sync-stat-list] )
 R1170 event-post-stmt -> EVENT POST ( event-variable [, sync-stat-list] )
 R1171 event-variable -> scalar-variable
 R1172 event-wait-stmt -> EVENT WAIT ( event-variable [, event-wait-spec-list] )
@@ -547,11 +547,12 @@ R1174 until-spec -> UNTIL_COUNT = scalar-int-expr
 R1175 form-team-stmt ->
         FORM TEAM ( team-number , team-variable [, form-team-spec-list] )
 R1176 team-number -> scalar-int-expr
-R1177 form-team-spec -> NEW_INDEX = scalar-int-expr | sync-stat
-R1178 lock-stmt -> LOCK ( lock-variable [, lock-stat-list] )
-R1179 lock-stat -> ACQUIRED_LOCK = scalar-logical-variable | sync-stat
-R1180 unlock-stmt -> UNLOCK ( lock-variable [, sync-stat-list] )
-R1181 lock-variable -> scalar-variable
+R1177 team-variable -> scalar-variable
+R1178 form-team-spec -> NEW_INDEX = scalar-int-expr | sync-stat
+R1179 lock-stmt -> LOCK ( lock-variable [, lock-stat-list] )
+R1180 lock-stat -> ACQUIRED_LOCK = scalar-logical-variable | sync-stat
+R1181 unlock-stmt -> UNLOCK ( lock-variable [, sync-stat-list] )
+R1182 lock-variable -> scalar-variable
 
 R1201 io-unit -> file-unit-number | * | internal-file-variable
 R1202 file-unit-number -> scalar-int-expr

--- a/lib/parser/grammar.h
+++ b/lib/parser/grammar.h
@@ -1509,16 +1509,16 @@ TYPE_CONTEXT_PARSER("image selector"_en_US,
     construct<ImageSelector>("[" >> nonemptyList(cosubscript / !"="_tok),
         defaulted("," >> nonemptyList(Parser<ImageSelectorSpec>{})) / "]"))
 
-// R1115 team-variable -> scalar-variable
-constexpr auto teamVariable{scalar(indirect(variable))};
+// R1115 team-value -> scalar-expr
+constexpr auto teamValue{scalar(indirect(expr))};
 
 // R926 image-selector-spec ->
-//        STAT = stat-variable | TEAM = team-variable |
+//        STAT = stat-variable | TEAM = team-value |
 //        TEAM_NUMBER = scalar-int-expr
 TYPE_PARSER(construct<ImageSelectorSpec>(construct<ImageSelectorSpec::Stat>(
                 "STAT =" >> scalar(integer(indirect(variable))))) ||
     construct<ImageSelectorSpec>(
-        construct<ImageSelectorSpec::Team>("TEAM =" >> teamVariable)) ||
+        construct<ImageSelectorSpec::Team>("TEAM =" >> teamValue)) ||
     construct<ImageSelectorSpec>(construct<ImageSelectorSpec::Team_Number>(
         "TEAM_NUMBER =" >> scalarIntExpr)))
 
@@ -2076,10 +2076,10 @@ TYPE_CONTEXT_PARSER("CHANGE TEAM construct"_en_US,
 
 // R1112 change-team-stmt ->
 //         [team-construct-name :] CHANGE TEAM
-//         ( team-variable [, coarray-association-list] [, sync-stat-list] )
+//         ( team-value [, coarray-association-list] [, sync-stat-list] )
 TYPE_CONTEXT_PARSER("CHANGE TEAM statement"_en_US,
     construct<ChangeTeamStmt>(maybe(name / ":"),
-        "CHANGE TEAM"_sptok >> "("_tok >> teamVariable,
+        "CHANGE TEAM"_sptok >> "("_tok >> teamValue,
         defaulted("," >> nonemptyList(Parser<CoarrayAssociation>{})),
         defaulted("," >> nonemptyList(statOrErrmsg))) /
         ")")
@@ -2346,9 +2346,9 @@ TYPE_CONTEXT_PARSER("SYNC MEMORY statement"_en_US,
     construct<SyncMemoryStmt>("SYNC MEMORY"_sptok >>
         defaulted(parenthesized(optionalList(statOrErrmsg)))))
 
-// R1169 sync-team-stmt -> SYNC TEAM ( team-variable [, sync-stat-list] )
+// R1169 sync-team-stmt -> SYNC TEAM ( team-value [, sync-stat-list] )
 TYPE_CONTEXT_PARSER("SYNC TEAM statement"_en_US,
-    construct<SyncTeamStmt>("SYNC TEAM"_sptok >> "("_tok >> teamVariable,
+    construct<SyncTeamStmt>("SYNC TEAM"_sptok >> "("_tok >> teamValue,
         defaulted("," >> nonemptyList(statOrErrmsg)) / ")"))
 
 // R1170 event-post-stmt -> EVENT POST ( event-variable [, sync-stat-list] )
@@ -2371,6 +2371,9 @@ constexpr auto untilSpec{"UNTIL_COUNT =" >> scalarIntExpr};
 TYPE_PARSER(construct<EventWaitStmt::EventWaitSpec>(untilSpec) ||
     construct<EventWaitStmt::EventWaitSpec>(statOrErrmsg))
 
+// R1177 team-variable -> scalar-variable
+constexpr auto teamVariable{scalar(variable)};
+
 // R1175 form-team-stmt ->
 //         FORM TEAM ( team-number , team-variable [, form-team-spec-list] )
 // R1176 team-number -> scalar-int-expr
@@ -2380,25 +2383,25 @@ TYPE_CONTEXT_PARSER("FORM TEAM statement"_en_US,
         defaulted("," >> nonemptyList(Parser<FormTeamStmt::FormTeamSpec>{})) /
             ")"))
 
-// R1177 form-team-spec -> NEW_INDEX = scalar-int-expr | sync-stat
+// R1178 form-team-spec -> NEW_INDEX = scalar-int-expr | sync-stat
 TYPE_PARSER(
     construct<FormTeamStmt::FormTeamSpec>("NEW_INDEX =" >> scalarIntExpr) ||
     construct<FormTeamStmt::FormTeamSpec>(statOrErrmsg))
 
-// R1181 lock-variable -> scalar-variable
+// R1182 lock-variable -> scalar-variable
 constexpr auto lockVariable{scalar(variable)};
 
-// R1178 lock-stmt -> LOCK ( lock-variable [, lock-stat-list] )
+// R1179 lock-stmt -> LOCK ( lock-variable [, lock-stat-list] )
 TYPE_CONTEXT_PARSER("LOCK statement"_en_US,
     construct<LockStmt>("LOCK (" >> lockVariable,
         defaulted("," >> nonemptyList(Parser<LockStmt::LockStat>{})) / ")"))
 
-// R1179 lock-stat -> ACQUIRED_LOCK = scalar-logical-variable | sync-stat
+// R1180 lock-stat -> ACQUIRED_LOCK = scalar-logical-variable | sync-stat
 TYPE_PARSER(
     construct<LockStmt::LockStat>("ACQUIRED_LOCK =" >> scalarLogicalVariable) ||
     construct<LockStmt::LockStat>(statOrErrmsg))
 
-// R1180 unlock-stmt -> UNLOCK ( lock-variable [, sync-stat-list] )
+// R1181 unlock-stmt -> UNLOCK ( lock-variable [, sync-stat-list] )
 TYPE_CONTEXT_PARSER("UNLOCK statement"_en_US,
     construct<UnlockStmt>("UNLOCK (" >> lockVariable,
         defaulted("," >> nonemptyList(statOrErrmsg)) / ")"))

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -1576,15 +1576,15 @@ struct SectionSubscript {
 // R925 cosubscript -> scalar-int-expr
 using Cosubscript = ScalarIntExpr;
 
-// R1115 team-variable -> scalar-variable
-using TeamVariable = Scalar<common::Indirection<Variable>>;
+// R1115 team-value -> scalar-expr
+using TeamValue = Scalar<common::Indirection<Expr>>;
 
 // R926 image-selector-spec ->
-//        STAT = stat-variable | TEAM = team-variable |
+//        STAT = stat-variable | TEAM = team-value |
 //        TEAM_NUMBER = scalar-int-expr
 struct ImageSelectorSpec {
   WRAPPER_CLASS(Stat, Scalar<Integer<common::Indirection<Variable>>>);
-  WRAPPER_CLASS(Team, TeamVariable);
+  WRAPPER_CLASS(Team, TeamValue);
   WRAPPER_CLASS(Team_Number, ScalarIntExpr);
   UNION_CLASS_BOILERPLATE(ImageSelectorSpec);
   std::variant<Stat, Team, Team_Number> u;
@@ -2100,10 +2100,10 @@ struct CoarrayAssociation {
 
 // R1112 change-team-stmt ->
 //         [team-construct-name :] CHANGE TEAM
-//         ( team-variable [, coarray-association-list] [, sync-stat-list] )
+//         ( team-value [, coarray-association-list] [, sync-stat-list] )
 struct ChangeTeamStmt {
   TUPLE_CLASS_BOILERPLATE(ChangeTeamStmt);
-  std::tuple<std::optional<Name>, TeamVariable, std::list<CoarrayAssociation>,
+  std::tuple<std::optional<Name>, TeamValue, std::list<CoarrayAssociation>,
       std::list<StatOrErrmsg>>
       t;
 };
@@ -2425,10 +2425,10 @@ struct SyncImagesStmt {
 // R1168 sync-memory-stmt -> SYNC MEMORY [( [sync-stat-list] )]
 WRAPPER_CLASS(SyncMemoryStmt, std::list<StatOrErrmsg>);
 
-// R1169 sync-team-stmt -> SYNC TEAM ( team-variable [, sync-stat-list] )
+// R1169 sync-team-stmt -> SYNC TEAM ( team-value [, sync-stat-list] )
 struct SyncTeamStmt {
   TUPLE_CLASS_BOILERPLATE(SyncTeamStmt);
-  std::tuple<TeamVariable, std::list<StatOrErrmsg>> t;
+  std::tuple<TeamValue, std::list<StatOrErrmsg>> t;
 };
 
 // R1171 event-variable -> scalar-variable
@@ -2453,10 +2453,13 @@ struct EventWaitStmt {
   std::tuple<EventVariable, std::list<EventWaitSpec>> t;
 };
 
+// R1177 team-variable -> scalar-variable
+using TeamVariable = Scalar<Variable>;
+
 // R1175 form-team-stmt ->
 //         FORM TEAM ( team-number , team-variable [, form-team-spec-list] )
 // R1176 team-number -> scalar-int-expr
-// R1177 form-team-spec -> NEW_INDEX = scalar-int-expr | sync-stat
+// R1178 form-team-spec -> NEW_INDEX = scalar-int-expr | sync-stat
 struct FormTeamStmt {
   struct FormTeamSpec {
     UNION_CLASS_BOILERPLATE(FormTeamSpec);
@@ -2466,11 +2469,11 @@ struct FormTeamStmt {
   std::tuple<ScalarIntExpr, TeamVariable, std::list<FormTeamSpec>> t;
 };
 
-// R1181 lock-variable -> scalar-variable
+// R1182 lock-variable -> scalar-variable
 using LockVariable = Scalar<Variable>;
 
-// R1178 lock-stmt -> LOCK ( lock-variable [, lock-stat-list] )
-// R1179 lock-stat -> ACQUIRED_LOCK = scalar-logical-variable | sync-stat
+// R1179 lock-stmt -> LOCK ( lock-variable [, lock-stat-list] )
+// R1180 lock-stat -> ACQUIRED_LOCK = scalar-logical-variable | sync-stat
 struct LockStmt {
   struct LockStat {
     UNION_CLASS_BOILERPLATE(LockStat);
@@ -2480,7 +2483,7 @@ struct LockStmt {
   std::tuple<LockVariable, std::list<LockStat>> t;
 };
 
-// R1180 unlock-stmt -> UNLOCK ( lock-variable [, sync-stat-list] )
+// R1181 unlock-stmt -> UNLOCK ( lock-variable [, sync-stat-list] )
 struct UnlockStmt {
   TUPLE_CLASS_BOILERPLATE(UnlockStmt);
   std::tuple<LockVariable, std::list<StatOrErrmsg>> t;

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -910,7 +910,7 @@ public:
   }
   void Unparse(const ChangeTeamStmt &x) {  // R1112
     Walk(std::get<std::optional<Name>>(x.t), ": ");
-    Word("CHANGE TEAM ("), Walk(std::get<TeamVariable>(x.t));
+    Word("CHANGE TEAM ("), Walk(std::get<TeamValue>(x.t));
     Walk(", ", std::get<std::list<CoarrayAssociation>>(x.t), ", ");
     Walk(", ", std::get<std::list<StatOrErrmsg>>(x.t), ", "), Put(')');
     Indent();
@@ -1100,7 +1100,7 @@ public:
     Word("SYNC MEMORY ("), Walk(x.v, ", "), Put(')');
   }
   void Unparse(const SyncTeamStmt &x) {  // R1169
-    Word("SYNC TEAM ("), Walk(std::get<TeamVariable>(x.t));
+    Word("SYNC TEAM ("), Walk(std::get<TeamValue>(x.t));
     Walk(", ", std::get<std::list<StatOrErrmsg>>(x.t), ", "), Put(')');
   }
   void Unparse(const EventPostStmt &x) {  // R1170
@@ -1120,13 +1120,13 @@ public:
     Walk(", ", std::get<std::list<EventWaitStmt::EventWaitSpec>>(x.t), ", ");
     Put(')');
   }
-  void Unparse(const FormTeamStmt &x) {  // R1175
+  void Unparse(const FormTeamStmt &x) {  // R1175, R1177
     Word("FORM TEAM ("), Walk(std::get<ScalarIntExpr>(x.t));
     Put(','), Walk(std::get<TeamVariable>(x.t));
     Walk(", ", std::get<std::list<FormTeamStmt::FormTeamSpec>>(x.t), ", ");
     Put(')');
   }
-  void Before(const FormTeamStmt::FormTeamSpec &x) {  // R1176, R1177
+  void Before(const FormTeamStmt::FormTeamSpec &x) {  // R1176, R1178
     std::visit(
         common::visitors{
             [&](const ScalarIntExpr &x) { Word("NEW_INDEX="); },
@@ -1134,12 +1134,12 @@ public:
         },
         x.u);
   }
-  void Unparse(const LockStmt &x) {  // R1178
+  void Unparse(const LockStmt &x) {  // R1179
     Word("LOCK ("), Walk(std::get<LockVariable>(x.t));
     Walk(", ", std::get<std::list<LockStmt::LockStat>>(x.t), ", ");
     Put(')');
   }
-  void Before(const LockStmt::LockStat &x) {  // R1179
+  void Before(const LockStmt::LockStat &x) {  // R1180
     std::visit(
         common::visitors{
             [&](const ScalarLogicalVariable &) { Word("ACQUIRED_LOCK="); },
@@ -1147,7 +1147,7 @@ public:
         },
         x.u);
   }
-  void Unparse(const UnlockStmt &x) {  // R1180
+  void Unparse(const UnlockStmt &x) {  // R1181
     Word("UNLOCK ("), Walk(std::get<LockVariable>(x.t));
     Walk(", ", std::get<std::list<StatOrErrmsg>>(x.t), ", ");
     Put(')');


### PR DESCRIPTION
Everywhere we had `team-variable` except for the FORM TEAM statement is
now `team-value`, according to the N2162 draft standard. The grammar
and parse tree are updated to reflect that.

The addition of the production for `team-value` caused productions
R1177-R1181 to have their numbers increased by one.