### PR TITLE
Resolve ambiguous I/O unit parse in favor of CharVariable.

### DIFF
--- a/lib/evaluate/type.cc
+++ b/lib/evaluate/type.cc
@@ -135,12 +135,12 @@ std::string DynamicType::AsFortran() const {
   } else if (charLength != nullptr) {
     std::string result{"CHARACTER(KIND="s + std::to_string(kind) + ",LEN="};
     if (charLength->isAssumed()) {
-      result += ",LEN=*";
+      result += '*';
     } else if (charLength->isDeferred()) {
-      result += ",LEN=:";
+      result += ':';
     } else if (const auto &length{charLength->GetExplicit()}) {
       std::stringstream ss;
-      length->AsFortran(ss << ",LEN=");
+      length->AsFortran(ss);
       result += ss.str();
     }
     return result + ')';

--- a/lib/parser/CMakeLists.txt
+++ b/lib/parser/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(FortranParser
   provenance.cc
   source.cc
   token-sequence.cc
+  tools.cc
   unparse.cc
   user-state.cc
 )

--- a/lib/parser/dump-parse-tree.h
+++ b/lib/parser/dump-parse-tree.h
@@ -127,7 +127,6 @@ public:
   NODE(parser, CharLiteralConstantSubstring)
   NODE(parser, CharSelector)
   NODE(parser::CharSelector, LengthAndKind)
-  NODE(parser, CharVariable)
   NODE(parser, CloseStmt)
   NODE(parser::CloseStmt, CloseSpec)
   NODE(parser, CoarrayAssociation)

--- a/lib/parser/grammar.h
+++ b/lib/parser/grammar.h
@@ -2422,8 +2422,10 @@ TYPE_CONTEXT_PARSER("UNLOCK statement"_en_US,
 
 // R1201 io-unit -> file-unit-number | * | internal-file-variable
 // R1203 internal-file-variable -> char-variable
-TYPE_PARSER(construct<IoUnit>(fileUnitNumber) || construct<IoUnit>(star) ||
-    construct<IoUnit>(charVariable / !"="_tok))
+// "char-variable" is attempted first since it's not type constrained but
+// syntactically ambiguous with "file-unit-number", which is constrained.
+TYPE_PARSER(construct<IoUnit>(charVariable / !"="_tok) ||
+    construct<IoUnit>(fileUnitNumber) || construct<IoUnit>(star))
 
 // R1202 file-unit-number -> scalar-int-expr
 TYPE_PARSER(construct<FileUnitNumber>(scalarIntExpr / !"="_tok))

--- a/lib/parser/grammar.h
+++ b/lib/parser/grammar.h
@@ -1441,9 +1441,6 @@ TYPE_CONTEXT_PARSER("variable"_en_US,
 // Appears only as part of scalar-logical-variable.
 constexpr auto scalarLogicalVariable{scalar(logical(variable))};
 
-// R905 char-variable -> variable
-constexpr auto charVariable{construct<CharVariable>(variable)};
-
 // R906 default-char-variable -> variable
 // Appears only as part of scalar-default-char-variable.
 constexpr auto scalarDefaultCharVariable{scalar(defaultChar(variable))};
@@ -2422,9 +2419,10 @@ TYPE_CONTEXT_PARSER("UNLOCK statement"_en_US,
 
 // R1201 io-unit -> file-unit-number | * | internal-file-variable
 // R1203 internal-file-variable -> char-variable
+// R905 char-variable -> variable
 // "char-variable" is attempted first since it's not type constrained but
 // syntactically ambiguous with "file-unit-number", which is constrained.
-TYPE_PARSER(construct<IoUnit>(charVariable / !"="_tok) ||
+TYPE_PARSER(construct<IoUnit>(variable / !"="_tok) ||
     construct<IoUnit>(fileUnitNumber) || construct<IoUnit>(star))
 
 // R1202 file-unit-number -> scalar-int-expr

--- a/lib/parser/parse-tree-visitor.h
+++ b/lib/parser/parse-tree-visitor.h
@@ -160,7 +160,8 @@ void Walk(std::pair<A, B> &x, M &mutator) {
   }
 }
 
-// Trait-determined traversal of empty, tuple, union, and wrapper classes.
+// Trait-determined traversal of empty, tuple, union, wrapper,
+// and constraint-checking classes.
 template<typename A, typename V>
 std::enable_if_t<EmptyTrait<A>> Walk(const A &x, V &visitor) {
   if (visitor.Pre(x)) {
@@ -219,6 +220,21 @@ std::enable_if_t<WrapperTrait<A>> Walk(A &x, M &mutator) {
   }
 }
 
+template<typename A, typename V>
+std::enable_if_t<ConstraintTrait<A>> Walk(const A &x, V &visitor) {
+  if (visitor.Pre(x)) {
+    Walk(x.thing, visitor);
+    visitor.Post(x);
+  }
+}
+template<typename A, typename M>
+std::enable_if_t<ConstraintTrait<A>> Walk(A &x, M &mutator) {
+  if (mutator.Pre(x)) {
+    Walk(x.thing, mutator);
+    mutator.Post(x);
+  }
+}
+
 template<typename T, typename V>
 void Walk(const common::Indirection<T> &x, V &visitor) {
   Walk(x.value(), visitor);
@@ -226,69 +242,6 @@ void Walk(const common::Indirection<T> &x, V &visitor) {
 template<typename T, typename M>
 void Walk(common::Indirection<T> &x, M &mutator) {
   Walk(x.value(), mutator);
-}
-
-// Walk a class with a single field 'thing'.
-template<typename T, typename V> void Walk(const Scalar<T> &x, V &visitor) {
-  if (visitor.Pre(x)) {
-    Walk(x.thing, visitor);
-    visitor.Post(x);
-  }
-}
-template<typename T, typename M> void Walk(Scalar<T> &x, M &mutator) {
-  if (mutator.Pre(x)) {
-    Walk(x.thing, mutator);
-    mutator.Post(x);
-  }
-}
-template<typename T, typename V> void Walk(const Constant<T> &x, V &visitor) {
-  if (visitor.Pre(x)) {
-    Walk(x.thing, visitor);
-    visitor.Post(x);
-  }
-}
-template<typename T, typename M> void Walk(Constant<T> &x, M &mutator) {
-  if (mutator.Pre(x)) {
-    Walk(x.thing, mutator);
-    mutator.Post(x);
-  }
-}
-template<typename T, typename V> void Walk(const Integer<T> &x, V &visitor) {
-  if (visitor.Pre(x)) {
-    Walk(x.thing, visitor);
-    visitor.Post(x);
-  }
-}
-template<typename T, typename M> void Walk(Integer<T> &x, M &mutator) {
-  if (mutator.Pre(x)) {
-    Walk(x.thing, mutator);
-    mutator.Post(x);
-  }
-}
-template<typename T, typename V> void Walk(const Logical<T> &x, V &visitor) {
-  if (visitor.Pre(x)) {
-    Walk(x.thing, visitor);
-    visitor.Post(x);
-  }
-}
-template<typename T, typename M> void Walk(Logical<T> &x, M &mutator) {
-  if (mutator.Pre(x)) {
-    Walk(x.thing, mutator);
-    mutator.Post(x);
-  }
-}
-template<typename T, typename V>
-void Walk(const DefaultChar<T> &x, V &visitor) {
-  if (visitor.Pre(x)) {
-    Walk(x.thing, visitor);
-    visitor.Post(x);
-  }
-}
-template<typename T, typename M> void Walk(DefaultChar<T> &x, M &mutator) {
-  if (mutator.Pre(x)) {
-    Walk(x.thing, mutator);
-    mutator.Post(x);
-  }
 }
 
 template<typename T, typename V> void Walk(const Statement<T> &x, V &visitor) {

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -2497,7 +2497,7 @@ WRAPPER_CLASS(FileUnitNumber, ScalarIntExpr);
 // R1203 internal-file-variable -> char-variable
 struct IoUnit {
   UNION_CLASS_BOILERPLATE(IoUnit);
-  std::variant<FileUnitNumber, Star, CharVariable> u;
+  std::variant<CharVariable, FileUnitNumber, Star> u;
 };
 
 // R1206 file-name-expr -> scalar-default-char-expr

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -55,6 +55,7 @@ CLASS_TRAIT(EmptyTrait)
 CLASS_TRAIT(WrapperTrait)
 CLASS_TRAIT(UnionTrait)
 CLASS_TRAIT(TupleTrait)
+CLASS_TRAIT(ConstraintTrait)
 
 // Some parse tree nodes have fields in them to cache the results of a
 // successful semantic analysis later.  Their types are forward declared
@@ -272,6 +273,7 @@ using Location = const char *;
 // These template class wrappers correspond to the Standard's modifiers
 // scalar-xyz, constant-xzy, int-xzy, default-char-xyz, & logical-xyz.
 template<typename A> struct Scalar {
+  using ConstraintTrait = std::true_type;
   Scalar(Scalar &&that) = default;
   Scalar(A &&that) : thing(std::move(that)) {}
   Scalar &operator=(Scalar &&) = default;
@@ -279,6 +281,7 @@ template<typename A> struct Scalar {
 };
 
 template<typename A> struct Constant {
+  using ConstraintTrait = std::true_type;
   Constant(Constant &&that) = default;
   Constant(A &&that) : thing(std::move(that)) {}
   Constant &operator=(Constant &&) = default;
@@ -286,6 +289,7 @@ template<typename A> struct Constant {
 };
 
 template<typename A> struct Integer {
+  using ConstraintTrait = std::true_type;
   Integer(Integer &&that) = default;
   Integer(A &&that) : thing(std::move(that)) {}
   Integer &operator=(Integer &&) = default;
@@ -293,6 +297,7 @@ template<typename A> struct Integer {
 };
 
 template<typename A> struct Logical {
+  using ConstraintTrait = std::true_type;
   Logical(Logical &&that) = default;
   Logical(A &&that) : thing(std::move(that)) {}
   Logical &operator=(Logical &&) = default;
@@ -300,6 +305,7 @@ template<typename A> struct Logical {
 };
 
 template<typename A> struct DefaultChar {
+  using ConstraintTrait = std::true_type;
   DefaultChar(DefaultChar &&that) = default;
   DefaultChar(A &&that) : thing(std::move(that)) {}
   DefaultChar &operator=(DefaultChar &&) = default;

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -1772,9 +1772,6 @@ struct Variable {
 // Appears only as part of scalar-logical-variable.
 using ScalarLogicalVariable = Scalar<Logical<Variable>>;
 
-// R905 char-variable -> variable
-WRAPPER_CLASS(CharVariable, Variable);
-
 // R906 default-char-variable -> variable
 // Appears only as part of scalar-default-char-variable.
 using ScalarDefaultCharVariable = Scalar<DefaultChar<Variable>>;
@@ -2495,9 +2492,14 @@ WRAPPER_CLASS(FileUnitNumber, ScalarIntExpr);
 
 // R1201 io-unit -> file-unit-number | * | internal-file-variable
 // R1203 internal-file-variable -> char-variable
+// R905 char-variable -> variable
+// When Variable appears as an IoUnit, it must be character of a default,
+// ASCII, or Unicode kind; this constraint is not automatically checked.
+// The parse is ambiguous and is repaired if necessary once the types of
+// symbols are known.
 struct IoUnit {
   UNION_CLASS_BOILERPLATE(IoUnit);
-  std::variant<CharVariable, FileUnitNumber, Star> u;
+  std::variant<Variable, FileUnitNumber, Star> u;
 };
 
 // R1206 file-name-expr -> scalar-default-char-expr

--- a/lib/parser/tools.cc
+++ b/lib/parser/tools.cc
@@ -1,0 +1,71 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tools.h"
+
+namespace Fortran::parser {
+
+const Name &GetLastName(const Name &x) { return x; }
+
+const Name &GetLastName(const StructureComponent &x) {
+  return GetLastName(x.component);
+}
+
+const Name &GetLastName(const DataRef &x) {
+  return std::visit(
+      common::visitors{
+          [](const Name &name) -> const Name & { return name; },
+          [](const common::Indirection<StructureComponent> &sc)
+              -> const Name & { return GetLastName(sc.value()); },
+          [](const common::Indirection<ArrayElement> &sc) -> const Name & {
+            return GetLastName(sc.value().base);
+          },
+          [](const common::Indirection<CoindexedNamedObject> &ci)
+              -> const Name & { return GetLastName(ci.value().base); },
+      },
+      x.u);
+}
+
+const Name &GetLastName(const Substring &x) {
+  return GetLastName(std::get<DataRef>(x.t));
+}
+
+const Name &GetLastName(const Designator &x) {
+  return std::visit(
+      [](const auto &y) -> const Name & { return GetLastName(y); }, x.u);
+}
+
+const Name &GetLastName(const ProcComponentRef &x) {
+  return GetLastName(x.v.thing);
+}
+
+const Name &GetLastName(const ProcedureDesignator &x) {
+  return std::visit(
+      [](const auto &y) -> const Name & { return GetLastName(y); }, x.u);
+}
+
+const Name &GetLastName(const Call &x) {
+  return GetLastName(std::get<ProcedureDesignator>(x.t));
+}
+
+const Name &GetLastName(const FunctionReference &x) { return GetLastName(x.v); }
+
+const Name &GetLastName(const Variable &x) {
+  return std::visit(
+      [](const auto &indirection) -> const Name & {
+        return GetLastName(indirection.value());
+      },
+      x.u);
+}
+}

--- a/lib/parser/tools.h
+++ b/lib/parser/tools.h
@@ -1,0 +1,76 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_PARSER_TOOLS_H_
+#define FORTRAN_PARSER_TOOLS_H_
+#include "parse-tree.h"
+namespace Fortran::parser {
+
+// GetLastName() isolates and returns a reference to the rightmost Name
+// in a variable (i.e., the Name whose symbol's type determines the type
+// of the variable or expression).
+
+const Name &GetLastName(const Name &x) { return x; }
+
+const Name &GetLastName(const StructureComponent &x) {
+  return GetLastName(x.component);
+}
+
+const Name &GetLastName(const DataRef &x) {
+  return std::visit(
+      common::visitors{
+          [](const Name &name) { return GetLastName(name); },
+          [](const common::Indirection<StructureComponent> &sc) {
+            return GetLastName(sc.value());
+          },
+          [](const common::Indirection<ArrayElement> &sc) {
+            return GetLastName(sc.value().base);
+          },
+          [](const common::Indirection<CoindexedNamedObject> &ci) {
+            return GetLastName(ci.value().base);
+          },
+      },
+      x.u);
+}
+
+const Name &GetLastName(const Substring &x) {
+  return GetType(std::get<DataRef>(x.t));
+}
+
+const Name &GetLastName(const Designator &x) {
+  return std::visit([](const auto &y) { return GetType(y); }, x.u);
+}
+
+const Name &GetLastName(const ProcComponentRef &x) {
+  return GetType(x.v.thing);
+}
+
+const Name &GetLastName(const ProcedureDesignator &x) {
+  return std::visit([](const auto &y) { return GetType(y); }, x.u);
+}
+
+const Name &GetLastName(const Call &x) {
+  return GetType(std::get<ProcedureDesignator>(x.t));
+}
+
+const Name &GetLastName(const FunctionReference &x) { return GetType(x.v); }
+
+const Name &GetLastName(const Variable &x) {
+  return std::visit(
+      [](const auto &indirection) { return GetType(indirection.value()); },
+      x.u);
+}
+
+}
+#endif  // FORTRAN_PARSER_TOOLS_H_

--- a/lib/semantics/check-coarray.cc
+++ b/lib/semantics/check-coarray.cc
@@ -19,6 +19,7 @@
 #include "../evaluate/expression.h"
 #include "../parser/message.h"
 #include "../parser/parse-tree.h"
+#include "../parser/tools.h"
 
 namespace Fortran::semantics {
 
@@ -56,7 +57,7 @@ void CoarrayChecker::Leave(const parser::FormTeamStmt &x) {
   AnalyzeExpr(context_, std::get<parser::ScalarIntExpr>(x.t));
   const auto &teamVar{std::get<parser::TeamVariable>(x.t)};
   AnalyzeExpr(context_, teamVar);
-  const parser::Name *name{GetSimpleName(teamVar.thing)};
+  const parser::Name *name{parser::Unwrap<parser::Name>(teamVar)};
   CHECK(name);
   if (const auto *type{name->symbol->GetType()}) {
     if (!IsTeamType(type->AsDerived())) {
@@ -86,8 +87,7 @@ void CoarrayChecker::CheckNamesAreDistinct(
           *prev, "Previous use of '%s'"_en_US);
     }
     // ResolveNames verified the selector is a simple name
-    const auto &variable{std::get<parser::Variable>(selector.u)};
-    const parser::Name *name{GetSimpleName(variable)};
+    const parser::Name *name{parser::Unwrap<parser::Name>(selector)};
     CHECK(name);
     if (auto *prev{getPreviousUse(*name)}) {
       Say2(name->source,  // C1113, C1115

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -34,6 +34,7 @@
 #include "../evaluate/type.h"
 #include "../parser/parse-tree-visitor.h"
 #include "../parser/parse-tree.h"
+#include "../parser/tools.h"
 #include <list>
 #include <map>
 #include <memory>
@@ -4668,7 +4669,7 @@ bool ResolveNamesVisitor::Pre(const parser::PointerAssignmentStmt &x) {
   ResolveDataRef(dataRef);
   Walk(bounds);
   // Resolve unrestricted specific intrinsic procedures as in "p => cos".
-  if (const parser::Name * name{GetSimpleName(expr)}) {
+  if (const parser::Name * name{parser::Unwrap<parser::Name>(expr)}) {
     if (NameIsKnownOrIntrinsic(*name)) {
       return false;
     }

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -263,31 +263,4 @@ bool ExprHasTypeCategory(const evaluate::GenericExprWrapper &expr,
   auto dynamicType{expr.v.GetType()};
   return dynamicType.has_value() && dynamicType->category == type;
 }
-
-static parser::Name *GetSimpleName(
-    common::Indirection<parser::Designator> *designator) {
-  if (designator) {
-    auto *dataRef{std::get_if<parser::DataRef>(&designator->value().u)};
-    return dataRef ? std::get_if<parser::Name>(&dataRef->u) : nullptr;
-  } else {
-    return nullptr;
-  }
-}
-
-parser::Name *GetSimpleName(parser::Expr &expr) {
-  return GetSimpleName(
-      std::get_if<common::Indirection<parser::Designator>>(&expr.u));
-}
-const parser::Name *GetSimpleName(const parser::Expr &expr) {
-  return GetSimpleName(const_cast<parser::Expr &>(expr));
-}
-
-parser::Name *GetSimpleName(parser::Variable &variable) {
-  return GetSimpleName(
-      std::get_if<common::Indirection<parser::Designator>>(&variable.u));
-}
-const parser::Name *GetSimpleName(const parser::Variable &variable) {
-  return GetSimpleName(const_cast<parser::Variable &>(variable));
-}
-
 }

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -97,11 +97,5 @@ const Symbol *FindExternallyVisibleObject(
 
 bool ExprHasTypeCategory(
     const evaluate::GenericExprWrapper &expr, const common::TypeCategory &type);
-
-// If this Expr or Variable represents a simple Name, return it.
-parser::Name *GetSimpleName(parser::Expr &);
-const parser::Name *GetSimpleName(const parser::Expr &);
-parser::Name *GetSimpleName(parser::Variable &);
-const parser::Name *GetSimpleName(const parser::Variable &);
 }
 #endif  // FORTRAN_SEMANTICS_TOOLS_H_


### PR DESCRIPTION
This tweak should dodge a premature automatic type constraint error message in an ambiguous parsing case that's resolved later once symbol tables are in hand.