### PR TITLE
Bug fix: resolve ComponentArraySpec

### DIFF
--- a/lib/semantics/resolve-names-utils.h
+++ b/lib/semantics/resolve-names-utils.h
@@ -24,6 +24,7 @@
 namespace Fortran::parser {
 class CharBlock;
 struct ArraySpec;
+struct ComponentArraySpec;
 struct CoarraySpec;
 struct DefinedOpName;
 struct GenericSpec;
@@ -70,6 +71,8 @@ private:
 
 // Analyze a parser::ArraySpec or parser::CoarraySpec
 ArraySpec AnalyzeArraySpec(SemanticsContext &, const parser::ArraySpec &);
+ArraySpec AnalyzeArraySpec(
+    SemanticsContext &, const parser::ComponentArraySpec &);
 ArraySpec AnalyzeCoarraySpec(
     SemanticsContext &context, const parser::CoarraySpec &);
 

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -358,6 +358,7 @@ private:
 class ArraySpecVisitor : public virtual BaseVisitor {
 public:
   void Post(const parser::ArraySpec &);
+  void Post(const parser::ComponentArraySpec &);
   void Post(const parser::CoarraySpec &);
   void Post(const parser::AttrSpec &) { PostAttrSpec(); }
   void Post(const parser::ComponentAttrSpec &) { PostAttrSpec(); }
@@ -1436,6 +1437,10 @@ bool ImplicitRulesVisitor::HandleImplicitNone(
 // ArraySpecVisitor implementation
 
 void ArraySpecVisitor::Post(const parser::ArraySpec &x) {
+  CHECK(arraySpec_.empty());
+  arraySpec_ = AnalyzeArraySpec(context(), x);
+}
+void ArraySpecVisitor::Post(const parser::ComponentArraySpec &x) {
   CHECK(arraySpec_.empty());
   arraySpec_ = AnalyzeArraySpec(context(), x);
 }

--- a/test/semantics/modfile24.f90
+++ b/test/semantics/modfile24.f90
@@ -63,7 +63,7 @@ end
 !Expect: m3.mod
 !module m3
 ! type::t
-!  real(4)::c[1_8:10_8,1_8:*]
+!  real(4)::c(1_8:5_8)[1_8:10_8,1_8:*]
 !  complex(4)::d[1_8:5_8,1_8:*]
 ! end type
 ! real(4),allocatable::e[:,:,:]

--- a/test/semantics/modfile24.f90
+++ b/test/semantics/modfile24.f90
@@ -49,8 +49,8 @@ end
 ! coarray-spec in components and with non-constants bounds
 module m3
   type t
-    real :: c(1:5)[1:10,1:*]
-    complex, codimension[5,*] :: d
+    real, allocatable :: c(1:5)[1:10,1:*]
+    complex, allocatable, codimension[5,*] :: d
   end type
   real, allocatable :: e[:,:,:]
 contains
@@ -63,8 +63,8 @@ end
 !Expect: m3.mod
 !module m3
 ! type::t
-!  real(4)::c(1_8:5_8)[1_8:10_8,1_8:*]
-!  complex(4)::d[1_8:5_8,1_8:*]
+!  real(4),allocatable::c(1_8:5_8)[1_8:10_8,1_8:*]
+!  complex(4),allocatable::d[1_8:5_8,1_8:*]
 ! end type
 ! real(4),allocatable::e[:,:,:]
 !contains


### PR DESCRIPTION
This used to work but broke due to coarray spec changes.
The fix is to extend AnalyzeArraySpec to work on ComponentArraySpec
and to call it when we encounter one.

modfile24.f90 tested this case but had the wrong expected results.

Thanks to Jean for finding this.