### PR TITLE
Flatten and fold array operations

### DIFF
--- a/lib/evaluate/descender.h
+++ b/lib/evaluate/descender.h
@@ -117,10 +117,14 @@ public:
   }
 
   template<typename R> void Descend(const ArrayConstructorValues<R> &avs) {
-    Visit(avs.values());
+    for (const auto &x : avs) {
+      Visit(x);
+    }
   }
   template<typename R> void Descend(ArrayConstructorValues<R> &avs) {
-    Visit(avs.values());
+    for (auto &x : avs) {
+      Visit(x);
+    }
   }
 
   template<int KIND>
@@ -155,13 +159,13 @@ public:
 
   void Descend(const StructureConstructor &sc) {
     Visit(sc.derivedTypeSpec());
-    for (const auto &pair : sc.values()) {
+    for (const auto &pair : sc) {
       Visit(pair.second);
     }
   }
   void Descend(StructureConstructor &sc) {
     Visit(sc.derivedTypeSpec());
-    for (const auto &pair : sc.values()) {
+    for (const auto &pair : sc) {
       Visit(pair.second);
     }
   }
@@ -241,8 +245,22 @@ public:
   template<typename T> void Descend(const Variable<T> &var) { Visit(var.u); }
   template<typename T> void Descend(Variable<T> &var) { Visit(var.u); }
 
-  void Descend(const ActualArgument &arg) { Visit(arg.value()); }
-  void Descend(ActualArgument &arg) { Visit(arg.value()); }
+  void Descend(const ActualArgument &arg) {
+    if (const auto *expr{arg.GetExpr()}) {
+      Visit(*expr);
+    } else {
+      const semantics::Symbol *aType{arg.GetAssumedTypeDummy()};
+      Visit(*aType);
+    }
+  }
+  void Descend(ActualArgument &arg) {
+    if (auto *expr{arg.GetExpr()}) {
+      Visit(*expr);
+    } else {
+      const semantics::Symbol *aType{arg.GetAssumedTypeDummy()};
+      Visit(*aType);
+    }
+  }
 
   void Descend(const ProcedureDesignator &p) { Visit(p.u); }
   void Descend(ProcedureDesignator &p) { Visit(p.u); }

--- a/lib/evaluate/fold.h
+++ b/lib/evaluate/fold.h
@@ -52,7 +52,7 @@ std::optional<Expr<T>> Fold(
 template<typename T>
 std::optional<Scalar<T>> GetScalarConstantValue(const Expr<T> &expr) {
   if (const auto *c{UnwrapExpr<Constant<T>>(expr)}) {
-    if (c->size() == 1) {
+    if (c->Rank() == 0) {
       return **c;
     } else {
       return std::nullopt;

--- a/lib/evaluate/intrinsics.h
+++ b/lib/evaluate/intrinsics.h
@@ -26,6 +26,8 @@
 
 namespace Fortran::evaluate {
 
+class FoldingContext;
+
 struct CallCharacteristics {
   parser::CharBlock name;
   bool isSubroutineCall{false};
@@ -61,8 +63,8 @@ public:
   // Probe the intrinsics for a match against a specific call.
   // On success, the actual arguments are transferred to the result
   // in dummy argument order.
-  std::optional<SpecificCall> Probe(const CallCharacteristics &,
-      ActualArguments &, parser::ContextualMessages *messages = nullptr) const;
+  std::optional<SpecificCall> Probe(
+      const CallCharacteristics &, ActualArguments &, FoldingContext &) const;
 
   // Probe the intrinsics with the name of a potential unrestricted specific
   // intrinsic.

--- a/lib/evaluate/shape.h
+++ b/lib/evaluate/shape.h
@@ -27,16 +27,20 @@
 
 namespace Fortran::evaluate {
 
+class FoldingContext;
+
 using ExtentType = SubscriptInteger;
 using ExtentExpr = Expr<ExtentType>;
 using MaybeExtent = std::optional<ExtentExpr>;
 using Shape = std::vector<MaybeExtent>;
 
-// Convert between various representations of shapes
+// Conversions between various representations of shapes.
 Shape AsShape(const Constant<ExtentType> &arrayConstant);
-std::optional<Shape> AsShape(ExtentExpr &&arrayExpr);
-std::optional<ExtentExpr> AsShapeArrayExpr(const Shape &);  // array constructor
+std::optional<Shape> AsShape(FoldingContext &, ExtentExpr &&arrayExpr);
+std::optional<ExtentExpr> AsExtentArrayExpr(const Shape &);
 std::optional<Constant<ExtentType>> AsConstantShape(const Shape &);
+ConstantSubscripts AsConstantExtents(const Constant<ExtentType> &);
+std::optional<ConstantSubscripts> AsConstantExtents(const Shape &);
 
 // Compute an element count for a triplet or trip count for a DO.
 ExtentExpr CountTrips(
@@ -49,132 +53,150 @@ MaybeExtent CountTrips(
 // Computes SIZE() == PRODUCT(shape)
 MaybeExtent GetSize(Shape &&);
 
-// Forward declarations
-template<typename... A>
-std::optional<Shape> GetShape(const std::variant<A...> &);
-template<typename A, bool COPY>
-std::optional<Shape> GetShape(const common::Indirection<A, COPY> &);
-template<typename A> std::optional<Shape> GetShape(const std::optional<A> &);
-
-template<typename T> std::optional<Shape> GetShape(const Expr<T> &expr) {
-  return GetShape(expr.u);
-}
-
-std::optional<Shape> GetShape(const Symbol &, const Component * = nullptr);
-std::optional<Shape> GetShape(const Symbol *);
-std::optional<Shape> GetShape(const BaseObject &);
-std::optional<Shape> GetShape(const Component &);
-std::optional<Shape> GetShape(const ArrayRef &);
-std::optional<Shape> GetShape(const CoarrayRef &);
-std::optional<Shape> GetShape(const DataRef &);
-std::optional<Shape> GetShape(const Substring &);
-std::optional<Shape> GetShape(const ComplexPart &);
-std::optional<Shape> GetShape(const ActualArgument &);
-std::optional<Shape> GetShape(const ProcedureRef &);
-std::optional<Shape> GetShape(const ImpliedDoIndex &);
-std::optional<Shape> GetShape(const Relational<SomeType> &);
-std::optional<Shape> GetShape(const StructureConstructor &);
-std::optional<Shape> GetShape(const DescriptorInquiry &);
-std::optional<Shape> GetShape(const BOZLiteralConstant &);
-std::optional<Shape> GetShape(const NullPointer &);
-
-template<typename T> std::optional<Shape> GetShape(const Constant<T> &c) {
-  Constant<ExtentType> shape{c.SHAPE()};
-  return AsShape(shape);
-}
-
-template<typename T>
-std::optional<Shape> GetShape(const Designator<T> &designator) {
-  return GetShape(designator.u);
-}
-
-template<typename T>
-std::optional<Shape> GetShape(const Variable<T> &variable) {
-  return GetShape(variable.u);
-}
-
-template<typename D, typename R, typename... O>
-std::optional<Shape> GetShape(const Operation<D, R, O...> &operation) {
-  if constexpr (sizeof...(O) > 1) {
-    if (operation.right().Rank() > 0) {
-      return GetShape(operation.right());
-    }
-  }
-  return GetShape(operation.left());
-}
-
-template<int KIND>
-std::optional<Shape> GetShape(const TypeParamInquiry<KIND> &) {
-  return Shape{};  // always scalar, even when applied to an array
-}
-
 // Utility predicate: does an expression reference any implied DO index?
 bool ContainsAnyImpliedDoIndex(const ExtentExpr &);
 
-template<typename T> MaybeExtent GetExtent(const ArrayConstructorValues<T> &);
+// Compilation-time shape conformance checking, when corresponding extents
+// are known.
+void CheckConformance(
+    parser::ContextualMessages &, const Shape &, const Shape &);
 
-template<typename T>
-MaybeExtent GetExtent(const ArrayConstructorValue<T> &value) {
-  return std::visit(
-      common::visitors{
-          [](const Expr<T> &x) -> MaybeExtent {
-            if (std::optional<Shape> xShape{GetShape(x)}) {
-              // Array values in array constructors get linearized.
-              return GetSize(std::move(*xShape));
-            }
-            return std::nullopt;
-          },
-          [](const ImpliedDo<T> &ido) -> MaybeExtent {
-            // Don't be heroic and try to figure out triangular implied DO
-            // nests.
-            if (!ContainsAnyImpliedDoIndex(ido.lower()) &&
-                !ContainsAnyImpliedDoIndex(ido.upper()) &&
-                !ContainsAnyImpliedDoIndex(ido.stride())) {
-              if (auto nValues{GetExtent(ido.values())}) {
-                return std::move(*nValues) *
-                    CountTrips(ido.lower(), ido.upper(), ido.stride());
-              }
-            }
-            return std::nullopt;
-          },
-      },
-      value.u);
-}
+// The implementation of GetShape() is wrapped in a helper class
+// so that the member functions may mutually recurse without prototypes.
+class GetShapeHelper {
+public:
+  explicit GetShapeHelper(FoldingContext &context) : context_{context} {}
 
-template<typename T>
-MaybeExtent GetExtent(const ArrayConstructorValues<T> &values) {
-  ExtentExpr result{0};
-  for (const auto &value : values.values()) {
-    if (MaybeExtent n{GetExtent(value)}) {
-      result = std::move(result) + std::move(*n);
+  template<typename T> std::optional<Shape> GetShape(const Expr<T> &expr) {
+    return GetShape(expr.u);
+  }
+
+  std::optional<Shape> GetShape(const Symbol &, const Component * = nullptr);
+  std::optional<Shape> GetShape(const Symbol *);
+  std::optional<Shape> GetShape(const BaseObject &);
+  std::optional<Shape> GetShape(const Component &);
+  std::optional<Shape> GetShape(const ArrayRef &);
+  std::optional<Shape> GetShape(const CoarrayRef &);
+  std::optional<Shape> GetShape(const DataRef &);
+  std::optional<Shape> GetShape(const Substring &);
+  std::optional<Shape> GetShape(const ComplexPart &);
+  std::optional<Shape> GetShape(const ActualArgument &);
+  std::optional<Shape> GetShape(const ProcedureRef &);
+  std::optional<Shape> GetShape(const ImpliedDoIndex &);
+  std::optional<Shape> GetShape(const Relational<SomeType> &);
+  std::optional<Shape> GetShape(const StructureConstructor &);
+  std::optional<Shape> GetShape(const DescriptorInquiry &);
+  std::optional<Shape> GetShape(const BOZLiteralConstant &);
+  std::optional<Shape> GetShape(const NullPointer &);
+
+  template<typename T> std::optional<Shape> GetShape(const Constant<T> &c) {
+    Constant<ExtentType> shape{c.SHAPE()};
+    return AsShape(shape);
+  }
+
+  template<typename T>
+  std::optional<Shape> GetShape(const Designator<T> &designator) {
+    return GetShape(designator.u);
+  }
+
+  template<typename T>
+  std::optional<Shape> GetShape(const Variable<T> &variable) {
+    return GetShape(variable.u);
+  }
+
+  template<typename D, typename R, typename... O>
+  std::optional<Shape> GetShape(const Operation<D, R, O...> &operation) {
+    if constexpr (sizeof...(O) > 1) {
+      if (operation.right().Rank() > 0) {
+        return GetShape(operation.right());
+      }
+    }
+    return GetShape(operation.left());
+  }
+
+  template<int KIND>
+  std::optional<Shape> GetShape(const TypeParamInquiry<KIND> &) {
+    return Shape{};  // always scalar, even when applied to an array
+  }
+
+  template<typename T>
+  std::optional<Shape> GetShape(const ArrayConstructor<T> &aconst) {
+    return Shape{GetExtent(aconst)};
+  }
+
+  template<typename... A>
+  std::optional<Shape> GetShape(const std::variant<A...> &u) {
+    return std::visit([&](const auto &x) { return GetShape(x); }, u);
+  }
+
+  template<typename A, bool COPY>
+  std::optional<Shape> GetShape(const common::Indirection<A, COPY> &p) {
+    return GetShape(p.value());
+  }
+
+  template<typename A>
+  std::optional<Shape> GetShape(const std::optional<A> &x) {
+    if (x.has_value()) {
+      return GetShape(*x);
     } else {
       return std::nullopt;
     }
   }
-  return result;
-}
 
-template<typename T>
-std::optional<Shape> GetShape(const ArrayConstructor<T> &aconst) {
-  return Shape{GetExtent(aconst)};
-}
+private:
+  MaybeExtent GetLowerBound(const Symbol &, const Component *, int dimension);
 
-template<typename... A>
-std::optional<Shape> GetShape(const std::variant<A...> &u) {
-  return std::visit([](const auto &x) { return GetShape(x); }, u);
-}
-
-template<typename A, bool COPY>
-std::optional<Shape> GetShape(const common::Indirection<A, COPY> &p) {
-  return GetShape(p.value());
-}
-
-template<typename A> std::optional<Shape> GetShape(const std::optional<A> &x) {
-  if (x.has_value()) {
-    return GetShape(*x);
-  } else {
-    return std::nullopt;
+  template<typename T>
+  MaybeExtent GetExtent(const ArrayConstructorValue<T> &value) {
+    return std::visit(
+        common::visitors{
+            [&](const Expr<T> &x) -> MaybeExtent {
+              if (std::optional<Shape> xShape{GetShape(x)}) {
+                // Array values in array constructors get linearized.
+                return GetSize(std::move(*xShape));
+              }
+              return std::nullopt;
+            },
+            [&](const ImpliedDo<T> &ido) -> MaybeExtent {
+              // Don't be heroic and try to figure out triangular implied DO
+              // nests.
+              if (!ContainsAnyImpliedDoIndex(ido.lower()) &&
+                  !ContainsAnyImpliedDoIndex(ido.upper()) &&
+                  !ContainsAnyImpliedDoIndex(ido.stride())) {
+                if (auto nValues{GetExtent(ido.values())}) {
+                  return std::move(*nValues) *
+                      CountTrips(ido.lower(), ido.upper(), ido.stride());
+                }
+              }
+              return std::nullopt;
+            },
+        },
+        value.u);
   }
+
+  template<typename T>
+  MaybeExtent GetExtent(const ArrayConstructorValues<T> &values) {
+    ExtentExpr result{0};
+    for (const auto &value : values) {
+      if (MaybeExtent n{GetExtent(value)}) {
+        result = std::move(result) + std::move(*n);
+      } else {
+        return std::nullopt;
+      }
+    }
+    return result;
+  }
+
+  MaybeExtent GetExtent(const Symbol &, const Component *, int dimension);
+  MaybeExtent GetExtent(
+      const Subscript &, const Symbol &, const Component *, int dimension);
+
+  FoldingContext &context_;
+};
+
+template<typename A>
+std::optional<Shape> GetShape(FoldingContext &context, const A &x) {
+  return GetShapeHelper{context}.GetShape(x);
 }
 }
 #endif  // FORTRAN_EVALUATE_SHAPE_H_

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1161,7 +1161,7 @@ template<typename T>
 ArrayConstructorValues<T> MakeSpecific(
     ArrayConstructorValues<SomeType> &&from) {
   ArrayConstructorValues<T> to;
-  for (ArrayConstructorValue<SomeType> &x : from.values()) {
+  for (ArrayConstructorValue<SomeType> &x : from) {
     std::visit(
         common::visitors{
             [&](common::CopyableIndirection<Expr<SomeType>> &&expr) {
@@ -1456,7 +1456,7 @@ auto ExpressionAnalyzer::Procedure(const parser::ProcedureDesignator &pd,
                 CallCharacteristics cc{n.source};
                 if (std::optional<SpecificCall> specificCall{
                         context().intrinsics().Probe(
-                            cc, arguments, &GetContextualMessages())}) {
+                            cc, arguments, GetFoldingContext())}) {
                   return {
                       CallAndArguments{ProcedureDesignator{std::move(
                                            specificCall->specificIntrinsic)},

--- a/test/evaluate/intrinsics.cc
+++ b/test/evaluate/intrinsics.cc
@@ -14,6 +14,7 @@
 
 #include "../../lib/evaluate/intrinsics.h"
 #include "testing.h"
+#include "../../lib/evaluate/common.h"
 #include "../../lib/evaluate/expression.h"
 #include "../../lib/evaluate/tools.h"
 #include "../../lib/parser/provenance.h"
@@ -111,7 +112,8 @@ struct TestCall {
     std::cout << ")\n";
     CallCharacteristics call{fName};
     auto messages{strings.Messages(buffer)};
-    std::optional<SpecificCall> si{table.Probe(call, args, &messages)};
+    FoldingContext context{messages};
+    std::optional<SpecificCall> si{table.Probe(call, args, context)};
     if (resultType.has_value()) {
       TEST(si.has_value());
       TEST(buffer.empty());

--- a/test/semantics/modfile25.f90
+++ b/test/semantics/modfile25.f90
@@ -29,7 +29,7 @@ module m1
   integer(8), parameter :: ac3bs(:) = shape([(1,j=4,1,-1)])
   integer(8), parameter :: ac4s(:) = shape([((j,k,j*k,k=1,3),j=1,4)])
   integer(8), parameter :: ac5s(:) = shape([((0,k=5,1,-2),j=9,2,-3)])
-  integer(8), parameter :: rss(:) = shape(reshape([(0,j=1,90)], [10_8,9_8]))
+  integer(8), parameter :: rss(:) = shape(reshape([(0,j=1,90)], -[2,3]*(-[5_8,3_8])))
  contains
   subroutine subr(x,n1,n2)
     real, intent(in) :: x(:,:)


### PR DESCRIPTION
Extend expression rewriting to "flatten" array operations, so that [A,1]+[B,2] becomes [A+B,1+2], and to fold array operations in an elementwise fashion (yielding [A+B,3]).  This clears up a bunch of TODO items and allows fairly arbitrary array expressions to appear as shapes and parameters.
