### PR TITLE
Replace formatting of CharBlock & string

### DIFF
--- a/lib/evaluate/characteristics.cc
+++ b/lib/evaluate/characteristics.cc
@@ -36,7 +36,7 @@ bool TypeAndShape::IsCompatibleWith(
     parser::ContextualMessages &messages, const TypeAndShape &that) const {
   if (!type_.IsTypeCompatibleWith(that.type_)) {
     messages.Say("Target type '%s' is not compatible with '%s'"_err_en_US,
-        that.type_.AsFortran().c_str(), type_.AsFortran().c_str());
+        that.type_.AsFortran(), type_.AsFortran());
     return false;
   }
   return CheckConformance(messages, shape_, that.shape_);

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -589,8 +589,7 @@ Expr<Type<TypeCategory::Real, KIND>> FoldOperation(FoldingContext &context,
             context, std::move(funcRef), *callable);
       } else {
         context.messages().Say(
-            "%s(real(kind=%d)) cannot be folded on host"_en_US, name.c_str(),
-            KIND);
+            "%s(real(kind=%d)) cannot be folded on host"_en_US, name, KIND);
       }
     }
     if (name == "atan" || name == "atan2" || name == "hypot" || name == "mod") {
@@ -604,7 +603,7 @@ Expr<Type<TypeCategory::Real, KIND>> FoldOperation(FoldingContext &context,
       } else {
         context.messages().Say(
             "%s(real(kind=%d), real(kind%d)) cannot be folded on host"_en_US,
-            name.c_str(), KIND, KIND);
+            name, KIND, KIND);
       }
     } else if (name == "bessel_jn" || name == "bessel_yn") {
       if (args.size() == 2) {  // elemental
@@ -624,7 +623,7 @@ Expr<Type<TypeCategory::Real, KIND>> FoldOperation(FoldingContext &context,
         } else {
           context.messages().Say(
               "%s(integer(kind=4), real(kind=%d)) cannot be folded on host"_en_US,
-              name.c_str(), KIND);
+              name, KIND);
         }
       }
     } else if (name == "abs") {
@@ -661,7 +660,7 @@ Expr<Type<TypeCategory::Real, KIND>> FoldOperation(FoldingContext &context,
             ValueWithRealFlags<Scalar<T>> y{x.AINT()};
             if (y.flags.test(RealFlag::Overflow)) {
               context.messages().Say(
-                  "%s intrinsic folding overflow"_en_US, name.c_str());
+                  "%s intrinsic folding overflow"_en_US, name);
             }
             return y.value;
           }));
@@ -714,8 +713,7 @@ Expr<Type<TypeCategory::Complex, KIND>> FoldOperation(FoldingContext &context,
             context, std::move(funcRef), *callable);
       } else {
         context.messages().Say(
-            "%s(complex(kind=%d)) cannot be folded on host"_en_US, name.c_str(),
-            KIND);
+            "%s(complex(kind=%d)) cannot be folded on host"_en_US, name, KIND);
       }
     } else if (name == "conjg") {
       return FoldElementalIntrinsic<T, T>(

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -908,7 +908,7 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
       return std::nullopt;
     } else if (!d.typePattern.categorySet.test(type->category)) {
       messages.Say("Actual argument for '%s=' has bad type '%s'"_err_en_US,
-          d.keyword, type->AsFortran().data());
+          d.keyword, type->AsFortran());
       return std::nullopt;  // argument has invalid type category
     }
     bool argOk{false};
@@ -961,7 +961,7 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
     if (!argOk) {
       messages.Say(
           "actual argument for '%s=' has bad type or kind '%s'"_err_en_US,
-          d.keyword, type->AsFortran().data());
+          d.keyword, type->AsFortran());
       return std::nullopt;
     }
   }
