### PR TITLE
Distinguish between unanalyzed and error expressions

### DIFF
--- a/lib/FIR/afforestation.cc
+++ b/lib/FIR/afforestation.cc
@@ -25,9 +25,13 @@
 
 namespace Fortran::FIR {
 namespace {
-Expression *ExprRef(const parser::Expr &a) { return &a.typedExpr.get()->v; }
+Expression *ExprRef(const parser::Expr &a) {
+  CHECK(a.typedExpr);
+  CHECK(a.typedExpr->v);
+  return &*a.typedExpr->v;
+}
 Expression *ExprRef(const common::Indirection<parser::Expr> &a) {
-  return &a.value().typedExpr.get()->v;
+  return ExprRef(a.value());
 }
 
 template<typename STMTTYPE, typename CT>

--- a/lib/FIR/builder.h
+++ b/lib/FIR/builder.h
@@ -56,7 +56,7 @@ struct FIRBuilder {
   BasicBlock *GetInsertionPoint() const { return cursorBlock_; }
 
   // create the various statements
-  QualifiedStmt<Addressable_impl> CreateAddr(const Expression *e) {
+  QualifiedStmt<Addressable_impl> CreateAddr(const Expression &e) {
     return QualifiedInsert<Addressable_impl>(LocateExprStmt::Create(e));
   }
   QualifiedStmt<Addressable_impl> CreateAddr(Expression &&e) {
@@ -80,16 +80,16 @@ struct FIRBuilder {
   Statement *CreateDealloc(QualifiedStmt<AllocateInsn> alloc) {
     return Insert(DeallocateInsn::Create(alloc));
   }
-  Statement *CreateExpr(const Expression *e) {
+  Statement *CreateExpr(const Expression &e) {
     return Insert(ApplyExprStmt::Create(e));
   }
   Statement *CreateExpr(Expression &&e) {
     return Insert(ApplyExprStmt::Create(std::move(e)));
   }
-  ApplyExprStmt *MakeAsExpr(const Expression *e) {
+  ApplyExprStmt *MakeAsExpr(const Expression &e) {
     return GetApplyExpr(CreateExpr(e));
   }
-  QualifiedStmt<ApplyExprStmt> QualifiedCreateExpr(const Expression *e) {
+  QualifiedStmt<ApplyExprStmt> QualifiedCreateExpr(const Expression &e) {
     return QualifiedInsert<ApplyExprStmt>(ApplyExprStmt::Create(e));
   }
   QualifiedStmt<ApplyExprStmt> QualifiedCreateExpr(Expression &&e) {

--- a/lib/FIR/statements.h
+++ b/lib/FIR/statements.h
@@ -230,7 +230,7 @@ public:
   struct Default {};  // RANK DEFAULT
   struct AssumedSize {};  // RANK(*)
   struct Exactly {  // RANK(n)
-    Expression *v;
+    const Expression *v;
   };
   using ValueType = std::variant<Exactly, AssumedSize, Default>;
   using ValueSuccPairType = std::pair<ValueType, BasicBlock *>;
@@ -295,7 +295,7 @@ protected:
 // Compute the value of an expression
 class ApplyExprStmt : public ActionStmt_impl {
 public:
-  static ApplyExprStmt Create(const Expression *e) { return ApplyExprStmt{*e}; }
+  static ApplyExprStmt Create(const Expression &e) { return ApplyExprStmt{e}; }
   static ApplyExprStmt Create(Expression &&e) {
     return ApplyExprStmt{std::move(e)};
   }
@@ -323,8 +323,8 @@ protected:
 // Compute the location of an expression
 class LocateExprStmt : public Addressable_impl {
 public:
-  static LocateExprStmt Create(const Expression *e) {
-    return LocateExprStmt(*e);
+  static LocateExprStmt Create(const Expression &e) {
+    return LocateExprStmt(e);
   }
   static LocateExprStmt Create(Expression &&e) { return LocateExprStmt(e); }
 

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -837,11 +837,12 @@ public:
 
 // This wrapper class is used, by means of a forward reference with
 // an owning pointer, to cache analyzed expressions in parse tree nodes.
+// v is nullopt if an error occurred during expression analysis.
 struct GenericExprWrapper {
-  GenericExprWrapper(Expr<SomeType> &&x) : v{std::move(x)} {}
+  GenericExprWrapper(std::optional<Expr<SomeType>> &&x) : v{std::move(x)} {}
   ~GenericExprWrapper();
   bool operator==(const GenericExprWrapper &) const;
-  Expr<SomeType> v;
+  std::optional<Expr<SomeType>> v;
 };
 
 std::ostream &DerivedTypeSpecAsFortran(

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -105,7 +105,8 @@ bool ExprTypeKindIsDefault(
 
 struct GetExprHelper {
   const SomeExpr *Get(const parser::Expr::TypedExpr &x) {
-    return x ? &x->v : nullptr;
+    CHECK(x);
+    return x->v ? &*x->v : nullptr;
   }
   const SomeExpr *Get(const parser::Expr &x) { return Get(x.typedExpr); }
   const SomeExpr *Get(const parser::Variable &x) { return Get(x.typedExpr); }


### PR DESCRIPTION
When an Expr or Variable is analyzed, always fill in a GenericExprWrapper
for it. That now holds the result of expression analysis which is
std::nullopt when there is an error.

After the ExprChecker pass has finished, the typedExpr data member of
Variables and top-level Exprs should be filled in. Assert that is the
case when we access them.