### PR TITLE
Keep track of test that produce confusing parse messages

### DIFF
--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -197,6 +197,13 @@ set(IF_TESTS
   if_stmt01.f90
 )
 
+# These tests show situations where we'd like the parser to produce
+# better error messages.  We don't run these tests normally
+# See issue 456
+#set(PARSE_TESTS
+#  parserquirk01.f90
+#)
+
 foreach(test ${ERROR_TESTS})
   add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_errors.sh ${test})
 endforeach()
@@ -228,3 +235,7 @@ endforeach()
 foreach(test ${IF_TESTS})
   add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_any.sh ${test})
 endforeach()
+
+#foreach(test ${PARSE_TESTS})
+#  add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_errors.sh ${test})
+#endforeach()

--- a/test/semantics/parsequirk01.f90
+++ b/test/semantics/parsequirk01.f90
@@ -1,0 +1,31 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! The parse of this source produces messages that make it difficult 
+! to figure out what the problem is.
+!
+! This program compiles and executes without error on GNU Fortran
+!
+! RUN: ${F18} -fparse-only %s 2>&1 | ${FileCheck} %s
+
+PROGRAM parsequirk01
+  IMPLICIT NONE
+  INTEGER :: n
+  INTEGER, DIMENSION(5) :: table
+  n = 1
+
+  DO CONCURRENT (table(n) = 1:n)
+    PRINT *, "Hello"
+  END DO
+END PROGRAM parsequirk01


### PR DESCRIPTION
In the process of creating tests for DO semantics, I created a test that compiles and executes without
error on GNU Fortran.  f18 fails to parse it, which is correct in that the program is not standard Fortran.
But the error messages seemed confusing to me and in need of improvement.

I want to keep track of this test so that, if and when we decide to improve the parser's messages, it can
serve as a test case.