@@ -1315,7 +1315,7 @@ SpecificCall IntrinsicProcTable::Implementation::HandleNull(
     } else if (arguments[0].has_value() && arguments[0]->keyword.has_value() &&
         arguments[0]->keyword->ToString() != "mold") {
       context.messages().Say("Unknown argument '%s' to NULL()"_err_en_US,
-          arguments[0]->keyword->ToString().data());
+          arguments[0]->keyword->ToString());
     } else {
       if (Expr<SomeType> * mold{arguments[0]->GetExpr()}) {
         if (IsAllocatableOrPointer(*mold)) {

--- a/lib/evaluate/type.h
+++ b/lib/evaluate/type.h
@@ -163,7 +163,6 @@ private:
   constexpr DynamicType() {}
 };
 
-
 template<TypeCategory CATEGORY, int KIND = 0> struct TypeBase {
   static constexpr TypeCategory category{CATEGORY};
   static constexpr int kind{KIND};

--- a/lib/parser/debug-parser.cc
+++ b/lib/parser/debug-parser.cc
@@ -23,7 +23,7 @@ std::optional<Success> DebugParser::Parse(ParseState &state) const {
   if (auto ustate{state.userState()}) {
     if (auto out{ustate->debugOutput()}) {
       std::string note{str_, length_};
-      Message message{state.GetLocation(), "parser debug: %S"_en_US, note};
+      Message message{state.GetLocation(), "parser debug: %s"_en_US, note};
       message.SetContext(state.context().get());
       message.Emit(*out, ustate->cooked(), true);
     }

--- a/lib/parser/message.cc
+++ b/lib/parser/message.cc
@@ -64,12 +64,21 @@ const char *MessageFormattedText::Convert(const std::string &s) {
   return conversions_.front().c_str();
 }
 
+const char *MessageFormattedText::Convert(std::string &s) {
+  conversions_.emplace_front(s);
+  return conversions_.front().c_str();
+}
+
 const char *MessageFormattedText::Convert(std::string &&s) {
   conversions_.emplace_front(std::move(s));
   return conversions_.front().c_str();
 }
 
 const char *MessageFormattedText::Convert(const CharBlock &x) {
+  return Convert(x.ToString());
+}
+
+const char *MessageFormattedText::Convert(CharBlock &x) {
   return Convert(x.ToString());
 }
 
@@ -80,6 +89,8 @@ const char *MessageFormattedText::Convert(CharBlock &&x) {
 const char *MessageFormattedText::Convert(const Name &n) {
   return Convert(n.source);
 }
+
+const char *MessageFormattedText::Convert(Name &n) { return Convert(n.source); }
 
 const char *MessageFormattedText::Convert(Name &&n) {
   return Convert(n.source);

--- a/lib/parser/message.cc
+++ b/lib/parser/message.cc
@@ -14,7 +14,6 @@
 
 #include "message.h"
 #include "char-set.h"
-#include "parse-tree.h"
 #include "../common/idioms.h"
 #include <algorithm>
 #include <cstdarg>
@@ -84,16 +83,6 @@ const char *MessageFormattedText::Convert(CharBlock &x) {
 
 const char *MessageFormattedText::Convert(CharBlock &&x) {
   return Convert(x.ToString());
-}
-
-const char *MessageFormattedText::Convert(const Name &n) {
-  return Convert(n.source);
-}
-
-const char *MessageFormattedText::Convert(Name &n) { return Convert(n.source); }
-
-const char *MessageFormattedText::Convert(Name &&n) {
-  return Convert(n.source);
 }
 
 std::string MessageExpectedText::ToString() const {

--- a/lib/parser/message.h
+++ b/lib/parser/message.h
@@ -35,8 +35,6 @@
 
 namespace Fortran::parser {
 
-struct Name;
-
 // Use "..."_err_en_US and "..."_en_US literals to define the static
 // text and fatality of a message.
 class MessageFixedText {
@@ -70,9 +68,9 @@ constexpr MessageFixedText operator""_err_en_US(
 
 // The construction of a MessageFormattedText uses a MessageFixedText
 // as a vsnprintf() formatting string that is applied to the
-// following arguments.  CharBlock and std::string argument values are
-// also supported; they are automatically converted into char pointers
-// that are suitable for '%s' formatting.
+// following arguments.  CharBlock and std::string argument
+// values are also supported; they are automatically converted into
+// char pointers that are suitable for '%s' formatting.
 class MessageFormattedText {
 public:
   template<typename... A>
@@ -90,8 +88,17 @@ public:
 
 private:
   void Format(const MessageFixedText *text, ...);
-  template<typename A> A Convert(A &x) { return x; }
+
+  template<typename A> A Convert(const A &x) {
+    static_assert(!std::is_class_v<std::decay_t<A>>);
+    return x;
+  }
+  template<typename A> A Convert(A &x) {
+    static_assert(!std::is_class_v<std::decay_t<A>>);
+    return x;
+  }
   template<typename A> common::IfNoLvalue<A, A> Convert(A &&x) {
+    static_assert(!std::is_class_v<std::decay_t<A>>);
     return std::move(x);
   }
   const char *Convert(const std::string &);
@@ -100,9 +107,6 @@ private:
   const char *Convert(const CharBlock &);
   const char *Convert(CharBlock &);
   const char *Convert(CharBlock &&);
-  const char *Convert(const Name &);
-  const char *Convert(Name &);
-  const char *Convert(Name &&);
 
   bool isFatal_{false};
   std::string string_;

--- a/lib/parser/message.h
+++ b/lib/parser/message.h
@@ -90,15 +90,18 @@ public:
 
 private:
   void Format(const MessageFixedText *text, ...);
-  template<typename A> A Convert(const A &x) { return x; }
+  template<typename A> A Convert(A &x) { return x; }
   template<typename A> common::IfNoLvalue<A, A> Convert(A &&x) {
     return std::move(x);
   }
   const char *Convert(const std::string &);
+  const char *Convert(std::string &);
   const char *Convert(std::string &&);
   const char *Convert(const CharBlock &);
+  const char *Convert(CharBlock &);
   const char *Convert(CharBlock &&);
   const char *Convert(const Name &);
+  const char *Convert(Name &);
   const char *Convert(Name &&);
 
   bool isFatal_{false};

--- a/lib/parser/parsing.cc
+++ b/lib/parser/parsing.cc
@@ -43,7 +43,7 @@ void Parsing::Prescan(const std::string &path, Options options) {
   }
   if (sourceFile == nullptr) {
     ProvenanceRange range{allSources.AddCompilerInsertion(path)};
-    messages_.Say(range, "%S"_err_en_US, fileError.str());
+    messages_.Say(range, "%s"_err_en_US, fileError.str());
     return;
   }
   if (sourceFile->bytes() == 0) {

--- a/lib/parser/preprocessor.cc
+++ b/lib/parser/preprocessor.cc
@@ -319,8 +319,7 @@ std::optional<TokenSequence> Preprocessor::MacroReplacement(
         }
       }
     }
-    if (argStart.size() == 1 && k == argStart[0] &&
-        def.argumentCount() == 0) {
+    if (argStart.size() == 1 && k == argStart[0] && def.argumentCount() == 0) {
       // Subtle: () is zero arguments, not one empty argument,
       // unless one argument was expected.
       argStart.clear();
@@ -472,12 +471,12 @@ void Preprocessor::Directive(const TokenSequence &dir, Prescanner *prescanner) {
     if (nameToken.empty()) {
       prescanner->Say(
           dir.GetIntervalProvenanceRange(dirOffset, tokens - dirOffset),
-          "#%S: missing name"_err_en_US, dirName);
+          "#%s: missing name"_err_en_US, dirName);
     } else {
       j = dir.SkipBlanks(j + 1);
       if (j != tokens) {
         prescanner->Say(dir.GetIntervalProvenanceRange(j, tokens - j),
-            "#%S: excess tokens at end of directive"_en_US, dirName);
+            "#%s: excess tokens at end of directive"_en_US, dirName);
       }
       doThen = IsNameDefined(nameToken) == (dirName == "ifdef");
     }
@@ -534,12 +533,12 @@ void Preprocessor::Directive(const TokenSequence &dir, Prescanner *prescanner) {
   } else if (dirName == "error") {
     prescanner->Say(
         dir.GetIntervalProvenanceRange(dirOffset, tokens - dirOffset),
-        "%S"_err_en_US, dir.ToString());
+        "%s"_err_en_US, dir.ToString());
   } else if (dirName == "warning" || dirName == "comment" ||
       dirName == "note") {
     prescanner->Say(
         dir.GetIntervalProvenanceRange(dirOffset, tokens - dirOffset),
-        "%S"_en_US, dir.ToString());
+        "%s"_en_US, dir.ToString());
   } else if (dirName == "include") {
     if (j == tokens) {
       prescanner->Say(
@@ -585,7 +584,7 @@ void Preprocessor::Directive(const TokenSequence &dir, Prescanner *prescanner) {
     const SourceFile *included{allSources_.Open(include, &error)};
     if (included == nullptr) {
       prescanner->Say(dir.GetTokenProvenanceRange(dirOffset),
-          "#include: %S"_err_en_US, error.str());
+          "#include: %s"_err_en_US, error.str());
     } else if (included->bytes() > 0) {
       ProvenanceRange fileRange{
           allSources_.AddIncludedFile(*included, dir.GetProvenanceRange())};
@@ -593,7 +592,7 @@ void Preprocessor::Directive(const TokenSequence &dir, Prescanner *prescanner) {
     }
   } else {
     prescanner->Say(dir.GetTokenProvenanceRange(dirOffset),
-        "#%S: unknown or unimplemented directive"_err_en_US, dirName);
+        "#%s: unknown or unimplemented directive"_err_en_US, dirName);
   }
 }
 
@@ -654,7 +653,7 @@ void Preprocessor::SkipDisabledConditionalCode(const std::string &dirName,
       }
     }
   }
-  prescanner->Say(provenanceRange, "#%S: missing #endif"_err_en_US, dirName);
+  prescanner->Say(provenanceRange, "#%s: missing #endif"_err_en_US, dirName);
 }
 
 // Precedence level codes used here to accommodate mixed Fortran and C:
@@ -773,7 +772,7 @@ static std::int64_t ExpressionValue(const TokenSequence &token,
     left = std::stoll(t, &consumed, 0 /*base to be detected*/);
     if (consumed < t.size()) {
       *error = Message{token.GetTokenProvenanceRange(opAt),
-          "Uninterpretable numeric constant '%S'"_err_en_US, t};
+          "Uninterpretable numeric constant '%s'"_err_en_US, t};
       return 0;
     }
   } else if (IsLegalIdentifierStart(t[0])) {

--- a/lib/parser/prescan.cc
+++ b/lib/parser/prescan.cc
@@ -729,7 +729,7 @@ void Prescanner::FortranInclude(const char *firstQuote) {
     allSources.PopSearchPathDirectory();
   }
   if (included == nullptr) {
-    Say(provenance, "INCLUDE: %S"_err_en_US, error.str());
+    Say(provenance, "INCLUDE: %s"_err_en_US, error.str());
   } else if (included->bytes() > 0) {
     ProvenanceRange includeLineRange{
         provenance, static_cast<std::size_t>(p - lineStart_)};

--- a/lib/semantics/assignment.cc
+++ b/lib/semantics/assignment.cc
@@ -38,7 +38,7 @@ void CheckPointerAssignment(parser::ContextualMessages &messages,
   // Default catch-all when RHS of pointer assignment isn't recognized
   messages.Say("Pointer target assigned to '%s' must be a designator or "
                "a call to a pointer-valued function"_err_en_US,
-      symbol.name().ToString().c_str());
+      symbol.name());
 }
 
 void CheckPointerAssignment(parser::ContextualMessages &messages,
@@ -99,8 +99,7 @@ void CheckPointerAssignment(parser::ContextualMessages &messages,
               "result of reference to procedure"_err_en_US;
     }
     if (error.has_value()) {
-      if (auto *msg{messages.Say(
-              *error, lhs.name().ToString().c_str(), funcName.c_str())}) {
+      if (auto *msg{messages.Say(*error, lhs.name(), funcName)}) {
         msg->Attach(lhs.name(), "Declaration of pointer"_en_US);
         if (ultimate != nullptr) {
           msg->Attach(ultimate->name(), "Declaration of function"_en_US);
@@ -138,8 +137,7 @@ void CheckPointerAssignment(parser::ContextualMessages &messages,
       }
     }
     if (error.has_value()) {
-      if (auto *msg{messages.Say(*error, lhs.name().ToString().c_str(),
-              ultimate.name().ToString().c_str())}) {
+      if (auto *msg{messages.Say(*error, lhs.name(), ultimate.name())}) {
         msg->Attach(lhs.name(), "Declaration of pointer being assigned"_en_US)
             .Attach(ultimate.name(), "Declaration of pointer target"_en_US);
       }
@@ -184,8 +182,7 @@ void CheckPointerAssignment(parser::ContextualMessages &messages,
             "is a procedure designator"_err_en_US;
   }
   if (error.has_value()) {
-    if (auto *msg{messages.Say(*error, lhs.name().ToString().c_str(),
-            rhsName.ToString().c_str())}) {
+    if (auto *msg{messages.Say(*error, lhs.name(), rhsName)}) {
       msg->Attach(lhs.name(), "Declaration of pointer being assigned"_en_US);
     }
   }

--- a/lib/semantics/check-allocate.cc
+++ b/lib/semantics/check-allocate.cc
@@ -541,16 +541,14 @@ bool AllocationCheckerHelper::RunCoarrayRelatedChecks(
           context
               .Say(allocateInfo_.typeSpecLoc.value(),
                   "Type-Spec in ALLOCATE must not be TEAM_TYPE from ISO_FORTRAN_ENV when an allocatable object is a coarray"_err_en_US)
-              .Attach(name_.source, "'%s' is a coarray"_en_US,
-                  name_.source.ToString().c_str());
+              .Attach(name_.source, "'%s' is a coarray"_en_US, name_.source);
           return false;
         } else if (IsDerivedTypeFromModule(derived, "iso_c_binding", "c_ptr") ||
             IsDerivedTypeFromModule(derived, "iso_c_binding", "c_funptr")) {
           context
               .Say(allocateInfo_.typeSpecLoc.value(),
                   "Type-Spec in ALLOCATE must not be C_PTR or C_FUNPTR from ISO_C_BINDING when an allocatable object is a coarray"_err_en_US)
-              .Attach(name_.source, "'%s' is a coarray"_en_US,
-                  name_.source.ToString().c_str());
+              .Attach(name_.source, "'%s' is a coarray"_en_US, name_.source);
           return false;
         }
       }
@@ -562,16 +560,14 @@ bool AllocationCheckerHelper::RunCoarrayRelatedChecks(
           context
               .Say(allocateInfo_.sourceExprLoc.value(),
                   "SOURCE or MOLD expression type must not be TEAM_TYPE from ISO_FORTRAN_ENV when an allocatable object is a coarray"_err_en_US)
-              .Attach(name_.source, "'%s' is a coarray"_en_US,
-                  name_.source.ToString().c_str());
+              .Attach(name_.source, "'%s' is a coarray"_en_US, name_.source);
           return false;
         } else if (IsDerivedTypeFromModule(derived, "iso_c_binding", "c_ptr") ||
             IsDerivedTypeFromModule(derived, "iso_c_binding", "c_funptr")) {
           context
               .Say(allocateInfo_.sourceExprLoc.value(),
                   "SOURCE or MOLD expression type must not be C_PTR or C_FUNPTR from ISO_C_BINDING when an allocatable object is a coarray"_err_en_US)
-              .Attach(name_.source, "'%s' is a coarray"_en_US,
-                  name_.source.ToString().c_str());
+              .Attach(name_.source, "'%s' is a coarray"_en_US, name_.source);
           return false;
         }
       }

--- a/lib/semantics/check-coarray.cc
+++ b/lib/semantics/check-coarray.cc
@@ -90,8 +90,8 @@ void CoarrayChecker::CheckNamesAreDistinct(
 void CoarrayChecker::Say2(const parser::CharBlock &name1,
     parser::MessageFixedText &&msg1, const parser::CharBlock &name2,
     parser::MessageFixedText &&msg2) {
-  context_.Say(name1, std::move(msg1), name1.ToString().c_str())
-      .Attach(name2, std::move(msg2), name2.ToString().c_str());
+  context_.Say(name1, std::move(msg1), name1)
+      .Attach(name2, std::move(msg2), name2);
 }
 
 }

--- a/lib/semantics/check-do-concurrent.cc
+++ b/lib/semantics/check-do-concurrent.cc
@@ -266,15 +266,14 @@ public:
       if (do_depth_ == 0) {
         messages_.Say(currentStatementSourcePosition_,
             "exit from DO CONCURRENT construct (%s)"_err_en_US,
-            doConcurrentSourcePosition_.ToString().data());
+            doConcurrentSourcePosition_);
       }
       // nesting of named constructs is assumed to have been previously checked
       // by the name/label resolution pass
     } else if (names_.find(nm.value().source) == names_.end()) {
       messages_.Say(currentStatementSourcePosition_,
           "exit from DO CONCURRENT construct (%s) to construct with name '%s'"_err_en_US,
-          doConcurrentSourcePosition_.ToString().data(),
-          nm.value().source.ToString().data());
+          doConcurrentSourcePosition_, nm.value().source);
     }
   }
   void checkLabelUse(const parser::Label &labelUsed) {

--- a/lib/semantics/check-io.cc
+++ b/lib/semantics/check-io.cc
@@ -139,7 +139,7 @@ void IoChecker::Enter(const parser::InputItem &spec) {
         // This check may be superseded by C928 or C1002.
         context_.Say(name.source,
             "'%s' must not be a whole assumed size array"_err_en_US,
-            name);  // C1231
+            name.source);  // C1231
       }
     }
   }

--- a/lib/semantics/check-io.cc
+++ b/lib/semantics/check-io.cc
@@ -139,7 +139,7 @@ void IoChecker::Enter(const parser::InputItem &spec) {
         // This check may be superseded by C928 or C1002.
         context_.Say(name.source,
             "'%s' must not be a whole assumed size array"_err_en_US,
-            name.ToString().c_str());  // C1231
+            name);  // C1231
       }
     }
   }
@@ -312,7 +312,7 @@ void IoChecker::Enter(const parser::StatusExpr &spec) {
     CHECK(stmt_ == IoStmtKind::Close);
     if (s != "DELETE" && s != "KEEP") {
       context_.Say(parser::FindSourceLocation(spec),
-          "invalid STATUS value '%s'"_err_en_US, (*charConst).c_str());
+          "invalid STATUS value '%s'"_err_en_US, *charConst);
     }
   }
 }
@@ -476,7 +476,7 @@ void IoChecker::SetSpecifier(IoSpecKind specKind) {
   // C1203, C1207, C1210, C1236, C1239, C1242, C1245
   if (specifierSet_.test(specKind)) {
     context_.Say("duplicate %s specifier"_err_en_US,
-        parser::ToUpperCaseLetters(common::EnumToString(specKind)).c_str());
+        parser::ToUpperCaseLetters(common::EnumToString(specKind)));
   }
   specifierSet_.set(specKind);
 }
@@ -506,8 +506,7 @@ void IoChecker::CheckStringValue(IoSpecKind specKind, const std::string &value,
   };
   if (!specValues.at(specKind).count(parser::ToUpperCaseLetters(value))) {
     context_.Say(source, "invalid %s value '%s'"_err_en_US,
-        parser::ToUpperCaseLetters(common::EnumToString(specKind)).c_str(),
-        value.c_str());
+        parser::ToUpperCaseLetters(common::EnumToString(specKind)), value);
   }
 }
 
