### PR TITLE
Remove ObjectName alternative from Designator

### DIFF
--- a/lib/parser/parse-tree.cc
+++ b/lib/parser/parse-tree.cc
@@ -45,7 +45,6 @@ CommonStmt::CommonStmt(std::optional<Name> &&name,
 bool Designator::EndsInBareName() const {
   return std::visit(
       common::visitors{
-          [](const ObjectName &) { return true; },
           [](const DataRef &dr) {
             return std::holds_alternative<Name>(dr.u) ||
                 std::holds_alternative<common::Indirection<StructureComponent>>(
@@ -163,7 +162,8 @@ Statement<ActionStmt> StmtFunctionStmt::ConvertToAssignment() {
   auto &funcExpr{std::get<Scalar<Expr>>(t).thing};
   std::list<Expr> subscripts;
   for (Name &arg : funcArgs) {
-    subscripts.push_back(Expr{common::Indirection{Designator{Name{arg}}}});
+    subscripts.push_back(
+        Expr{common::Indirection{Designator{DataRef{Name{arg}}}}});
   }
   auto variable{Variable{common::Indirection{
       MakeArrayElementRef(funcName, std::move(subscripts))}}};

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -1757,7 +1757,7 @@ struct CharLiteralConstantSubstring {
 struct Designator {
   UNION_CLASS_BOILERPLATE(Designator);
   bool EndsInBareName() const;
-  std::variant<ObjectName, DataRef, Substring> u;
+  std::variant<DataRef, Substring> u;
 };
 
 // R902 variable -> designator | function-reference

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -14,7 +14,11 @@
 
 #include "tools.h"
 #include "scope.h"
-#include "../evaluate/variable.h"
+#include "symbol.h"
+#include "type.h"
+#include "../common/indirection.h"
+#include "../parser/message.h"
+#include "../parser/parse-tree.h"
 #include <algorithm>
 #include <set>
 #include <variant>
@@ -273,4 +277,31 @@ void CheckScalarLogicalExpr(
     messages.Say(expr.source, "Expected a LOGICAL expression"_err_en_US);
   }
 }
+
+static parser::Name *GetSimpleName(
+    common::Indirection<parser::Designator> *designator) {
+  if (designator) {
+    auto *dataRef{std::get_if<parser::DataRef>(&designator->value().u)};
+    return dataRef ? std::get_if<parser::Name>(&dataRef->u) : nullptr;
+  } else {
+    return nullptr;
+  }
+}
+
+parser::Name *GetSimpleName(parser::Expr &expr) {
+  return GetSimpleName(
+      std::get_if<common::Indirection<parser::Designator>>(&expr.u));
+}
+const parser::Name *GetSimpleName(const parser::Expr &expr) {
+  return GetSimpleName(const_cast<parser::Expr &>(expr));
+}
+
+parser::Name *GetSimpleName(parser::Variable &variable) {
+  return GetSimpleName(
+      std::get_if<common::Indirection<parser::Designator>>(&variable.u));
+}
+const parser::Name *GetSimpleName(const parser::Variable &variable) {
+  return GetSimpleName(const_cast<parser::Variable &>(variable));
+}
+
 }

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -18,14 +18,26 @@
 // Simple predicates and look-up functions that are best defined
 // canonically for use in semantic checking.
 
-#include "scope.h"
-#include "symbol.h"
-#include "type.h"
+#include "../common/Fortran.h"
 #include "../evaluate/variable.h"
-#include "../parser/message.h"
-#include "../parser/parse-tree.h"
+
+namespace Fortran::parser {
+class Messages;
+struct Expr;
+struct Name;
+struct Variable;
+}
+
+namespace Fortran::evaluate {
+class GenericExprWrapper;
+}
 
 namespace Fortran::semantics {
+
+class DeclTypeSpec;
+class DerivedTypeSpec;
+class Scope;
+class Symbol;
 
 const Symbol *FindCommonBlockContaining(const Symbol &object);
 const Scope *FindProgramUnitContaining(const Scope &);
@@ -87,5 +99,12 @@ bool ExprHasTypeCategory(
     const evaluate::GenericExprWrapper &expr, const common::TypeCategory &type);
 void CheckScalarLogicalExpr(
     const parser::Expr &expr, parser::Messages &messages);
+
+// If this Expr or Variable represents a simple Name, return it.
+parser::Name *GetSimpleName(parser::Expr &);
+const parser::Name *GetSimpleName(const parser::Expr &);
+parser::Name *GetSimpleName(parser::Variable &);
+const parser::Name *GetSimpleName(const parser::Variable &);
+
 }
 #endif  // FORTRAN_SEMANTICS_TOOLS_H_


### PR DESCRIPTION
A simple name in a `Designator` is always parsed as a `DataRef`, not
an `ObjectName`. So remove that alternative.

`StmtFunctionStmt::ConvertToAssignment` was creating a `Designator` with
that alternative: change it to do the same thing as the parser.

Add `GetSimpleName` utility functions to check if an `Expr` or `Variable`
represents a simple name. Many of the places that checked for `ObjectName`
in `Designator` are trying to do that.

Clean up includes and forward declarations in `tools.h`.