### PR TITLE
OpenMP 4.5 grammar related minor fixes

### DIFF
--- a/documentation/OpenMP-4.5-grammar.txt
+++ b/documentation/OpenMP-4.5-grammar.txt
@@ -5,11 +5,11 @@
 2.1.1 sentinel -> !$omp | c$omp | *$omp
 2.1.2 sentinel -> !$omp
 # directive-name(constructs)
-2.5 parallel -> PARALLEL 
-2.7.1 do -> DO 
+2.5 parallel -> PARALLEL
+2.7.1 do -> DO
 2.7.2 sections -> SECTIONS
-2.7.3 workshare -> WORKSHARE 
-2.7.4 single-construct -> SINGLE 
+2.7.3 workshare -> WORKSHARE
+2.7.4 single-construct -> SINGLE
 2.8.1 simd-construct -> SIMD
 2.8.2 declare-simd -> DECLARE SIMD
 2.8.3 do-simd-construct -> DO SIMD
@@ -18,36 +18,36 @@
 2.9.3 taskloop-simd -> TASKLOOP SIMD
 2.9.4 taskyield -> TASKYIELD
 2.10.1 target-data -> TARGET DATA
-2.10.2 target-enter-data -> TARGET ENTER DATA 
-2.10.3 target-exit-data -> TARGET EXIT DATA 
+2.10.2 target-enter-data -> TARGET ENTER DATA
+2.10.3 target-exit-data -> TARGET EXIT DATA
 2.10.4 target -> TARGET
 2.10.5 target-update -> TARGET UPDATE
 2.10.6 declare-target -> DECLARE TARGET
 2.10.7 teams -> TEAMS
 2.10.8 distribute -> DISTRIBUTE
 2.10.9 distribute-simd -> DISTRIBUTE SIMD
-2.10.10 distribute-parellel-do -> DISTRIBUTE PARALLEL DO 
+2.10.10 distribute-parellel-do -> DISTRIBUTE PARALLEL DO
 2.10.11 distribute-parallel-do-simd ->DISTRIBUTE PARALLEL DO SIMD
 2.11.1 parallel-do -> PARALLEL DO
-2.11.2 parallel-sections -> PARALLEL SECTIONS 
+2.11.2 parallel-sections -> PARALLEL SECTIONS
 2.11.3 parallel-workshare -> PARALLEL WORKSHARE
 2.11.4 parallel-do-simd -> PARALLEL DO SIMD
 2.11.5 target-parallel -> TARGET PARALLEL
-2.11.6 target-parallel-do -> TARGET PARALLEL DO 
-2.11.7 target-parallel-do-simd -> TARGET PARALLEL DO SIMD 
+2.11.6 target-parallel-do -> TARGET PARALLEL DO
+2.11.7 target-parallel-do-simd -> TARGET PARALLEL DO SIMD
 2.11.8 target-simd -> TARGET SIMD
 2.11.9 target-teams -> TARGET TEAMS
 2.11.10 teams-distribute -> TEAMS DISTRIBUTE
-2.11.11 teams distribute-simd -> TEAMS DISTRIBUTE SIME 
-2.11.12 target-teams-distribute -> TARGET TEAMS DISTRIBUTE 
-2.11.13 target-teams-distribute-simd -> TARGET TEAMS DISTRIBUTE SIMD 
-2.11.14 teams-distribute-parallel-do -> TEAMS DISTRIBUTE PARALLEL DO 
-2.11.15 target-teams-distribute-parallel-do -> 
-                             TARGET TEAMS DISTRIBUTE PARALLEL DO 
-2.11.16 teams-distribute-parallel-do-simd -> 
-                             TEAMS DISTRIBUTE PARALLEL DO 
+2.11.11 teams distribute-simd -> TEAMS DISTRIBUTE SIMD
+2.11.12 target-teams-distribute -> TARGET TEAMS DISTRIBUTE
+2.11.13 target-teams-distribute-simd -> TARGET TEAMS DISTRIBUTE SIMD
+2.11.14 teams-distribute-parallel-do -> TEAMS DISTRIBUTE PARALLEL DO
+2.11.15 target-teams-distribute-parallel-do ->
+                             TARGET TEAMS DISTRIBUTE PARALLEL DO
+2.11.16 teams-distribute-parallel-do-simd ->
+                             TEAMS DISTRIBUTE PARALLEL DO SIMD
 2.11.17 target-teams-distribute-parallel-do-simd ->
-                             TARGET TEAMS DISTRIBUTE PARALLEL DO SIMD 
+                             TARGET TEAMS DISTRIBUTE PARALLEL DO SIMD
 2.13.1 master -> MASTER
 2.13.2 critical -> CRITICAL
 2.13.3 barrier -> BARRIER
@@ -89,7 +89,7 @@
 2.9.2 priority -> PRIORITY (scalar-int-expr)
 2.9.2 mergeable -> MERGEABLE
 2.9.2 final -> FINAL (scalar-int-expr)
-2.10.1 use_deice_ptr -> USE_DEVICE_PTR (variable-name-list)
+2.10.1 use_device_ptr -> USE_DEVICE_PTR (variable-name-list)
 2.10.1 device -> DEVICE (scalar-integer-expr)
 2.10.5 to -> TO (variable-name-list)
 2.10.5 from -> FROM (variable-name-list)

--- a/lib/parser/openmp-grammar.h
+++ b/lib/parser/openmp-grammar.h
@@ -80,7 +80,7 @@ TYPE_PARSER(construct<OmpScheduleModifierType>(
     "SIMD" >> pure(OmpScheduleModifierType::ModType::Simd)))
 
 TYPE_PARSER(construct<OmpScheduleModifier>(Parser<OmpScheduleModifierType>{},
-    maybe(","_tok >> Parser<OmpScheduleModifierType>{})))
+    maybe(","_tok >> Parser<OmpScheduleModifierType>{}) / ":"_tok))
 
 TYPE_PARSER(construct<OmpScheduleClause>(maybe(Parser<OmpScheduleModifier>{}),
     "STATIC" >> pure(OmpScheduleClause::ScheduleType::Static) ||

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -1790,7 +1790,7 @@ public:
   }
   void Unparse(const OmpScheduleClause &x) {
     Word("SCHEDULE(");
-    Walk(std::get<std::optional<OmpScheduleModifier>>(x.t));
+    Walk(std::get<std::optional<OmpScheduleModifier>>(x.t), ":");
     Walk(std::get<OmpScheduleClause::ScheduleType>(x.t));
     Walk(",", std::get<std::optional<ScalarIntExpr>>(x.t));
     Put(")");
@@ -1968,7 +1968,7 @@ public:
     Put(")");
   }
   void Unparse(const OmpClause::ThreadLimit &x) {
-    Word("THREADLIMIT(");
+    Word("THREAD_LIMIT(");
     Walk(x.v);
     Put(")");
   }


### PR DESCRIPTION
1. typo and trailing spaces within OpenMP-4.5-grammar.txt

2. parse (openmp-grammar.h) and unparse(unparse.cc) for:

   SCHEDULE ([modifier [, modifier]:]kind[, chunk_size])
   Modifier ->  MONITONIC | NONMONOTONIC | SIMD

where ":" is optional except at least one modifier is present.