### PR TITLE
correct text: pointer can point to allocatable

### DIFF
--- a/documentation/FortranForCProgrammers.md
+++ b/documentation/FortranForCProgrammers.md
@@ -260,8 +260,7 @@ little like C++17's `std::visit()` on a discriminated union.
 Pointers
 --------
 Pointers are objects in Fortran, not data types.
-Pointers can point to data, arrays, and subprograms, but not to other pointers
-or to an allocatable.
+Pointers can point to data, arrays, and subprograms, but not to other pointers.
 A pointer can only point to data that has the `TARGET` attribute.
 Outside of the pointer assignment statement (`P=>X`) and some intrinsic
 functions and cases with pointer dummy arguments, pointers are implicitly

--- a/documentation/FortranForCProgrammers.md
+++ b/documentation/FortranForCProgrammers.md
@@ -261,6 +261,7 @@ Pointers
 --------
 Pointers are objects in Fortran, not data types.
 Pointers can point to data, arrays, and subprograms, but not to other pointers.
+A pointer to an `ALLOCATABLE` points to the `ALLOCATABLE's` data.
 A pointer can only point to data that has the `TARGET` attribute.
 Outside of the pointer assignment statement (`P=>X`) and some intrinsic
 functions and cases with pointer dummy arguments, pointers are implicitly


### PR DESCRIPTION
Minor text change to eliminate wrong statement.