### PR TITLE
Fix issue 392, improve the error message when a DO loop is

### DIFF
--- a/lib/semantics/resolve-labels.cc
+++ b/lib/semantics/resolve-labels.cc
@@ -893,17 +893,19 @@ void CheckLabelDoConstraints(const SourceStmtList &dos,
           parser::MessageFormattedText{
               "label '%u' is not in scope"_en_US, SayLabel(label)});
     } else if (!doTarget.labeledStmtClassificationSet.test(
-                   TargetStatementEnum::Do) &&
-        !doTarget.labeledStmtClassificationSet.test(
-            TargetStatementEnum::CompatibleDo)) {
-      errorHandler.Say(doTarget.parserCharBlock,
-          parser::MessageFormattedText{
-              "'%u' invalid DO terminal statement"_err_en_US, SayLabel(label)});
-    } else if (!doTarget.labeledStmtClassificationSet.test(
                    TargetStatementEnum::Do)) {
-      errorHandler.Say(doTarget.parserCharBlock,
-          parser::MessageFormattedText{
-              "'%u' invalid DO terminal statement"_en_US, SayLabel(label)});
+      if (!doTarget.labeledStmtClassificationSet.test(
+              TargetStatementEnum::CompatibleDo)) {
+        errorHandler.Say(doTarget.parserCharBlock,
+            parser::MessageFormattedText{
+                "'%u' DO statements must terminate with END DO or CONTINUE"_err_en_US,
+                SayLabel(label)});
+      } else {
+        errorHandler.Say(doTarget.parserCharBlock,
+            parser::MessageFormattedText{
+                "'%u' Obsolete construct not allowed.  DO statements must terminate with END DO or CONTINUE"_en_US,
+                SayLabel(label)});
+      }
     } else {
       loopBodies.emplace_back(SkipLabel(position), doTarget.parserCharBlock);
     }

--- a/lib/semantics/resolve-labels.cc
+++ b/lib/semantics/resolve-labels.cc
@@ -898,12 +898,12 @@ void CheckLabelDoConstraints(const SourceStmtList &dos,
               TargetStatementEnum::CompatibleDo)) {
         errorHandler.Say(doTarget.parserCharBlock,
             parser::MessageFormattedText{
-                "'%u' DO statements must terminate with END DO or CONTINUE"_err_en_US,
+                "'%u' Obsolete construct.  A DO loop should terminate with END DO or CONTINUE"_err_en_US,
                 SayLabel(label)});
       } else {
         errorHandler.Say(doTarget.parserCharBlock,
             parser::MessageFormattedText{
-                "'%u' Obsolete construct not allowed.  DO statements must terminate with END DO or CONTINUE"_en_US,
+                "'%u' A DO loop should terminate with END DO or CONTINUE statement"_en_US,
                 SayLabel(label)});
       }
     } else {

--- a/lib/semantics/resolve-labels.cc
+++ b/lib/semantics/resolve-labels.cc
@@ -898,7 +898,7 @@ void CheckLabelDoConstraints(const SourceStmtList &dos,
               TargetStatementEnum::CompatibleDo)) {
         errorHandler.Say(doTarget.parserCharBlock,
             parser::MessageFormattedText{
-                "Only an END DO or CONTINUE should be used to terminate a labeled DO loop"_err_en_US,
+                "Only an END DO or CONTINUE must be used to terminate a labeled DO loop"_err_en_US,
                 SayLabel(label)});
       } else {
         errorHandler.Say(doTarget.parserCharBlock,

--- a/lib/semantics/resolve-labels.cc
+++ b/lib/semantics/resolve-labels.cc
@@ -898,12 +898,12 @@ void CheckLabelDoConstraints(const SourceStmtList &dos,
               TargetStatementEnum::CompatibleDo)) {
         errorHandler.Say(doTarget.parserCharBlock,
             parser::MessageFormattedText{
-                "'%u' Obsolete construct.  A DO loop should terminate with END DO or CONTINUE"_err_en_US,
+                "Only an END DO or CONTINUE should be used to terminate a labeled DO loop"_err_en_US,
                 SayLabel(label)});
       } else {
         errorHandler.Say(doTarget.parserCharBlock,
             parser::MessageFormattedText{
-                "'%u' A DO loop should terminate with END DO or CONTINUE statement"_en_US,
+                "Only an END DO or CONTINUE should be used to terminate a labeled DO loop"_en_US,
                 SayLabel(label)});
       }
     } else {

--- a/test/semantics/canondo07.f90
+++ b/test/semantics/canondo07.f90
@@ -16,7 +16,7 @@
 ! See R1131 and C1131
 
 ! RUN: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
-! CHECK: Obsolete construct not allowed.  DO statements must terminate with END DO or CONTINUE
+! CHECK: A DO loop should terminate with END DO or CONTINUE
 
 program endDo
   do 10 i = 1, 5

--- a/test/semantics/canondo07.f90
+++ b/test/semantics/canondo07.f90
@@ -1,0 +1,24 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Error test -- DO loop uses obsolete loop termination statement
+! See R1131 and C1131
+
+! RUN: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
+! CHECK: Obsolete construct not allowed.  DO statements must terminate with END DO or CONTINUE
+
+program endDo
+  do 10 i = 1, 5
+10  print *, "in loop"
+end program endDo

--- a/test/semantics/canondo07.f90
+++ b/test/semantics/canondo07.f90
@@ -16,7 +16,7 @@
 ! See R1131 and C1131
 
 ! RUN: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
-! CHECK: A DO loop should terminate with END DO or CONTINUE
+! CHECK: Only an END DO or CONTINUE should be used to terminate a labeled DO loop
 
 program endDo
   do 10 i = 1, 5


### PR DESCRIPTION
I wanted to give more information about why the compiler puts out an error message when a DO loop
is terminated by a labeled statement that's not an END DO or CONTINUE.

I also cleaned up the code a little in resolve-labels.cc and added a test for new message.