### PR TITLE
Delete the default copy constructor for Scope.

### DIFF
--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -46,6 +46,7 @@ public:
       symbol->set_scope(this);
     }
   }
+  Scope(const Scope &) = delete;
 
   bool operator==(const Scope &that) const { return this == &that; }
   bool operator!=(const Scope &that) const { return this != &that; }


### PR DESCRIPTION
Avoid a potential bug that cropped up in a code review when a `Scope` was copied into a local variable that wasn't declared as a reference.