### PR TITLE
Added a test for C1121, DO scalar-mask-expr cannot reference IMPURE procedure

### DIFF
--- a/lib/semantics/check-do-concurrent.cc
+++ b/lib/semantics/check-do-concurrent.cc
@@ -407,6 +407,7 @@ private:
   }
   void CheckMaskIsPure(const parser::ScalarLogicalExpr &mask) const {
     // C1121 - procedures in mask must be pure
+    // TODO - add the name of the impure procedure to the message
     CS references{GatherReferencesFromExpression(mask.thing.thing.value())};
     for (auto *r : references) {
       if (isProcedure(r->flags()) && !isPure(r->attrs())) {

--- a/lib/semantics/check-do-concurrent.cc
+++ b/lib/semantics/check-do-concurrent.cc
@@ -411,7 +411,7 @@ private:
     for (auto *r : references) {
       if (isProcedure(r->flags()) && !isPure(r->attrs())) {
         messages_.Say(currentStatementSourcePosition_,
-            "concurrent-header mask expression cannot reference impure"
+            "concurrent-header mask expression cannot reference an impure"
             " procedure"_err_en_US);
         return;
       }

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -123,6 +123,7 @@ set(ERROR_TESTS
   allocate12.f90
   allocate13.f90
   dosemantics01.f90
+  dosemantics02.f90
   expr-errors01.f90
   null01.f90
 )

--- a/test/semantics/dosemantics02.f90
+++ b/test/semantics/dosemantics02.f90
@@ -1,0 +1,33 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! C1121 -- any procedure referenced in a concurrent header must be pure
+
+! RUN: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
+! CHECK: image control statement not allowed in DO CONCURRENT
+
+SUBROUTINE do_concurrent_c1121(i,n)
+  IMPLICIT NONE
+  INTEGER :: i, n, flag
+!ERROR: concurrent-header mask expression cannot reference an impure procedure
+  DO CONCURRENT (i = 1:n, random() < 3)
+    flag = 3
+  END DO
+
+  CONTAINS
+    IMPURE FUNCTION random() RESULT(i)
+      INTEGER :: i
+      i = 35
+    END FUNCTION random
+END SUBROUTINE do_concurrent_c1121

--- a/test/semantics/dosemantics02.f90
+++ b/test/semantics/dosemantics02.f90
@@ -15,7 +15,6 @@
 ! C1121 -- any procedure referenced in a concurrent header must be pure
 
 ! RUN: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
-! CHECK: image control statement not allowed in DO CONCURRENT
 
 SUBROUTINE do_concurrent_c1121(i,n)
   IMPLICIT NONE


### PR DESCRIPTION
scalar-mask-expr cannot reference an IMPURE procedure.