### PR TITLE
Use parameter packs to simplify parser combinators.  Work around g++ …

### DIFF
--- a/lib/parser/token-parsers.h
+++ b/lib/parser/token-parsers.h
@@ -192,23 +192,16 @@ operator>>(const char *str, const PA &p) {
 
 template<class PA>
 inline constexpr std::enable_if_t<std::is_class_v<PA>,
-    InvertedSequenceParser<PA, TokenStringMatch>>
+    FollowParser<PA, TokenStringMatch>>
 operator/(const PA &p, const char *str) {
-  return InvertedSequenceParser<PA, TokenStringMatch>{
-      p, TokenStringMatch{str, false}};
+  return FollowParser<PA, TokenStringMatch>{p, TokenStringMatch{str, false}};
 }
 
-template<class PA>
-inline constexpr SequenceParser<TokenStringMatch,
-    InvertedSequenceParser<PA, TokenStringMatch>>
-parenthesized(const PA &p) {
+template<class PA> inline constexpr auto parenthesized(const PA &p) {
   return "(" >> p / ")";
 }
 
-template<class PA>
-inline constexpr SequenceParser<TokenStringMatch,
-    InvertedSequenceParser<PA, TokenStringMatch>>
-bracketed(const PA &p) {
+template<class PA> inline constexpr auto bracketed(const PA &p) {
   return "[" >> p / "]";
 }
 


### PR DESCRIPTION
…bug better.

This pull request attends to a long-standing concern on my part with the templates that implement parser constructors for things like `construct<TYPE>(p1, p2, p3)`, which runs the parsers `p1, p2, p3` in succession, succeeds if they all do, and returns a result that is constructed from their results.  The implementations weren't fully general template classes that took an arbitrary number of parsers as their arguments; instead, they were repetitively specialized for 1-6 arguments.  With this change, they're now generalized, and this saves nearly 500 lines of code in the parser.  I won't pretend that the use of template parameter packs in C++ is clear or easy to follow, but at least there's less of it.

Also, while debugging this change, I ran into an old g++ internal compiler error that I'd worked around in the past, and came up with a better work-around for it, which allowed the code to be further simplified by removing its previous work-around.

Parsing behavior is unchanged and performance is within the margin of timing measurement error (maybe a little faster).