### PR TITLE
Continue semantic checking after name resolution error

### DIFF
--- a/lib/semantics/assignment.cc
+++ b/lib/semantics/assignment.cc
@@ -270,7 +270,7 @@ void AssignmentContext::Analyze(const parser::ConcurrentHeader &header) {
       std::get<std::list<parser::ConcurrentControl>>(header.t)) {
     const parser::Name &name{std::get<parser::Name>(control.t)};
     bool inserted{forall_->activeNames.insert(name.source).second};
-    CHECK(inserted || HasError(name));
+    CHECK(inserted || context_.HasError(name));
   }
 }
 

--- a/lib/semantics/assignment.cc
+++ b/lib/semantics/assignment.cc
@@ -15,6 +15,7 @@
 #include "assignment.h"
 #include "expression.h"
 #include "symbol.h"
+#include "tools.h"
 #include "../common/idioms.h"
 #include "../evaluate/expression.h"
 #include "../evaluate/fold.h"
@@ -267,9 +268,9 @@ void AssignmentContext::Analyze(const parser::ConcurrentHeader &header) {
       std::get<std::optional<parser::IntegerTypeSpec>>(header.t));
   for (const auto &control :
       std::get<std::list<parser::ConcurrentControl>>(header.t)) {
-    const parser::CharBlock &name{std::get<parser::Name>(control.t).source};
-    bool inserted{forall_->activeNames.insert(name).second};
-    CHECK(inserted);
+    const parser::Name &name{std::get<parser::Name>(control.t)};
+    bool inserted{forall_->activeNames.insert(name.source).second};
+    CHECK(inserted || HasError(name));
   }
 }
 