@@ -520,8 +519,8 @@ void IoChecker::CheckStringValue(IoSpecKind specKind, const std::string &value,
 void IoChecker::CheckForRequiredSpecifier(IoSpecKind specKind) const {
   if (!specifierSet_.test(specKind)) {
     context_.Say("%s statement must have a %s specifier"_err_en_US,
-        parser::ToUpperCaseLetters(common::EnumToString(stmt_)).c_str(),
-        parser::ToUpperCaseLetters(common::EnumToString(specKind)).c_str());
+        parser::ToUpperCaseLetters(common::EnumToString(stmt_)),
+        parser::ToUpperCaseLetters(common::EnumToString(specKind)));
   }
 }
 
@@ -529,8 +528,7 @@ void IoChecker::CheckForRequiredSpecifier(
     bool condition, const std::string &s) const {
   if (!condition) {
     context_.Say("%s statement must have a %s specifier"_err_en_US,
-        parser::ToUpperCaseLetters(common::EnumToString(stmt_)).c_str(),
-        s.c_str());
+        parser::ToUpperCaseLetters(common::EnumToString(stmt_)), s);
   }
 }
 
@@ -538,8 +536,8 @@ void IoChecker::CheckForRequiredSpecifier(
     IoSpecKind specKind1, IoSpecKind specKind2) const {
   if (specifierSet_.test(specKind1) && !specifierSet_.test(specKind2)) {
     context_.Say("if %s appears, %s must also appear"_err_en_US,
-        parser::ToUpperCaseLetters(common::EnumToString(specKind1)).c_str(),
-        parser::ToUpperCaseLetters(common::EnumToString(specKind2)).c_str());
+        parser::ToUpperCaseLetters(common::EnumToString(specKind1)),
+        parser::ToUpperCaseLetters(common::EnumToString(specKind2)));
   }
 }
 
