### PR TITLE
Fix #425, build fail with libc++

### DIFF
--- a/lib/evaluate/call.cc
+++ b/lib/evaluate/call.cc
@@ -20,6 +20,12 @@
 
 namespace Fortran::evaluate {
 
+ActualArgument::ActualArgument(Expr<SomeType> &&x) : u_{std::move(x)} {}
+ActualArgument::ActualArgument(common::CopyableIndirection<Expr<SomeType>> &&v)
+  : u_{std::move(v)} {}
+ActualArgument::ActualArgument(AssumedType x) : u_{x} {}
+ActualArgument::~ActualArgument() {}
+
 ActualArgument::AssumedType::AssumedType(const semantics::Symbol &symbol)
   : symbol_{&symbol} {
   const semantics::DeclTypeSpec *type{symbol.GetType()};

--- a/lib/evaluate/call.h
+++ b/lib/evaluate/call.h
@@ -59,11 +59,10 @@ public:
     const semantics::Symbol *symbol_;
   };
 
-  explicit ActualArgument(Expr<SomeType> &&x) : u_{std::move(x)} {}
-  explicit ActualArgument(common::CopyableIndirection<Expr<SomeType>> &&v)
-    : u_{std::move(v)} {}
-  explicit ActualArgument(AssumedType x) : u_{x} {}
-
+  explicit ActualArgument(Expr<SomeType> &&);
+  explicit ActualArgument(common::CopyableIndirection<Expr<SomeType>> &&);
+  explicit ActualArgument(AssumedType);
+  ~ActualArgument();
   ActualArgument &operator=(Expr<SomeType> &&);
 
   Expr<SomeType> *GetExpr() {

--- a/lib/evaluate/characteristics.cc
+++ b/lib/evaluate/characteristics.cc
@@ -187,6 +187,9 @@ bool IsOptional(const DummyArgument &da) {
       da);
 }
 
+FunctionResult::FunctionResult(DynamicType t) : u{TypeAndShape{t}} {}
+FunctionResult::FunctionResult(TypeAndShape &&t) : u{std::move(t)} {}
+FunctionResult::FunctionResult(Procedure &&p) : u{std::move(p)} {}
 FunctionResult::~FunctionResult() = default;
 
 bool FunctionResult::operator==(const FunctionResult &that) const {

--- a/lib/evaluate/characteristics.h
+++ b/lib/evaluate/characteristics.h
@@ -127,9 +127,9 @@ std::optional<DummyArgument> CharacterizeDummyArgument(
 struct FunctionResult {
   ENUM_CLASS(Attr, Allocatable, Pointer, Contiguous)
   DECLARE_CONSTRUCTORS_AND_ASSIGNMENTS(FunctionResult)
-  explicit FunctionResult(DynamicType t) : u{TypeAndShape{t}} {}
-  explicit FunctionResult(TypeAndShape &&t) : u{std::move(t)} {}
-  explicit FunctionResult(Procedure &&p) : u{std::move(p)} {}
+  explicit FunctionResult(DynamicType);
+  explicit FunctionResult(TypeAndShape &&);
+  explicit FunctionResult(Procedure &&);
   ~FunctionResult();
   bool operator==(const FunctionResult &) const;
   static std::optional<FunctionResult> Characterize(


### PR DESCRIPTION
Move a few new constructors that use forward-referenced types from headers into source files to dodge a build problem with libc++.