### PR TITLE
Rewrite read-stmt/write-stmt parse trees for misparsed namelist group…

### DIFF
--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -2613,7 +2613,7 @@ struct ReadStmt {
   std::optional<IoUnit> iounit;  // if first in controls without UNIT=
   std::optional<Format> format;  // if second in controls without FMT=, or
                                  // no (io-control-spec-list); might be
-                                 // an untagged namelist group name (TODO)
+                                 // an untagged namelist group name, too
   std::list<IoControlSpec> controls;
   std::list<InputItem> items;
 };
@@ -2633,7 +2633,7 @@ struct WriteStmt {
       items(std::move(its)) {}
   std::optional<IoUnit> iounit;  // if first in controls without UNIT=
   std::optional<Format> format;  // if second in controls without FMT=;
-                                 // might be an untagged namelist group (TODO)
+                                 // might be an untagged namelist group, too
   std::list<IoControlSpec> controls;
   std::list<OutputItem> items;
 };

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -2610,10 +2610,11 @@ struct ReadStmt {
       std::list<IoControlSpec> &&cs, std::list<InputItem> &&its)
     : iounit{std::move(i)}, format{std::move(f)}, controls(std::move(cs)),
       items(std::move(its)) {}
-  std::optional<IoUnit> iounit;  // if first in controls without UNIT=
-  std::optional<Format> format;  // if second in controls without FMT=, or
+  std::optional<IoUnit> iounit;  // if first in controls without UNIT= &/or
+                                 // followed by untagged format/namelist
+  std::optional<Format> format;  // if second in controls without FMT=/NML=, or
                                  // no (io-control-spec-list); might be
-                                 // an untagged namelist group name, too
+                                 // an untagged namelist group name
   std::list<IoControlSpec> controls;
   std::list<InputItem> items;
 };
@@ -2631,8 +2632,9 @@ struct WriteStmt {
       std::list<IoControlSpec> &&cs, std::list<OutputItem> &&its)
     : iounit{std::move(i)}, format{std::move(f)}, controls(std::move(cs)),
       items(std::move(its)) {}
-  std::optional<IoUnit> iounit;  // if first in controls without UNIT=
-  std::optional<Format> format;  // if second in controls without FMT=;
+  std::optional<IoUnit> iounit;  // if first in controls without UNIT= &/or
+                                 // followed by untagged format/namelist
+  std::optional<Format> format;  // if second in controls without FMT=/NML=;
                                  // might be an untagged namelist group, too
   std::list<IoControlSpec> controls;
   std::list<OutputItem> items;

--- a/lib/semantics/rewrite-parse-tree.cc
+++ b/lib/semantics/rewrite-parse-tree.cc
@@ -110,7 +110,7 @@ bool RewriteMutator::Pre(parser::ExecutionPart &x) {
 // name had appeared with NML=.
 template<typename READ_OR_WRITE>
 void FixMisparsedUntaggedNamelistName(READ_OR_WRITE &x) {
-  if (x.format.has_value()) {
+  if (x.iounit.has_value() && x.format.has_value()) {
     if (auto *charExpr{
             std::get_if<parser::DefaultCharExpr>(&x.format.value().u)}) {
       parser::Expr &expr{charExpr->thing.value()};


### PR DESCRIPTION
… names

The parser parses untagged namelist group names (e.g., `READ(10,NLG)` as if the untagged namelist group name had been a format expression.  Fix that during parse tree rewriting once we have symbols and can distinguish namelist group names from other expressions.