@@ -547,32 +545,30 @@ void IoChecker::CheckForRequiredSpecifier(
     IoSpecKind specKind, bool condition, const std::string &s) const {
   if (specifierSet_.test(specKind) && !condition) {
     context_.Say("if %s appears, %s must also appear"_err_en_US,
-        parser::ToUpperCaseLetters(common::EnumToString(specKind)).c_str(),
-        s.c_str());
+        parser::ToUpperCaseLetters(common::EnumToString(specKind)), s);
   }
 }
 
 void IoChecker::CheckForRequiredSpecifier(
     bool condition, const std::string &s, IoSpecKind specKind) const {
   if (condition && !specifierSet_.test(specKind)) {
-    context_.Say("if %s appears, %s must also appear"_err_en_US, s.c_str(),
-        parser::ToUpperCaseLetters(common::EnumToString(specKind)).c_str());
+    context_.Say("if %s appears, %s must also appear"_err_en_US, s,
+        parser::ToUpperCaseLetters(common::EnumToString(specKind)));
   }
 }
 
 void IoChecker::CheckForRequiredSpecifier(bool condition1,
     const std::string &s1, bool condition2, const std::string &s2) const {
   if (condition1 && !condition2) {
-    context_.Say(
-        "if %s appears, %s must also appear"_err_en_US, s1.c_str(), s2.c_str());
+    context_.Say("if %s appears, %s must also appear"_err_en_US, s1, s2);
   }
 }
 
 void IoChecker::CheckForProhibitedSpecifier(IoSpecKind specKind) const {
   if (specifierSet_.test(specKind)) {
     context_.Say("%s statement must not have a %s specifier"_err_en_US,
-        parser::ToUpperCaseLetters(common::EnumToString(stmt_)).c_str(),
-        parser::ToUpperCaseLetters(common::EnumToString(specKind)).c_str());
+        parser::ToUpperCaseLetters(common::EnumToString(stmt_)),
+        parser::ToUpperCaseLetters(common::EnumToString(specKind)));
   }
 }
 