--- a/lib/semantics/check-coarray.cc
+++ b/lib/semantics/check-coarray.cc
@@ -83,6 +83,9 @@ void CoarrayChecker::CheckNamesAreDistinct(
     const auto &decl{std::get<parser::CodimensionDecl>(assoc.t)};
     const auto &selector{std::get<parser::Selector>(assoc.t)};
     const auto &declName{std::get<parser::Name>(decl.t)};
+    if (HasError(declName)) {
+      continue;  // already reported an error about this name
+    }
     if (auto *prev{getPreviousUse(declName)}) {
       Say2(declName.source,  // C1113
           "Coarray '%s' was already used as a selector or coarray in this statement"_err_en_US,
@@ -90,11 +93,12 @@ void CoarrayChecker::CheckNamesAreDistinct(
     }
     // ResolveNames verified the selector is a simple name
     const parser::Name *name{parser::Unwrap<parser::Name>(selector)};
-    CHECK(name);
-    if (auto *prev{getPreviousUse(*name)}) {
-      Say2(name->source,  // C1113, C1115
-          "Selector '%s' was already used as a selector or coarray in this statement"_err_en_US,
-          *prev, "Previous use of '%s'"_en_US);
+    if (name) {
+      if (auto *prev{getPreviousUse(*name)}) {
+        Say2(name->source,  // C1113, C1115
+            "Selector '%s' was already used as a selector or coarray in this statement"_err_en_US,
+            *prev, "Previous use of '%s'"_en_US);
+      }
     }
   }
 }

--- a/lib/semantics/check-coarray.cc
+++ b/lib/semantics/check-coarray.cc
@@ -83,7 +83,7 @@ void CoarrayChecker::CheckNamesAreDistinct(
     const auto &decl{std::get<parser::CodimensionDecl>(assoc.t)};
     const auto &selector{std::get<parser::Selector>(assoc.t)};
     const auto &declName{std::get<parser::Name>(decl.t)};
-    if (HasError(declName)) {
+    if (context_.HasError(declName)) {
       continue;  // already reported an error about this name
     }
     if (auto *prev{getPreviousUse(declName)}) {

--- a/lib/semantics/check-deallocate.cc
+++ b/lib/semantics/check-deallocate.cc
@@ -27,7 +27,7 @@ void DeallocateChecker::Leave(const parser::DeallocateStmt &deallocateStmt) {
         common::visitors{
             [&](const parser::Name &name) {
               auto const *symbol{name.symbol};
-              if (HasError(symbol)) {
+              if (context_.HasError(symbol)) {
                 // already reported an error
               } else if (!IsVariableName(*symbol)) {
                 context_.Say(name.source,

--- a/lib/semantics/check-deallocate.cc
+++ b/lib/semantics/check-deallocate.cc
@@ -27,7 +27,9 @@ void DeallocateChecker::Leave(const parser::DeallocateStmt &deallocateStmt) {
         common::visitors{
             [&](const parser::Name &name) {
               auto const *symbol{name.symbol};
-              if (!IsVariableName(*symbol)) {
+              if (HasError(symbol)) {
+                // already reported an error
+              } else if (!IsVariableName(*symbol)) {
                 context_.Say(name.source,
                     "name in DEALLOCATE statement must be a variable name"_err_en_US);
               } else if (!IsAllocatableOrPointer(*symbol)) {  // C932

--- a/lib/semantics/check-nullify.cc
+++ b/lib/semantics/check-nullify.cc
@@ -27,7 +27,7 @@ void NullifyChecker::Leave(const parser::NullifyStmt &nullifyStmt) {
         common::visitors{
             [&](const parser::Name &name) {
               auto const *symbol{name.symbol};
-              if (HasError(symbol)) {
+              if (context_.HasError(symbol)) {
                 // already reported an error
               } else if (!IsVariableName(*symbol) && !IsProcName(*symbol)) {
                 context_.Say(name.source,

--- a/lib/semantics/check-nullify.cc
+++ b/lib/semantics/check-nullify.cc
@@ -27,7 +27,9 @@ void NullifyChecker::Leave(const parser::NullifyStmt &nullifyStmt) {
         common::visitors{
             [&](const parser::Name &name) {
               auto const *symbol{name.symbol};
-              if (!IsVariableName(*symbol) && !IsProcName(*symbol)) {
+              if (HasError(symbol)) {
+                // already reported an error
+              } else if (!IsVariableName(*symbol) && !IsProcName(*symbol)) {
                 context_.Say(name.source,
                     "name in NULLIFY statement must be a variable or procedure pointer name"_err_en_US);
               } else if (!IsPointer(*symbol)) {  // C951

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -651,7 +651,7 @@ MaybeExpr ExpressionAnalyzer::Analyze(const parser::Name &n) {
   if (std::optional<int> kind{IsAcImpliedDo(n.source)}) {
     return AsMaybeExpr(ConvertToKind<TypeCategory::Integer>(
         *kind, AsExpr(ImpliedDoIndex{n.source})));
-  } else if (!semantics::HasError(n)) {
+  } else if (!context_.HasError(n)) {
     const Symbol &ultimate{n.symbol->GetUltimate()};
     if (ultimate.attrs().test(semantics::Attr::PARAMETER)) {
       if (auto *details{ultimate.detailsIf<semantics::ObjectEntityDetails>()}) {
@@ -889,7 +889,7 @@ MaybeExpr ExpressionAnalyzer::Analyze(const parser::StructureComponent &sc) {
     return std::nullopt;
   }
   Symbol *sym{sc.component.symbol};
-  if (HasError(sym)) {
+  if (context_.HasError(sym)) {
     return std::nullopt;
   }
   const auto &name{sc.component.source};
@@ -1446,7 +1446,7 @@ auto ExpressionAnalyzer::Procedure(const parser::ProcedureDesignator &pd,
       common::visitors{
           [&](const parser::Name &n) -> std::optional<CallAndArguments> {
             const Symbol *symbol{n.symbol};
-            if (HasError(symbol)) {
+            if (context_.HasError(symbol)) {
               return std::nullopt;
             }
             if (IsProcedure(*symbol)) {

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -1480,7 +1480,6 @@ void ScopeHandler::SayAlreadyDeclared(const parser::Name &name, Symbol &prev) {
   SayAlreadyDeclared(name.source, prev);
 }
 void ScopeHandler::SayAlreadyDeclared(const SourceName &name, Symbol &prev) {
-  SetError(prev);
   auto &msg{
       Say(name, "'%s' is already declared in this scoping unit"_err_en_US)};
   if (const auto *details{prev.detailsIf<UseDetails>()}) {
@@ -1492,14 +1491,15 @@ void ScopeHandler::SayAlreadyDeclared(const SourceName &name, Symbol &prev) {
     msg.Attach(prev.name(), "Previous declaration of '%s'"_en_US,
         prev.name().ToString().c_str());
   }
+  context().SetError(prev);
 }
 
 void ScopeHandler::SayWithDecl(
     const parser::Name &name, Symbol &symbol, MessageFixedText &&msg) {
-  SetError(symbol, msg.isFatal());
   Say2(name, std::move(msg), symbol,
       symbol.test(Symbol::Flag::Implicit) ? "Implicit declaration of '%s'"_en_US
                                           : "Declaration of '%s'"_en_US);
+  context().SetError(symbol, msg.isFatal());
 }
 void ScopeHandler::SayDerivedType(
     const SourceName &name, MessageFixedText &&msg, const Scope &type) {
@@ -1516,13 +1516,13 @@ void ScopeHandler::Say2(const SourceName &name1, MessageFixedText &&msg1,
 }
 void ScopeHandler::Say2(const SourceName &name, MessageFixedText &&msg1,
     Symbol &symbol, MessageFixedText &&msg2) {
-  SetError(symbol, msg1.isFatal());
   Say2(name, std::move(msg1), symbol.name(), std::move(msg2));
+  context().SetError(symbol, msg1.isFatal());
 }
 void ScopeHandler::Say2(const parser::Name &name, MessageFixedText &&msg1,
     Symbol &symbol, MessageFixedText &&msg2) {
-  SetError(symbol, msg1.isFatal());
   Say2(name.source, std::move(msg1), symbol.name(), std::move(msg2));
+  context().SetError(symbol, msg1.isFatal());
 }
 
 Scope &ScopeHandler::InclusiveScope() {
@@ -2730,7 +2730,7 @@ Symbol &DeclarationVisitor::DeclareObjectEntity(
       if (details->IsArray()) {
         Say(name,
             "The dimensions of '%s' have already been declared"_err_en_US);
-        SetError(symbol);
+        context().SetError(symbol);
       } else {
         details->set_shape(arraySpec());
       }
@@ -2740,7 +2740,7 @@ Symbol &DeclarationVisitor::DeclareObjectEntity(
       if (details->IsCoarray()) {
         Say(name,
             "The codimensions of '%s' have already been declared"_err_en_US);
-        SetError(symbol);
+        context().SetError(symbol);
       } else {
         details->set_coshape(coarraySpec());
       }
@@ -3893,7 +3893,8 @@ bool ConstructVisitor::Pre(const parser::LocalitySpec::Shared &x) {
       symbol.set(Symbol::Flag::LocalityShared);
     } else {
       Say(name, "Variable '%s' not found"_err_en_US);
-      SetError(MakeSymbol(name, ObjectEntityDetails{EntityDetails{}}));
+      context().SetError(
+          MakeSymbol(name, ObjectEntityDetails{EntityDetails{}}));
     }
   }
   return false;

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -415,16 +415,16 @@ public:
 
   // Special messages: already declared; referencing symbol's declaration;
   // about a type; two names & locations
-  void SayAlreadyDeclared(const SourceName &, const Symbol &);
-  void SayAlreadyDeclared(const parser::Name &, const Symbol &);
-  void SayWithDecl(const parser::Name &, const Symbol &, MessageFixedText &&);
+  void SayAlreadyDeclared(const SourceName &, Symbol &);
+  void SayAlreadyDeclared(const parser::Name &, Symbol &);
+  void SayWithDecl(const parser::Name &, Symbol &, MessageFixedText &&);
   void SayDerivedType(const SourceName &, MessageFixedText &&, const Scope &);
   void Say2(const SourceName &, MessageFixedText &&, const SourceName &,
       MessageFixedText &&);
-  void Say2(const SourceName &, MessageFixedText &&, const Symbol &,
-      MessageFixedText &&);
-  void Say2(const parser::Name &, MessageFixedText &&, const Symbol &,
-      MessageFixedText &&);
+  void Say2(
+      const SourceName &, MessageFixedText &&, Symbol &, MessageFixedText &&);
+  void Say2(
+      const parser::Name &, MessageFixedText &&, Symbol &, MessageFixedText &&);
 
   // Search for symbol by name in current and containing scopes
   Symbol *FindSymbol(const parser::Name &);
@@ -754,9 +754,8 @@ protected:
   Symbol *DeclareStatementEntity(
       const parser::Name &, const std::optional<parser::IntegerTypeSpec> &);
   bool CheckUseError(const parser::Name &);
-  void CheckAccessibility(const SourceName &, bool, const Symbol &);
+  void CheckAccessibility(const SourceName &, bool, Symbol &);
   bool CheckAccessibleComponent(const SourceName &, const Symbol &);
-  void CheckScalarIntegerType(const parser::Name &);
   void CheckCommonBlocks();
   void CheckSaveStmts();
   bool CheckNotInBlock(const char *);
@@ -1477,12 +1476,11 @@ void ArraySpecVisitor::PostAttrSpec() {
 
 // ScopeHandler implementation
 
-void ScopeHandler::SayAlreadyDeclared(
-    const parser::Name &name, const Symbol &prev) {
+void ScopeHandler::SayAlreadyDeclared(const parser::Name &name, Symbol &prev) {
   SayAlreadyDeclared(name.source, prev);
 }
-void ScopeHandler::SayAlreadyDeclared(
-    const SourceName &name, const Symbol &prev) {
+void ScopeHandler::SayAlreadyDeclared(const SourceName &name, Symbol &prev) {
+  SetError(prev);
   auto &msg{
       Say(name, "'%s' is already declared in this scoping unit"_err_en_US)};
   if (const auto *details{prev.detailsIf<UseDetails>()}) {
@@ -1497,7 +1495,8 @@ void ScopeHandler::SayAlreadyDeclared(
 }
 
 void ScopeHandler::SayWithDecl(
-    const parser::Name &name, const Symbol &symbol, MessageFixedText &&msg) {
+    const parser::Name &name, Symbol &symbol, MessageFixedText &&msg) {
+  SetError(symbol, msg.isFatal());
   Say2(name, std::move(msg), symbol,
       symbol.test(Symbol::Flag::Implicit) ? "Implicit declaration of '%s'"_en_US
                                           : "Declaration of '%s'"_en_US);
@@ -1516,11 +1515,13 @@ void ScopeHandler::Say2(const SourceName &name1, MessageFixedText &&msg1,
       .Attach(name2, std::move(msg2), name2.ToString().c_str());
 }
 void ScopeHandler::Say2(const SourceName &name, MessageFixedText &&msg1,
-    const Symbol &symbol, MessageFixedText &&msg2) {
+    Symbol &symbol, MessageFixedText &&msg2) {
+  SetError(symbol, msg1.isFatal());
   Say2(name, std::move(msg1), symbol.name(), std::move(msg2));
 }
 void ScopeHandler::Say2(const parser::Name &name, MessageFixedText &&msg1,
-    const Symbol &symbol, MessageFixedText &&msg2) {
+    Symbol &symbol, MessageFixedText &&msg2) {
+  SetError(symbol, msg1.isFatal());
   Say2(name.source, std::move(msg1), symbol.name(), std::move(msg2));
 }
 
@@ -2130,7 +2131,7 @@ void InterfaceVisitor::ResolveSpecificsInGeneric(Symbol &generic) {
 void InterfaceVisitor::CheckGenericProcedures(Symbol &generic) {
   ResolveSpecificsInGeneric(generic);
   auto &details{generic.get<GenericDetails>()};
-  if (const auto *proc{details.CheckSpecific()}) {
+  if (auto *proc{details.CheckSpecific()}) {
     SayAlreadyDeclared(generic.name(), *proc);
   }
   auto &specifics{details.specificProcs()};
@@ -2490,7 +2491,7 @@ bool DeclarationVisitor::CheckUseError(const parser::Name &name) {
 
 // Report error if accessibility of symbol doesn't match isPrivate.
 void DeclarationVisitor::CheckAccessibility(
-    const SourceName &name, bool isPrivate, const Symbol &symbol) {
+    const SourceName &name, bool isPrivate, Symbol &symbol) {
   if (symbol.attrs().test(Attr::PRIVATE) != isPrivate) {
     Say2(name,
         "'%s' does not have the same accessibility as its previous declaration"_err_en_US,
@@ -2527,22 +2528,6 @@ bool DeclarationVisitor::CheckAccessibleComponent(
         name.ToString());
   }
   return false;
-}
-
-void DeclarationVisitor::CheckScalarIntegerType(const parser::Name &name) {
-  if (name.symbol != nullptr) {
-    const Symbol &symbol{*name.symbol};
-    if (symbol.IsObjectArray()) {
-      Say(name, "Variable '%s' is not scalar"_err_en_US);
-      return;
-    }
-    if (auto *type{symbol.GetType()}) {
-      if (!type->IsNumeric(TypeCategory::Integer)) {
-        Say(name, "Variable '%s' is not INTEGER"_err_en_US);
-        return;
-      }
-    }
-  }
 }
 
 void DeclarationVisitor::Post(const parser::DimensionStmt::Declaration &x) {
@@ -2745,6 +2730,7 @@ Symbol &DeclarationVisitor::DeclareObjectEntity(
       if (details->IsArray()) {
         Say(name,
             "The dimensions of '%s' have already been declared"_err_en_US);
+        SetError(symbol);
       } else {
         details->set_shape(arraySpec());
       }
@@ -2754,6 +2740,7 @@ Symbol &DeclarationVisitor::DeclareObjectEntity(
       if (details->IsCoarray()) {
         Say(name,
             "The codimensions of '%s' have already been declared"_err_en_US);
+        SetError(symbol);
       } else {
         details->set_coshape(coarraySpec());
       }
@@ -3270,7 +3257,7 @@ bool DeclarationVisitor::Pre(const parser::TypeBoundGenericStmt &x) {
   const auto &bindingNames{std::get<std::list<parser::Name>>(x.t)};
   SymbolList specificProcs;
   for (const auto &bindingName : bindingNames) {
-    const auto *symbol{FindInTypeOrParents(bindingName)};
+    auto *symbol{FindInTypeOrParents(bindingName)};
     if (!symbol) {
       Say(bindingName,
           "Binding name '%s' not found in this derived type"_err_en_US);
@@ -3290,7 +3277,7 @@ bool DeclarationVisitor::Pre(const parser::TypeBoundGenericStmt &x) {
     if (!genericSymbol->has<GenericBindingDetails>()) {
       genericSymbol = nullptr;  // MakeTypeSymbol will report the error below
     }
-  } else if (const auto *inheritedSymbol{
+  } else if (auto *inheritedSymbol{
                  FindInTypeOrParents(currScope(), symbolName)}) {
     // look in parent types:
     if (inheritedSymbol->has<GenericBindingDetails>()) {
@@ -3718,7 +3705,6 @@ Symbol *DeclarationVisitor::DeclareStatementEntity(const parser::Name &name,
   } else {
     ApplyImplicitRules(symbol);
   }
-  CheckScalarIntegerType(name);
   return Resolve(name, &symbol);
 }
 
@@ -3907,6 +3893,7 @@ bool ConstructVisitor::Pre(const parser::LocalitySpec::Shared &x) {
       symbol.set(Symbol::Flag::LocalityShared);
     } else {
       Say(name, "Variable '%s' not found"_err_en_US);
+      SetError(MakeSymbol(name, ObjectEntityDetails{EntityDetails{}}));
     }
   }
   return false;
@@ -3999,7 +3986,7 @@ void ConstructVisitor::Post(const parser::ConcurrentControl &x) {
       return;
     }
   }
-  CheckScalarIntegerType(name);
+  EvaluateExpr(parser::Scalar{parser::Integer{common::Clone(name)}});
 }
 
 bool ConstructVisitor::Pre(const parser::ForallConstruct &) {

--- a/lib/semantics/rewrite-parse-tree.cc
+++ b/lib/semantics/rewrite-parse-tree.cc
@@ -33,7 +33,9 @@ using namespace parser::literals;
 /// unit number expressions.
 class RewriteMutator {
 public:
-  RewriteMutator(parser::Messages &messages) : messages_{messages} {}
+  RewriteMutator(SemanticsContext &context)
+    : errorOnUnresolvedName_{!context.AnyFatalError()},
+      messages_{context.messages()} {}
 
   // Default action for a parse tree node is to visit children.
   template<typename T> bool Pre(T &) { return true; }
@@ -154,7 +156,7 @@ void RewriteMutator::Post(parser::WriteStmt &x) {
 }
 
 bool RewriteParseTree(SemanticsContext &context, parser::Program &program) {
-  RewriteMutator mutator{context.messages()};
+  RewriteMutator mutator{context};
   parser::Walk(program, mutator);
   return !context.AnyFatalError();
 }

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -127,6 +127,25 @@ bool SemanticsContext::AnyFatalError() const {
   return !messages_.empty() &&
       (warningsAreErrors_ || messages_.AnyFatalError());
 }
+bool SemanticsContext::HasError(const Symbol &symbol) {
+  return CheckError(symbol.test(Symbol::Flag::Error));
+}
+bool SemanticsContext::HasError(const Symbol *symbol) {
+  return CheckError(!symbol || HasError(*symbol));
+}
+bool SemanticsContext::HasError(const parser::Name &name) {
+  return HasError(name.symbol);
+}
+void SemanticsContext::SetError(Symbol &symbol, bool value) {
+  if (value) {
+    CHECK(AnyFatalError());
+    symbol.set(Symbol::Flag::Error);
+  }
+}
+bool SemanticsContext::CheckError(bool error) {
+  CHECK(!error || AnyFatalError());
+  return error;
+}
 
 const Scope &SemanticsContext::FindScope(parser::CharBlock source) const {
   return const_cast<SemanticsContext *>(this)->FindScope(source);

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -86,7 +86,9 @@ using StatementSemanticsPass2 = SemanticsVisitor<AllocateChecker,
     ReturnStmtChecker, StopChecker>;
 
 static bool PerformStatementSemantics(
-    SemanticsContext &context, const parser::Program &program) {
+    SemanticsContext &context, parser::Program &program) {
+  ResolveNames(context, program);
+  RewriteParseTree(context, program);
   StatementSemanticsPass1{context}.Walk(program);
   return StatementSemanticsPass2{context}.Walk(program);
 }
@@ -141,8 +143,6 @@ Scope &SemanticsContext::FindScope(parser::CharBlock source) {
 bool Semantics::Perform() {
   return ValidateLabels(context_.messages(), program_) &&
       parser::CanonicalizeDo(program_) &&  // force line break
-      ResolveNames(context_, program_) &&
-      RewriteParseTree(context_, program_) &&
       PerformStatementSemantics(context_, program_) &&
       ModFileWriter{context_}.WriteAll();
 }

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -29,11 +29,14 @@ class IntrinsicTypeDefaultKinds;
 }
 
 namespace Fortran::parser {
+struct Name;
 struct Program;
 class CookedSource;
 }
 
 namespace Fortran::semantics {
+
+class Symbol;
 
 class SemanticsContext {
 public:
@@ -83,6 +86,12 @@ public:
 
   bool AnyFatalError() const;
 
+  // Test or set the Error flag on a Symbol
+  bool HasError(const Symbol &);
+  bool HasError(const Symbol *);
+  bool HasError(const parser::Name &);
+  void SetError(Symbol &, bool = true);
+
   template<typename... A>
   common::IfNoLvalue<parser::Message &, A...> Say(
       parser::CharBlock at, A &&... args) {
@@ -112,6 +121,8 @@ private:
   Scope globalScope_;
   parser::Messages messages_;
   evaluate::FoldingContext foldingContext_;
+
+  bool CheckError(bool);
 };
 
 class Semantics {

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -171,6 +171,9 @@ void GenericDetails::set_derivedType(Symbol &derivedType) {
 }
 
 const Symbol *GenericDetails::CheckSpecific() const {
+  return const_cast<GenericDetails *>(this)->CheckSpecific();
+}
+Symbol *GenericDetails::CheckSpecific() {
   if (specific_) {
     for (const auto *proc : specificProcs_) {
       if (proc == specific_) {

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -404,6 +404,7 @@ public:
   // Check that specific is one of the specificProcs. If not, return the
   // specific as a raw pointer.
   const Symbol *CheckSpecific() const;
+  Symbol *CheckSpecific();
 
 private:
   GenericKind kind_{GenericKind::Name};
@@ -429,6 +430,7 @@ std::string DetailsToString(const Details &);
 class Symbol {
 public:
   ENUM_CLASS(Flag,
+      Error,  // an error has been reported on this symbol
       Function,  // symbol is a function
       Subroutine,  // symbol is a subroutine
       Implicit,  // symbol is implicitly typed

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -189,7 +189,8 @@ bool IsProcedure(const Symbol &symbol) {
       common::visitors{
           [](const SubprogramDetails &) { return true; },
           [](const SubprogramNameDetails &) { return true; },
-          [](const ProcEntityDetails &x) { return true; },
+          [](const ProcEntityDetails &) { return true; },
+          [](const GenericDetails &) { return true; },
           [](const UseDetails &x) { return IsProcedure(x.symbol()); },
           [](const auto &) { return false; },
       },
@@ -276,6 +277,16 @@ const Symbol *FindExternallyVisibleObject(
     return block;
   } else {
     return nullptr;
+  }
+}
+
+bool HasError(const Symbol &symbol) { return symbol.test(Symbol::Flag::Error); }
+bool HasError(const Symbol *symbol) { return !symbol || HasError(*symbol); }
+bool HasError(const parser::Name &name) { return HasError(name.symbol); }
+
+void SetError(Symbol &symbol, bool value) {
+  if (value) {
+    symbol.set(Symbol::Flag::Error);
   }
 }
 

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -280,16 +280,6 @@ const Symbol *FindExternallyVisibleObject(
   }
 }
 
-bool HasError(const Symbol &symbol) { return symbol.test(Symbol::Flag::Error); }
-bool HasError(const Symbol *symbol) { return !symbol || HasError(*symbol); }
-bool HasError(const parser::Name &name) { return HasError(name.symbol); }
-
-void SetError(Symbol &symbol, bool value) {
-  if (value) {
-    symbol.set(Symbol::Flag::Error);
-  }
-}
-
 bool ExprHasTypeCategory(
     const SomeExpr &expr, const common::TypeCategory &type) {
   auto dynamicType{expr.GetType()};

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -60,12 +60,6 @@ bool IsAllocatable(const Symbol &);
 bool IsAllocatableOrPointer(const Symbol &);
 bool IsProcedurePointer(const Symbol &);
 
-// Test or set the Error flag on a Symbol
-bool HasError(const Symbol &);
-bool HasError(const Symbol *);
-bool HasError(const parser::Name &);
-void SetError(Symbol &, bool value = true);
-
 // Determines whether an object might be visible outside a
 // PURE function (C1594); returns a non-null Symbol pointer for
 // diagnostic purposes if so.

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -25,13 +25,6 @@
 #include "../evaluate/variable.h"
 #include "../parser/parse-tree.h"
 
-namespace Fortran::parser {
-class Messages;
-struct Expr;
-struct Name;
-struct Variable;
-}
-
 namespace Fortran::semantics {
 
 class DeclTypeSpec;
@@ -66,6 +59,12 @@ bool IsVariableName(const Symbol &symbol);  // variable-name
 bool IsAllocatable(const Symbol &);
 bool IsAllocatableOrPointer(const Symbol &);
 bool IsProcedurePointer(const Symbol &);
+
+// Test or set the Error flag on a Symbol
+bool HasError(const Symbol &);
+bool HasError(const Symbol *);
+bool HasError(const parser::Name &);
+void SetError(Symbol &, bool value = true);
 
 // Determines whether an object might be visible outside a
 // PURE function (C1594); returns a non-null Symbol pointer for

--- a/test/semantics/coarrays01.f90
+++ b/test/semantics/coarrays01.f90
@@ -67,7 +67,6 @@ subroutine s3
   change team(t2%a, x[10,*] => y)
   end team
   !ERROR: Must be a scalar value, but is a rank-1 array
-  !ERROR: Team value must be of type TEAM_TYPE from module ISO_FORTRAN_ENV
   change team(t3, x[10,*] => y)
   end team
   !ERROR: Team value must be of type TEAM_TYPE from module ISO_FORTRAN_ENV
@@ -79,7 +78,6 @@ subroutine s3
   !ERROR: Team value must be of type TEAM_TYPE from module ISO_FORTRAN_ENV
   form team(3, t3(2))
   !ERROR: Must be a scalar value, but is a rank-1 array
-  !ERROR: Team value must be of type TEAM_TYPE from module ISO_FORTRAN_ENV
   form team(3, t3)
 end
 

--- a/test/semantics/doconcurrent04.f90
+++ b/test/semantics/doconcurrent04.f90
@@ -13,7 +13,7 @@
 ! limitations under the License.
 
 ! RUN: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
-! CHECK: Variable 'j' is not INTEGER
+! CHECK: Must have INTEGER type, but is REAL\\(4\\)
 
 subroutine do_concurrent_test1(n)
   implicit none

--- a/test/semantics/resolve30.f90
+++ b/test/semantics/resolve30.f90
@@ -43,8 +43,12 @@ end
 
 subroutine s4
   real :: i, j
-  !ERROR: Variable 'i' is not INTEGER
+  !ERROR: Must have INTEGER type, but is REAL(4)
   real :: a(16) = [(i, i=1, 16)]
-  !ERROR: Variable 'j' is not INTEGER
-  data(a(j), j=1, 16) / 16 * 0.0 /
+  data(
+    !ERROR: Must have INTEGER type, but is REAL(4)
+    a(j), &
+    !ERROR: Must have INTEGER type, but is REAL(4)
+    j=1, 16 &
+  ) / 16 * 0.0 /
 end

--- a/test/semantics/resolve35.f90
+++ b/test/semantics/resolve35.f90
@@ -46,12 +46,16 @@ subroutine s4
   real :: a(10), b(10)
   complex :: x
   integer :: i(2)
-  !ERROR: Variable 'x' is not INTEGER
+  !ERROR: Must have INTEGER type, but is COMPLEX(4)
   forall(x=1:10)
+    !ERROR: Must have INTEGER type, but is COMPLEX(4)
+    !ERROR: Must have INTEGER type, but is COMPLEX(4)
     a(x) = b(x)
   end forall
-  !ERROR: Variable 'y' is not INTEGER
+  !ERROR: Must have INTEGER type, but is REAL(4)
   forall(y=1:10)
+    !ERROR: Must have INTEGER type, but is REAL(4)
+    !ERROR: Must have INTEGER type, but is REAL(4)
     a(y) = b(y)
   end forall
   !ERROR: Index variable 'i' is not scalar


### PR DESCRIPTION
When an error occurs in name resolution, continue semantic processing
in order to detect other errors. This means we can no longer assume
that every `parser::Name` has a symbol even after name resolution
completes. In `RewriteMutator`, only report internal error for unresolved
symbol if there have been no fatal errors.

Add `Error` flag to `Symbol` to indicate that an error occurred related
to it. Once we report an error about a symbol we should avoid reporting
any more to prevent cascading errors. Add `HasError()` and `SetError()`
to simplify working with this flag.

Change some places that we assume that a `parser::Name` has a non-null
symbol. There are probably more.

`resolve-names.cc`: Set the `Error` flag when we report a fatal error
related to a symbol. (This requires making some symbols non-const.)
Remove `CheckScalarIntegerType()` as `ExprChecker` will take care of
those constraints if they are expressed in the parse tree. One exception
to that is the name in a `ConcurrentControl`. Explicitly perform that
check using `EvaluateExpr()` and constraint classes so we get consistent
error messages.

In expression analysis, when a constraint is violated (like `Scalar<>`
or `Integer<>`), reset the wrapped expression so that we don't assume it
is valid. A `GenericExprWrapper` holding a std::nullopt indicates error.
Change `EnforceTypeConstraint()` to return false when the constraint
fails to enable this.

check-do-concurrent.cc: Reorganize the Gather*VariableNames functions
into one to simplify the task of filtering out unresolved names. Remove
`CheckNoDuplicates()` and `CheckNoCollisions()` as those checks is
already done in name resolution when the names are added to the scope.