### PR TITLE
Add software subnormal flushing around host library calls for hosts that cannot do it in HW 

### DIFF
--- a/lib/evaluate/host.cc
+++ b/lib/evaluate/host.cc
@@ -45,24 +45,26 @@ void HostFloatingPointEnvironment::SetUpHostFloatingPointEnvironment(
   }
 #elif defined(__aarch64__)
 #if defined(__GNU_LIBRARY__)
+  hasSubnormalFlushingHardwareControl_ = true;
   if (context.flushSubnormalsToZero()) {
     currentFenv_.__fpcr |= (1U << 24);  // control register
   } else {
     currentFenv_.__fpcr &= ~(1U << 24);  // control register
   }
 #elif defined(__BIONIC__)
+  hasSubnormalFlushingHardwareControl_ = true;
   if (context.flushSubnormalsToZero()) {
     currentFenv_.__control |= (1U << 24);  // control register
   } else {
     currentFenv_.__control &= ~(1U << 24);  // control register
   }
 #else
-  // TODO other C libraries on AArch64
-  context.messages().Say(
-      "TODO: flushing mode for subnormals is not set for this host architecture due to incompatible C library it uses"_en_US);
+  // If F18 is built with other C libraries on AArch64, software flushing will
+  // be performed around host library calls if subnormal flushing is requested
 #endif
 #else