@@ -580,8 +576,8 @@ void IoChecker::CheckForProhibitedSpecifier(
     IoSpecKind specKind1, IoSpecKind specKind2) const {
   if (specifierSet_.test(specKind1) && specifierSet_.test(specKind2)) {
     context_.Say("if %s appears, %s must not appear"_err_en_US,
-        parser::ToUpperCaseLetters(common::EnumToString(specKind1)).c_str(),
-        parser::ToUpperCaseLetters(common::EnumToString(specKind2)).c_str());
+        parser::ToUpperCaseLetters(common::EnumToString(specKind1)),
+        parser::ToUpperCaseLetters(common::EnumToString(specKind2)));
   }
 }
 
@@ -589,16 +585,15 @@ void IoChecker::CheckForProhibitedSpecifier(
     IoSpecKind specKind, bool condition, const std::string &s) const {
   if (specifierSet_.test(specKind) && condition) {
     context_.Say("if %s appears, %s must not appear"_err_en_US,
-        parser::ToUpperCaseLetters(common::EnumToString(specKind)).c_str(),
-        s.c_str());
+        parser::ToUpperCaseLetters(common::EnumToString(specKind)), s);
   }
 }
 
 void IoChecker::CheckForProhibitedSpecifier(
     bool condition, const std::string &s, IoSpecKind specKind) const {
   if (condition && specifierSet_.test(specKind)) {
-    context_.Say("if %s appears, %s must not appear"_err_en_US, s.c_str(),
-        parser::ToUpperCaseLetters(common::EnumToString(specKind)).c_str());
+    context_.Say("if %s appears, %s must not appear"_err_en_US, s,
+        parser::ToUpperCaseLetters(common::EnumToString(specKind)));
   }
 }
 

