### PR TITLE
Allocate semantic checks (second and last part)

### DIFF
--- a/lib/parser/tools.cc
+++ b/lib/parser/tools.cc
@@ -73,4 +73,28 @@ const Name &GetLastName(const AllocateObject &x) {
   return std::visit(
       [](const auto &y) -> const Name & { return GetLastName(y); }, x.u);
 }
+
+const CoindexedNamedObject *GetCoindexedNamedObject(const DataRef &base) {
+  return std::visit(
+      common::visitors{
+          [](const Name &) -> const CoindexedNamedObject * { return nullptr; },
+          [](const common::Indirection<CoindexedNamedObject> &x)
+              -> const CoindexedNamedObject * { return &x.value(); },
+          [](const auto &x) -> const CoindexedNamedObject * {
+            return GetCoindexedNamedObject(x.value().base);
+          },
+      },
+      base.u);
+}
+const CoindexedNamedObject *GetCoindexedNamedObject(
+    const AllocateObject &allocateObject) {
+  return std::visit(
+      common::visitors{
+          [](const StructureComponent &x) -> const CoindexedNamedObject * {
+            return GetCoindexedNamedObject(x.base);
+          },
+          [](const auto &x) -> const CoindexedNamedObject * { return nullptr; },
+      },
+      allocateObject.u);
+}
 }

--- a/lib/parser/tools.h
+++ b/lib/parser/tools.h
@@ -86,5 +86,9 @@ template<typename A, typename B> const A *Unwrap(const B &x) {
   return UnwrapperHelper::Unwrap<A>(x);
 }
 
+// Get the CoindexedNamedObject if the entity is a coindexed object.
+const CoindexedNamedObject *GetCoindexedNamedObject(const AllocateObject &);
+const CoindexedNamedObject *GetCoindexedNamedObject(const DataRef &);
+
 }
 #endif  // FORTRAN_PARSER_TOOLS_H_

