### PR TITLE
Handle remaining cases in expression tree traversal

### DIFF
--- a/lib/evaluate/descender.h
+++ b/lib/evaluate/descender.h
@@ -107,19 +107,23 @@ public:
   template<typename T> void Descend(const Expr<T> &expr) { Visit(expr.u); }
   template<typename T> void Descend(Expr<T> &expr) { Visit(expr.u); }
 
-  template<typename D, typename R, typename... O>
-  void Descend(const Operation<D, R, O...> &op) {
+  template<typename D, typename R, typename X>
+  void Descend(const Operation<D, R, X> &op) {
     Visit(op.left());
-    if constexpr (op.operands > 1) {
-      Visit(op.right());
-    }
   }
-  template<typename D, typename R, typename... O>
-  void Descend(Operation<D, R, O...> &op) {
+  template<typename D, typename R, typename X>
+  void Descend(Operation<D, R, X> &op) {
     Visit(op.left());
-    if constexpr (op.operands > 1) {
-      Visit(op.right());
-    }
+  }
+  template<typename D, typename R, typename X, typename Y>
+  void Descend(const Operation<D, R, X, Y> &op) {
+    Visit(op.left());
+    Visit(op.right());
+  }
+  template<typename D, typename R, typename X, typename Y>
+  void Descend(Operation<D, R, X, Y> &op) {
+    Visit(op.left());
+    Visit(op.right());
   }
 
   void Descend(const Relational<SomeType> &r) { Visit(r.u); }

--- a/lib/evaluate/descender.h
+++ b/lib/evaluate/descender.h
@@ -233,9 +233,15 @@ public:
     Visit(triplet.stride());
   }
   void Descend(Triplet &triplet) {
-    Visit(triplet.lower());
-    Visit(triplet.upper());
-    Visit(triplet.stride());
+    if (auto x{triplet.lower()}) {
+      Visit(*x);
+      triplet.set_lower(std::move(*x));
+    }
+    if (auto x{triplet.upper()}) {
+      Visit(*x);
+      triplet.set_upper(std::move(*x));
+    }
+    triplet.set_stride(Visit(triplet.stride()));
   }
 
   void Descend(const Subscript &sscript) { Visit(sscript.u); }
@@ -261,8 +267,14 @@ public:
     Visit(caref.base());
     Visit(caref.subscript());
     Visit(caref.cosubscript());
-    Visit(caref.stat());
-    Visit(caref.team());
+    if (auto x{caref.stat()}) {
+      Visit(*x);
+      caref.set_stat(std::move(*x));
+    }
+    if (auto x{caref.team()}) {
+      Visit(*x);
+      caref.set_team(std::move(*x), caref.teamIsTeamNumber());
+    }
   }
 
   void Descend(const DataRef &data) { Visit(data.u); }