--- a/lib/semantics/resolve-labels.cc
+++ b/lib/semantics/resolve-labels.cc
@@ -387,12 +387,12 @@ public:
           if (optionalGenericSpec.has_value()) {
             if (const auto *otherPointer{
                     std::get_if<parser::Name>(&optionalGenericSpec->u)}) {
-              if (namePointer->ToString() != otherPointer->ToString()) {
+              if (namePointer->source != otherPointer->source) {
                 errorHandler_
                     .Say(currentPosition_,
                         parser::MessageFormattedText{
                             "INTERFACE generic-name (%s) mismatch"_en_US,
-                            namePointer->ToString().c_str()})
+                            namePointer->source})
                     .Attach(interfaceStmt.source, "mismatched INTERFACE"_en_US);
               }
             }

--- a/lib/semantics/rewrite-parse-tree.cc
+++ b/lib/semantics/rewrite-parse-tree.cc
@@ -75,8 +75,8 @@ private:
 // Check that name has been resolved to a symbol
 void RewriteMutator::Post(parser::Name &name) {
   if (name.symbol == nullptr && errorOnUnresolvedName_) {
-    messages_.Say(name.source, "Internal: no symbol found for '%s'"_err_en_US,
-        name.ToString().c_str());
+    messages_.Say(
+        name.source, "Internal: no symbol found for '%s'"_err_en_US, name);
   }
 }
 