--- a/lib/semantics/check-coarray.cc
+++ b/lib/semantics/check-coarray.cc
@@ -23,22 +23,6 @@
 
 namespace Fortran::semantics {
 
-// Is this a derived type from module with this name?
-static bool IsDerivedTypeFromModule(
-    const DerivedTypeSpec *derived, const char *module, const char *name) {
-  if (!derived) {
-    return false;
-  } else {
-    const auto &symbol{derived->typeSymbol()};
-    return symbol.name() == name && symbol.owner().IsModule() &&
-        symbol.owner().name() == module;
-  }
-}
-
-static bool IsTeamType(const DerivedTypeSpec *derived) {
-  return IsDerivedTypeFromModule(derived, "iso_fortran_env", "team_type");
-}
-
 template<typename T>
 static void CheckTeamType(SemanticsContext &context, const T &x) {
   if (const auto *expr{GetExpr(x)}) {

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -308,4 +308,93 @@ const Symbol *FindFunctionResult(const Symbol &symbol) {
   }
   return nullptr;
 }
+
+bool IsDerivedTypeFromModule(
+    const DerivedTypeSpec *derived, const char *module, const char *name) {
+  if (!derived) {
+    return false;
+  } else {
+    const auto &symbol{derived->typeSymbol()};
+    return symbol.name() == name && symbol.owner().IsModule() &&
+        symbol.owner().name() == module;
+  }
+}
+
+bool IsTeamType(const DerivedTypeSpec *derived) {
+  return IsDerivedTypeFromModule(derived, "iso_fortran_env", "team_type");
+}
+
+const Symbol *HasCoarrayUltimateComponent(
+    const DerivedTypeSpec &derivedTypeSpec) {
+  const Symbol &symbol{derivedTypeSpec.typeSymbol()};
+  // TODO is it guaranteed that derived type symbol have a scope and is it the
+  // right scope to look into?
+  CHECK(symbol.scope());
+  for (const Symbol *componentSymbol :
+      symbol.get<DerivedTypeDetails>().OrderComponents(*symbol.scope())) {
+    CHECK(componentSymbol);
+    const ObjectEntityDetails &objectDetails{
+        componentSymbol->get<ObjectEntityDetails>()};
+    if (objectDetails.IsCoarray()) {
+      // Coarrays are ultimate components because they must be allocatable
+      // according to C746.
+      return componentSymbol;
+    }
+    if (!IsAllocatableOrPointer(*componentSymbol)) {
+      if (const DeclTypeSpec * declTypeSpec{objectDetails.type()}) {
+        if (const DerivedTypeSpec *
+            componentDerivedTypeSpec{declTypeSpec->AsDerived()}) {
+          // Avoid infinite loop, though this should not happen due to C744
+          CHECK(&symbol != &componentDerivedTypeSpec->typeSymbol());
+          if (const Symbol *
+              subcomponent{
+                  HasCoarrayUltimateComponent(*componentDerivedTypeSpec)}) {
+            return subcomponent;
+          }
+        }
+      }
+    }
+  }
+  return nullptr;
+}
+
+const bool IsEventTypeOrLockType(const DerivedTypeSpec *derivedTypeSpec) {
+  return IsDerivedTypeFromModule(
+             derivedTypeSpec, "iso_fortran_env", "event_type") ||
+      IsDerivedTypeFromModule(derivedTypeSpec, "iso_fortran_env", "lock_type");
+}
+
+const Symbol *HasEventOrLockPotentialComponent(
+    const DerivedTypeSpec &derivedTypeSpec) {
+
+  const Symbol &symbol{derivedTypeSpec.typeSymbol()};
+  // TODO is it guaranteed that derived type symbol have a scope and is it the
+  // right scope to look into?
+  CHECK(symbol.scope());
+  for (const Symbol *componentSymbol :
+      symbol.get<DerivedTypeDetails>().OrderComponents(*symbol.scope())) {
+    CHECK(componentSymbol);
+    if (!IsPointer(*componentSymbol)) {
+      if (const DeclTypeSpec * declTypeSpec{componentSymbol->GetType()}) {
+        if (const DerivedTypeSpec *
+            componentDerivedTypeSpec{declTypeSpec->AsDerived()}) {
+          // Avoid infinite loop, that may happen if the component
+          // is an allocatable of the same type as the derived type.
+          // TODO: Is it legal to have longer type loops: i.e type B has a
+          // component of type A that has an allocatable component of type B?
+          if (&symbol != &componentDerivedTypeSpec->typeSymbol()) {
+            if (IsEventTypeOrLockType(componentDerivedTypeSpec)) {
+              return componentSymbol;
+            } else if (const Symbol *
+                subcomponent{HasEventOrLockPotentialComponent(
+                    *componentDerivedTypeSpec)}) {
+              return subcomponent;
+            }
+          }
+        }
+      }
+    }
+  }
+  return nullptr;
+}
 }

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -59,6 +59,21 @@ bool IsVariableName(const Symbol &symbol);  // variable-name
 bool IsAllocatable(const Symbol &);
 bool IsAllocatableOrPointer(const Symbol &);
 bool IsProcedurePointer(const Symbol &);
+// Is this a derived type from module with this name?
+bool IsDerivedTypeFromModule(
+    const DerivedTypeSpec *derived, const char *module, const char *name);
+bool IsTeamType(const DerivedTypeSpec *derived);
+const bool IsEventTypeOrLockType(const DerivedTypeSpec *);
+// Returns an ultimate component symbol that is a
+// coarray or nullptr if there are no such component.
+// There is no guarantee regarding which ultimate coarray
+// component is returned in case there are several because this
+// does not really matter for the checks where it is needed.
+const Symbol *HasCoarrayUltimateComponent(const DerivedTypeSpec &);
+// Same logic as HasCoarrayUltimateComponent, but looking for
+// potential component of EVENT_TYPE or LOCK_TYPE from
+// ISO_FORTRAN_ENV module.
+const Symbol *HasEventOrLockPotentialComponent(const DerivedTypeSpec &);
 
 // Determines whether an object might be visible outside a
 // PURE function (C1594); returns a non-null Symbol pointer for

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -117,6 +117,11 @@ set(ERROR_TESTS
   allocate06.f90
   allocate07.f90
   allocate08.f90
+  allocate09.f90
+  allocate10.f90
+  allocate11.f90
+  allocate12.f90
+  allocate13.f90
   dosemantics01.f90
 )
 

--- a/test/semantics/allocate01.f90
+++ b/test/semantics/allocate01.f90
@@ -39,29 +39,29 @@ subroutine C932(ed1, ed5, ed7, edc9, edc10, okad1, okpd1, okacd5)
   real, allocatable, save :: oka3, okac4[:,:]
   real, allocatable :: okacd5(:, :)[:]
 
-  !ERROR: name in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  !ERROR: Entity in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
   allocate(ed1)
-  !ERROR: name in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  !ERROR: Entity in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
   allocate(e2)
-  !ERROR: name in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  !ERROR: Entity in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
   allocate(e3)
-  !ERROR: name in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  !ERROR: Entity in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
   allocate(e4)
-  !ERROR: name in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  !ERROR: Entity in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
   allocate(ed5)
-  !ERROR: name in ALLOCATE statement must be a variable name
+  !ERROR: Name in ALLOCATE statement must be a variable name
   allocate(e6)
-  !ERROR: name in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  !ERROR: Entity in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
   allocate(ed7)
-  !ERROR: component in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  !ERROR: Entity in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
   allocate(ed7%nok(2))
-  !ERROR: name in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  !ERROR: Entity in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
   allocate(ed8)
-  !ERROR: name in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  !ERROR: Entity in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
   allocate(ed8)
-  !ERROR: component in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  !ERROR: Entity in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
   allocate(edc9%nok)
-  !ERROR: name in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
+  !ERROR: Entity in ALLOCATE statement must have the ALLOCATABLE or POINTER attribute
   allocate(edc10)
 
   ! No errors expected below:
@@ -71,8 +71,8 @@ subroutine C932(ed1, ed5, ed7, edc9, edc10, okad1, okpd1, okacd5)
   allocate(okp3, oka3)
   allocate(okac4[2:4,4:*])
   allocate(okacd5(1:2,3:4)[5:*])
-  allocate(ed7%ok)
-  allocate(e8%ok(7))
-  allocate(edc9%ok)
-  allocate(edc10%ok(4))
+  allocate(ed7%ok(7))
+  allocate(e8%ok)
+  allocate(edc9%ok(4))
+  allocate(edc10%ok)
 end subroutine

--- a/test/semantics/allocate06.f90
+++ b/test/semantics/allocate06.f90
@@ -58,7 +58,7 @@ subroutine C935(l, ac1, ac2, ac3, dc1, dc2, ec1, ec2, aa, ab, ea, eb, da, db, wh
   allocate(character(len=*):: ac1, ac3(3))
   allocate(character*(*):: ac2(5))
   allocate(B(*, 5):: aa, ab(2)) !OK but segfault GCC
-  allocate(B(*, *):: ab2)
+  allocate(B(*, *):: ab2(2))
   allocate(C(la=*, lb=10, lc1=*, lc2=5, lc3=*):: something(5))
   allocate(C(la=*, lb=10, lc1=2, lc2=5, lc3=3):: aa)
   allocate(character(5):: whatever)
@@ -86,7 +86,7 @@ subroutine C935(l, ac1, ac2, ac3, dc1, dc2, ec1, ec2, aa, ab, ea, eb, da, db, wh
 
   ! Must not be *
   !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
-  allocate(character(len=*):: ac1, dc1, ac3)
+  allocate(character(len=*):: ac1, dc1, ac3(2))
   !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE
   allocate(character*(*):: dc2(5))
   !ERROR: Type parameters in type-spec must be assumed if and only if they are assumed for allocatable object in ALLOCATE

--- a/test/semantics/allocate09.f90
+++ b/test/semantics/allocate09.f90
@@ -1,0 +1,136 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check for semantic errors in ALLOCATE statements
+
+subroutine C946(param_ca_4_assumed, param_ta_4_assumed, param_ca_4_deferred)
+! If source-expr appears, the kind type parameters of each allocate-object shall
+! have the same values as the corresponding type parameters of source-expr.
+
+  real(kind=4), allocatable :: x1, x2(:)
+
+  type WithParam(k1, l1)
+    integer, kind :: k1=1
+    integer, len :: l1=2
+    real x
+  end type
+
+  type, extends(WithParam) :: WithParamExtent(k2, l2)
+    integer, kind :: k2
+    integer, len :: l2
+  end type
+
+  type, extends(WithParamExtent) :: WithParamExtent2(k3, l3)
+    integer, kind :: k3 = 8
+    integer, len :: l3
+  end type
+
+  real(kind=4) srcx, srcx_array(10)
+  real(kind=8) srcx8, srcx8_array(10)
+  class(WithParam(4, 2)) src_a_4_2
+  type(WithParam(8, 2)) src_a_8_2
+  class(WithParam(4, *)) src_a_4_star
+  class(WithParam(8, *)) src_a_8_star
+  type(WithParamExtent(4, 2, 8, 3)) src_b_4_2_8_3
+  class(WithParamExtent(4, *, 8, 3)) src_b_4_star_8_3
+  type(WithParamExtent(8, 2, 8, 3)) src_b_8_2_8_3
+  class(WithParamExtent(8, *, 8, 3)) src_b_8_star_8_3
+  type(WithParamExtent2(k1=4, l1=5, k2=5, l2=6, l3=8 )) src_c_4_5_5_6_8_8
+  class(WithParamExtent2(k1=4, l1=2, k2=5, l2=6, k3=5, l3=8)) src_c_4_2_5_6_5_8
+  class(WithParamExtent2(k2=5, l2=6, k3=5, l3=8)) src_c_1_2_5_6_5_8
+  type(WithParamExtent2(k1=5, l1=5, k2=5, l2=6, l3=8 )) src_c_5_5_5_6_8_8
+  type(WithParamExtent2(k1=5, l1=2, k2=5, l2=6, k3=5, l3=8)) src_c_5_2_5_6_5_8
+
+
+  type(WithParam(4, 2)), allocatable :: param_ta_4_2
+  class(WithParam(4, 2)), pointer :: param_ca_4_2
+
+  type(WithParam(4, *)), pointer :: param_ta_4_assumed
+  class(WithParam(4, *)), allocatable :: param_ca_4_assumed
+
+  type(WithParam(4, :)), allocatable :: param_ta_4_deferred
+  class(WithParam(4, :)), pointer :: param_ca_4_deferred
+  class(WithParam), allocatable :: param_defaulted
+
+  type(WithParamExtent2(k1=4, l1=:, k2=5, l2=:, l3=8 )), pointer :: extended2
+
+  class(*), pointer :: whatever
+
+  ! Nominal test cases
+  allocate(x1, x2(10), source=srcx)
+  allocate(x2(10), source=srcx_array)
+  allocate(param_ta_4_2, param_ca_4_2, mold=src_a_4_2)
+  allocate(param_ca_4_2, source=src_b_4_2_8_3)
+  allocate(param_ta_4_2, param_ca_4_2, mold=src_a_4_star) ! no C935 equivalent for source-expr
+  allocate(param_ca_4_2, source=src_b_4_star_8_3) ! no C935 equivalent for source-expr
+  allocate(param_ta_4_assumed, param_ca_4_assumed, source=src_a_4_star)
+  allocate(param_ca_4_assumed, mold=src_b_4_star_8_3)
+  allocate(param_ta_4_assumed, param_ca_4_assumed, source=src_a_4_2) ! no C935 equivalent for source-expr
+  allocate(param_ca_4_assumed, mold=src_b_4_2_8_3) ! no C935 equivalent for source-expr
+  allocate(param_ta_4_deferred, param_ca_4_deferred, source =src_a_4_2)
+  allocate(param_ca_4_deferred, mold=src_b_4_star_8_3)
+
+  allocate(extended2, source=src_c_4_5_5_6_8_8)
+  allocate(param_ca_4_2, mold= src_c_4_2_5_6_5_8)
+  allocate(param_defaulted, mold=WithParam(5))
+  allocate(param_defaulted, source=WithParam(k1=1)(x=5))
+  allocate(param_defaulted, mold=src_c_1_2_5_6_5_8)
+  allocate(whatever, source=src_c_1_2_5_6_5_8)
+
+
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(x1, source=cos(0._8))
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(x2(10), source=srcx8)
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(x2(10), mold=srcx8_array)
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(param_ta_4_2, source=src_a_8_2)
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(param_ca_4_2, mold=src_a_8_2)
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(param_ta_4_2, source=src_a_8_star)
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(param_ca_4_2, source=src_b_8_2_8_3)
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(param_ca_4_2, mold=src_b_8_star_8_3)
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(param_ta_4_assumed, source=src_a_8_star)
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(param_ta_4_assumed, mold=src_a_8_2)
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(param_ca_4_assumed, mold=src_a_8_star)
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(param_ca_4_assumed, source=src_b_8_2_8_3)
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(param_ta_4_deferred, mold=src_a_8_2)
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(param_ca_4_deferred, source=src_a_8_star)
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(param_ca_4_deferred, mold=src_b_8_2_8_3)
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(extended2, source=src_c_5_5_5_6_8_8)
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(param_ca_4_2, mold=src_c_5_2_5_6_5_8)
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(extended2, source=WithParamExtent2(k1=4, l1=5, k2=5, l2=6, k3=5, l3=8)(x=5))
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(param_ca_4_2, mold=param_defaulted)
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(param_defaulted, source=param_ca_4_2)
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(param_defaulted, mold=WithParam(k1=2)(x=5))
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(param_defaulted, source=src_c_5_2_5_6_5_8)
+end subroutine

--- a/test/semantics/allocate10.f90
+++ b/test/semantics/allocate10.f90
@@ -1,0 +1,171 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check for semantic errors in ALLOCATE statements
+
+!TODO: mixing expr and source-expr?
+!TODO: using subcomponent in source expressions
+
+subroutine C939_C942a_C945b(xsrc1a, xsrc1c, xsrc0, xsrc2a, xsrc2c, pos)
+! C939: If an allocate-object is an array, either allocate-shape-spec-list shall
+! appear in its allocation, or source-expr shall appear in the ALLOCATE
+! statement and have the same rank as the allocate-object.
+  type A
+    real, pointer :: x(:)
+  end type
+  real, allocatable :: x0
+  real, allocatable :: x1(:)
+  real, pointer :: x2(:, :, :)
+  type(A) a1
+  type(A), allocatable :: a2(:, :)
+
+  real xsrc0
+  real xsrc1a(*)
+  real xsrc1b(2:7)
+  real, pointer :: xsrc1c(:)
+  real xsrc2a(4:8, 12, *)
+  real xsrc2b(2:7, 5, 9)
+  real, pointer :: xsrc2c(:, :, :)
+  integer pos
+
+  allocate(x1(5))
+  allocate(x1(2:7))
+  allocate(x1, SOURCE=xsrc1a(2:7))
+  allocate(x1, MOLD=xsrc1b)
+  allocate(x1, SOURCE=xsrc1c)
+
+  allocate(x2(2,3,4))
+  allocate(x2(2:7,3:8,4:9))
+  allocate(x2, SOURCE=xsrc2a(4:8, 1:12, 2:5))
+  allocate(x2, MOLD=cos(xsrc2b))
+  allocate(x2, SOURCE=xsrc2c)
+
+  allocate(x1(5), x2(2,3,4), a1%x(5), a2(1,2)%x(4))
+  allocate(x1, a1%x, a2(1,2)%x, SOURCE=xsrc1a(2:7))
+  allocate(x1, a1%x, a2(1,2)%x, MOLD=xsrc1b)
+  allocate(x1, a1%x, a2(1,2)%x, SOURCE=xsrc1c)
+
+  allocate(x0, x1(5), x2(2,3,4), a1%x(5), SOURCE=xsrc0)
+
+  ! There are NO requirements that mold expression rank match the
+  ! allocated-objects when allocate-shape-spec-lists are given.
+  ! If it is not needed, the shape of MOLD should be simply ignored.
+  allocate(x0, x1(5), x2(2,3,4), a1%x(5), MOLD=xsrc0)
+  allocate(x0, x1(5), x2(2,3,4), a1%x(5), MOLD=xsrc1b)
+  allocate(x0, x1(5), x2(2,3,4), a1%x(5), MOLD=xsrc2b)
+
+  !ERROR: Arrays in ALLOCATE must have a shape specification or an expression of the same rank must appear in SOURCE or MOLD
+  allocate(x1)
+  !ERROR: Arrays in ALLOCATE must have a shape specification or an expression of the same rank must appear in SOURCE or MOLD
+  allocate(x1, SOURCE=xsrc0)
+  !ERROR: Arrays in ALLOCATE must have a shape specification or an expression of the same rank must appear in SOURCE or MOLD
+  allocate(x1, MOLD=xsrc2c)
+
+  !ERROR: Arrays in ALLOCATE must have a shape specification or an expression of the same rank must appear in SOURCE or MOLD
+  allocate(x2, SOURCE=xsrc1a(2:7))
+  !ERROR: Arrays in ALLOCATE must have a shape specification or an expression of the same rank must appear in SOURCE or MOLD
+  allocate(x2, MOLD=xsrc1b)
+  !ERROR: Arrays in ALLOCATE must have a shape specification or an expression of the same rank must appear in SOURCE or MOLD
+  allocate(x2, SOURCE=xsrc1c)
+
+  !ERROR: Arrays in ALLOCATE must have a shape specification or an expression of the same rank must appear in SOURCE or MOLD
+  allocate(a1%x)
+  !ERROR: Arrays in ALLOCATE must have a shape specification or an expression of the same rank must appear in SOURCE or MOLD
+  allocate(a2(5,3)%x)
+  !ERROR: Arrays in ALLOCATE must have a shape specification or an expression of the same rank must appear in SOURCE or MOLD
+  allocate(x1(5), x2(2,3,4), a1%x, a2(1,2)%x(4))
+  !ERROR: Arrays in ALLOCATE must have a shape specification or an expression of the same rank must appear in SOURCE or MOLD
+  allocate(x2, a2(1,2)%x, SOURCE=xsrc2a(4:8, 1:12, 2:5))
+  !ERROR: Arrays in ALLOCATE must have a shape specification or an expression of the same rank must appear in SOURCE or MOLD
+  allocate(a1%x, MOLD=xsrc0)
+
+ !C942a: The number of allocate-shape-specs in an allocate-shape-spec-list shall
+ !be the same as the rank of the allocate-object. [...] (co-array stuffs).
+
+ !ERROR: The number of shape specifications, when they appear, must match the rank of allocatable object
+ allocate(x1(5, 5))
+ !ERROR: The number of shape specifications, when they appear, must match the rank of allocatable object
+ allocate(x1(2:3, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 1, 2, 1, 2))
+ !ERROR: The number of shape specifications, when they appear, must match the rank of allocatable object
+ allocate(x2(pos))
+ !ERROR: The number of shape specifications, when they appear, must match the rank of allocatable object
+ allocate(x2(2, 3, pos+1, 5))
+ !ERROR: The number of shape specifications, when they appear, must match the rank of allocatable object
+ allocate(x1(5), x2(2,4), a1%x(5), a2(1,2)%x(4))
+
+ !ERROR: The number of shape specifications, when they appear, must match the rank of allocatable object
+ allocate(x1(2), a1%x(2,5), a2(1,2)%x(2))
+
+ ! Test the check is not influenced by SOURCE
+ !ERROR: The number of shape specifications, when they appear, must match the rank of allocatable object
+ allocate(a1%x(5, 4, 3), SOURCE=xsrc2a(1:5, 1:4, 1:3))
+ !ERROR: The number of shape specifications, when they appear, must match the rank of allocatable object
+ allocate(x2(5), MOLD=xsrc1a(1:5))
+ !ERROR: The number of shape specifications, when they appear, must match the rank of allocatable object
+ allocate(a1%x(5, 4, 3), MOLD=xsrc1b)
+ !ERROR: The number of shape specifications, when they appear, must match the rank of allocatable object
+ allocate(x2(5), SOURCE=xsrc2b)
+
+ ! C945b: If SOURCE= appears, source-expr shall be a scalar or have the same
+ ! rank as each allocate-object.
+ !ERROR: If SOURCE appears, the related expression must be scalar or have the same rank as each allocatable object in ALLOCATE
+ allocate(x0, SOURCE=xsrc1b)
+ !ERROR: If SOURCE appears, the related expression must be scalar or have the same rank as each allocatable object in ALLOCATE
+ allocate(x2(2, 5, 7), SOURCE=xsrc1a(2:7))
+ !ERROR: If SOURCE appears, the related expression must be scalar or have the same rank as each allocatable object in ALLOCATE
+ allocate(x2(2, 5, 7), SOURCE=xsrc1c)
+
+ !ERROR: If SOURCE appears, the related expression must be scalar or have the same rank as each allocatable object in ALLOCATE
+ allocate(x1(5), SOURCE=xsrc2a(4:8, 1:12, 2:5))
+ !ERROR: If SOURCE appears, the related expression must be scalar or have the same rank as each allocatable object in ALLOCATE
+ allocate(x1(3), SOURCE=cos(xsrc2b))
+ !ERROR: If SOURCE appears, the related expression must be scalar or have the same rank as each allocatable object in ALLOCATE
+ allocate(x1(100), SOURCE=xsrc2c)
+
+ !ERROR: If SOURCE appears, the related expression must be scalar or have the same rank as each allocatable object in ALLOCATE
+ allocate(a1%x(10), x2(20, 30, 40), a2(1,2)%x(50), SOURCE=xsrc1c)
+ !ERROR: If SOURCE appears, the related expression must be scalar or have the same rank as each allocatable object in ALLOCATE
+ allocate(a1%x(25), SOURCE=xsrc2b)
+
+end subroutine
+
+subroutine C940(a1, pos)
+! If allocate-object is scalar, allocate-shape-spec-list shall not appear.
+  type A
+    integer(kind=8), allocatable :: i
+  end type
+
+  type B(k, l1, l2, l3)
+    integer, kind :: k
+    integer, len :: l1, l2, l3
+    real(kind=k) x(-1:l1, 0:l2, 1:l3)
+  end type
+
+  integer pos
+  class(A), allocatable :: a1(:)
+  real, pointer :: x
+  type(B(8,4,5,6)), allocatable :: b1
+
+  ! Nominal
+  allocate(x)
+  allocate(a1(pos)%i)
+  allocate(b1)
+
+  !ERROR: Shape specifications must not appear when allocatable object is scalar
+  allocate(x(pos))
+  !ERROR: Shape specifications must not appear when allocatable object is scalar
+  allocate(a1(pos)%i(5:2))
+  !ERROR: Shape specifications must not appear when allocatable object is scalar
+  allocate(b1(1))
+end subroutine

--- a/test/semantics/allocate11.f90
+++ b/test/semantics/allocate11.f90
@@ -16,7 +16,7 @@
 
 ! TODO: Function Pointer in allocate and derived types!
 
-! Rules I should know when working wit coarrays and derived type:
+! Rules I should know when working with coarrays and derived type:
 
 ! C736: If EXTENDS appears and the type being defined has a coarray ultimate
 ! component, its parent type shall have a coarray ultimate component.
@@ -67,12 +67,13 @@ subroutine C937(var)
 
   class(*), allocatable :: var
   ! unlimited polymorphic is the ONLY way to get an allocatable/pointer 'var' that can be
-  ! allocated with a type-spec T that has coarray ultimate component.
-  ! Rational:
+  ! allocated with a type-spec T that has coarray ultimate component without
+  ! violating other rules than C937.
+  ! Rationale:
   !   C934 => var must be type compatible with T.
   !        => var type is T, a type P extended by T, or unlimited polymorphic
   !   C825 => var cannot be of type T.
-  !   C736 => all parent type P of T must have a coarray unlimited component
+  !   C736 => all parent types P of T must have a coarray ultimate component
   !        => var cannot be of type P (C825)
   !        => if var can be defined, it can only be unlimited polymorphic
 

--- a/test/semantics/allocate11.f90
+++ b/test/semantics/allocate11.f90
@@ -1,0 +1,185 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check for semantic errors in ALLOCATE statements
+
+! TODO: Function Pointer in allocate and derived types!
+
+! Rules I should know when working wit coarrays and derived type:
+
+! C736: If EXTENDS appears and the type being defined has a coarray ultimate
+! component, its parent type shall have a coarray ultimate component.
+
+! C746: (R737) If a coarray-spec appears, it shall be a deferred-coshape-spec-list
+! and the component shall have the ALLOCATABLE attribute.
+
+! C747: If a coarray-spec appears, the component shall not be of type C_PTR or
+! C_FUNPTR from the intrinsic module ISO_C_BINDING (18.2), or of type TEAM_TYPE from the
+! intrinsic module ISO_FORTRAN_ENV (16.10.2).
+
+! C748: A data component whose type has a coarray ultimate component shall be a
+! nonpointer nonallocatable scalar and shall not be a coarray.
+
+! 7.5.4.3 Coarray components
+! 7.5.6 Final subroutines: C786
+
+
+! C825 An entity whose type has a coarray ultimate component shall be a
+! nonpointer nonallocatable scalar, shall not be a coarray, and shall not be a function result.
+
+! C826 A coarray or an object with a coarray ultimate component shall be an
+! associate name, a dummy argument, or have the ALLOCATABLE or SAVE attribute.
+
+subroutine C937(var)
+! Type-spec shall not specify a type that has a coarray ultimate component.
+
+
+  type A
+    real, allocatable :: x[:]
+  end type
+
+  type B
+    type(A) y
+    type(B), pointer :: forward
+    real :: u
+  end type
+
+  type C
+    type(B) z
+  end type
+
+  type D
+    type(A), pointer :: potential
+  end type
+
+
+
+  class(*), allocatable :: var
+  ! unlimited polymorphic is the ONLY way to get an allocatable/pointer 'var' that can be
+  ! allocated with a type-spec T that has coarray ultimate component.
+  ! Rational:
+  !   C934 => var must be type compatible with T.
+  !        => var type is T, a type P extended by T, or unlimited polymorphic
+  !   C825 => var cannot be of type T.
+  !   C736 => all parent type P of T must have a coarray unlimited component
+  !        => var cannot be of type P (C825)
+  !        => if var can be defined, it can only be unlimited polymorphic
+
+  ! Also, as per C826 or C852, var can only be an allocatable, not a pointer
+
+  ! OK, x is not an ultimate component
+  allocate(D:: var)
+
+  !ERROR: Type-spec in ALLOCATE must not specify a type with a coarray ultimate component
+  allocate(A:: var)
+  !ERROR: Type-spec in ALLOCATE must not specify a type with a coarray ultimate component
+  allocate(B:: var)
+  !ERROR: Type-spec in ALLOCATE must not specify a type with a coarray ultimate component
+  allocate(C:: var)
+end subroutine
+
+module iso_fortran_env
+  type :: team_type
+  end type
+end module
+
+module iso_c_binding
+  type :: c_ptr
+    integer(kind=8) ptr
+  end type
+  type :: c_funptr
+    integer(kind=8) ptr
+  end type
+end module
+
+!TODO: type extending team_type !? subcomponents !?
+
+subroutine C938_C947(var2, ptr, ptr2, fptr, my_team, srca)
+! If an allocate-object is a coarray, type-spec shall not specify type C_PTR or
+! C_FUNPTR from the intrinsic module ISO_C_BINDING, or type TEAM_TYPE from the intrinsic module
+! ISO_FORTRAN_ENV.
+  use ISO_FORTRAN_ENV
+  use ISO_C_BINDING
+
+  type A(k, l)
+    integer, kind :: k
+    integer, len :: l
+    real(kind=k) x(l,l)
+  end type
+
+! Again, I do not see any other way to violate this rule and not others without
+! having var being an unlimited polymorphic.
+! Suppose var of type P and T, the type in type-spec
+! Per C934, P must be compatible with T. P cannot be a forbidden type per C824.
+! Per C728 and 7.5.7.1, P cannot extend a c_ptr or _c_funptr. hence, P has to be
+! unlimited polymorphic or a type that extends TEAM_TYPE.
+  class(*), allocatable :: var[:], var2(:)[:]
+  class(*), allocatable :: varok, varok2(:)
+
+  Type(C_PTR) :: ptr, ptr2(2:10)
+  Type(C_FUNPTR) fptr
+  Type(TEAM_TYPE) my_team
+  Type(A(4, 10)) :: srca
+
+  ! Valid constructs
+  allocate(real:: var[5:*])
+  allocate(A(4, 10):: var[5:*])
+  allocate(TEAM_TYPE:: varok, varok2(2))
+  allocate(C_PTR:: varok, varok2(2))
+  allocate(C_FUNPTR:: varok, varok2(2))
+
+  !ERROR: Type-Spec in ALLOCATE must not be TEAM_TYPE from ISO_FORTRAN_ENV when an allocatable object is a coarray
+  allocate(TEAM_TYPE:: var[5:*])
+  !ERROR: Type-Spec in ALLOCATE must not be C_PTR or C_FUNPTR from ISO_C_BINDING when an allocatable object is a coarray
+  allocate(C_PTR:: varok, var[5:*])
+  !ERROR: Type-Spec in ALLOCATE must not be C_PTR or C_FUNPTR from ISO_C_BINDING when an allocatable object is a coarray
+  allocate(C_FUNPTR:: var[5:*])
+  !ERROR: Type-Spec in ALLOCATE must not be TEAM_TYPE from ISO_FORTRAN_ENV when an allocatable object is a coarray
+  allocate(TEAM_TYPE:: var2(2)[5:*])
+  !ERROR: Type-Spec in ALLOCATE must not be C_PTR or C_FUNPTR from ISO_C_BINDING when an allocatable object is a coarray
+  allocate(C_PTR:: var2(2)[5:*])
+  !ERROR: Type-Spec in ALLOCATE must not be C_PTR or C_FUNPTR from ISO_C_BINDING when an allocatable object is a coarray
+  allocate(C_FUNPTR:: varok2(2), var2(2)[5:*])
+
+
+! C947: The declared type of source-expr shall not be C_PTR or C_FUNPTR from the
+! intrinsic module ISO_C_BINDING, or TEAM_TYPE from the intrinsic module
+! ISO_FORTRAN_ENV, if an allocateobject is a coarray.
+!
+!  ! Valid constructs
+  allocate(var[5:*], SOURCE=cos(0.5_4))
+  allocate(var[5:*], MOLD=srca)
+  allocate(varok, varok2(2), SOURCE=ptr)
+  allocate(varok2, MOLD=ptr2)
+  allocate(varok, varok2(2), SOURCE=my_team)
+  allocate(varok, varok2(2), MOLD=fptr)
+
+  !ERROR: SOURCE or MOLD expression type must not be TEAM_TYPE from ISO_FORTRAN_ENV when an allocatable object is a coarray
+  allocate(var[5:*], SOURCE=my_team)
+  !ERROR: SOURCE or MOLD expression type must not be C_PTR or C_FUNPTR from ISO_C_BINDING when an allocatable object is a coarray
+  allocate(var[5:*], SOURCE=ptr)
+  !ERROR: SOURCE or MOLD expression type must not be C_PTR or C_FUNPTR from ISO_C_BINDING when an allocatable object is a coarray
+  allocate(varok, var[5:*], MOLD=ptr(1))
+  !ERROR: SOURCE or MOLD expression type must not be C_PTR or C_FUNPTR from ISO_C_BINDING when an allocatable object is a coarray
+  allocate(var[5:*], MOLD=fptr)
+  !ERROR: SOURCE or MOLD expression type must not be TEAM_TYPE from ISO_FORTRAN_ENV when an allocatable object is a coarray
+  allocate(var2(2)[5:*], MOLD=my_team)
+  !ERROR: SOURCE or MOLD expression type must not be C_PTR or C_FUNPTR from ISO_C_BINDING when an allocatable object is a coarray
+  allocate(var2(2)[5:*], MOLD=ptr)
+  !ERROR: SOURCE or MOLD expression type must not be C_PTR or C_FUNPTR from ISO_C_BINDING when an allocatable object is a coarray
+  allocate(var2(2)[5:*], SOURCE=ptr2)
+  !ERROR: SOURCE or MOLD expression type must not be C_PTR or C_FUNPTR from ISO_C_BINDING when an allocatable object is a coarray
+  allocate(varok2(2), var2(2)[5:*], SOURCE=fptr)
+
+end subroutine

--- a/test/semantics/allocate12.f90
+++ b/test/semantics/allocate12.f90
@@ -1,0 +1,131 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check for semantic errors in ALLOCATE statements
+
+subroutine C941_C942b_C950(xsrc, x1, a2, b2, cx1, ca2, cb1, cb2, c1)
+! C941: An allocate-coarray-spec shall appear if and only if the allocate-object
+! is a coarray.
+  type type0
+    real, allocatable :: array(:)
+  end type
+  type type1
+    class(type0), pointer :: t0
+  end type
+
+  type type2
+    type(type1) :: t1(:)
+  end type
+
+  type A
+    real x(10)
+  end type
+
+  type B
+    real, allocatable :: x(:)
+  end type
+
+  type C
+    class(type2), allocatable :: ct2(:, :)[:, :, :]
+    class(A), allocatable :: cx(:, :)[:, :, :]
+    class(A), allocatable :: x(:, :)
+  end type
+
+  real :: xsrc(10)
+  real, allocatable :: x1, x2(:)
+  class(A), pointer :: a1, a2(:)
+
+  real, allocatable :: cx1[:], cx2(:)[:, :]
+  class(A), allocatable :: ca1[:, :], ca2(:)[:]
+
+  type(B) :: b1, b2(*)
+  type(B) :: cb1[5:*], cb2(*)[2, -1:*]
+
+  type(C) :: c1
+
+  class(*), allocatable :: var(:), cvar(:)[:]
+
+  ! Valid constructs
+  allocate(x1, x2(10), cx1[*], cx2(10)[2, -1:*])
+  allocate(a1, a2(10), ca1[2, -1:*], ca2(10)[*])
+  allocate(b1%x, b2(1)%x, cb1%x, cb2(1)%x, SOURCE=xsrc)
+  allocate(c1%x(-1:10, 1:5), c1%cx(-1:10, 1:5)[-1:5, 1:2, 2:*])
+  allocate(A:: var(5), cvar(10)[*])
+
+
+  !ERROR: Coarray specification must not appear in ALLOCATE when allocatable object is not a coarray
+  allocate(x1[*])
+  !ERROR: Coarray specification must not appear in ALLOCATE when allocatable object is not a coarray
+  allocate(x2(10)[*])
+  !ERROR: Coarray specification must appear in ALLOCATE when allocatable object is a coarray
+  allocate(cx1)
+  !ERROR: Coarray specification must appear in ALLOCATE when allocatable object is a coarray
+  allocate(cx2(10))
+
+  !ERROR: Coarray specification must not appear in ALLOCATE when allocatable object is not a coarray
+  allocate(cx1[*], a1[*])
+  !ERROR: Coarray specification must not appear in ALLOCATE when allocatable object is not a coarray
+  allocate(cx1[*], a2(10)[*])
+  !ERROR: Coarray specification must appear in ALLOCATE when allocatable object is a coarray
+  allocate(x1, ca1)
+  !ERROR: Coarray specification must appear in ALLOCATE when allocatable object is a coarray
+  allocate(ca1[2, -1:*], ca2(10))
+
+  !ERROR: Coarray specification must not appear in ALLOCATE when allocatable object is not a coarray
+  allocate(b1%x[5:*] , SOURCE=xsrc)
+  !ERROR: Coarray specification must not appear in ALLOCATE when allocatable object is not a coarray
+  allocate(b2(1)%x[2, -1:*], SOURCE=xsrc)
+  !ERROR: Coarray specification must not appear in ALLOCATE when allocatable object is not a coarray
+  allocate(cb1%x[5:*] , SOURCE=xsrc)
+  !ERROR: Coarray specification must not appear in ALLOCATE when allocatable object is not a coarray
+  allocate(cb2(1)%x[2, -1:*], SOURCE=xsrc)
+
+  !ERROR: Coarray specification must not appear in ALLOCATE when allocatable object is not a coarray
+  allocate(c1%x(-1:10, 1:5)[-1:5, 1:2, 2:*])
+  !ERROR: Coarray specification must appear in ALLOCATE when allocatable object is a coarray
+  allocate(c1%cx(-1:10, 1:5))
+
+  !ERROR: Coarray specification must not appear in ALLOCATE when allocatable object is not a coarray
+  allocate(A:: var(5)[*], cvar(10)[*])
+  !ERROR: Coarray specification must appear in ALLOCATE when allocatable object is a coarray
+  allocate(A:: var(5), cvar(10))
+
+! C942b: [... (shape related stuff not tested here) ...]. The number of
+! allocate-coshape-specs in an allocate-coarray-spec shall be one less
+! than the corank of the allocate-object.
+
+  ! Valid constructs already tested above
+
+  !ERROR: Corank of coarray specification in ALLOCATE must match corank of alloctable coarray
+  allocate(cx1[2,-1:*], cx2(10)[2, -1:*])
+  !ERROR: Corank of coarray specification in ALLOCATE must match corank of alloctable coarray
+  allocate(ca1[*], ca2(10)[*])
+  !ERROR: Corank of coarray specification in ALLOCATE must match corank of alloctable coarray
+  allocate(c1%cx(-1:10, 1:5)[-1:5, 1:*])
+  !ERROR: Corank of coarray specification in ALLOCATE must match corank of alloctable coarray
+  allocate(A:: cvar(10)[2,2,*])
+
+! C950: An allocate-object shall not be a coindexed object.
+
+  ! Valid construct
+  allocate(c1%ct2(2,5)%t1(2)%t0%array(10))
+
+  !ERROR: Allocatable object must not be coindexed in ALLOCATE
+  allocate(b1%x, b2(1)%x, cb1[2]%x, SOURCE=xsrc)
+  !ERROR: Allocatable object must not be coindexed in ALLOCATE
+  allocate(b1%x, b2(1)%x, cb2(1)[2,-1]%x, MOLD=xsrc)
+  !ERROR: Allocatable object must not be coindexed in ALLOCATE
+  allocate(c1%ct2(2,5)[1,1,1]%t1(2)%t0%array(10))
+
+end subroutine

--- a/test/semantics/allocate13.f90
+++ b/test/semantics/allocate13.f90
@@ -1,0 +1,193 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check for semantic errors in ALLOCATE statements
+
+module iso_fortran_env
+  type event_type
+  end type
+  type lock_type
+  end type
+end module
+
+module not_iso_fortran_env
+  type event_type
+  end type
+  type lock_type
+  end type
+end module
+
+subroutine C948_a()
+! If SOURCE= appears, the declared type of source-expr shall not be EVENT_TYPE
+! or LOCK_-TYPE from the intrinsic module ISO_FORTRAN_ENV, or have a potential subobject
+! component of type EVENT_TYPE or LOCK_TYPE.
+  use iso_fortran_env
+
+  type oktype1
+    type(event_type), pointer :: event
+    type(lock_type), pointer :: lock
+  end type
+
+  type oktype2
+    class(oktype1), allocatable :: t1a
+    type(oktype1) :: t1b
+  end type
+
+  type, extends(oktype1) :: oktype3
+    real, allocatable :: x(:)
+  end type
+
+  type noktype1
+    type(event_type), allocatable :: event
+  end type
+
+  type noktype2
+    type(event_type) :: event
+  end type
+
+  type noktype3
+    type(lock_type), allocatable :: lock
+  end type
+
+  type noktype4
+    type(lock_type) :: lock
+  end type
+
+  type, extends(noktype4) :: noktype5
+    real, allocatable :: x(:)
+  end type
+
+  type, extends(event_type) :: noktype6
+    real, allocatable :: x(:)
+  end type
+
+  type recursiveType
+    real x(10)
+    type(recursiveType), allocatable :: next
+  end type
+
+  type recursiveTypeNok
+    real x(10)
+    type(recursiveType), allocatable :: next
+    type(noktype5), allocatable :: trouble
+  end type
+
+  ! variable with event_type or lock_type have to be coarrays
+  ! see C1604 and 1608.
+  type(oktype1), allocatable :: okt1[:]
+  class(oktype2), allocatable :: okt2(:)[:]
+  type(oktype3), allocatable :: okt3[:]
+  type(noktype1), allocatable :: nokt1[:]
+  type(noktype2), allocatable :: nokt2[:]
+  class(noktype3), allocatable :: nokt3[:]
+  type(noktype4), allocatable :: nokt4[:]
+  type(noktype5), allocatable :: nokt5[:]
+  class(noktype6), allocatable :: nokt6(:)[:]
+  type(event_type), allocatable :: event[:]
+  type(lock_type), allocatable :: lock(:)[:]
+  class(recursiveType), allocatable :: recok
+  type(recursiveTypeNok), allocatable :: recnok[:]
+  class(*), allocatable :: whatever[:]
+
+  type(oktype1), allocatable :: okt1src[:]
+  class(oktype2), allocatable :: okt2src(:)[:]
+  type(oktype3), allocatable :: okt3src[:]
+  class(noktype1), allocatable :: nokt1src[:]
+  type(noktype2), allocatable :: nokt2src[:]
+  type(noktype3), allocatable :: nokt3src[:]
+  class(noktype4), allocatable :: nokt4src[:]
+  type(noktype5), allocatable :: nokt5src[:]
+  class(noktype6), allocatable :: nokt6src(:)[:]
+  type(event_type), allocatable :: eventsrc[:]
+  type(lock_type), allocatable :: locksrc(:)[:]
+  type(recursiveType), allocatable :: recoksrc
+  class(recursiveTypeNok), allocatable :: recnoksrc[:]
+
+  ! Valid constructs
+  allocate(okt1[*], SOURCE=okt1src)
+  allocate(okt2[*], SOURCE=okt2src)
+  allocate(okt3[*], SOURCE=okt3src)
+  allocate(whatever[*], SOURCE=okt3src)
+  allocate(recok, SOURCE=recoksrc)
+
+  allocate(nokt1[*])
+  allocate(nokt2[*])
+  allocate(nokt3[*])
+  allocate(nokt4[*])
+  allocate(nokt5[*])
+  allocate(nokt6(10)[*])
+  allocate(lock(10)[*])
+  allocate(event[*])
+  allocate(recnok[*])
+
+  allocate(nokt1[*], MOLD=nokt1src)
+  allocate(nokt2[*], MOLD=nokt2src)
+  allocate(nokt3[*], MOLD=nokt3src)
+  allocate(nokt4[*], MOLD=nokt4src)
+  allocate(nokt5[*], MOLD=nokt5src)
+  allocate(nokt6[*], MOLD=nokt6src)
+  allocate(lock[*],  MOLD=locksrc)
+  allocate(event[*], MOLD=eventsrc)
+  allocate(recnok[*],MOLD=recnoksrc)
+  allocate(whatever[*],MOLD=nokt6src)
+
+  !ERROR: SOURCE expression type must not have potential subobject component of type EVENT_TYPE or LOCK_TYPE from ISO_FORTRAN_ENV
+  allocate(nokt1[*], SOURCE=nokt1src)
+  !ERROR: SOURCE expression type must not have potential subobject component of type EVENT_TYPE or LOCK_TYPE from ISO_FORTRAN_ENV
+  allocate(nokt2[*], SOURCE=nokt2src)
+  !ERROR: SOURCE expression type must not have potential subobject component of type EVENT_TYPE or LOCK_TYPE from ISO_FORTRAN_ENV
+  allocate(nokt3[*], SOURCE=nokt3src)
+  !ERROR: SOURCE expression type must not have potential subobject component of type EVENT_TYPE or LOCK_TYPE from ISO_FORTRAN_ENV
+  allocate(nokt4[*], SOURCE=nokt4src)
+  !ERROR: SOURCE expression type must not have potential subobject component of type EVENT_TYPE or LOCK_TYPE from ISO_FORTRAN_ENV
+  allocate(nokt5[*], SOURCE=nokt5src)
+  !ERROR: SOURCE expression type must not have potential subobject component of type EVENT_TYPE or LOCK_TYPE from ISO_FORTRAN_ENV
+  allocate(nokt6[*], SOURCE=nokt6src)
+  !ERROR: SOURCE expression type must not be EVENT_TYPE or LOCK_TYPE from ISO_FORTRAN_ENV
+  allocate(lock[*],  SOURCE=locksrc)
+  !ERROR: SOURCE expression type must not be EVENT_TYPE or LOCK_TYPE from ISO_FORTRAN_ENV
+  allocate(event[*], SOURCE=eventsrc)
+  !ERROR: SOURCE expression type must not have potential subobject component of type EVENT_TYPE or LOCK_TYPE from ISO_FORTRAN_ENV
+  allocate(recnok[*],SOURCE=recnoksrc)
+  !ERROR: SOURCE expression type must not have potential subobject component of type EVENT_TYPE or LOCK_TYPE from ISO_FORTRAN_ENV
+  allocate(whatever[*],SOURCE=nokt5src)
+end subroutine
+
+
+subroutine C948_b()
+  use not_iso_fortran_env !type restriction do not apply
+
+  type oktype1
+    type(event_type), allocatable :: event
+  end type
+
+  type oktype2
+    type(lock_type) :: lock
+  end type
+
+  type(oktype1), allocatable :: okt1[:]
+  class(oktype2), allocatable :: okt2[:]
+  type(event_type), allocatable :: team[:]
+  class(lock_type), allocatable :: lock[:]
+
+  type(oktype1), allocatable :: okt1src[:]
+  class(oktype2), allocatable :: okt2src[:]
+  class(event_type), allocatable :: teamsrc[:]
+  type(lock_type), allocatable :: locksrc[:]
+
+  allocate(okt1[*], SOURCE=okt1src)
+  allocate(okt2[*], SOURCE=okt2src)
+  allocate(team[*], SOURCE=teamsrc)
+  allocate(lock[*], SOURCE=locksrc)
+end subroutine


### PR DESCRIPTION
Implement semantic checks and related tests for constraints:
C937, C938, C939, C940, C941, C942, C945 (second part),
C946, C947, C948, C949 and C950.

