### PR TITLE
Structure constructor semantics, part 1 of 2

### DIFF
--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -73,13 +73,11 @@ std::optional<DynamicType> ExpressionBase<A>::GetType() const {
     return Result::GetType();
   } else {
     return std::visit(
-        [](const auto &x) -> std::optional<DynamicType> {
-          using Ty = std::decay_t<decltype(x)>;
-          if constexpr (!std::is_same_v<Ty, BOZLiteralConstant> &&
-              !std::is_same_v<Ty, NullPointer>) {
+        [&](const auto &x) -> std::optional<DynamicType> {
+          if constexpr (!common::HasMember<decltype(x), TypelessExpression>) {
             return x.GetType();
           }
-          return std::nullopt;  // typeless really means "no type"
+          return std::nullopt;
         },
         derived().u);
   }
@@ -88,8 +86,7 @@ std::optional<DynamicType> ExpressionBase<A>::GetType() const {
 template<typename A> int ExpressionBase<A>::Rank() const {
   return std::visit(
       [](const auto &x) {
-        if constexpr (std::is_same_v<std::decay_t<decltype(x)>,
-                          BOZLiteralConstant>) {
+        if constexpr (common::HasMember<decltype(x), TypelessExpression>) {
           return 0;
         } else {
           return x.Rank();

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -52,7 +52,7 @@ class FoldingContext;
 // Note that typeless (BOZ literal) values don't have a distinct type category.
 // These typeless arguments are represented in the tables as if they were
 // INTEGER with a special "typeless" kind code.  Arguments of intrinsic types
-// that can also be be typeless values are encoded with an "elementalOrBOZ"
+// that can also be typeless values are encoded with an "elementalOrBOZ"
 // rank pattern.
 // Assumed-type (TYPE(*)) dummy arguments can be forwarded along to some
 // intrinsic functions that accept AnyType + Rank::anyOrAssumedRank.
@@ -289,7 +289,8 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
     {"cmplx", {{"x", AnyComplex}, DefaultingKIND}, KINDComplex},
     {"cmplx",
         {{"x", SameIntOrReal, Rank::elementalOrBOZ},
-            {"y", SameIntOrReal, Rank::elementalOrBOZ}, DefaultingKIND},
+            {"y", SameIntOrReal, Rank::elementalOrBOZ, Optionality::optional},
+            DefaultingKIND},
         KINDComplex},
     {"command_argument_count", {}, DefaultInt, Rank::scalar},
     {"conjg", {{"z", SameComplex}}, SameComplex},
@@ -878,24 +879,35 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
           d.typePattern.kindCode == KindCode::any &&
           d.rank == Rank::anyOrAssumedRank) {
         continue;
+      } else {
+        messages.Say("Assumed type TYPE(*) dummy argument not allowed "
+                     "for '%s=' intrinsic argument"_err_en_US,
+            d.keyword);
+        return std::nullopt;
       }
-      messages.Say("Assumed type TYPE(*) dummy argument not allowed "
-                   "for '%s=' intrinsic argument"_err_en_US,
-          d.keyword);
-      return std::nullopt;
     }
     std::optional<DynamicType> type{arg->GetType()};
     if (!type.has_value()) {
       CHECK(arg->Rank() == 0);
-      if (d.typePattern.kindCode == KindCode::typeless ||
-          d.rank == Rank::elementalOrBOZ) {
-        continue;
+      const Expr<SomeType> *expr{arg->GetExpr()};
+      CHECK(expr != nullptr);
+      if (std::holds_alternative<BOZLiteralConstant>(expr->u)) {
+        if (d.typePattern.kindCode == KindCode::typeless ||
+            d.rank == Rank::elementalOrBOZ) {
+          continue;
+        } else {
+          messages.Say(
+              "Typeless (BOZ) not allowed for '%s=' argument"_err_en_US,
+              d.keyword);
+        }
+      } else {
+        // NULL(), pointer to subroutine, &c.
+        messages.Say("Typeless item not allowed for '%s=' argument"_err_en_US,
+            d.keyword);
       }
-      messages.Say(
-          "typeless (BOZ) not allowed for '%s=' argument"_err_en_US, d.keyword);
       return std::nullopt;
     } else if (!d.typePattern.categorySet.test(type->category)) {
-      messages.Say("actual argument for '%s=' has bad type '%s'"_err_en_US,
+      messages.Say("Actual argument for '%s=' has bad type '%s'"_err_en_US,
           d.keyword, type->AsFortran().data());
       return std::nullopt;  // argument has invalid type category
     }
@@ -1048,42 +1060,41 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
 
   // Calculate the characteristics of the function result, if any
   std::optional<DynamicType> resultType;
-  if (result.categorySet.empty()) {
-    if (!call.isSubroutineCall) {
-      return std::nullopt;
-    }
-    CHECK(result.kindCode == KindCode::none);
-  } else {
-    // Determine the result type.
+  if (auto category{result.categorySet.LeastElement()}) {
+    // The intrinsic is not a subroutine.
     if (call.isSubroutineCall) {
       return std::nullopt;
     }
-    resultType = DynamicType{result.categorySet.LeastElement().value(), 0};
     switch (result.kindCode) {
     case KindCode::defaultIntegerKind:
       CHECK(result.categorySet == IntType);
-      CHECK(resultType->category == TypeCategory::Integer);
-      resultType->kind = defaults.GetDefaultKind(TypeCategory::Integer);
+      CHECK(*category == TypeCategory::Integer);
+      resultType = DynamicType{TypeCategory::Integer,
+          defaults.GetDefaultKind(TypeCategory::Integer)};
       break;
     case KindCode::defaultRealKind:
-      CHECK(result.categorySet == CategorySet{resultType->category});
-      CHECK(FloatingType.test(resultType->category));
-      resultType->kind = defaults.GetDefaultKind(TypeCategory::Real);
+      CHECK(result.categorySet == CategorySet{*category});
+      CHECK(FloatingType.test(*category));
+      resultType =
+          DynamicType{*category, defaults.GetDefaultKind(TypeCategory::Real)};
       break;
     case KindCode::doublePrecision:
       CHECK(result.categorySet == RealType);
-      CHECK(resultType->category == TypeCategory::Real);
-      resultType->kind = defaults.doublePrecisionKind();
+      CHECK(*category == TypeCategory::Real);
+      resultType =
+          DynamicType{TypeCategory::Real, defaults.doublePrecisionKind()};
       break;
     case KindCode::defaultCharKind:
       CHECK(result.categorySet == CharType);
-      CHECK(resultType->category == TypeCategory::Character);
-      resultType->kind = defaults.GetDefaultKind(TypeCategory::Character);
+      CHECK(*category == TypeCategory::Character);
+      resultType = DynamicType{TypeCategory::Character,
+          defaults.GetDefaultKind(TypeCategory::Character)};
       break;
     case KindCode::defaultLogicalKind:
       CHECK(result.categorySet == LogicalType);
-      CHECK(resultType->category == TypeCategory::Logical);
-      resultType->kind = defaults.GetDefaultKind(TypeCategory::Logical);
+      CHECK(*category == TypeCategory::Logical);
+      resultType = DynamicType{TypeCategory::Logical,
+          defaults.GetDefaultKind(TypeCategory::Logical)};
       break;
     case KindCode::same:
       CHECK(sameArg != nullptr);
@@ -1091,19 +1102,19 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
         if (result.categorySet.test(aType->category)) {
           resultType = *aType;
         } else {
-          resultType->kind = aType->kind;
+          resultType = DynamicType{*category, aType->kind};
         }
       }
       break;
     case KindCode::effectiveKind:
       CHECK(kindDummyArg != nullptr);
-      CHECK(result.categorySet == CategorySet{resultType->category});
+      CHECK(result.categorySet == CategorySet{*category});
       if (kindArg != nullptr) {
         if (auto *expr{kindArg->GetExpr()}) {
           CHECK(expr->Rank() == 0);
           if (auto code{ToInt64(*expr)}) {
-            if (IsValidKindOfIntrinsicType(resultType->category, *code)) {
-              resultType->kind = *code;
+            if (IsValidKindOfIntrinsicType(*category, *code)) {
+              resultType = DynamicType{*category, static_cast<int>(*code)};
               break;
             }
           }
@@ -1117,12 +1128,13 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
         resultType = *sameArg->GetType();
       } else if (kindDummyArg->optionality ==
           Optionality::defaultsToSubscriptKind) {
-        CHECK(resultType->category == TypeCategory::Integer);
-        resultType->kind = defaults.subscriptIntegerKind();
+        CHECK(*category == TypeCategory::Integer);
+        resultType =
+            DynamicType{TypeCategory::Integer, defaults.subscriptIntegerKind()};
       } else {
         CHECK(kindDummyArg->optionality ==
             Optionality::defaultsToDefaultForResult);
-        resultType->kind = defaults.GetDefaultKind(resultType->category);
+        resultType = DynamicType{*category, defaults.GetDefaultKind(*category)};
       }
       break;
     case KindCode::likeMultiply:
@@ -1142,6 +1154,11 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
       break;
     default: CRASH_NO_CASE;
     }
+  } else {
+    if (!call.isSubroutineCall) {
+      return std::nullopt;
+    }
+    CHECK(result.kindCode == KindCode::none);
   }
 
   // At this point, the call is acceptable.
@@ -1181,11 +1198,6 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
   }
   CHECK(resultRank >= 0);
 
-  semantics::Attrs attrs;
-  if (elementalRank > 0) {
-    attrs.set(semantics::Attr::ELEMENTAL);
-  }
-
   // Rearrange the actual arguments into dummy argument order.
   ActualArguments rearranged(dummies);
   for (std::size_t j{0}; j < dummies; ++j) {
@@ -1194,9 +1206,57 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
     }
   }
 
-  return std::make_optional<SpecificCall>(
-      SpecificIntrinsic{name, std::move(resultType), resultRank, attrs},
-      std::move(rearranged));
+  // Characterize the specific intrinsic function.
+  characteristics::TypeAndShape typeAndShape{resultType.value(), resultRank};
+  characteristics::FunctionResult funcResult{std::move(typeAndShape)};
+  characteristics::DummyArguments dummyArgs;
+  std::optional<int> sameDummyArg;
+  for (std::size_t j{0}; j < dummies; ++j) {
+    const IntrinsicDummyArgument &d{dummy[std::min(j, dummyArgPatterns - 1)]};
+    if (const auto &arg{rearranged[j]}) {
+      const Expr<SomeType> *expr{arg->GetExpr()};
+      CHECK(expr != nullptr);
+      std::optional<characteristics::TypeAndShape> typeAndShape;
+      if (auto type{expr->GetType()}) {
+        if (auto shape{GetShape(context, *expr)}) {
+          typeAndShape.emplace(*type, std::move(*shape));
+        } else {
+          typeAndShape.emplace(*type);
+        }
+      } else {
+        typeAndShape.emplace(DynamicType::TypelessIntrinsicArgument());
+      }
+      dummyArgs.emplace_back(
+          characteristics::DummyDataObject{std::move(typeAndShape.value())});
+      if (d.typePattern.kindCode == KindCode::same &&
+          !sameDummyArg.has_value()) {
+        sameDummyArg = j;
+      }
+    } else {
+      // optional argument is absent
+      CHECK(d.optionality != Optionality::required);
+      if (d.typePattern.kindCode == KindCode::same) {
+        dummyArgs.emplace_back(dummyArgs[sameDummyArg.value()]);
+      } else {
+        auto category{d.typePattern.categorySet.LeastElement().value()};
+        characteristics::TypeAndShape typeAndShape{
+            DynamicType{category, defaults.GetDefaultKind(category)}};
+        dummyArgs.emplace_back(
+            characteristics::DummyDataObject{std::move(typeAndShape)});
+      }
+      std::get<characteristics::DummyDataObject>(dummyArgs.back())
+          .attrs.set(characteristics::DummyDataObject::Attr::Optional);
+    }
+  }
+  characteristics::Procedure::Attrs attrs;
+  if (elementalRank > 0) {
+    attrs.set(characteristics::Procedure::Attr::Elemental);
+  }
+  characteristics::Procedure chars{
+      std::move(funcResult), std::move(dummyArgs), attrs};
+
+  return SpecificCall{
+      SpecificIntrinsic{name, std::move(chars)}, std::move(rearranged)};
 }
 
 class IntrinsicProcTable::Implementation {
@@ -1213,8 +1273,8 @@ public:
 
   bool IsIntrinsic(const std::string &) const;
 
-  std::optional<SpecificCall> Probe(
-      const CallCharacteristics &, ActualArguments &, FoldingContext &) const;
+  std::optional<SpecificCall> Probe(const CallCharacteristics &,
+      ActualArguments &, FoldingContext &, const IntrinsicProcTable &) const;
 
   std::optional<UnrestrictedSpecificIntrinsicFunctionInterface>
   IsUnrestrictedSpecificIntrinsicFunction(const std::string &) const;
@@ -1222,11 +1282,13 @@ public:
   std::ostream &Dump(std::ostream &) const;
 
 private:
+  DynamicType GetSpecificType(const TypePattern &) const;
+  SpecificCall HandleNull(
+      ActualArguments &, FoldingContext &, const IntrinsicProcTable &) const;
+
   common::IntrinsicTypeDefaultKinds defaults_;
   std::multimap<std::string, const IntrinsicInterface *> genericFuncs_;
   std::multimap<std::string, const SpecificIntrinsicInterface *> specificFuncs_;
-
-  DynamicType GetSpecificType(const TypePattern &) const;
 };
 
 bool IntrinsicProcTable::Implementation::IsIntrinsic(
@@ -1243,15 +1305,90 @@ bool IntrinsicProcTable::Implementation::IsIntrinsic(
   return name == "null";  // TODO more
 }
 
+// The NULL() intrinsic is a special case.
+SpecificCall IntrinsicProcTable::Implementation::HandleNull(
+    ActualArguments &arguments, FoldingContext &context,
+    const IntrinsicProcTable &intrinsics) const {
+  if (!arguments.empty()) {
+    if (arguments.size() > 1) {
+      context.messages().Say("Too many arguments to NULL()"_err_en_US);
+    } else if (arguments[0].has_value() && arguments[0]->keyword.has_value() &&
+        arguments[0]->keyword->ToString() != "mold") {
+      context.messages().Say("Unknown argument '%s' to NULL()"_err_en_US,
+          arguments[0]->keyword->ToString().data());
+    } else {
+      if (Expr<SomeType> * mold{arguments[0]->GetExpr()}) {
+        if (IsAllocatableOrPointer(*mold)) {
+          characteristics::DummyArguments args;
+          std::optional<characteristics::FunctionResult> fResult;
+          if (IsProcedurePointer(*mold)) {
+            // MOLD= procedure pointer
+            const Symbol *last{GetLastSymbol(*mold)};
+            CHECK(last != nullptr);
+            auto procPointer{
+                characteristics::Procedure::Characterize(*last, intrinsics)};
+            characteristics::DummyProcedure dp{
+                common::Clone(procPointer.value())};
+            args.emplace_back(std::move(dp));
+            fResult.emplace(std::move(procPointer.value()));
+          } else if (auto type{mold->GetType()}) {
+            // MOLD= object pointer
+            std::optional<characteristics::TypeAndShape> typeAndShape;
+            if (auto shape{GetShape(context, *mold)}) {
+              typeAndShape.emplace(*type, std::move(*shape));
+            } else {
+              typeAndShape.emplace(*type);
+            }
+            characteristics::DummyDataObject ddo{typeAndShape.value()};
+            args.emplace_back(std::move(ddo));
+            fResult.emplace(std::move(*typeAndShape));
+          } else {
+            context.messages().Say(
+                "MOLD= argument to NULL() lacks type"_err_en_US);
+          }
+          fResult->attrs.set(characteristics::FunctionResult::Attr::Pointer);
+          characteristics::Procedure::Attrs attrs;
+          attrs.set(characteristics::Procedure::Attr::NullPointer);
+          characteristics::Procedure chars{
+              std::move(*fResult), std::move(args), attrs};
+          return SpecificCall{SpecificIntrinsic{"null"s, std::move(chars)},
+              std::move(arguments)};
+        }
+      }
+      context.messages().Say(
+          "MOLD= argument to NULL() must be a pointer or allocatable"_err_en_US);
+    }
+  }
+  characteristics::Procedure::Attrs attrs;
+  attrs.set(characteristics::Procedure::Attr::NullPointer);
+  arguments.clear();
+  return SpecificCall{
+      SpecificIntrinsic{"null"s,
+          characteristics::Procedure{characteristics::DummyArguments{}, attrs}},
+      std::move(arguments)};
+}
+
 // Probe the configured intrinsic procedure pattern tables in search of a
 // match for a given procedure reference.
 std::optional<SpecificCall> IntrinsicProcTable::Implementation::Probe(
     const CallCharacteristics &call, ActualArguments &arguments,
-    FoldingContext &context) const {
+    FoldingContext &context, const IntrinsicProcTable &intrinsics) const {
   if (call.isSubroutineCall) {
     return std::nullopt;  // TODO
   }
   parser::Messages *finalBuffer{context.messages().messages()};
+  // Special case: NULL()
+  if (call.name.ToString() == "null") {
+    parser::Messages nullBuffer;
+    parser::ContextualMessages nullErrors{
+        call.name, finalBuffer ? &nullBuffer : nullptr};
+    FoldingContext nullContext{context, nullErrors};
+    auto result{HandleNull(arguments, nullContext, intrinsics)};
+    if (finalBuffer != nullptr) {
+      finalBuffer->Annex(std::move(nullBuffer));
+    }
+    return result;
+  }
   // Probe the specific intrinsic function table first.
   parser::Messages specificBuffer;
   parser::ContextualMessages specificErrors{
@@ -1282,31 +1419,7 @@ std::optional<SpecificCall> IntrinsicProcTable::Implementation::Probe(
       return specificCall;
     }
   }
-  // Special cases of intrinsic functions
-  if (call.name.ToString() == "null") {
-    if (arguments.size() == 0) {
-      return std::make_optional<SpecificCall>(
-          SpecificIntrinsic{"null"s}, std::move(arguments));
-    } else if (arguments.size() > 1) {
-      genericErrors.Say("too many arguments to NULL()"_err_en_US);
-    } else if (arguments[0].has_value() && arguments[0]->keyword.has_value() &&
-        arguments[0]->keyword->ToString() != "mold") {
-      genericErrors.Say("unknown argument '%s' to NULL()"_err_en_US,
-          arguments[0]->keyword->ToString().data());
-    } else {
-      if (Expr<SomeType> * mold{arguments[0]->GetExpr()}) {
-        if (IsPointerOrAllocatable(*mold)) {
-          return std::make_optional<SpecificCall>(
-              SpecificIntrinsic{"null"s, mold->GetType(), mold->Rank(),
-                  semantics::Attrs{semantics::Attr::POINTER}},
-              std::move(arguments));
-        }
-      }
-      genericErrors.Say("MOLD argument to NULL() must be a pointer "
-                        "or allocatable"_err_en_US);
-    }
-  }
-  // No match
+  // No match; report the right errors, if any
   if (finalBuffer != nullptr) {
     if (genericBuffer.empty()) {
       finalBuffer->Annex(std::move(specificBuffer));
@@ -1324,24 +1437,26 @@ IntrinsicProcTable::Implementation::IsUnrestrictedSpecificIntrinsicFunction(
   for (auto iter{specificRange.first}; iter != specificRange.second; ++iter) {
     const SpecificIntrinsicInterface &specific{*iter->second};
     if (!specific.isRestrictedSpecific) {
-      UnrestrictedSpecificIntrinsicFunctionInterface result;
+      std::string genericName{name};
       if (specific.generic != nullptr) {
-        result.genericName = std::string(specific.generic);
-      } else {
-        result.genericName = name;
+        genericName = std::string(specific.generic);
       }
-      result.attrs.set(characteristics::Procedure::Attr::Pure);
-      result.attrs.set(characteristics::Procedure::Attr::Elemental);
+      characteristics::FunctionResult fResult{GetSpecificType(specific.result)};
+      characteristics::DummyArguments args;
       int dummies{specific.CountArguments()};
       for (int j{0}; j < dummies; ++j) {
         characteristics::DummyDataObject dummy{
             GetSpecificType(specific.dummy[j].typePattern)};
         dummy.intent = common::Intent::In;
-        result.dummyArguments.emplace_back(std::move(dummy));
+        args.emplace_back(std::move(dummy));
       }
-      result.functionResult.emplace(
-          characteristics::FunctionResult{GetSpecificType(specific.result)});
-      return result;
+      characteristics::Procedure::Attrs attrs;
+      attrs.set(characteristics::Procedure::Attr::Pure)
+          .set(characteristics::Procedure::Attr::Elemental);
+      characteristics::Procedure chars{
+          std::move(fResult), std::move(args), attrs};
+      return UnrestrictedSpecificIntrinsicFunctionInterface{
+          std::move(chars), genericName};
     }
   }
   return std::nullopt;
@@ -1377,7 +1492,7 @@ std::optional<SpecificCall> IntrinsicProcTable::Probe(
     const CallCharacteristics &call, ActualArguments &arguments,
     FoldingContext &context) const {
   CHECK(impl_ != nullptr || !"IntrinsicProcTable: not configured");
-  return impl_->Probe(call, arguments, context);
+  return impl_->Probe(call, arguments, context, *this);
 }
 
 std::optional<UnrestrictedSpecificIntrinsicFunctionInterface>

--- a/lib/evaluate/intrinsics.h
+++ b/lib/evaluate/intrinsics.h
@@ -42,6 +42,9 @@ struct SpecificCall {
 
 struct UnrestrictedSpecificIntrinsicFunctionInterface
   : public characteristics::Procedure {
+  UnrestrictedSpecificIntrinsicFunctionInterface(
+      characteristics::Procedure &&p, std::string n)
+    : characteristics::Procedure{std::move(p)}, genericName{n} {}
   std::string genericName;
   // N.B. If there are multiple arguments, they all have the same type.
   // All argument and result types are intrinsic types with default kinds.
@@ -62,7 +65,8 @@ public:
 
   // Probe the intrinsics for a match against a specific call.
   // On success, the actual arguments are transferred to the result
-  // in dummy argument order.
+  // in dummy argument order; on failure, the actual arguments remain
+  // untouched.
   std::optional<SpecificCall> Probe(
       const CallCharacteristics &, ActualArguments &, FoldingContext &) const;
 

--- a/lib/evaluate/shape.h
+++ b/lib/evaluate/shape.h
@@ -22,6 +22,7 @@
 #include "tools.h"
 #include "type.h"
 #include "../common/indirection.h"
+#include "../parser/message.h"
 #include <optional>
 #include <variant>
 
@@ -58,8 +59,9 @@ bool ContainsAnyImpliedDoIndex(const ExtentExpr &);
 
 // Compilation-time shape conformance checking, when corresponding extents
 // are known.
-void CheckConformance(
-    parser::ContextualMessages &, const Shape &, const Shape &);
+bool CheckConformance(parser::ContextualMessages &, const Shape &,
+    const Shape &, const char * = "left operand",
+    const char * = "right operand");
 
 // The implementation of GetShape() is wrapped in a helper class
 // so that the member functions may mutually recurse without prototypes.
@@ -81,6 +83,7 @@ public:
   std::optional<Shape> GetShape(const Substring &);
   std::optional<Shape> GetShape(const ComplexPart &);
   std::optional<Shape> GetShape(const ActualArgument &);
+  std::optional<Shape> GetShape(const ProcedureDesignator &);
   std::optional<Shape> GetShape(const ProcedureRef &);
   std::optional<Shape> GetShape(const ImpliedDoIndex &);
   std::optional<Shape> GetShape(const Relational<SomeType> &);
@@ -144,8 +147,6 @@ public:
   }
 
 private:
-  MaybeExtent GetLowerBound(const Symbol &, const Component *, int dimension);
-
   template<typename T>
   MaybeExtent GetExtent(const ArrayConstructorValue<T> &value) {
     return std::visit(
@@ -187,6 +188,8 @@ private:
     return result;
   }
 
+  // The dimension here is zero-based, unlike DIM= intrinsic arguments.
+  MaybeExtent GetLowerBound(const Symbol &, const Component *, int dimension);
   MaybeExtent GetExtent(const Symbol &, const Component *, int dimension);
   MaybeExtent GetExtent(
       const Subscript &, const Symbol &, const Component *, int dimension);

--- a/lib/evaluate/tools.cc
+++ b/lib/evaluate/tools.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "tools.h"
+#include "traversal.h"
 #include "../common/idioms.h"
 #include "../parser/message.h"
 #include <algorithm>
@@ -351,6 +352,14 @@ std::optional<Expr<SomeType>> Negation(
             messages.Say("NULL() cannot be negated"_err_en_US);
             return NoExpr();
           },
+          [&](ProcedureDesignator &&) {
+            messages.Say("Subroutine cannot be negated"_err_en_US);
+            return NoExpr();
+          },
+          [&](ProcedureRef &&) {
+            messages.Say("Pointer to subroutine cannot be negated"_err_en_US);
+            return NoExpr();
+          },
           [&](Expr<SomeInteger> &&x) { return Package(-std::move(x)); },
           [&](Expr<SomeReal> &&x) { return Package(-std::move(x)); },
           [&](Expr<SomeComplex> &&x) { return Package(-std::move(x)); },
@@ -505,8 +514,7 @@ std::optional<Expr<SomeType>> ConvertToNumeric(int kind, Expr<SomeType> &&x) {
   return std::visit(
       [=](auto &&cx) -> std::optional<Expr<SomeType>> {
         using cxType = std::decay_t<decltype(cx)>;
-        if constexpr (!std::is_same_v<cxType, BOZLiteralConstant> &&
-            !std::is_same_v<cxType, NullPointer>) {
+        if constexpr (!common::HasMember<cxType, TypelessExpression>) {
           if constexpr (IsNumericTypeCategory(ResultType<cxType>::category)) {
             return std::make_optional(
                 Expr<SomeType>{ConvertToKind<TO>(kind, std::move(cx))});
@@ -573,7 +581,7 @@ std::optional<Expr<SomeType>> ConvertToType(
       return std::nullopt;
     }
   }
-  if (auto symType{GetSymbolType(symbol)}) {
+  if (auto symType{DynamicType::From(symbol)}) {
     return ConvertToType(*symType, std::move(x));
   }
   return std::nullopt;
@@ -585,6 +593,24 @@ std::optional<Expr<SomeType>> ConvertToType(
     return ConvertToType(type, std::move(*x));
   } else {
     return std::nullopt;
+  }
+}
+
+bool IsAssumedRank(const semantics::Symbol &symbol) {
+  if (const auto *details{symbol.detailsIf<semantics::ObjectEntityDetails>()}) {
+    return details->IsAssumedRank();
+  } else {
+    return false;
+  }
+}
+
+bool IsAssumedRank(const ActualArgument &arg) {
+  if (const auto *expr{arg.GetExpr()}) {
+    return IsAssumedRank(*expr);
+  } else {
+    const semantics::Symbol *assumedTypeDummy{arg.GetAssumedTypeDummy()};
+    CHECK(assumedTypeDummy != nullptr);
+    return IsAssumedRank(*assumedTypeDummy);
   }
 }
 }

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -77,17 +77,16 @@ template<typename A> bool IsVariable(const Expr<A> &expr) {
 }
 
 // Predicate: true when an expression is assumed-rank
+bool IsAssumedRank(const semantics::Symbol &);
+bool IsAssumedRank(const ActualArgument &);
 template<typename A> bool IsAssumedRank(const A &) { return false; }
 template<typename A> bool IsAssumedRank(const Designator<A> &designator) {
-  if (const auto *symbolPtr{
+  if (const auto *symbol{
           std::get_if<const semantics::Symbol *>(&designator.u)}) {
-    if (const auto *details{
-            (*symbolPtr)
-                ->template detailsIf<semantics::ObjectEntityDetails>()}) {
-      return details->IsAssumedRank();
-    }
+    return IsAssumedRank(*symbol);
+  } else {
+    return false;
   }
-  return false;
 }
 template<typename A> bool IsAssumedRank(const Expr<A> &expr) {
   return std::visit([](const auto &x) { return IsAssumedRank(x); }, expr.u);
@@ -112,7 +111,11 @@ Expr<SomeKind<CATEGORY>> AsCategoryExpr(Expr<SomeKind<CATEGORY>> &&x) {
 
 template<typename A>
 common::IfNoLvalue<Expr<SomeType>, A> AsGenericExpr(A &&x) {
-  return Expr<SomeType>{AsCategoryExpr(std::move(x))};
+  if constexpr (common::HasMember<A, TypelessExpression>) {
+    return Expr<SomeType>{std::move(x)};
+  } else {
+    return Expr<SomeType>{AsCategoryExpr(std::move(x))};
+  }
 }
 
 template<typename A>
@@ -123,14 +126,6 @@ common::IfNoLvalue<Expr<SomeKind<ResultType<A>::category>>, A> AsCategoryExpr(
 
 inline Expr<SomeType> AsGenericExpr(Expr<SomeType> &&x) { return std::move(x); }
 
-inline Expr<SomeType> AsGenericExpr(BOZLiteralConstant &&x) {
-  return Expr<SomeType>{std::move(x)};
-}
-
-inline Expr<SomeType> AsGenericExpr(NullPointer &&x) {
-  return Expr<SomeType>{std::move(x)};
-}
-
 Expr<SomeReal> GetComplexPart(
     const Expr<SomeComplex> &, bool isImaginary = false);
 
@@ -140,6 +135,14 @@ Expr<SomeComplex> MakeComplex(Expr<Type<TypeCategory::Real, KIND>> &&re,
   return AsCategoryExpr(ComplexConstructor<KIND>{std::move(re), std::move(im)});
 }
 
+template<typename A> constexpr bool IsNumericCategoryExpr() {
+  if constexpr (common::HasMember<A, TypelessExpression>) {
+    return false;
+  } else {
+    return common::HasMember<ResultType<A>, NumericCategoryTypes>;
+  }
+}
+
 // Specializing extractor.  If an Expr wraps some type of object, perhaps
 // in several layers, return a pointer to it; otherwise null.
 template<typename A, typename B>
@@ -147,8 +150,7 @@ auto UnwrapExpr(B &x) -> common::Constify<A, B> * {
   using Ty = std::decay_t<B>;
   if constexpr (std::is_same_v<A, Ty>) {
     return &x;
-  } else if constexpr (std::is_same_v<Ty, BOZLiteralConstant> ||
-      std::is_same_v<Ty, NullPointer>) {
+  } else if constexpr (common::HasMember<Ty, TypelessExpression>) {
     return nullptr;
   } else if constexpr (std::is_same_v<Ty, Expr<ResultType<A>>>) {
     return common::Unwrap<A>(x.u);
@@ -226,7 +228,8 @@ template<typename TO> Expr<TO> ConvertToType(BOZLiteralConstant &&x) {
   } else {
     static_assert(TO::category == TypeCategory::Real);
     using Word = typename Value::Word;
-    return Expr<TO>{Constant<TO>{Word::ConvertUnsigned(std::move(x)).value}};
+    return Expr<TO>{
+        Constant<TO>{Value{Word::ConvertUnsigned(std::move(x)).value}}};
   }
 }
 
@@ -543,6 +546,14 @@ const semantics::Symbol *GetLastSymbol(const Designator<T> &x) {
   return x.GetLastSymbol();
 }
 
+inline const semantics::Symbol *GetLastSymbol(const ProcedureDesignator &x) {
+  return x.GetSymbol();
+}
+
+inline const semantics::Symbol *GetLastSymbol(const ProcedureRef &x) {
+  return GetLastSymbol(x.proc());
+}
+
 template<typename T> const semantics::Symbol *GetLastSymbol(const Expr<T> &x) {
   return std::visit([](const auto &y) { return GetLastSymbol(y); }, x.u);
 }
@@ -555,9 +566,17 @@ template<typename A> semantics::Attrs GetAttrs(const A &x) {
   }
 }
 
-template<typename A> bool IsPointerOrAllocatable(const A &x) {
+template<typename A> bool IsAllocatableOrPointer(const A &x) {
   return GetAttrs(x).HasAny(
       semantics::Attrs{semantics::Attr::POINTER, semantics::Attr::ALLOCATABLE});
+}
+
+template<typename A> bool IsProcedurePointer(const A &) { return false; }
+inline bool IsProcedurePointer(const ProcedureDesignator &) { return true; }
+inline bool IsProcedurePointer(const ProcedureRef &) { return true; }
+inline bool IsProcedurePointer(const Expr<SomeType> &expr) {
+  return std::visit(
+      [](const auto &x) { return IsProcedurePointer(x); }, expr.u);
 }
 }
 #endif  // FORTRAN_EVALUATE_TOOLS_H_

--- a/lib/evaluate/variable.cc
+++ b/lib/evaluate/variable.cc
@@ -221,14 +221,14 @@ std::optional<Expr<SomeCharacter>> Substring::Fold(FoldingContext &context) {
 DescriptorInquiry::DescriptorInquiry(const Symbol &symbol, Field field, int dim)
   : base_{&symbol}, field_{field}, dimension_{dim} {
   CHECK(IsDescriptor(symbol));
-  CHECK(dim >= 1 && dim <= symbol.Rank());
+  CHECK(dim >= 0 && dim < symbol.Rank());
 }
 DescriptorInquiry::DescriptorInquiry(
     Component &&component, Field field, int dim)
   : base_{std::move(component)}, field_{field}, dimension_{dim} {
   const Symbol &symbol{std::get<Component>(base_).GetLastSymbol()};
   CHECK(IsDescriptor(symbol));
-  CHECK(dim >= 1 && dim <= symbol.Rank());
+  CHECK(dim >= 0 && dim < symbol.Rank());
 }
 DescriptorInquiry::DescriptorInquiry(
     SymbolOrComponent &&x, Field field, int dim)
@@ -240,7 +240,7 @@ DescriptorInquiry::DescriptorInquiry(
       },
       base_)};
   CHECK(symbol != nullptr && IsDescriptor(*symbol));
-  CHECK(dim >= 1 && dim <= symbol->Rank());
+  CHECK(dim >= 0 && dim < symbol->Rank());
 }
 
 // LEN()
@@ -513,7 +513,7 @@ template<typename T> std::optional<DynamicType> Designator<T>::GetType() const {
   if constexpr (IsLengthlessIntrinsicType<Result>) {
     return {Result::GetType()};
   } else {
-    return GetSymbolType(GetLastSymbol());
+    return DynamicType::From(GetLastSymbol());
   }
 }
 

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -236,6 +236,14 @@ public:
 
   const Symbol *GetParentComponent(const Scope &) const;
 
+  std::optional<SourceName> GetParentComponentName() const {
+    if (componentNames_.empty()) {
+      return std::nullopt;
+    } else {
+      return componentNames_.front();
+    }
+  }
+
 private:
   // These are (1) the names of the derived type parameters in the order
   // in which they appear on the type definition statement(s), and (2) the

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -125,24 +125,8 @@ bool IsDummy(const Symbol &symbol) {
   }
 }
 
-bool IsPointer(const Symbol &symbol) {
-  return symbol.attrs().test(Attr::POINTER);
-}
-
-bool IsAllocatable(const Symbol &symbol) {
-  return symbol.attrs().test(Attr::ALLOCATABLE);
-}
-
 bool IsPointerDummy(const Symbol &symbol) {
   return IsPointer(symbol) && IsDummy(symbol);
-}
-
-bool IsAllocatableOrPointer(const Symbol &symbol) {
-  return IsPointer(symbol) || IsAllocatable(symbol);
-}
-
-bool IsParameter(const Symbol &symbol) {
-  return symbol.attrs().test(Attr::PARAMETER);
 }
 
 // variable-name

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -48,7 +48,6 @@ bool DoesScopeContain(const Scope *, const Symbol &);
 bool IsUseAssociated(const Symbol *, const Scope &);
 bool IsHostAssociated(const Symbol &, const Scope &);
 bool IsDummy(const Symbol &);
-bool IsPointer(const Symbol &);
 bool IsPointerDummy(const Symbol &);
 bool IsFunction(const Symbol &);
 bool IsPureFunction(const Symbol &);
@@ -56,9 +55,20 @@ bool IsPureFunction(const Scope &);
 bool IsProcedure(const Symbol &);
 bool IsProcName(const Symbol &symbol);  // proc-name
 bool IsVariableName(const Symbol &symbol);  // variable-name
-bool IsAllocatable(const Symbol &);
-bool IsAllocatableOrPointer(const Symbol &);
 bool IsProcedurePointer(const Symbol &);
+
+inline bool IsPointer(const Symbol &symbol) {
+  return symbol.attrs().test(Attr::POINTER);
+}
+inline bool IsAllocatable(const Symbol &symbol) {
+  return symbol.attrs().test(Attr::ALLOCATABLE);
+}
+inline bool IsAllocatableOrPointer(const Symbol &symbol) {
+  return IsPointer(symbol) || IsAllocatable(symbol);
+}
+inline bool IsParameter(const Symbol &symbol) {
+  return symbol.attrs().test(Attr::PARAMETER);
+}
 
 // Determines whether an object might be visible outside a
 // PURE function (C1594); returns a non-null Symbol pointer for

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -293,14 +293,6 @@ const LogicalTypeSpec &DeclTypeSpec::logicalTypeSpec() const {
   CHECK(category_ == Logical);
   return std::get<LogicalTypeSpec>(typeSpec_);
 }
-const DerivedTypeSpec &DeclTypeSpec::derivedTypeSpec() const {
-  CHECK(category_ == TypeDerived || category_ == ClassDerived);
-  return std::get<DerivedTypeSpec>(typeSpec_);
-}
-DerivedTypeSpec &DeclTypeSpec::derivedTypeSpec() {
-  CHECK(category_ == TypeDerived || category_ == ClassDerived);
-  return std::get<DerivedTypeSpec>(typeSpec_);
-}
 bool DeclTypeSpec::operator==(const DeclTypeSpec &that) const {
   return category_ == that.category_ && typeSpec_ == that.typeSpec_;
 }

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -289,8 +289,14 @@ public:
     CHECK(category_ == Character);
     return std::get<CharacterTypeSpec>(typeSpec_);
   }
-  const DerivedTypeSpec &derivedTypeSpec() const;
-  DerivedTypeSpec &derivedTypeSpec();
+  const DerivedTypeSpec &derivedTypeSpec() const {
+    CHECK(category_ == TypeDerived || category_ == ClassDerived);
+    return std::get<DerivedTypeSpec>(typeSpec_);
+  }
+  DerivedTypeSpec &derivedTypeSpec() {
+    CHECK(category_ == TypeDerived || category_ == ClassDerived);
+    return std::get<DerivedTypeSpec>(typeSpec_);
+  }
 
   IntrinsicTypeSpec *AsIntrinsic();
   const IntrinsicTypeSpec *AsIntrinsic() const {

--- a/test/evaluate/intrinsics.cc
+++ b/test/evaluate/intrinsics.cc
@@ -117,10 +117,19 @@ struct TestCall {
     if (resultType.has_value()) {
       TEST(si.has_value());
       TEST(buffer.empty());
-      TEST(*resultType == si->specificIntrinsic.type);
-      MATCH(rank, si->specificIntrinsic.rank);
+      const auto &proc{si->specificIntrinsic.characteristics.value()};
+      const auto &fr{proc.functionResult};
+      TEST(fr.has_value());
+      if (fr) {
+        const auto *ts{fr->GetTypeAndShape()};
+        TEST(ts != nullptr);
+        if (ts) {
+          TEST(*resultType == ts->type());
+          MATCH(rank, ts->Rank());
+        }
+      }
       MATCH(isElemental,
-          si->specificIntrinsic.attrs.test(semantics::Attr::ELEMENTAL));
+          proc.attrs.test(characteristics::Procedure::Attr::Elemental));
     } else {
       TEST(!si.has_value());
       TEST(!buffer.empty() || name == "bad");


### PR DESCRIPTION
These are the changes to `lib/evaluate` that have accumulated while I wrapped up work on structure constructor expression semantics in `lib/semantics`.  Those changes will follow this PR.

I tried to split this work up into smaller changes, but they're interdependent.

- `Expr<SomeType>` can now hold a procedure designator or procedure pointer returned from a function reference.  Some conveniences were added to make it easier to distinguish instances of `Expr<SomeType>` that (like these new possibilities, plus BOZ literals and `NULL()`) don't have types in the Fortran sense from those that do.
- The representation of procedure characteristics has been worked over and extended as I've been using it in semantics.
- Intrinsic function table probes now return characteristics of the specific intrinsics they find, and these characteristics are retained in the `SpecificIntrinsic` structure used to represent the call in the expression.
- Some bugs in intrinsics were found and fixed along the way; conversions of BOZ literals to Fortran types should not convert the BOZ as if it were an integer.
- `DynamicType` was rearranged a little, and now has static member functions for creating its instances from symbol table entries and types, rather than associated functions that would have to become friends of the class when I get around to privatizing its members.

Some changes are attached that need to be made to compile `lib/semantics` with these expression changes.  Some of them are final, others are temporary updates that will be replaced with my next PR that finishes up structure constructor semantics once this work is merged.