@@ -278,8 +290,12 @@ public:
   }
   void Descend(Substring &ss) {
     Visit(ss.parent());
-    Visit(ss.lower());
-    Visit(ss.upper());
+    auto lx{ss.lower()};
+    Visit(lx);
+    ss.set_lower(std::move(lx));
+    auto ux{ss.upper()};
+    Visit(ux);
+    ss.set_lower(std::move(ux));
   }
 
   template<typename T> void Descend(const Designator<T> &designator) {

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -638,10 +638,10 @@ FOR_EACH_CHARACTER_KIND(extern template class Expr, )
 // addition operator.  Character relations must have the same kind.
 // There are no relations between LOGICAL values.
 
-template<typename A>
-struct Relational : public Operation<Relational<A>, LogicalResult, A, A> {
+template<typename T>
+struct Relational : public Operation<Relational<T>, LogicalResult, T, T> {
   using Result = LogicalResult;
-  using Base = Operation<Relational, LogicalResult, A, A>;
+  using Base = Operation<Relational, LogicalResult, T, T>;
   using Operand = typename Base::template Operand<0>;
   static_assert(Operand::category == TypeCategory::Integer ||
       Operand::category == TypeCategory::Real ||

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -158,8 +158,13 @@ DataRef FoldOperation(FoldingContext &context, DataRef &&dataRef) {
 }
 
 Substring FoldOperation(FoldingContext &context, Substring &&substring) {
-  std::optional<Expr<SubscriptInteger>> lower{Fold(context, substring.lower())};
-  std::optional<Expr<SubscriptInteger>> upper{Fold(context, substring.upper())};
+  std::optional<Expr<SubscriptInteger>> lower, upper;
+  if (auto *p{substring.lower()}) {
+    lower = Fold(context, std::move(*p));
+  }
+  if (auto *p{substring.upper()}) {
+    upper = Fold(context, std::move(*p));
+  }
   if (const DataRef * dataRef{substring.GetParentIf<DataRef>()}) {
     return Substring{FoldOperation(context, DataRef{*dataRef}),
         std::move(lower), std::move(upper)};

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -158,13 +158,8 @@ DataRef FoldOperation(FoldingContext &context, DataRef &&dataRef) {
 }
 
 Substring FoldOperation(FoldingContext &context, Substring &&substring) {
-  std::optional<Expr<SubscriptInteger>> lower, upper;
-  if (auto *p{substring.lower()}) {
-    lower = Fold(context, std::move(*p));
-  }
-  if (auto *p{substring.upper()}) {
-    upper = Fold(context, std::move(*p));
-  }
+  auto lower{Fold(context, substring.lower())};
+  auto upper{Fold(context, substring.upper())};
   if (const DataRef * dataRef{substring.GetParentIf<DataRef>()}) {
     return Substring{FoldOperation(context, DataRef{*dataRef}),
         std::move(lower), std::move(upper)};

--- a/lib/evaluate/variable.cc
+++ b/lib/evaluate/variable.cc
@@ -50,6 +50,11 @@ std::optional<Expr<SubscriptInteger>> Triplet::lower() const {
   return std::nullopt;
 }
 
+Triplet &Triplet::set_lower(Expr<SubscriptInteger> &&expr) {
+  lower_.emplace(std::move(expr));
+  return *this;
+}
+
 std::optional<Expr<SubscriptInteger>> Triplet::upper() const {
   if (upper_) {
     return {upper_.value().value()};
@@ -57,7 +62,17 @@ std::optional<Expr<SubscriptInteger>> Triplet::upper() const {
   return std::nullopt;
 }
 
+Triplet &Triplet::set_upper(Expr<SubscriptInteger> &&expr) {
+  upper_.emplace(std::move(expr));
+  return *this;
+}
+
 Expr<SubscriptInteger> Triplet::stride() const { return stride_.value(); }
+
+Triplet &Triplet::set_stride(Expr<SubscriptInteger> &&expr) {
+  stride_.value() = std::move(expr);
+  return *this;
+}
 
 bool Triplet::IsStrideOne() const {
   if (auto stride{ToInt64(stride_.value())}) {
@@ -114,10 +129,10 @@ const Symbol &CoarrayRef::GetLastSymbol() const { return *base_.back(); }
 void Substring::SetBounds(std::optional<Expr<SubscriptInteger>> &lower,
     std::optional<Expr<SubscriptInteger>> &upper) {
   if (lower.has_value()) {
-    lower_.emplace(std::move(lower.value()));
+    set_lower(std::move(lower.value()));
   }
   if (upper.has_value()) {
-    upper_.emplace(std::move(upper.value()));
+    set_upper(std::move(upper.value()));
   }
 }
 
@@ -129,12 +144,9 @@ Expr<SubscriptInteger> Substring::lower() const {
   }
 }
 
-Expr<SubscriptInteger> *Substring::lower() {
-  if (lower_.has_value()) {
-    return &lower_.value().value();
-  } else {
-    return nullptr;
-  }
+Substring &Substring::set_lower(Expr<SubscriptInteger> &&expr) {
+  lower_.emplace(std::move(expr));
+  return *this;
 }
 
 Expr<SubscriptInteger> Substring::upper() const {
@@ -152,12 +164,9 @@ Expr<SubscriptInteger> Substring::upper() const {
   }
 }
 
-Expr<SubscriptInteger> *Substring::upper() {
-  if (upper_.has_value()) {
-    return &upper_.value().value();
-  } else {
-    return nullptr;
-  }
+Substring &Substring::set_upper(Expr<SubscriptInteger> &&expr) {
+  upper_.emplace(std::move(expr));
+  return *this;
 }
 
 std::optional<Expr<SomeCharacter>> Substring::Fold(FoldingContext &context) {

--- a/lib/evaluate/variable.cc
+++ b/lib/evaluate/variable.cc
@@ -129,6 +129,14 @@ Expr<SubscriptInteger> Substring::lower() const {
   }
 }
 
+Expr<SubscriptInteger> *Substring::lower() {
+  if (lower_.has_value()) {
+    return &lower_.value().value();
+  } else {
+    return nullptr;
+  }
+}
+
 Expr<SubscriptInteger> Substring::upper() const {
   if (upper_.has_value()) {
     return upper_.value().value();
@@ -141,6 +149,14 @@ Expr<SubscriptInteger> Substring::upper() const {
             },
         },
         parent_);
+  }
+}
+
+Expr<SubscriptInteger> *Substring::upper() {
+  if (upper_.has_value()) {
+    return &upper_.value().value();
+  } else {
+    return nullptr;
   }
 }
 

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -273,6 +273,8 @@ struct DataRef {
 // In the F2018 standard, substrings of array sections are parsed as
 // variants of sections instead.
 class Substring {
+  using Parent = std::variant<DataRef, StaticDataObject::Pointer>;
+
 public:
   CLASS_BOILERPLATE(Substring)
   Substring(DataRef &&parent, std::optional<Expr<SubscriptInteger>> &&lower,
@@ -288,7 +290,12 @@ public:
   }
 
   Expr<SubscriptInteger> lower() const;
+  Expr<SubscriptInteger> *lower();
   Expr<SubscriptInteger> upper() const;
+  Expr<SubscriptInteger> *upper();
+  const Parent &parent() const { return parent_; }
+  Parent &parent() { return parent_; }
+
   int Rank() const;
   template<typename A> const A *GetParentIf() const {
     return std::get_if<A>(&parent_);

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -140,9 +140,14 @@ public:
   Triplet(std::optional<Expr<SubscriptInteger>> &&,
       std::optional<Expr<SubscriptInteger>> &&,
       std::optional<Expr<SubscriptInteger>> &&);
+
   std::optional<Expr<SubscriptInteger>> lower() const;
+  Triplet &set_lower(Expr<SubscriptInteger> &&);
   std::optional<Expr<SubscriptInteger>> upper() const;
-  Expr<SubscriptInteger> stride() const;
+  Triplet &set_upper(Expr<SubscriptInteger> &&);
+  Expr<SubscriptInteger> stride() const;  // N.B. result is not optional<>
+  Triplet &set_stride(Expr<SubscriptInteger> &&);
+
   bool operator==(const Triplet &) const;
   bool IsStrideOne() const;
   std::ostream &AsFortran(std::ostream &) const;
@@ -290,9 +295,9 @@ public:
   }
 
   Expr<SubscriptInteger> lower() const;
-  Expr<SubscriptInteger> *lower();
+  Substring &set_lower(Expr<SubscriptInteger> &&);
   Expr<SubscriptInteger> upper() const;
-  Expr<SubscriptInteger> *upper();
+  Substring &set_upper(Expr<SubscriptInteger> &&);
   const Parent &parent() const { return parent_; }
   Parent &parent() { return parent_; }
 

--- a/lib/semantics/check-do-concurrent.cc
+++ b/lib/semantics/check-do-concurrent.cc
@@ -339,7 +339,8 @@ static CS GatherReferencesFromExpression(const parser::Expr &expression) {
       explicit CollectSymbols(int) {}
       void Handle(const Symbol *symbol) { result().push_back(symbol); }
     };
-    return evaluate::Visitor<CollectSymbols>{0}.Traverse(*expression.typedExpr);
+    return evaluate::Visitor<GRFECollectSymbols>{0}.Traverse(
+        expression.typedExpr->v);
   } else {
     GatherSymbols gatherSymbols;
     parser::Walk(expression, gatherSymbols);

--- a/lib/semantics/check-do-concurrent.cc
+++ b/lib/semantics/check-do-concurrent.cc
@@ -332,19 +332,13 @@ static CS GatherVariables(const std::list<parser::LocalitySpec> &localitySpecs,
 }
 
 static CS GatherReferencesFromExpression(const parser::Expr &expression) {
-  // Use the new expression traversal framework if possible, for testing.
-  if (expression.typedExpr) {
+  if (const auto *expr{GetExpr(expression)}) {
     struct CollectSymbols : public virtual evaluate::VisitorBase<CS> {
       using Result = CS;
       explicit CollectSymbols(int) {}
       void Handle(const Symbol *symbol) { result().push_back(symbol); }
     };
-    return evaluate::Visitor<CollectSymbols>{0}.Traverse(
-        expression.typedExpr->v);
-  } else {
-    GatherSymbols gatherSymbols;
-    parser::Walk(expression, gatherSymbols);
-    return gatherSymbols.symbols;
+    return evaluate::Visitor<CollectSymbols>{0}.Traverse(*expr);
   }
 }
 

--- a/lib/semantics/check-do-concurrent.cc
+++ b/lib/semantics/check-do-concurrent.cc
@@ -339,7 +339,7 @@ static CS GatherReferencesFromExpression(const parser::Expr &expression) {
       explicit CollectSymbols(int) {}
       void Handle(const Symbol *symbol) { result().push_back(symbol); }
     };
-    return evaluate::Visitor<GRFECollectSymbols>{0}.Traverse(
+    return evaluate::Visitor<CollectSymbols>{0}.Traverse(
         expression.typedExpr->v);
   } else {
     GatherSymbols gatherSymbols;

--- a/lib/semantics/check-do-concurrent.cc
+++ b/lib/semantics/check-do-concurrent.cc
@@ -339,6 +339,8 @@ static CS GatherReferencesFromExpression(const parser::Expr &expression) {
       void Handle(const Symbol *symbol) { result().push_back(symbol); }
     };
     return evaluate::Visitor<CollectSymbols>{0}.Traverse(*expr);
+  } else {
+    return {};
   }
 }
 


### PR DESCRIPTION
Pete noticed some odd behavior; this PR fills in the gaps, and removes the dangerous "no-op by default" base case so that we know all cases are handled.