-  // Software flushing will be performed around host library calls if needed.
+  // If F18 is not built on one of the above host architecture, software
+  // flushing will be performed around host library calls if needed.
 #endif
   errno = 0;
   if (fesetenv(&currentFenv_) != 0) {

--- a/lib/evaluate/host.cc
+++ b/lib/evaluate/host.cc
@@ -35,7 +35,7 @@ void HostFloatingPointEnvironment::SetUpHostFloatingPointEnvironment(
     return;
   }
 #if __x86_64__
-  HasSubnormalFlushingHardwareControl_ = true;
+  hasSubnormalFlushingHardwareControl_ = true;
   if (context.flushSubnormalsToZero()) {
     currentFenv_.__mxcsr |= 0x8000;  // result
     currentFenv_.__mxcsr |= 0x0040;  // operands

--- a/lib/evaluate/host.cc
+++ b/lib/evaluate/host.cc
@@ -35,6 +35,7 @@ void HostFloatingPointEnvironment::SetUpHostFloatingPointEnvironment(
     return;
   }
 #if __x86_64__
+  HasSubnormalFlushingHardwareControl_ = true;
   if (context.flushSubnormalsToZero()) {
     currentFenv_.__mxcsr |= 0x8000;  // result
     currentFenv_.__mxcsr |= 0x0040;  // operands
@@ -61,9 +62,7 @@ void HostFloatingPointEnvironment::SetUpHostFloatingPointEnvironment(
       "TODO: flushing mode for subnormals is not set for this host architecture due to incompatible C library it uses"_en_US);
 #endif
 #else
-  // TODO other architectures
-  context.messages().Say(
-      "TODO: flushing mode for subnormals is not set for this host architecture when folding with host runtime functions"_en_US);
+  // Software flushing will be performed around host library calls if needed.
 #endif
   errno = 0;
   if (fesetenv(&currentFenv_) != 0) {

--- a/lib/evaluate/host.h
+++ b/lib/evaluate/host.h
@@ -40,13 +40,13 @@ public:
   void SetUpHostFloatingPointEnvironment(FoldingContext &);
   void CheckAndRestoreFloatingPointEnvironment(FoldingContext &);
   bool HasSubnormalFlushingHardwareControl() {
-    return HasSubnormalFlushingHardwareControl_;
+    return hasSubnormalFlushingHardwareControl_;
   }
 
 private:
   std::fenv_t originalFenv_;
   std::fenv_t currentFenv_;
-  bool HasSubnormalFlushingHardwareControl_{false};
+  bool hasSubnormalFlushingHardwareControl_{false};
 };
 
 // Type mapping from F18 types to host types

--- a/lib/evaluate/host.h
+++ b/lib/evaluate/host.h
@@ -39,7 +39,7 @@ class HostFloatingPointEnvironment {
 public:
   void SetUpHostFloatingPointEnvironment(FoldingContext &);
   void CheckAndRestoreFloatingPointEnvironment(FoldingContext &);
-  bool HasSubnormalFlushingHardwareControl() {
+  bool hasSubnormalFlushingHardwareControl() {
     return hasSubnormalFlushingHardwareControl_;
   }
 

--- a/lib/evaluate/host.h
+++ b/lib/evaluate/host.h
@@ -39,10 +39,14 @@ class HostFloatingPointEnvironment {
 public:
   void SetUpHostFloatingPointEnvironment(FoldingContext &);
   void CheckAndRestoreFloatingPointEnvironment(FoldingContext &);
+  bool HasSubnormalFlushingHardwareControl() {
+    return HasSubnormalFlushingHardwareControl_;
+  }
 
 private:
   std::fenv_t originalFenv_;
   std::fenv_t currentFenv_;
+  bool HasSubnormalFlushingHardwareControl_{false};
 };
 
 // Type mapping from F18 types to host types

--- a/lib/evaluate/intrinsics-library-templates.h
+++ b/lib/evaluate/intrinsics-library-templates.h
@@ -90,7 +90,7 @@ template<typename TR, typename... ArgInfo> struct CallableHostWrapper {
       hostFPE.SetUpHostFloatingPointEnvironment(context);
       host::HostType<TR> res{};
       if (context.flushSubnormalsToZero() &&
-          !hostFPE.HasSubnormalFlushingHardwareControl()) {
+          !hostFPE.hasSubnormalFlushingHardwareControl()) {
         res = func(host::CastFortranToHost<typename ArgInfo::Type>(
             Flusher<typename ArgInfo::Type>::FlushSubnormals(x))...);
         hostFPE.CheckAndRestoreFloatingPointEnvironment(context);

--- a/test/evaluate/folding.cc
+++ b/test/evaluate/folding.cc
@@ -23,12 +23,6 @@
 
 using namespace Fortran::evaluate;
 
-template<typename A> std::string AsFortran(const A &x) {
-  std::stringstream ss;
-  ss << x;
-  return ss.str();
-}
-
 // helper to call functions on all types from tuple
 template<typename... T> struct RunOnTypes {};
 template<typename Test, typename... T>

--- a/test/evaluate/folding.cc
+++ b/test/evaluate/folding.cc
@@ -16,9 +16,17 @@
 #include "../../lib/evaluate/call.h"
 #include "../../lib/evaluate/expression.h"
 #include "../../lib/evaluate/fold.h"
+#include "../../lib/evaluate/host.h"
+#include "../../lib/evaluate/tools.h"
 #include <tuple>
 
 using namespace Fortran::evaluate;
+
+template<typename A> std::string AsFortran(const A &x) {
+  std::stringstream ss;
+  ss << x;
+  return ss.str();
+}
 
 // helper to call functions on all types from tuple
 template<typename... T> struct RunOnTypes {};
@@ -26,13 +34,6 @@ template<typename Test, typename... T>
 struct RunOnTypes<Test, std::tuple<T...>> {
   static void Run() { (..., Test::template Run<T>()); }
 };
-
-// helper to get an empty context to give to fold
-FoldingContext getTestFoldingContext(Fortran::parser::Messages &m) {
-  Fortran::parser::CharBlock at{};
-  Fortran::parser::ContextualMessages cm{at, &m};
-  return Fortran::evaluate::FoldingContext(cm);
-}
 
 // test for fold.h GetScalarConstantValue function
 struct TestGetScalarConstantValue {
@@ -46,7 +47,59 @@ struct TestGetScalarConstantValue {
   }
 };
 
+template<typename T>
+static FunctionRef<T> CreateIntrinsicElementalCall(
+    const std::string &name, const Expr<T> &arg) {
+  Fortran::semantics::Attrs attrs;
+  attrs.set(Fortran::semantics::Attr::ELEMENTAL);
+  ActualArguments args{ActualArgument{AsGenericExpr(arg)}};
+  ProcedureDesignator intrinsic{
+      SpecificIntrinsic{name, T::GetType(), 0, attrs}};
+  return FunctionRef<T>{std::move(intrinsic), std::move(args)};
+}
+
+// Test flushSubnormalsToZero when folding with host runtime.
+// Subnormal value flushing on host is handle in host.cc
+// HostFloatingPointEnvironment::SetUpHostFloatingPointEnvironment
+
+void TestSubnormalFlushing() {
+  using R4 = Type<TypeCategory::Real, 4>;
+  if constexpr (host::HostTypeExists<R4>()) {
+    Fortran::parser::CharBlock src;
+    Fortran::parser::ContextualMessages messages{src, nullptr};
+    FoldingContext flushingContext{messages, defaultRounding, true};
+    FoldingContext noFlushingContext{messages, defaultRounding, false};
+
+    // Biggest IEEE 32bits subnormal value
+    host::HostType<R4> subnormal{5.87747175411144e-39};
+    Scalar<R4> x{host::CastHostToFortran<R4>(subnormal)};
+    Expr<R4> arg{Constant<R4>{x}};
+    FunctionRef<R4> func{CreateIntrinsicElementalCall("log", arg)};
+
+    auto resFlushing{Fold(flushingContext, AsGenericExpr(func))};
+    auto resNoFlushing{Fold(noFlushingContext, AsGenericExpr(func))};
+    TEST("(-1._4/0.)" == AsFortran(resFlushing));
+    TEST("(-1._4/0.)" != AsFortran(resNoFlushing));
+
+    // Check that the NoFlushing gave a correct result
+    if (auto *typedExpr{UnwrapExpr<Expr<R4>>(resNoFlushing)}) {
+      if (auto y{GetScalarConstantValue(*typedExpr)}) {
+        // log around zero is not very precise allow 2% error.
+        host::HostType<R4> yhost{host::CastFortranToHost<R4>(*y)};
+        TEST(std::abs(yhost - (-88.)) < 2);
+      } else {
+        TEST(false);
+      }
+    } else {
+      TEST(false);
+    }
+  } else {
+    TEST(false);  // Cannot run this test on the host
+  }
+}
+
 int main() {
   RunOnTypes<TestGetScalarConstantValue, AllIntrinsicTypes>::Run();
+  TestSubnormalFlushing();
   return testing::Complete();
 }

--- a/test/evaluate/folding.cc
+++ b/test/evaluate/folding.cc
@@ -72,7 +72,7 @@ float SubnormalFlusher2(float f) {  // given f/2 is subnormal
   return f / 2.3;  // returns 0 if subnormal
 }
 
-void TestSubnormalFlushing() {
+void TestHostRuntimeSubnormalFlushing() {
   using R4 = Type<TypeCategory::Real, 4>;
   if constexpr (std::is_same_v<host::HostType<R4>, float>) {
     Fortran::parser::CharBlock src;
@@ -119,6 +119,6 @@ void TestSubnormalFlushing() {
 
 int main() {
   RunOnTypes<TestGetScalarConstantValue, AllIntrinsicTypes>::Run();
-  TestSubnormalFlushing();
+  TestHostRuntimeSubnormalFlushing();
   return testing::Complete();
 }


### PR DESCRIPTION
This PR goes in Parallel with PR #396. Following PR #396 discussion, it adds the possibility to perform the subnormal flushing in software around the call to host library functions so that we can get rid of the clunky user warnings that was here as a TODO for now.

I think keeping the possibility to do hardware flushing on X86_64 and Aarch64 host make sens because it will yield a better fp determinism between host folding and target run-time computations when host and target are the same. As we have seen, some math libraries try to do weird things to circumvent hardware subnormal flushing. e.g some logf returning constant -1.03972076416015625e2_4 for all positive subnormal values instead of -inf.... There is no way to reproduce this kind of behaviors with software flushing around host library call.

Also add test related to subnormal flushing and use of host library functions.

@pawosm-arm, I will rebase this PR and remove your warning when @sscalpone merge #396.