### PR TITLE
Fix bug with comment clipping on compiler directives

### DIFF
--- a/lib/parser/prescan.cc
+++ b/lib/parser/prescan.cc
@@ -193,7 +193,7 @@ void Prescanner::Statement() {
       NormalizeCompilerDirectiveCommentMarker(*preprocessed);
       preprocessed->ToLowerCase();
       SourceFormChange(preprocessed->ToString());
-      preprocessed->ClipComment().Emit(cooked_);
+      preprocessed->ClipComment(true /* skip first ! */).Emit(cooked_);
       break;
     case LineClassification::Kind::Source:
       if (inFixedForm_) {

--- a/lib/parser/token-sequence.cc
+++ b/lib/parser/token-sequence.cc
@@ -221,16 +221,20 @@ TokenSequence &TokenSequence::RemoveRedundantBlanks(std::size_t firstChar) {
   return *this;
 }
 
-TokenSequence &TokenSequence::ClipComment() {
+TokenSequence &TokenSequence::ClipComment(bool skipFirst) {
   std::size_t tokens{SizeInTokens()};
   for (std::size_t j{0}; j < tokens; ++j) {
     if (TokenAt(j).FirstNonBlank() == '!') {
-      TokenSequence result;
-      if (j > 0) {
-        result.Put(*this, 0, j - 1);
+      if (skipFirst) {
+        skipFirst = false;
+      } else {
+        TokenSequence result;
+        if (j > 0) {
+          result.Put(*this, 0, j - 1);
+        }
+        swap(result);
+        return *this;
       }
-      swap(result);
-      return *this;
     }
   }
   return *this;

--- a/lib/parser/token-sequence.h
+++ b/lib/parser/token-sequence.h
@@ -108,7 +108,7 @@ public:
   bool HasRedundantBlanks(std::size_t firstChar = 0) const;
   TokenSequence &RemoveBlanks(std::size_t firstChar = 0);
   TokenSequence &RemoveRedundantBlanks(std::size_t firstChar = 0);
-  TokenSequence &ClipComment();
+  TokenSequence &ClipComment(bool skipFirst = false);
   void Emit(CookedSource &) const;
   void Dump(std::ostream &) const;
 


### PR DESCRIPTION
A recent fix to the prescanner to remove Fortran comments created by macro expansion had the side effect of removing anything that looks like a comment, such as OpenMP compiler directives.  Fix it so that comments are removed but directives are not.