--- a/lib/semantics/rewrite-parse-tree.cc
+++ b/lib/semantics/rewrite-parse-tree.cc
@@ -75,8 +75,8 @@ private:
 // Check that name has been resolved to a symbol
 void RewriteMutator::Post(parser::Name &name) {
   if (name.symbol == nullptr && errorOnUnresolvedName_) {
-    messages_.Say(
-        name.source, "Internal: no symbol found for '%s'"_err_en_US, name);
+    messages_.Say(name.source, "Internal: no symbol found for '%s'"_err_en_US,
+        name.source);
   }
 }
 

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -298,8 +298,7 @@ const DeclTypeSpec &Scope::InstantiateIntrinsicType(
           "did not resolve to a supported value"_err_en_US,
           static_cast<std::intmax_t>(*value),
           parser::ToUpperCaseLetters(
-              common::EnumToString(intrinsic->category()))
-              .data());
+              common::EnumToString(intrinsic->category())));
     }
   }
   switch (spec.category()) {

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -92,15 +92,13 @@ public:
   bool HasError(const parser::Name &);
   void SetError(Symbol &, bool = true);
 
-  template<typename... A>
-  common::IfNoLvalue<parser::Message &, A...> Say(
-      parser::CharBlock at, A &&... args) {
-    return messages_.Say(at, std::move(args)...);
+  template<typename... A> parser::Message &Say(A &&... args) {
+    CHECK(location_);
+    return messages_.Say(*location_, std::forward<A>(args)...);
   }
   template<typename... A>
-  common::IfNoLvalue<parser::Message &, A...> Say(A &&... args) {
-    CHECK(location_);
-    return messages_.Say(*location_, std::move(args)...);
+  parser::Message &Say(parser::CharBlock at, A &&... args) {
+    return messages_.Say(at, std::forward<A>(args)...);
   }
   parser::Message &Say(parser::Message &&msg) {
     return messages_.Say(std::move(msg));

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -105,7 +105,7 @@ void DerivedTypeSpec::Instantiate(
           if (auto *msg{foldingContext.messages().Say(
                   "Value of kind type parameter '%s' (%s) is not "
                   "scalar INTEGER constant"_err_en_US,
-                  name.ToString().data(), fortran.str().data())}) {
+                  name, fortran.str())}) {
             msg->Attach(name, "declared here"_en_US);
           }
         }


### PR DESCRIPTION
Based on a suggestion from Jean.  Allows for formatting of CharBlock and std::string with regular '%s' formats.