### PR TITLE
Fix source positions during parse tree rewriting

### DIFF
--- a/lib/parser/parse-tree-visitor.h
+++ b/lib/parser/parse-tree-visitor.h
@@ -494,6 +494,34 @@ template<typename M> void Walk(Expr &x, M &mutator) {
     mutator.Post(x);
   }
 }
+template<typename V> void Walk(const Designator &x, V &visitor) {
+  if (visitor.Pre(x)) {
+    Walk(x.source, visitor);
+    Walk(x.u, visitor);
+    visitor.Post(x);
+  }
+}
+template<typename M> void Walk(Designator &x, M &mutator) {
+  if (mutator.Pre(x)) {
+    Walk(x.source, mutator);
+    Walk(x.u, mutator);
+    mutator.Post(x);
+  }
+}
+template<typename V> void Walk(const Call &x, V &visitor) {
+  if (visitor.Pre(x)) {
+    Walk(x.source, visitor);
+    Walk(x.t, visitor);
+    visitor.Post(x);
+  }
+}
+template<typename M> void Walk(Call &x, M &mutator) {
+  if (mutator.Pre(x)) {
+    Walk(x.source, mutator);
+    Walk(x.t, mutator);
+    mutator.Post(x);
+  }
+}
 template<typename V> void Walk(const PartRef &x, V &visitor) {
   if (visitor.Pre(x)) {
     Walk(x.name, visitor);


### PR DESCRIPTION
When a StmtFunctionStmt was rewritten as an array element assignment
the subscripts were not getting correct source locations. They need
to be copied from the function args.

Also, the entire array element expression (e.g. `a(i)`) did not have a
source position. This was tricky because there is no source position
in the original parse that matches what we need. So we take the source
position from the beginning of the function name to the end of the last
arg and extend it one more character to include the closing parenthesis.

Change `ActualArgToExpr()` to return `Expr` rather than
`std::optional<Expr>` because callers always call `.value()` on the
result anyway.

Add `WithSource()` utility to update the `source` data member of a
parse tree node.

This bug shows up as incorrect source positions for error messages. For
example, in this program the error (due to real subscript) did not have
a source position:
```
real :: a(10), x, y
a(x) = y
end
```