### PR TITLE
First batch of semantic checks for allocate

### DIFF
--- a/lib/parser/tools.cc
+++ b/lib/parser/tools.cc
@@ -68,4 +68,9 @@ const Name &GetLastName(const Variable &x) {
       },
       x.u);
 }
+
+const Name &GetLastName(const AllocateObject &x) {
+  return std::visit(
+      [](const auto &y) -> const Name & { return GetLastName(y); }, x.u);
+}
 }

--- a/lib/parser/tools.h
+++ b/lib/parser/tools.h
@@ -32,6 +32,7 @@ const Name &GetLastName(const ProcedureDesignator &);
 const Name &GetLastName(const Call &);
 const Name &GetLastName(const FunctionReference &);
 const Name &GetLastName(const Variable &);
+const Name &GetLastName(const AllocateObject &);
 
 // When a parse tree node is an instance of a specific type wrapped in
 // layers of packaging, return a pointer to that object.

--- a/lib/semantics/CMakeLists.txt
+++ b/lib/semantics/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(FortranSemantics
   assignment.cc
   attr.cc
   canonicalize-do.cc
+  check-allocate.cc
   check-arithmeticif.cc
   check-coarray.cc
   check-deallocate.cc

--- a/lib/semantics/check-allocate.cc
+++ b/lib/semantics/check-allocate.cc
@@ -1,0 +1,411 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "check-allocate.h"
+#include "attr.h"
+#include "expression.h"
+#include "tools.h"
+#include "type.h"
+#include "../evaluate/fold.h"
+#include "../evaluate/type.h"
+#include "../parser/parse-tree.h"
+
+namespace Fortran::semantics {
+
+struct AllocateCheckerInfo {
+  const DeclTypeSpec *typeSpec{nullptr};
+  std::optional<evaluate::DynamicType> sourceExprType;
+  bool gotStat{false};
+  bool gotMsg{false};
+  bool gotTypeSpec{false};
+  bool gotSrc{false};
+  bool gotMold{false};
+};
+
+static const parser::Name &GetName(
+    const parser::AllocateObject &allocateObject) {
+  return std::visit(
+      common::visitors{
+          [&](const parser::Name &name) -> const parser::Name & {
+            return name;
+          },
+          [&](const parser::StructureComponent &structureComponent)
+              -> const parser::Name & { return structureComponent.component; },
+      },
+      allocateObject.u);
+}
+
+class AllocationChecker {
+public:
+  AllocationChecker(
+      const parser::AllocateObject &obj, AllocateCheckerInfo &info)
+    : allocateInfo_{info}, name_{GetName(obj)}, type_{name_.symbol->GetType()},
+      isSubobject_{std::holds_alternative<parser::StructureComponent>(obj.u)} {
+    CHECK(type_ != nullptr);
+    if (type_->category() == DeclTypeSpec::Category::Character) {
+      hasDefferedTypeParameter_ =
+          type_->characterTypeSpec().length().isDeferred();
+    } else if (const DerivedTypeSpec * derivedTypeSpec{type_->AsDerived()}) {
+      for (auto it{derivedTypeSpec->parameters().begin()};
+           it != derivedTypeSpec->parameters().end(); ++it) {
+        hasDefferedTypeParameter_ |= it->second.isDeferred();
+      }
+      isAbstract_ = derivedTypeSpec->typeSymbol().attrs().test(Attr::ABSTRACT);
+    }
+    isUnlimitedPolymorphic_ =
+        type_->category() == DeclTypeSpec::Category::ClassStar;
+  }
+
+  bool RunChecks(SemanticsContext &context);
+
+private:
+  AllocateCheckerInfo &allocateInfo_;
+  const parser::Name &name_;
+  const DeclTypeSpec *type_;
+  bool isSubobject_;
+  bool hasDefferedTypeParameter_{false};
+  bool isUnlimitedPolymorphic_{false};
+  bool isAbstract_{false};
+};
+
+static std::optional<AllocateCheckerInfo> CheckAllocateOptions(
+    const parser::AllocateStmt &, SemanticsContext &);
+static bool IsTypeCompatible(const DeclTypeSpec &, const DeclTypeSpec &);
+static bool IsTypeCompatible(
+    const DeclTypeSpec &type1, const evaluate::DynamicType &type2);
+static bool HaveSameAssumedTypeParameters(
+    const DeclTypeSpec &, const DeclTypeSpec &);
+static bool HaveCompatibleKindParameters(
+    const DeclTypeSpec &, const DeclTypeSpec &);
+
+void AllocateChecker::Leave(const parser::AllocateStmt &allocateStmt) {
+  if (auto info{CheckAllocateOptions(allocateStmt, context_)}) {
+    for (const parser::Allocation &allocation :
+        std::get<std::list<parser::Allocation>>(allocateStmt.t)) {
+      AllocationChecker allocationChecker{
+          std::get<parser::AllocateObject>(allocation.t), *info};
+      allocationChecker.RunChecks(context_);
+    }
+  }
+}
+
+static std::optional<AllocateCheckerInfo> CheckAllocateOptions(
+    const parser::AllocateStmt &allocateStmt, SemanticsContext &context) {
+  AllocateCheckerInfo info;
+  evaluate::ExpressionAnalyzer analyzer{context};  // can emit error messages
+  bool stopCheckingAllocate{false};  // for errors that would lead to ambiguity
+  info.gotTypeSpec =
+      std::get<std::optional<parser::TypeSpec>>(allocateStmt.t).has_value();
+  if (info.gotTypeSpec) {
+    info.typeSpec = std::get<std::optional<parser::TypeSpec>>(allocateStmt.t)
+                        .value()
+                        .declTypeSpec;
+  }
+
+  const parser::Expr *parserSourceExpr{nullptr};
+  for (const parser::AllocOpt &allocOpt :
+      std::get<std::list<parser::AllocOpt>>(allocateStmt.t)) {
+    std::visit(
+        common::visitors{
+            [&](const parser::StatOrErrmsg &statOrErr) {
+              std::visit(
+                  common::visitors{
+                      [&](const parser::StatVariable &statVariable) {
+                        analyzer.Analyze(statVariable.v);
+                        if (info.gotStat) {  // C943
+                          context.Say(
+                              "STAT may not be duplicated in a ALLOCATE statement"_err_en_US);
+                        }
+                        info.gotStat = true;
+                      },
+                      [&](const parser::MsgVariable &msgVariable) {
+                        analyzer.Analyze(msgVariable.v);
+                        if (info.gotMsg) {  // C943
+                          context.Say(
+                              "ERRMSG may not be duplicated in a ALLOCATE statement"_err_en_US);
+                        }
+                        info.gotMsg = true;
+                      },
+                  },
+                  statOrErr.u);
+            },
+            [&](const parser::AllocOpt::Source &source) {
+              analyzer.Analyze(source.v);
+              if (info.gotSrc) {  // C943
+                context.Say(
+                    "SOURCE may not be duplicated in a ALLOCATE statement"_err_en_US);
+                stopCheckingAllocate = true;
+              }
+              if (info.gotMold || info.gotTypeSpec) {  // C944
+                context.Say(
+                    "At most one of source-expr and type-spec may appear in a ALLOCATE statement"_err_en_US);
+                stopCheckingAllocate = true;
+              }
+              parserSourceExpr = &source.v.value();
+              info.gotSrc = true;
+            },
+            [&](const parser::AllocOpt::Mold &mold) {
+              analyzer.Analyze(mold.v);
+              if (info.gotMold) {  // C943
+                context.Say(
+                    "MOLD may not be duplicated in a ALLOCATE statement"_err_en_US);
+                stopCheckingAllocate = true;
+              }
+              if (info.gotSrc || info.gotTypeSpec) {  // C944
+                context.Say(
+                    "At most one of source-expr and type-spec may appear in a ALLOCATE statement"_err_en_US);
+                stopCheckingAllocate = true;
+              }
+              parserSourceExpr = &mold.v.value();
+              info.gotMold = true;
+            },
+        },
+        allocOpt.u);
+  }
+
+  if (stopCheckingAllocate) {
+    return std::nullopt;
+  }
+
+  if (info.gotSrc || info.gotMold) {
+    CHECK(parserSourceExpr);
+    CHECK(parserSourceExpr->typedExpr);  // TODO: Can we reach this spot without
+                                         // a valid expression?
+    info.sourceExprType = parserSourceExpr->typedExpr->v.GetType();
+    if (!info.sourceExprType.has_value()) {
+      context.Say(parserSourceExpr->source,
+          "Source expression in ALLOCATE must be a valid expression"_err_en_US);
+      return std::nullopt;
+    }
+  }
+  return info;
+}
+
+bool AllocationChecker::RunChecks(SemanticsContext &context) {
+  if (!IsVariableName(*name_.symbol)) {  // C932 pre-requisite
+    context.Say(name_.source,
+        "name in ALLOCATE statement must be a variable name"_err_en_US);
+    return false;
+  }
+  if (!IsAllocatableOrPointer(*name_.symbol)) {  // C932
+    context.Say(name_.source,
+        "%s in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute"_err_en_US,
+        (isSubobject_ ? "component" : "name"));
+    return false;
+  }
+  bool gotSourceExprOrTypeSpec{allocateInfo_.gotMold ||
+      allocateInfo_.gotTypeSpec || allocateInfo_.gotSrc};
+  if (hasDefferedTypeParameter_ && !gotSourceExprOrTypeSpec) {
+    // C933
+    context.Say(name_.source,
+        "Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters"_err_en_US);
+    return false;
+  }
+  if (isUnlimitedPolymorphic_ && !gotSourceExprOrTypeSpec) {
+    // C933
+    context.Say(name_.source,
+        "Either type-spec or source-expr shall appear in ALLOCATE when allocatable object is unlimited polymorphic"_err_en_US);
+    return false;
+  }
+  if (isAbstract_ && !gotSourceExprOrTypeSpec) {
+    // C933
+    context.Say(name_.source,
+        "Either type-spec or source-expr shall appear in ALLOCATE when allocatable object is of abstract type"_err_en_US);
+    return false;
+  }
+  if (allocateInfo_.gotTypeSpec) {
+    if (!IsTypeCompatible(*type_, *allocateInfo_.typeSpec)) {
+      // C934
+      context.Say(name_.source,
+          "Allocatable object in ALLOCATE shall be type compatible with type-spec"_err_en_US);
+      return false;
+    }
+    if (!HaveCompatibleKindParameters(*type_, *allocateInfo_.typeSpec)) {
+      context.Say(name_.source,
+          // C936
+          "Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec"_err_en_US);
+      return false;
+    }
+    if (!HaveSameAssumedTypeParameters(*type_, *allocateInfo_.typeSpec)) {
+      // C935
+      context.Say(name_.source,
+          "Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE"_err_en_US);
+      return false;
+    }
+  } else if (allocateInfo_.gotSrc || allocateInfo_.gotMold) {
+    if (!IsTypeCompatible(*type_, allocateInfo_.sourceExprType.value())) {
+      // first part of C945
+      context.Say(name_.source,
+          "Allocatable object in ALLOCATE shall be type compatible with source expression from MOLD or SOURCE"_err_en_US);
+      return false;
+    }
+  }
+  // TODO: Second part of C945, and C946. Shape related checks (C939, C940,
+  // C942), Coarray related checks (C937, C941, C949, C950). Blacklisted type
+  // checks (C938, C947, C948)
+  return true;
+}
+
+// Beware, type compatibility is not symmetric, IsTypeCompatible checks that
+// type1 is type compatible with type2. Note: type parameters are not considered
+// in this test.
+static bool IsTypeCompatible(
+    const DeclTypeSpec &type1, const DerivedTypeSpec &derivedType2) {
+  if (const DerivedTypeSpec * derivedType1{type1.AsDerived()}) {
+    if (type1.category() == DeclTypeSpec::Category::TypeDerived) {
+      return &derivedType1->typeSymbol() == &derivedType2.typeSymbol();
+    } else if (type1.category() == DeclTypeSpec::Category::ClassDerived) {
+      for (const DerivedTypeSpec *parent{&derivedType2}; parent != nullptr;
+           parent = parent->typeSymbol().GetParentTypeSpec()) {
+        if (&derivedType1->typeSymbol() == &parent->typeSymbol()) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+static bool IsTypeCompatible(
+    const DeclTypeSpec &type1, const DeclTypeSpec &type2) {
+  if (type1.category() == DeclTypeSpec::Category::ClassStar) {
+    // TypeStar does not make sens in allocate context because assumed type
+    // cannot be allocatable (C709)
+    return true;
+  }
+  if (const IntrinsicTypeSpec * intrinsicType2{type2.AsIntrinsic()}) {
+    if (const IntrinsicTypeSpec * intrinsicType1{type1.AsIntrinsic()}) {
+      return intrinsicType1->category() == intrinsicType2->category();
+    } else {
+      return false;
+    }
+  } else if (const DerivedTypeSpec * derivedType2{type2.AsDerived()}) {
+    return IsTypeCompatible(type1, *derivedType2);
+  }
+  return false;
+}
+
+static bool IsTypeCompatible(
+    const DeclTypeSpec &type1, const evaluate::DynamicType &type2) {
+  if (type1.category() == DeclTypeSpec::Category::ClassStar) {
+    // TypeStar does not make sens in allocate context because assumed type
+    // cannot be allocatable (C709)
+    return true;
+  }
+  if (type2.category != evaluate::TypeCategory::Derived) {
+    if (const IntrinsicTypeSpec * intrinsicType1{type1.AsIntrinsic()}) {
+      return intrinsicType1->category() == type2.category;
+    } else {
+      return false;
+    }
+  } else {
+    CHECK(type2.derived);
+    return IsTypeCompatible(type1, *type2.derived);
+  }
+  return false;
+}
+
+// Note: Check assumes  type1 is compatible with type2. type2 may have more type
+// parameters than type1 but if a type2 type parameter is assumed, then this
+// check enforce that type1 has it. type1 can be unlimited polymorphic, but not
+// type2.
+static bool HaveSameAssumedTypeParameters(
+    const DeclTypeSpec &type1, const DeclTypeSpec &type2) {
+  if (type2.category() == DeclTypeSpec::Category::Character) {
+    bool type2LengthIsAssumed{type2.characterTypeSpec().length().isAssumed()};
+    if (type1.category() == DeclTypeSpec::Category::Character) {
+      return type1.characterTypeSpec().length().isAssumed() ==
+          type2LengthIsAssumed;
+    }
+    // It is possible to reach this if type1 is unlimited polymorphic
+    return !type2LengthIsAssumed;
+  } else if (const DerivedTypeSpec * derivedType2{type2.AsDerived()}) {
+    int type2AssumedParametersCount{0};
+    int type1AssumedParametersCount{0};
+    for (auto it{derivedType2->parameters().begin()};
+         it != derivedType2->parameters().end(); ++it) {
+      type2AssumedParametersCount += it->second.isAssumed();
+    }
+    if (const DerivedTypeSpec *
+        derivedType1{
+            type1.AsDerived()}) {  // type1 may be unlimited polymorphic
+      for (auto it{derivedType1->parameters().begin()};
+           it != derivedType1->parameters().end(); ++it) {
+        if (it->second.isAssumed()) {
+          ++type1AssumedParametersCount;
+          if (const ParamValue *
+              param{derivedType2->FindParameter(it->first)}) {
+            if (!param->isAssumed()) {
+              return false;  // type1 has an assumed param that is not assumed
+                             // in type2
+            }
+          } else {
+            return false;  // type1 has an assumed param that is not a type
+                           // param of type2.
+          }
+        }
+      }
+    }
+    // Will return false if type2 has type parameters that are not assumed in
+    // type1 or do not exist in type1
+    return type1AssumedParametersCount == type2AssumedParametersCount;
+  }
+  return true;  // other intrinsic types have no length type parameters
+}
+
+static std::optional<std::int64_t> GetTypeParameterInt64Value(
+    const Symbol &parameterSymbol, const DerivedTypeSpec &derivedType) {
+  if (const ParamValue *
+      paramValue{derivedType.FindParameter(parameterSymbol.name())}) {
+    return evaluate::ToInt64(paramValue->GetExplicit());
+  } else {
+    // Type parameter with default value and omitted in DerivedTypeSpec
+    return evaluate::ToInt64(parameterSymbol.get<TypeParamDetails>().init());
+  }
+}
+
+// Assumes type1 is type compatible with type2 (except for kind type parameters)
+static bool HaveCompatibleKindParameters(
+    const DeclTypeSpec &type1, const DeclTypeSpec &type2) {
+  if (type1.category() == DeclTypeSpec::Category::ClassStar) {
+    return true;
+  }
+  if (const IntrinsicTypeSpec * intrinsicType1{type1.AsIntrinsic()}) {
+    const IntrinsicTypeSpec *intrinsicType2{type2.AsIntrinsic()};
+    CHECK(intrinsicType2);  // Violation of type compatibility hypothesis.
+    return intrinsicType1->kind() == intrinsicType2->kind();
+  } else if (const DerivedTypeSpec * derivedType1{type1.AsDerived()}) {
+    const DerivedTypeSpec *derivedType2{type2.AsDerived()};
+    CHECK(derivedType2);  // Violation of type compatibility hypothesis.
+    const DerivedTypeDetails &typeDetails{
+        derivedType1->typeSymbol().get<DerivedTypeDetails>()};
+    for (const Symbol *symbol :
+        typeDetails.OrderParameterDeclarations(derivedType1->typeSymbol())) {
+      if (symbol->get<TypeParamDetails>().attr() ==
+          common::TypeParamAttr::Kind) {
+        // At this point, it should have been ensured that these contain integer
+        // constants, so die if this is not the case.
+        if (GetTypeParameterInt64Value(*symbol, *derivedType1).value() !=
+            GetTypeParameterInt64Value(*symbol, *derivedType2).value()) {
+          return false;
+        }
+      }
+    }
+    return true;
+  } else {
+    common::die("unexpected type1 category");
+  }
+}
+
+}

--- a/lib/semantics/check-allocate.cc
+++ b/lib/semantics/check-allocate.cc
@@ -237,9 +237,8 @@ static bool HaveSameAssumedTypeParameters(
     for (const auto &pair : derivedType2->parameters()) {
       type2AssumedParametersCount += pair.second.isAssumed();
     }
-    if (const DerivedTypeSpec *
-        derivedType1{
-            type1.AsDerived()}) {  // type1 may be unlimited polymorphic
+    // type1 may be unlimited polymorphic
+    if (const DerivedTypeSpec * derivedType1{type1.AsDerived()}) {
       for (auto it{derivedType1->parameters().begin()};
            it != derivedType1->parameters().end(); ++it) {
         if (it->second.isAssumed()) {

--- a/lib/semantics/check-allocate.h
+++ b/lib/semantics/check-allocate.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_SEMANTICS_CHECK_ALLOCATE_H_
+#define FORTRAN_SEMANTICS_CHECK_ALLOCATE_H_
+
+#include "semantics.h"
+
+namespace Fortran::parser {
+struct AllocateStmt;
+}
+
+namespace Fortran::semantics {
+class AllocateChecker : public virtual BaseChecker {
+public:
+  AllocateChecker(SemanticsContext &context) : context_{context} {}
+  void Leave(const parser::AllocateStmt &);
+
+private:
+  SemanticsContext &context_;
+};
+}
+#endif  // FORTRAN_SEMANTICS_CHECK_ALLOCATE_H_

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -15,6 +15,7 @@
 #include "semantics.h"
 #include "assignment.h"
 #include "canonicalize-do.h"
+#include "check-allocate.h"
 #include "check-arithmeticif.h"
 #include "check-coarray.h"
 #include "check-deallocate.h"
@@ -79,9 +80,10 @@ private:
 };
 
 using StatementSemanticsPass1 = ExprChecker;
-using StatementSemanticsPass2 = SemanticsVisitor<ArithmeticIfStmtChecker,
-    AssignmentChecker, CoarrayChecker, DeallocateChecker, DoConcurrentChecker,
-    IfStmtChecker, NullifyChecker, ReturnStmtChecker, StopChecker>;
+using StatementSemanticsPass2 = SemanticsVisitor<AllocateChecker,
+    ArithmeticIfStmtChecker, AssignmentChecker, CoarrayChecker,
+    DeallocateChecker, DoConcurrentChecker, IfStmtChecker, NullifyChecker,
+    ReturnStmtChecker, StopChecker>;
 
 static bool PerformStatementSemantics(
     SemanticsContext &context, const parser::Program &program) {

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -103,6 +103,14 @@ set(ERROR_TESTS
 #  altreturn02.f90
 #  altreturn03.f90
   altreturn04.f90
+  allocate01.f90
+  allocate02.f90
+  allocate03.f90
+  allocate04.f90
+  allocate05.f90
+  allocate06.f90
+  allocate07.f90
+  allocate08.f90
 )
 
 # These test files have expected symbols in the source

--- a/test/semantics/allocate01.f90
+++ b/test/semantics/allocate01.f90
@@ -1,0 +1,78 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check for semantic errors in ALLOCATE statements
+
+subroutine C932(ed1, ed5, ed7, edc9, edc10, okad1, okpd1, okacd5)
+! Each allocate-object shall be a data pointer or an allocatable variable.
+  type TestType1
+    integer, allocatable :: ok(:)
+    integer :: nok(:)
+  end type
+  type TestType2
+    integer, pointer :: ok
+    integer :: nok
+  end type
+  real ed1(:), e2
+  real, save :: e3[*]
+  real , target :: e4, ed5(:)
+  real , parameter :: e6 = 5.
+  type(TestType1) ed7
+  type(TestType2) e8
+  type(TestType1) edc9[*]
+  type(TestType2) edc10[*]
+
+  real, allocatable :: oka1(:, :), okad1(:, :), oka2
+  real, pointer :: okp1(:, :), okpd1(:, :), okp2
+  real, pointer, save :: okp3
+  real, allocatable, save :: oka3, okac4[:,:]
+  real, allocatable :: okacd5(:, :)[:]
+
+  !ERROR: name in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  allocate(ed1)
+  !ERROR: name in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  allocate(e2)
+  !ERROR: name in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  allocate(e3)
+  !ERROR: name in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  allocate(e4)
+  !ERROR: name in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  allocate(ed5)
+  !ERROR: name in ALLOCATE statement must be a variable name
+  allocate(e6)
+  !ERROR: name in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  allocate(ed7)
+  !ERROR: component in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  allocate(ed7%nok(2))
+  !ERROR: name in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  allocate(ed8)
+  !ERROR: name in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  allocate(ed8)
+  !ERROR: component in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  allocate(edc9%nok)
+  !ERROR: name in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  allocate(edc10)
+
+  ! No errors expected below:
+  allocate(oka1(5, 7), okad1(4, 8), oka2)
+  allocate(okp1(5, 7), okpd1(4, 8), okp2)
+  allocate(okp1(5, 7), okpd1(4, 8), okp2)
+  allocate(okp3, oka3)
+  allocate(okac4[2:4,4:*])
+  allocate(okacd5(1:2,3:4)[5:*])
+  allocate(ed7%ok)
+  allocate(e8%ok(7))
+  allocate(edc9%ok)
+  allocate(edc10%ok(4))
+end subroutine

--- a/test/semantics/allocate02.f90
+++ b/test/semantics/allocate02.f90
@@ -46,7 +46,7 @@ subroutine C943_C944(src, src2)
   allocate(x9, mold=mld, errmsg=msg, stat=stat, errmsg= msg)
 
 ! C944
-! At most one of source-expr and type-spec shall appear.
+! At most one of source-expr and type-spec must appear.
 
   !Nominal cases already tested in C943 and type-spec tests (e.g C934)
 

--- a/test/semantics/allocate02.f90
+++ b/test/semantics/allocate02.f90
@@ -1,0 +1,62 @@
+
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check for semantic errors in ALLOCATE statements
+
+subroutine C943_C944(src, src2)
+! C943
+! No alloc-opt shall appear more than once in a given alloc-opt-list.
+  character(50) msg
+  integer stat, stat2
+  real src(2:4), src2(2:4)
+  real mld(2:4), mld2(2:4)
+  real, allocatable :: x1(:), x2(:), x3(:), x4(:), x5(:), x6(:), x7(:), x8(:), x9(:)
+  real, allocatable :: y1(:), y2(:), y3(:), y4(:)
+  real, pointer :: p1, p2
+
+  !Nominal cases, no error expected
+  allocate(x1, source=src)
+  allocate(x2, mold=mld)
+  allocate(x3(2:4), stat=stat)
+  allocate(x4(2:4), stat=stat, errmsg=msg)
+  allocate(x5(2:4), source=src, stat=stat, errmsg=msg)
+
+  !ERROR: STAT may not be duplicated in a ALLOCATE statement
+  allocate(x6, stat=stat, source=src, stat=stat2)
+
+  !ERROR: SOURCE may not be duplicated in a ALLOCATE statement
+  allocate(x7, source=src, stat=stat, source=src2)
+
+  !ERROR: MOLD may not be duplicated in a ALLOCATE statement
+  allocate(x8, mold=mld, stat=stat, mold=mld)
+
+  !ERROR: ERRMSG may not be duplicated in a ALLOCATE statement
+  allocate(x9, mold=mld, errmsg=msg, stat=stat, errmsg= msg)
+
+! C944
+! At most one of source-expr and type-spec shall appear.
+
+  !Nominal cases already tested in C943 and type-spec tests (e.g C934)
+
+  !ERROR: At most one of source-expr and type-spec may appear in a ALLOCATE statement
+  allocate(real:: y1, source=src)
+  !ERROR: At most one of source-expr and type-spec may appear in a ALLOCATE statement
+  allocate(real:: y2, mold=mld)
+  !ERROR: At most one of source-expr and type-spec may appear in a ALLOCATE statement
+  allocate(y3, source=src, stat=stat, errmsg=msg, mold=mld)
+  !ERROR: At most one of source-expr and type-spec may appear in a ALLOCATE statement
+  !ERROR: At most one of source-expr and type-spec may appear in a ALLOCATE statement
+  allocate(real:: y4, source=src, stat=stat, errmsg=msg, mold=mld)
+end subroutine

--- a/test/semantics/allocate03.f90
+++ b/test/semantics/allocate03.f90
@@ -54,33 +54,33 @@ subroutine C933_a(ca3, ca4, cp3, cp3mold, cp4, cp7, cp8, bsrc)
   type(SomeType(4, *, 8)) bsrc
 
   ! Expecting errors: need type-spec/src-expr
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object has a deferred type parameters
   allocate(ca1)
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object has a deferred type parameters
   allocate(ca2(4))
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object has a deferred type parameters
   allocate(cp1)
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object has a deferred type parameters
   allocate(cp2(2))
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object has a deferred type parameters
   allocate(cp3)
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object has a deferred type parameters
   allocate(cp4(2))
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object has a deferred type parameters
   allocate(cp5)
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object has a deferred type parameters
   allocate(cp6(2))
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object has a deferred type parameters
   allocate(b1%msg)
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object has a deferred type parameters
   allocate(b1%something)
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object has a deferred type parameters
   allocate(b2%msg)
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object has a deferred type parameters
   allocate(b2%something)
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object has a deferred type parameters
   allocate(b3%msg)
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object has a deferred type parameters
   allocate(b3%something)
 
   ! Nominal cases, expecting no errors

--- a/test/semantics/allocate03.f90
+++ b/test/semantics/allocate03.f90
@@ -1,0 +1,116 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check for semantic errors in ALLOCATE statements
+
+subroutine C933_a(ca3, ca4, cp3, cp3mold, cp4, cp7, cp8, bsrc)
+! If any allocate-object has a deferred type parameter, is unlimited polymorphic,
+! or is of abstract type, either type-spec or source-expr shall appear.
+
+! Only testing deferred type parameters here.
+
+  type SomeType(k, l1, l2)
+    integer, kind :: k = 1
+    integer, len :: l1
+    integer, len :: l2 = 3
+    character(len=l2+l1) str
+  end type
+
+  type B(l)
+    integer, len :: l
+    character(:), allocatable :: msg
+    type(SomeType(4, l, :)), pointer :: something
+  end type
+
+  character(len=:), allocatable :: ca1, ca2(:)
+  character(len=*), allocatable :: ca3, ca4(:)
+  character(len=2), allocatable :: ca5, ca6(:)
+  character(len=5) mold
+
+  type(SomeType(l1=:,l2=:)), pointer :: cp1, cp2(:)
+  type(SomeType(l1=3,l2=4)) cp1mold
+  type(SomeType(1,*,:)), pointer :: cp3, cp4(:)
+  type(SomeType(1,*,5)) cp3mold
+  type(SomeType(l1=:)), pointer :: cp5, cp6(:)
+  type(SomeType(l1=6)) cp5mold
+  type(SomeType(1,*,*)), pointer :: cp7, cp8(:)
+  type(SomeType(1, l1=3)), pointer :: cp9, cp10(:)
+
+  type(B(*)) b1
+  type(B(:)) b2
+  type(B(5)) b3
+
+  type(SomeType(4, *, 8)) bsrc
+
+  ! Expecting errors: need type-spec/src-expr
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  allocate(ca1)
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  allocate(ca2(4))
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  allocate(cp1)
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  allocate(cp2(2))
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  allocate(cp3)
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  allocate(cp4(2))
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  allocate(cp5)
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  allocate(cp6(2))
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  allocate(b1%msg)
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  allocate(b1%something)
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  allocate(b2%msg)
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  allocate(b2%something)
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  allocate(b3%msg)
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object has a deferred type parameters
+  allocate(b3%something)
+
+  ! Nominal cases, expecting no errors
+  allocate(character(len=5):: ca2(4))
+  allocate(character(len=5):: ca1)
+  allocate(character*5:: ca1)
+  allocate(ca2(4), MOLD = "abcde")
+  allocate(ca2(2), MOLD = (/"abcde", "fghij"/))
+  allocate(ca1, MOLD = mold)
+  allocate(ca2(4), SOURCE = "abcde")
+  allocate(ca2(2), SOURCE = (/"abcde", "fghij"/))
+  allocate(ca1, SOURCE = mold)
+  allocate(SomeType(l1=1, l2=2):: cp1, cp2(2))
+  allocate(SomeType(1,*,5):: cp3, cp4(2)) !OK, but segfaults gfortran
+  allocate(SomeType(l1=1):: cp5, cp6(2))
+  allocate(cp1, cp2(2), mold = cp1mold)
+  allocate(cp3, cp4(2), mold = cp3mold)
+  allocate(cp5, cp6(2), mold = cp5mold)
+  allocate(cp1, cp2(2), source = cp1mold)
+  allocate(cp3, cp4(2), source = cp3mold)
+  allocate(cp5, cp6(2), source = cp5mold)
+  allocate(character(len=10):: b1%msg, b2%msg, b3%msg)
+  allocate(SomeType(4, b1%l, 9):: b1%something)
+  allocate(b2%something, source=bsrc)
+  allocate(SomeType(4, 5, 8):: b3%something)
+
+  ! assumed/explicit length do not need type-spec/mold
+  allocate(ca3, ca4(4))
+  allocate(ca5, ca6(4))
+  allocate(cp7, cp8(2))
+  allocate(cp9, cp10(2))
+
+end subroutine

--- a/test/semantics/allocate04.f90
+++ b/test/semantics/allocate04.f90
@@ -45,21 +45,21 @@ subroutine C933_b(n)
   class(B), pointer :: p3, p4(:)
   type(A) :: molda = A(1, 2)
 
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object is unlimited polymorphic
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object is unlimited polymorphic
   allocate(u1)
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object is unlimited polymorphic
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object is unlimited polymorphic
   allocate(u2(2))
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object is unlimited polymorphic
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object is unlimited polymorphic
   allocate(n1%whatever)
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object is unlimited polymorphic
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object is unlimited polymorphic
   allocate(n2(2)%whatever)
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object is of abstract type
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object is of abstract type
   allocate(p1)
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object is of abstract type
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object is of abstract type
   allocate(p2(2))
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object is of abstract type
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object is of abstract type
   allocate(p3%y)
-  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object is of abstract type
+  !ERROR: Either type-spec or source-expr must appear in ALLOCATE when allocatable object is of abstract type
   allocate(p4(2)%y)
   !WRONG allocate(Base:: u1) !C703
 

--- a/test/semantics/allocate04.f90
+++ b/test/semantics/allocate04.f90
@@ -1,0 +1,92 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check for semantic errors in ALLOCATE statements
+
+
+subroutine C933_b(n)
+! If any allocate-object has a deferred type parameter, is unlimited polymorphic,
+! or is of abstract type, either type-spec or source-expr shall appear.
+
+! only testing unlimited polymorphic and abstract-type here
+
+  type, abstract :: Base
+    integer x
+  end type
+
+  type, extends(Base) :: A
+    integer y
+  end type
+
+  type, extends(Base) :: B
+    class(Base), allocatable :: y
+  end type
+
+  type C
+    class(*), pointer :: whatever
+    real, pointer :: y
+  end type
+
+  integer n
+  class(*), allocatable :: u1, u2(:)
+  class(C), allocatable :: n1, n2(:)
+  class(Base), pointer :: p1, p2(:)
+  class(B), pointer :: p3, p4(:)
+  type(A) :: molda = A(1, 2)
+
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object is unlimited polymorphic
+  allocate(u1)
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object is unlimited polymorphic
+  allocate(u2(2))
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object is unlimited polymorphic
+  allocate(n1%whatever)
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object is unlimited polymorphic
+  allocate(n2(2)%whatever)
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object is of abstract type
+  allocate(p1)
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object is of abstract type
+  allocate(p2(2))
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object is of abstract type
+  allocate(p3%y)
+  !ERROR: Either type-spec or source-expr shall appear in ALLOCATE when allocatable object is of abstract type
+  allocate(p4(2)%y)
+  !WRONG allocate(Base:: u1) !C703
+
+  ! No error expected
+  allocate(real:: u1, u2(2))
+  allocate(A:: u1, u2(2))
+  allocate(C:: u1, u2(2))
+  allocate(character(n):: u1, u2(2))
+  allocate(C:: n1%whatever, n2(2)%whatever)
+  allocate(A:: p1, p2(2))
+  allocate(B:: p3%y, p4(2)%y)
+  allocate(u1, u2(2), MOLD = cos(5.+n))
+  allocate(u1, u2(2), MOLD = molda)
+  allocate(u1, u2(2), MOLD = n1)
+  allocate(u1, u2(2), MOLD = new_line("a"))
+  allocate(n1%whatever, MOLD = n2(1))
+  allocate(p1, p2(2), MOLD = p3)
+  allocate(p3%y, p4(2)%y, MOLD = B(5))
+  allocate(u1, u2(2), SOURCE = cos(5.+n))
+  allocate(u1, u2(2), SOURCE = molda)
+  allocate(u1, u2(2), SOURCE = n1)
+  allocate(u1, u2(2), SOURCE = new_line("a"))
+  allocate(n1%whatever, SOURCE = n2(1))
+  allocate(p1, p2(2), SOURCE = p3)
+  allocate(p3%y, p4(2)%y, SOURCE = B(5))
+
+  ! OK, not unlimited polymorphic or abstract
+  allocate(n1, n2(2))
+  allocate(p3, p4(2))
+end subroutine

--- a/test/semantics/allocate05.f90
+++ b/test/semantics/allocate05.f90
@@ -61,20 +61,20 @@ subroutine C934()
     npca1, npca2(2:4))
 
 
-  !ERROR: Allocatable object in ALLOCATE shall be type compatible with type-spec
+  !ERROR: Allocatable object in ALLOCATE must be type compatible with type-spec
   allocate(complex:: x1)
-  !ERROR: Allocatable object in ALLOCATE shall be type compatible with type-spec
+  !ERROR: Allocatable object in ALLOCATE must be type compatible with type-spec
   allocate(complex:: x2(2))
-  !ERROR: Allocatable object in ALLOCATE shall be type compatible with type-spec
+  !ERROR: Allocatable object in ALLOCATE must be type compatible with type-spec
   allocate(logical:: bp2(3)%x(5))
-  !ERROR: Allocatable object in ALLOCATE shall be type compatible with type-spec
+  !ERROR: Allocatable object in ALLOCATE must be type compatible with type-spec
   allocate(A:: unrelat)
-  !ERROR: Allocatable object in ALLOCATE shall be type compatible with type-spec
+  !ERROR: Allocatable object in ALLOCATE must be type compatible with type-spec
   allocate(B:: unrelat%notpolymorph)
-  !ERROR: Allocatable object in ALLOCATE shall be type compatible with type-spec
+  !ERROR: Allocatable object in ALLOCATE must be type compatible with type-spec
   allocate(B:: npaa1)
-  !ERROR: Allocatable object in ALLOCATE shall be type compatible with type-spec
+  !ERROR: Allocatable object in ALLOCATE must be type compatible with type-spec
   allocate(B:: npaa2(4))
-  !ERROR: Allocatable object in ALLOCATE shall be type compatible with type-spec
+  !ERROR: Allocatable object in ALLOCATE must be type compatible with type-spec
   allocate(C:: npca1, bp1, npbp1)
 end subroutine

--- a/test/semantics/allocate05.f90
+++ b/test/semantics/allocate05.f90
@@ -1,0 +1,80 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check for semantic errors in ALLOCATE statements
+
+
+subroutine C934()
+! If type-spec appears, it shall specify a type with which each
+! allocate-object is type compatible.
+
+  type A
+    integer i
+  end type
+
+  type, extends(A) :: B
+    real, allocatable :: x(:)
+  end type
+
+  type, extends(B) :: C
+    character(5) s
+  end type
+
+  type Unrelated
+    class(A), allocatable :: polymorph
+    type(A), allocatable :: notpolymorph
+  end type
+
+  real, allocatable :: x1, x2(:)
+  class(A), allocatable :: aa1, aa2(:)
+  class(B), pointer :: bp1, bp2(:)
+  class(C), allocatable :: ca1, ca2(:)
+  class(*), pointer :: up1, up2(:)
+  type(A), allocatable :: npaa1, npaa2(:)
+  type(B), pointer :: npbp1, npbp2(:)
+  type(C), allocatable :: npca1, npca2(:)
+  class(Unrelated), allocatable :: unrelat
+
+  allocate(real:: x1)
+  allocate(real:: x2(2))
+  allocate(real:: bp2(3)%x(5))
+  !OK, type-compatible with A
+  allocate(A:: aa1, aa2(2), up1, up2(3), &
+    unrelat%polymorph, unrelat%notpolymorph, npaa1, npaa2(4))
+  !OK, type compatible with B
+  allocate(B:: aa1, aa2(2), up1, up2(3), &
+    unrelat%polymorph, bp1, bp2(2), npbp1, npbp2(2:4))
+  !OK, type compatible with C
+  allocate(C:: aa1, aa2(2), up1, up2(3), &
+    unrelat%polymorph, bp1, bp2(2), ca1, ca2(4), &
+    npca1, npca2(2:4))
+
+
+  !ERROR: Allocatable object in ALLOCATE shall be type compatible with type-spec
+  allocate(complex:: x1)
+  !ERROR: Allocatable object in ALLOCATE shall be type compatible with type-spec
+  allocate(complex:: x2(2))
+  !ERROR: Allocatable object in ALLOCATE shall be type compatible with type-spec
+  allocate(logical:: bp2(3)%x(5))
+  !ERROR: Allocatable object in ALLOCATE shall be type compatible with type-spec
+  allocate(A:: unrelat)
+  !ERROR: Allocatable object in ALLOCATE shall be type compatible with type-spec
+  allocate(B:: unrelat%notpolymorph)
+  !ERROR: Allocatable object in ALLOCATE shall be type compatible with type-spec
+  allocate(B:: npaa1)
+  !ERROR: Allocatable object in ALLOCATE shall be type compatible with type-spec
+  allocate(B:: npaa2(4))
+  !ERROR: Allocatable object in ALLOCATE shall be type compatible with type-spec
+  allocate(C:: npca1, bp1, npbp1)
+end subroutine

--- a/test/semantics/allocate06.f90
+++ b/test/semantics/allocate06.f90
@@ -1,0 +1,116 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check for semantic errors in ALLOCATE statements
+
+
+subroutine C935(l, ac1, ac2, ac3, dc1, dc2, ec1, ec2, aa, ab, ea, eb, da, db, whatever, something)
+! A type-param-value in a type-spec shall be an asterisk if and only if each
+! allocate-object is a dummy argument for which the corresponding type parameter
+! is assumed.
+
+  type A(la)
+    integer, len :: la
+    integer vector(la)
+  end type
+
+  type, extends(A) :: B(lb)
+    integer, len :: lb
+    integer matrix(lb, lb)
+  end type
+
+  type, extends(B) :: C(lc1, lc2, lc3)
+    integer, len :: lc1, lc2, lc3
+    integer array(lc1, lc2, lc3)
+  end type
+
+  integer l
+  character(len=*), pointer :: ac1, ac2(:)
+  character*(*), allocatable :: ac3(:)
+  character*(:), allocatable :: dc1
+  character(len=:), pointer :: dc2(:)
+  character(len=l), pointer :: ec1
+  character*5, allocatable :: ec2(:)
+
+  class(A(*)), pointer :: aa
+  type(B(* , 5)), allocatable :: ab(:)
+  type(B(* , *)), pointer :: ab2(:)
+  class(A(l)), allocatable :: ea
+  type(B(5 , 5)), pointer :: eb(:)
+  class(A(:)), allocatable :: da
+  type(B(: , 5)), pointer :: db(:)
+  class(*), allocatable :: whatever
+  type(C(la=*, lb=:, lc1=*, lc2=5, lc3=*)), pointer :: something(:)
+  type(C(la=*, lb=:, lc1=5, lc2=5, lc3=*)), pointer :: something_else(:)
+
+  ! OK
+  allocate(character(len=*):: ac1, ac3(3))
+  allocate(character*(*):: ac2(5))
+  allocate(B(*, 5):: aa, ab(2)) !OK but segfault GCC
+  allocate(B(*, *):: ab2)
+  allocate(C(la=*, lb=10, lc1=*, lc2=5, lc3=*):: something(5))
+  allocate(C(la=*, lb=10, lc1=2, lc2=5, lc3=3):: aa)
+  allocate(character(5):: whatever)
+
+  ! Not OK
+
+  ! Should be * or no type-spec
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(character(len=5):: ac1)
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(character(len=5):: ac2(3), ac3)
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(character(len=l):: ac1)
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(character(len=l):: ac2(3), ac3)
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(A(5):: aa)
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(B(5, 5):: ab(5))
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(B(l, 5):: aa, ab(5))
+
+  ! Must not be *
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(character(len=*):: ac1, dc1, ac3)
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(character*(*):: dc2(5))
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(character*(*):: ec1)
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(character(*):: whatever)
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(character(len=*):: ac2(5), ec2(5))
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(A(*):: ea) !segfault gfortran
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(B(*, 5):: eb(2)) !segfault gfortran
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(A(*):: da) !segfault gfortran
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(B(*, 5):: db(2)) !segfault gfortran
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(A(*):: aa, whatever)
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(B(*, *):: aa)
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(C(la=*, lb=10, lc1=*, lc2=5, lc3=*):: something_else(5))
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(C(la=5, lb=10, lc1=4, lc2=5, lc3=3):: aa)
+  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  allocate(C(la=*, lb=10, lc1=*, lc2=5, lc3=*):: aa)
+end subroutine

--- a/test/semantics/allocate06.f90
+++ b/test/semantics/allocate06.f90
@@ -66,51 +66,51 @@ subroutine C935(l, ac1, ac2, ac3, dc1, dc2, ec1, ec2, aa, ab, ea, eb, da, db, wh
   ! Not OK
 
   ! Should be * or no type-spec
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(character(len=5):: ac1)
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(character(len=5):: ac2(3), ac3)
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(character(len=l):: ac1)
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(character(len=l):: ac2(3), ac3)
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(A(5):: aa)
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(B(5, 5):: ab(5))
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(B(l, 5):: aa, ab(5))
 
   ! Must not be *
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(character(len=*):: ac1, dc1, ac3)
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(character*(*):: dc2(5))
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(character*(*):: ec1)
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(character(*):: whatever)
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(character(len=*):: ac2(5), ec2(5))
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(A(*):: ea) !segfault gfortran
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(B(*, 5):: eb(2)) !segfault gfortran
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(A(*):: da) !segfault gfortran
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(B(*, 5):: db(2)) !segfault gfortran
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(A(*):: aa, whatever)
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(B(*, *):: aa)
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(C(la=*, lb=10, lc1=*, lc2=5, lc3=*):: something_else(5))
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(C(la=5, lb=10, lc1=4, lc2=5, lc3=3):: aa)
-  !ERROR: Type parameters in type-spec shall be assumed if and only if they are assumed for allocatable object in ALLOCATE
+  !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(C(la=*, lb=10, lc1=*, lc2=5, lc3=*):: aa)
 end subroutine

--- a/test/semantics/allocate07.f90
+++ b/test/semantics/allocate07.f90
@@ -67,40 +67,40 @@ subroutine C936(param_ca_4_assumed, param_ta_4_assumed, param_ca_4_deferred)
   allocate(WithParamExtent2(k1=1, l1=2, k2=5, l2=6, k3=5, l3=8 ):: whatever)
 
 
-  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE must be the same as the corresponding ones in type-spec
   allocate(real(kind=8):: x1)
-  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE must be the same as the corresponding ones in type-spec
   allocate(real(kind=8):: x2(10))
-  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE must be the same as the corresponding ones in type-spec
   allocate(WithParam(8, 2):: param_ta_4_2)
-  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE must be the same as the corresponding ones in type-spec
   allocate(WithParam(8, 2):: param_ca_4_2)
-  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE must be the same as the corresponding ones in type-spec
   allocate(WithParamExtent(8, 2, 8, 3):: param_ca_4_2)
-  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE must be the same as the corresponding ones in type-spec
   allocate(WithParam(8, *):: param_ta_4_assumed)
-  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE must be the same as the corresponding ones in type-spec
   allocate(WithParam(8, *):: param_ca_4_assumed)
-  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE must be the same as the corresponding ones in type-spec
   allocate(WithParamExtent(8, *, 8, 3):: param_ca_4_assumed)
-  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE must be the same as the corresponding ones in type-spec
   allocate(WithParam(8, 2):: param_ta_4_deferred)
-  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE must be the same as the corresponding ones in type-spec
   allocate(WithParam(8, 2):: param_ca_4_deferred)
-  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE must be the same as the corresponding ones in type-spec
   allocate(WithParamExtent(8, 2, 8, 3):: param_ca_4_deferred)
-  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE must be the same as the corresponding ones in type-spec
   allocate(WithParamExtent2(k1=5, l1=5, k2=5, l2=6, l3=8 ):: extended2)
-  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE must be the same as the corresponding ones in type-spec
   allocate(WithParamExtent2(k1=5, l1=2, k2=5, l2=6, k3=5, l3=8 ):: param_ca_4_2)
-  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE must be the same as the corresponding ones in type-spec
   allocate(WithParamExtent2(k1=4, l1=5, k2=5, l2=6, k3=5, l3=8 ):: extended2)
-  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE must be the same as the corresponding ones in type-spec
   allocate(WithParam:: param_ca_4_2)
-  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE must be the same as the corresponding ones in type-spec
   allocate(WithParam(k1=2, l1=2):: param_defaulted)
-  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE must be the same as the corresponding ones in type-spec
   allocate(WithParam(k1=2):: param_defaulted)
-  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE must be the same as the corresponding ones in type-spec
   allocate(WithParamExtent2(k1=5, l1=2, k2=5, l2=6, k3=5, l3=8 ):: param_defaulted)
 end subroutine

--- a/test/semantics/allocate07.f90
+++ b/test/semantics/allocate07.f90
@@ -1,0 +1,106 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check for semantic errors in ALLOCATE statements
+
+subroutine C936(param_ca_4_assumed, param_ta_4_assumed, param_ca_4_deferred)
+! If type-spec appears, the kind type parameter values of each
+! allocate-object shall be the same as the corresponding type
+! parameter values of the type-spec.
+
+  real(kind=4), allocatable :: x1, x2(:)
+
+  type WithParam(k1, l1)
+    integer, kind :: k1=1
+    integer, len :: l1=2
+  end type
+
+  type, extends(WithParam) :: WithParamExtent(k2, l2)
+    integer, kind :: k2
+    integer, len :: l2
+  end type
+
+  type, extends(WithParamExtent) :: WithParamExtent2(k3, l3)
+    integer, kind :: k3 = 8
+    integer, len :: l3
+  end type
+
+  type(WithParam(4, 2)), allocatable :: param_ta_4_2
+  class(WithParam(4, 2)), pointer :: param_ca_4_2
+
+  type(WithParam(4, *)), pointer :: param_ta_4_assumed
+  class(WithParam(4, *)), allocatable :: param_ca_4_assumed
+
+  type(WithParam(4, :)), allocatable :: param_ta_4_deferred
+  class(WithParam(4, :)), pointer :: param_ca_4_deferred
+  class(WithParam), allocatable :: param_defaulted
+
+  type(WithParamExtent2(k1=4, l1=:, k2=5, l2=:, l3=8 )), pointer :: extended2
+
+  class(*), pointer :: whatever
+
+  ! Nominal test cases
+  allocate(real(kind=4):: x1, x2(10))
+  allocate(WithParam(4, 2):: param_ta_4_2, param_ca_4_2)
+  allocate(WithParamExtent(4, 2, 8, 3):: param_ca_4_2)
+  allocate(WithParam(4, *):: param_ta_4_assumed, param_ca_4_assumed)
+  allocate(WithParamExtent(4, *, 8, 3):: param_ca_4_assumed)
+  allocate(WithParam(4, 2):: param_ta_4_deferred, param_ca_4_deferred)
+  allocate(WithParamExtent(4, 2, 8, 3):: param_ca_4_deferred)
+  allocate(WithParamExtent2(k1=4, l1=5, k2=5, l2=6, l3=8 ):: extended2)
+  allocate(WithParamExtent2(k1=4, l1=2, k2=5, l2=6, k3=5, l3=8 ):: param_ca_4_2)
+  allocate(WithParam:: param_defaulted)
+  allocate(WithParam(k1=1, l1=2):: param_defaulted)
+  allocate(WithParam(k1=1):: param_defaulted)
+  allocate(WithParamExtent2(k1=1, l1=2, k2=5, l2=6, k3=5, l3=8 ):: param_defaulted)
+  allocate(WithParamExtent2(k1=1, l1=2, k2=5, l2=6, k3=5, l3=8 ):: whatever)
+
+
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  allocate(real(kind=8):: x1)
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  allocate(real(kind=8):: x2(10))
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  allocate(WithParam(8, 2):: param_ta_4_2)
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  allocate(WithParam(8, 2):: param_ca_4_2)
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  allocate(WithParamExtent(8, 2, 8, 3):: param_ca_4_2)
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  allocate(WithParam(8, *):: param_ta_4_assumed)
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  allocate(WithParam(8, *):: param_ca_4_assumed)
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  allocate(WithParamExtent(8, *, 8, 3):: param_ca_4_assumed)
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  allocate(WithParam(8, 2):: param_ta_4_deferred)
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  allocate(WithParam(8, 2):: param_ca_4_deferred)
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  allocate(WithParamExtent(8, 2, 8, 3):: param_ca_4_deferred)
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  allocate(WithParamExtent2(k1=5, l1=5, k2=5, l2=6, l3=8 ):: extended2)
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  allocate(WithParamExtent2(k1=5, l1=2, k2=5, l2=6, k3=5, l3=8 ):: param_ca_4_2)
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  allocate(WithParamExtent2(k1=4, l1=5, k2=5, l2=6, k3=5, l3=8 ):: extended2)
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  allocate(WithParam:: param_ca_4_2)
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  allocate(WithParam(k1=2, l1=2):: param_defaulted)
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  allocate(WithParam(k1=2):: param_defaulted)
+  !ERROR: Kind type parameters of allocatable object in ALLOCATE shall be the same as the corresponding ones in type-spec
+  allocate(WithParamExtent2(k1=5, l1=2, k2=5, l2=6, k3=5, l3=8 ):: param_defaulted)
+end subroutine

--- a/test/semantics/allocate08.f90
+++ b/test/semantics/allocate08.f90
@@ -69,20 +69,20 @@ subroutine C945_a(srca, srcb, srcc, src_complex, src_logical, &
   allocate(aa2, up2, bp2, ca2, npca2, source=srcc2)
 
 
-  !ERROR: Allocatable object in ALLOCATE shall be type compatible with source expression from MOLD or SOURCE
+  !ERROR: Allocatable object in ALLOCATE must be type compatible with source expression from MOLD or SOURCE
   allocate(x1, mold=src_complex)
-  !ERROR: Allocatable object in ALLOCATE shall be type compatible with source expression from MOLD or SOURCE
+  !ERROR: Allocatable object in ALLOCATE must be type compatible with source expression from MOLD or SOURCE
   allocate(x2(2), source=src_complex2)
-  !ERROR: Allocatable object in ALLOCATE shall be type compatible with source expression from MOLD or SOURCE
+  !ERROR: Allocatable object in ALLOCATE must be type compatible with source expression from MOLD or SOURCE
   allocate(bp2(3)%x, mold=src_logical)
-  !ERROR: Allocatable object in ALLOCATE shall be type compatible with source expression from MOLD or SOURCE
+  !ERROR: Allocatable object in ALLOCATE must be type compatible with source expression from MOLD or SOURCE
   allocate(unrelat, mold=srca)
-  !ERROR: Allocatable object in ALLOCATE shall be type compatible with source expression from MOLD or SOURCE
+  !ERROR: Allocatable object in ALLOCATE must be type compatible with source expression from MOLD or SOURCE
   allocate(unrelat%notpolymorph, source=srcb)
-  !ERROR: Allocatable object in ALLOCATE shall be type compatible with source expression from MOLD or SOURCE
+  !ERROR: Allocatable object in ALLOCATE must be type compatible with source expression from MOLD or SOURCE
   allocate(npaa1, mold=srcb)
-  !ERROR: Allocatable object in ALLOCATE shall be type compatible with source expression from MOLD or SOURCE
+  !ERROR: Allocatable object in ALLOCATE must be type compatible with source expression from MOLD or SOURCE
   allocate(npaa2, source=srcb2)
-  !ERROR: Allocatable object in ALLOCATE shall be type compatible with source expression from MOLD or SOURCE
+  !ERROR: Allocatable object in ALLOCATE must be type compatible with source expression from MOLD or SOURCE
   allocate(npca1, bp1, npbp1, mold=srcc)
 end subroutine

--- a/test/semantics/allocate08.f90
+++ b/test/semantics/allocate08.f90
@@ -1,0 +1,88 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check for semantic errors in ALLOCATE statements
+
+subroutine C945_a(srca, srcb, srcc, src_complex, src_logical, &
+  srca2, srcb2, srcc2, src_complex2, srcx, srcx2)
+! If type-spec appears, it shall specify a type with which each
+! allocate-object is type compatible.
+
+!second part C945, specific to SOURCE, is not checked here.
+
+  type A
+    integer i
+  end type
+
+  type, extends(A) :: B
+    real, allocatable :: x(:)
+  end type
+
+  type, extends(B) :: C
+    character(5) s
+  end type
+
+  type Unrelated
+    class(A), allocatable :: polymorph
+    type(A), allocatable :: notpolymorph
+  end type
+
+  real srcx, srcx2(6)
+  class(A) srca, srca2(5)
+  type(B) srcb, srcb2(6)
+  class(C) srcc, srcc2(7)
+  complex src_complex, src_complex2(8)
+  complex src_logical(5)
+  real, allocatable :: x1, x2(:)
+  class(A), allocatable :: aa1, aa2(:)
+  class(B), pointer :: bp1, bp2(:)
+  class(C), allocatable :: ca1, ca2(:)
+  class(*), pointer :: up1, up2(:)
+  type(A), allocatable :: npaa1, npaa2(:)
+  type(B), pointer :: npbp1, npbp2(:)
+  type(C), allocatable :: npca1, npca2(:)
+  class(Unrelated), allocatable :: unrelat
+
+  allocate(x1, source=srcx)
+  allocate(x2, mold=srcx2)
+  allocate(bp2(3)%x, source=srcx2)
+  !OK, type-compatible with A
+  allocate(aa1, up1, unrelat%polymorph, unrelat%notpolymorph, &
+    npaa1, source=srca)
+  allocate(aa2, up2, npaa2, source=srca2)
+  !OK, type compatible with B
+  allocate(aa1, up1, unrelat%polymorph, bp1, npbp1, mold=srcb)
+  allocate(aa2, up2, bp2, npbp2, mold=srcb2)
+  !OK, type compatible with C
+  allocate(aa1, up1, unrelat%polymorph, bp1, ca1, npca1, mold=srcc)
+  allocate(aa2, up2, bp2, ca2, npca2, source=srcc2)
+
+
+  !ERROR: Allocatable object in ALLOCATE shall be type compatible with source expression from MOLD or SOURCE
+  allocate(x1, mold=src_complex)
+  !ERROR: Allocatable object in ALLOCATE shall be type compatible with source expression from MOLD or SOURCE
+  allocate(x2(2), source=src_complex2)
+  !ERROR: Allocatable object in ALLOCATE shall be type compatible with source expression from MOLD or SOURCE
+  allocate(bp2(3)%x, mold=src_logical)
+  !ERROR: Allocatable object in ALLOCATE shall be type compatible with source expression from MOLD or SOURCE
+  allocate(unrelat, mold=srca)
+  !ERROR: Allocatable object in ALLOCATE shall be type compatible with source expression from MOLD or SOURCE
+  allocate(unrelat%notpolymorph, source=srcb)
+  !ERROR: Allocatable object in ALLOCATE shall be type compatible with source expression from MOLD or SOURCE
+  allocate(npaa1, mold=srcb)
+  !ERROR: Allocatable object in ALLOCATE shall be type compatible with source expression from MOLD or SOURCE
+  allocate(npaa2, source=srcb2)
+  !ERROR: Allocatable object in ALLOCATE shall be type compatible with source expression from MOLD or SOURCE
+  allocate(npca1, bp1, npbp1, mold=srcc)
+end subroutine

--- a/test/semantics/deallocate01.f90
+++ b/test/semantics/deallocate01.f90
@@ -31,7 +31,7 @@ CHARACTER(256) :: e
 
 Integer, Pointer :: pi
 
-Allocate(p)
+Allocate(pi)
 Allocate(x(3))
 
 Deallocate(x(2)%p)


### PR DESCRIPTION
Implements first batch of semantic checks for allocate statement constraints: C932, C933, C934, C935, C936, C943, C944 and first part of C945.
Checks for remaining constraints left as a TODO will be done once this PR goes through review.