### PR TITLE
Misc code cleanup.

### DIFF
--- a/lib/semantics/check-arithmeticif.cc
+++ b/lib/semantics/check-arithmeticif.cc
@@ -33,14 +33,14 @@ void ArithmeticIfStmtChecker::Leave(
   // C849 that shall not be of type complex.
   auto &expr{std::get<parser::Expr>(arithmeticIfStmt.t)};
   if (expr.typedExpr->v.Rank() > 0) {
-    context_.messages().Say(expr.source,
+    context_.Say(expr.source,
         "ARITHMETIC IF expression must be a scalar expression"_err_en_US);
   } else if (ExprHasTypeCategory(
                  *expr.typedExpr, common::TypeCategory::Complex)) {
-    context_.messages().Say(expr.source,
+    context_.Say(expr.source,
         "ARITHMETIC IF expression must not be a COMPLEX expression"_err_en_US);
   } else if (!IsNumericExpr(*expr.typedExpr)) {
-    context_.messages().Say(expr.source,
+    context_.Say(expr.source,
         "ARITHMETIC IF expression must be a numeric expression"_err_en_US);
   }
   // The labels have already been checked in resolve-labels.

--- a/lib/semantics/check-arithmeticif.h
+++ b/lib/semantics/check-arithmeticif.h
@@ -24,8 +24,7 @@ struct ArithmeticIfStmt;
 namespace Fortran::semantics {
 class ArithmeticIfStmtChecker : public virtual BaseChecker {
 public:
-  inline ArithmeticIfStmtChecker(SemanticsContext &context)
-    : context_(context){};
+  ArithmeticIfStmtChecker(SemanticsContext &context) : context_(context){};
   void Leave(const parser::ArithmeticIfStmt &);
 
 private:

--- a/lib/semantics/check-computed-goto.cc
+++ b/lib/semantics/check-computed-goto.cc
@@ -26,11 +26,11 @@ void ComputedGotoStmtChecker::Leave(
   auto &expr{
       std::get<parser::ScalarIntExpr>(computedGotoStmt.t).thing.thing.value()};
   if (expr.typedExpr->v.Rank() > 0) {
-    context_.messages().Say(expr.source,
+    context_.Say(expr.source,
         "Computed GOTO expression must be a scalar expression"_err_en_US);
   } else if (!ExprHasTypeCategory(
                  *expr.typedExpr, common::TypeCategory::Integer)) {
-    context_.messages().Say(expr.source,
+    context_.Say(expr.source,
         "Computed GOTO expression must be an integer expression"_err_en_US);
   }
 }

--- a/lib/semantics/check-computed-goto.h
+++ b/lib/semantics/check-computed-goto.h
@@ -24,8 +24,7 @@ struct ComputedGotoStmt;
 namespace Fortran::semantics {
 class ComputedGotoStmtChecker : public virtual BaseChecker {
 public:
-  inline ComputedGotoStmtChecker(SemanticsContext &context)
-    : context_{context} {}
+  ComputedGotoStmtChecker(SemanticsContext &context) : context_{context} {}
   void Leave(const parser::ComputedGotoStmt &);
 
 private:

--- a/lib/semantics/check-deallocate.cc
+++ b/lib/semantics/check-deallocate.cc
@@ -56,7 +56,7 @@ void DeallocateChecker::Leave(const parser::DeallocateStmt &deallocateStmt) {
             [&](const parser::StatVariable &statVariable) {
               // ExpressionAnalyzer emits error messages
               evaluate::ExpressionAnalyzer analyzer{context_};
-              (void)analyzer.Analyze(statVariable.v);
+              analyzer.Analyze(statVariable.v);
               if (gotStat) {
                 context_.Say(
                     "STAT may not be duplicated in a DEALLOCATE statement"_err_en_US);
@@ -66,7 +66,7 @@ void DeallocateChecker::Leave(const parser::DeallocateStmt &deallocateStmt) {
             [&](const parser::MsgVariable &msgVariable) {
               // ExpressionAnalyzer emits error messages
               evaluate::ExpressionAnalyzer analyzer{context_};
-              (void)analyzer.Analyze(msgVariable.v);
+              analyzer.Analyze(msgVariable.v);
               if (gotMsg) {
                 context_.Say(
                     "ERRMSG may not be duplicated in a DEALLOCATE statement"_err_en_US);

--- a/lib/semantics/check-deallocate.h
+++ b/lib/semantics/check-deallocate.h
@@ -24,7 +24,7 @@ struct DeallocateStmt;
 namespace Fortran::semantics {
 class DeallocateChecker : public virtual BaseChecker {
 public:
-  inline DeallocateChecker(SemanticsContext &context) : context_{context} {}
+  DeallocateChecker(SemanticsContext &context) : context_{context} {}
   void Leave(const parser::DeallocateStmt &);
 
 private:

--- a/lib/semantics/check-if-construct.h
+++ b/lib/semantics/check-if-construct.h
@@ -24,7 +24,7 @@ struct IfConstruct;
 namespace Fortran::semantics {
 class IfConstructChecker : public virtual BaseChecker {
 public:
-  inline IfConstructChecker(SemanticsContext &context) : context_{context} {}
+  IfConstructChecker(SemanticsContext &context) : context_{context} {}
   void Leave(const parser::IfConstruct &);
 
 private:

--- a/lib/semantics/check-if-stmt.cc
+++ b/lib/semantics/check-if-stmt.cc
@@ -28,7 +28,7 @@ void IfStmtChecker::Leave(const parser::IfStmt &ifStmt) {
       std::get<parser::UnlabeledStatement<parser::ActionStmt>>(ifStmt.t)};
   if (std::holds_alternative<common::Indirection<parser::IfStmt>>(
           body.statement.u)) {
-    context_.messages().Say(
+    context_.Say(
         body.source, "IF statement is not allowed in IF statement"_err_en_US);
   }
 }

--- a/lib/semantics/check-if-stmt.h
+++ b/lib/semantics/check-if-stmt.h
@@ -24,7 +24,7 @@ struct IfStmt;
 namespace Fortran::semantics {
 class IfStmtChecker : public virtual BaseChecker {
 public:
-  inline IfStmtChecker(SemanticsContext &context) : context_{context} {}
+  IfStmtChecker(SemanticsContext &context) : context_{context} {}
   void Leave(const parser::IfStmt &);
 
 private:

--- a/lib/semantics/check-nullify.cc
+++ b/lib/semantics/check-nullify.cc
@@ -28,10 +28,10 @@ void NullifyChecker::Leave(const parser::NullifyStmt &nullifyStmt) {
             [&](const parser::Name &name) {
               auto const *symbol{name.symbol};
               if (!IsVariableName(*symbol) && !IsProcName(*symbol)) {
-                context_.messages().Say(name.source,
+                context_.Say(name.source,
                     "name in NULLIFY statement must be a variable or procedure pointer name"_err_en_US);
               } else if (!IsPointer(*symbol)) {  // C951
-                context_.messages().Say(name.source,
+                context_.Say(name.source,
                     "name in NULLIFY statement must have the POINTER attribute"_err_en_US);
               }
             },
@@ -39,7 +39,7 @@ void NullifyChecker::Leave(const parser::NullifyStmt &nullifyStmt) {
               evaluate::ExpressionAnalyzer analyzer{context_};
               if (MaybeExpr checked{analyzer.Analyze(structureComponent)}) {
                 if (!IsPointer(*structureComponent.component.symbol)) {  // C951
-                  context_.messages().Say(structureComponent.component.source,
+                  context_.Say(structureComponent.component.source,
                       "component in NULLIFY statement must have the POINTER attribute"_err_en_US);
                 }
               }

--- a/lib/semantics/check-nullify.h
+++ b/lib/semantics/check-nullify.h
@@ -24,7 +24,7 @@ struct NullifyStmt;
 namespace Fortran::semantics {
 class NullifyChecker : public virtual BaseChecker {
 public:
-  inline NullifyChecker(SemanticsContext &context) : context_{context} {}
+  NullifyChecker(SemanticsContext &context) : context_{context} {}
   void Leave(const parser::NullifyStmt &);
 
 private:

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -154,8 +154,10 @@ public:
   const ArraySpec &coshape() const { return coshape_; }
   void set_shape(const ArraySpec &);
   void set_coshape(const ArraySpec &);
-  const Symbol *commonBlock() const { return commonBlock_; }    
-  void set_commonBlock(const Symbol &commonBlock) { commonBlock_ = &commonBlock; }
+  const Symbol *commonBlock() const { return commonBlock_; }
+  void set_commonBlock(const Symbol &commonBlock) {
+    commonBlock_ = &commonBlock;
+  }
   bool IsArray() const { return !shape_.empty(); }
   bool IsCoarray() const { return !coshape_.empty(); }
   bool IsAssumedShape() const {
@@ -260,7 +262,7 @@ private:
   std::optional<SourceName> passName_;  // name in PASS attribute
 };
 
-ENUM_CLASS(GenericKind, // Kinds of generic-spec
+ENUM_CLASS(GenericKind,  // Kinds of generic-spec
     Name, DefinedOp,  // these have a Name associated with them
     Assignment,  // user-defined assignment
     OpPower, OpMultiply, OpDivide, OpAdd, OpSubtract, OpConcat, OpLT, OpLE,


### PR DESCRIPTION
Remove unnecessary inline keyword.  Remove unnecessary (void) casts when ignoring return values. Call context_.Say() directly instead of via messages(). Fix up some formatting issues using clang-format.