### PR TITLE
Add location to folding warnings and related tests and prevent spurious "re-folding"

### DIFF
--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -1715,6 +1715,7 @@ Expr<T> FoldOperation(FoldingContext &context, Divide<T> &&x) {
       auto quotAndRem{folded->first.DivideSigned(folded->second)};
       if (quotAndRem.divisionByZero) {
         context.messages().Say("INTEGER(%d) division by zero"_en_US, T::kind);
+        return Expr<T>{std::move(x)};
       }
       if (quotAndRem.overflow) {
         context.messages().Say(
@@ -1964,6 +1965,15 @@ public:
       // TODO: Obviously many other intrinsics can be allowed
     } else {
       Return(false);
+    }
+  }
+
+  // Forbid integer divide by zero in constants.
+  template<int KIND>
+  void Handle(const Divide<Type<TypeCategory::Integer, KIND>> &division) {
+    using T = Type<TypeCategory::Integer, KIND>;
+    if (const auto divisor{GetScalarConstantValue<T>(division.right())}) {
+      Check(!divisor->IsZero());
     }
   }
 

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -195,7 +195,7 @@ static inline Expr<TR> FoldElementalIntrinsicHelper(FoldingContext &context,
       (... && IsSpecificIntrinsicType<TA>));  // TODO derived types for MERGE?
   static_assert(sizeof...(TA) > 0);
   std::tuple<const Constant<TA> *...> args{
-      UnwrapExpr<Constant<TA>>(*funcRef.arguments()[I].value().GetExpr())...};
+      GetConstantValue<TA>(*funcRef.arguments()[I].value().GetExpr())...};
   if ((... && (std::get<I>(args) != nullptr))) {
     // Compute the shape of the result based on shapes of arguments
     ConstantSubscripts shape;

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -159,8 +159,7 @@ public:
     if (auto maybeExpr{AnalyzeExpr(*context_, expr)}) {
       if (auto converted{
               evaluate::ConvertToType(symbol, std::move(*maybeExpr))}) {
-        return FoldExpr(
-            evaluate::ConvertToType(symbol, AnalyzeExpr(*context_, expr)));
+        return FoldExpr(std::move(*converted));
       } else {
         Say(source,
             "Initialization expression could not be converted to declared type of symbol '%s'"_err_en_US,

--- a/test/evaluate/CMakeLists.txt
+++ b/test/evaluate/CMakeLists.txt
@@ -119,6 +119,7 @@ target_link_libraries(folding-test
 set(FOLDING_TESTS
   folding01.f90
   folding02.f90
+  folding03.f90
 )
 
 

--- a/test/evaluate/CMakeLists.txt
+++ b/test/evaluate/CMakeLists.txt
@@ -120,6 +120,7 @@ set(FOLDING_TESTS
   folding01.f90
   folding02.f90
   folding03.f90
+  folding04.f90
 )
 
 

--- a/test/evaluate/folding03.f90
+++ b/test/evaluate/folding03.f90
@@ -15,261 +15,289 @@
 ! Test operation folding edge case (both expected value and messages)
 ! These tests make assumptions regarding real(4) and integer(4) extrema.
 
-program test
-  integer(4), parameter :: i4_neg_max = int(Z'FFFFFFFF')
-  integer(4), parameter :: i4_nmax = -2147483647_4 - 1_4 !TODO bug that -2147483648_4 cannot be written ?
-  integer(4), parameter :: i4_nmax2 = -2147483648_4
-  integer(4), parameter :: i4_pmax1 = 2147483647_4
-  integer(4), parameter :: i4_pmax2 = 2147483648_4
+#define TEST_ISNAN(v) logical, parameter :: test_##v =.NOT.(v.EQ.v)
 
-print*, "i4_neg_max ", i4_neg_max
-print*, "i4_nmax ", i4_nmax
-print*, "i4_nmax2 ", i4_nmax2
-print*, "i4_pmax1 ", i4_pmax1
-print*, "i4_pmax2 ", i4_pmax2
+! TODO: 2 behaviors to clarify:
 
-end program
+!  Biggest negative literal integer(4): -(2**31) or -(2**31-1) ?
+!   -> Fortran standard says representable value set must be in [-HUGE, HUGE].
+!      For f18 integer(4) that means [-(2**31-1), 2**31-1].
+!   -> Current f18 behavior is to emit an error for -2147483648_4 literal (-2**31), but not for
+!      -2147483647_4 -1_4 which is folded to -2147483648_4 without errors/warnings.
+!  It seems to me that biggest negative literal and representable value should
+!  be the same.
+!   -> pgfortran and ifort are OK with -2147483648_4 literal.
+!   -> gfortran gives an error for both -2147483648_4 unless -fno-range-check is used.
+!      It never raises errors for -2147483647_4 -1_4 and fold it to -2147483648_4.
 
-!module integer_tests
-  ! These test assume a 
-!  integer(4), parameter :: i4_neg_max = int(Z'FFFFFFFF')
-!  integer(4), parameter :: i4_pmax = 2147483647_4
-!  integer(4), parameter :: i4_nmax = -2147483647_4 - 1_4 !TODO bug that -2147483648_4 cannot be written ?
-! ! Or maybe it is a bug that it -2147483648_4 can be reached because it is not
-! ! representable in the 16.4 bit model... ??
-!
-!  ! TODO: Should we test something for 0/0 hw seems to handle this differently (0 or pinf)?
-!  ! integer(4), parameter :: i4_nan = (0_4/0_4).EQ.i4_pmax ! Very undefined. Looks like this is zero on power
-!
-!  !WARN: INTEGER(4) division by zero
-!  logical, parameter :: test_pinf = (1_4/0_4).EQ.i4_pmax
-!  !WARN: INTEGER(4) division by zero
-!  logical, parameter :: test_ninf = (-1_4/0_4).EQ.i4_nmax ! TODO : should it be -2147483648_4 instead of -2147483647_4 ?
-!
-!  !WARN: INTEGER(4) negation overflowed
-!  logical, parameter :: test_overflow_unary_minus1 = (-i4_nmax).EQ.i4_nmax
-!  logical, parameter :: test_no_overflow_unary_minus1 = (-i4_pmax).EQ.(i4_nmax+1_4)
-!  logical, parameter :: test_no_overflow_unary_plus1 = (+i4_pmax).EQ.i4_pmax
-!  logical, parameter :: test_no_overflow_unary_plus2 = (+i4_nmax).EQ.i4_nmax
-!
-!  !WARN: INTEGER(4) addition overflowed
-!  logical, parameter :: test_overflow_add1 = (i4_pmax+1_4).EQ.i4_nmax
-!  !WARN: INTEGER(4) addition overflowed
-!  logical, parameter :: test_overflow_add2 = (i4_nmax + (-1_4)).EQ.i4_pmax
-!  !WARN: INTEGER(4) addition overflowed
-!  logical, parameter :: test_overflow_add3 = (i4_pmax + i4_pmax).EQ.(-2_4)
-!  !WARN: INTEGER(4) addition overflowed
-!  logical, parameter :: test_overflow_add4 = (i4_nmax + i4_nmax).EQ.(0_4)
-!  logical, parameter :: test_no_overflow_add1 = (i4_pmax + 0_4).EQ.i4_pmax
-!  logical, parameter :: test_no_overflow_add2 = (i4_nmax + (-0_4)).EQ.i4_nmax
-!  logical, parameter :: test_no_overflow_add3 = (i4_pmax + i4_nmax).EQ.(-1_4)
-!  logical, parameter :: test_no_overflow_add4 = (i4_nmax + i4_pmax).EQ.(-1_4)
-!
-!  !WARN: INTEGER(4) subtraction overflowed
-!  logical, parameter :: test_overflow_sub1 = (i4_nmax - 1_4).EQ.i4_pmax
-!  !WARN: INTEGER(4) subtraction overflowed
-!  logical, parameter :: test_overflow_sub2 = (i4_pmax - (-1_4)).EQ.i4_nmax
-!  !WARN: INTEGER(4) subtraction overflowed
-!  logical, parameter :: test_overflow_sub3 = (i4_nmax - i4_pmax).EQ.(1_4)
-!  !WARN: INTEGER(4) subtraction overflowed
-!  logical, parameter :: test_overflow_sub4 = (i4_pmax - i4_nmax).EQ.(-1_4)
-!  logical, parameter :: test_no_overflow_sub1 = (i4_nmax - 0_4).EQ.i4_nmax
-!  logical, parameter :: test_no_overflow_sub2 = (i4_pmax - (-0_4)).EQ.i4_pmax
-!  logical, parameter :: test_no_overflow_sub3 = (i4_nmax - i4_nmax).EQ.0_4
-!  logical, parameter :: test_no_overflow_sub4 = (i4_pmax - i4_pmax).EQ.0_4
-!
-!
-!  !WARN: INTEGER(4) multiplication overflowed
-!  logical, parameter :: test_overflow_mult1 = (i4_pmax*2_4).EQ.(-2_4)
-!  !WARN: INTEGER(4) multiplication overflowed
-!  logical, parameter :: test_overflow_mult2 = (i4_nmax*2_4).EQ.(0_4)
-!  !WARN: INTEGER(4) multiplication overflowed
-!  logical, parameter :: test_overflow_mult3 = (i4_nmax*i4_nmax).EQ.(0_4)
-!  !WARN: INTEGER(4) multiplication overflowed
-!  logical, parameter :: test_overflow_mult4 = (i4_pmax*i4_pmax).EQ.(1_4)
+! Proposal: add option to control literal range. Make -2147483648_4 accepted by
+! default?
 
-!end module
+! How to handle 0_4/0_4:
+!  -> raise an error (pgfortran, gfortran, ifort)
+!  -> warning and return 2147483647_4 (currently f18)
+!  -> warning and return 0_4 (maybe power HW (not tested))
+! Actually, gfortran, pgfortran and ifort forbid integer divide by zero in all
+! case.
 
-!module real_tests
-!  ! Test real(4) operation folding on edge cases (inf and NaN)
-!
-!  real(4), parameter :: r4_pmax = 3.4028235E38
-!  real(4), parameter :: r4_nmax = -3.4028235E38
-!  !WARN: invalid argument on division
-!  real(4), parameter :: r4_nan = (0._4/0._4)
-!  !WARN: division by zero on division
-!  real(4), parameter :: r4_pinf = (1._4/0._4)
-!  !WARN: division by zero on division
-!  real(4), parameter :: r4_ninf = (-1._4/0._4)
-!
-!
-!  ! No warnings expected
-!  logical, parameter :: test_r4_negation1 = (-r4_pmax).EQ.r4_nmax
-!  logical, parameter :: test_r4_negation2 = (-r4_nmax).EQ.r4_pmax
-!  logical, parameter :: test_r4_negation3 = (-r4_pinf).EQ.r4_ninf
-!  logical, parameter :: test_r4_negation4 = (-r4_ninf).EQ.r4_pinf
-!  logical, parameter :: test_r4_plus1 = (+r4_pmax).EQ.r4_pmax
-!  logical, parameter :: test_r4_plus2 = (+r4_nmax).EQ.r4_nmax
-!  logical, parameter :: test_r4_plus3 = (+r4_pinf).EQ.r4_pinf
-!  logical, parameter :: test_r4_plus4 = (+r4_ninf).EQ.r4_ninf
-!  ! NaN propagation , no warnings expected (quiet)
-!  real(4), parameter :: r_r4_nan_minus = (-r4_nan)
-!  real(4), parameter :: r_r4_nan_plus = (+r4_nan)
-!
-!  !WARN: overflow on addition
-!  logical, parameter :: test_inf_r4_add9 = (r4_pmax + r4_pmax).eq.(r4_pinf)
-!  !WARN: overflow on addition
-!  logical, parameter :: test_inf_r4_add10 = (r4_nmax + r4_nmax).eq.(r4_ninf)
-!  !WARN: overflow on subtraction
-!  logical, parameter :: test_inf_r4_sub9 = (r4_pmax - r4_nmax).eq.(r4_pinf)
-!  !WARN: overflow on subtraction
-!  logical, parameter :: test_inf_r4_sub10 = (r4_nmax - r4_pmax).eq.(r4_ninf)
-!
-!  ! No warnings expected below (inf propagation).
-!  logical, parameter :: test_inf_r4_add1 = (r4_pinf + r4_pinf).EQ.(r4_pinf)
-!  logical, parameter :: test_inf_r4_add2 = (r4_ninf + r4_ninf).EQ.(r4_ninf)
-!  logical, parameter :: test_inf_r4_add3 = (r4_pinf + r4_nmax).EQ.(r4_pinf)
-!  logical, parameter :: test_inf_r4_add4 = (r4_pinf + r4_pmax).EQ.(r4_pinf)
-!  logical, parameter :: test_inf_r4_add5 = (r4_ninf + r4_pmax).EQ.(r4_ninf)
-!  logical, parameter :: test_inf_r4_add6 = (r4_ninf + r4_nmax).EQ.(r4_ninf)
-!  logical, parameter :: test_inf_r4_add7 = (r4_ninf + 0._4).EQ.(r4_ninf)
-!  logical, parameter :: test_inf_r4_add8 = (r4_pinf + 0._4).EQ.(r4_pinf)
-!
-!  !WARN: invalid argument on subtraction
-!  real(4), parameter :: r_nan_r4_sub1 = r4_pinf - r4_pinf
-!  !WARN: invalid argument on subtraction
-!  real(4), parameter :: r_nan_r4_sub2 = r4_ninf - r4_ninf
-!  !WARN: invalid argument on addition
-!  real(4), parameter :: r_nan_r4_add1 = r4_ninf + r4_pinf
-!  !WARN: invalid argument on addition
-!  real(4), parameter :: r_nan_r4_add2 = r4_pinf + r4_ninf
-!
-!  ! No warnings expected here (quite NaN propagation)
-!  real(4), parameter :: r_nan_r4_sub3 = 0._4 - r4_nan
-!  real(4), parameter :: r_nan_r4_sub4 = r4_nan - r4_pmax
-!  real(4), parameter :: r_nan_r4_sub5 = r4_nan - r4_nmax
-!  real(4), parameter :: r_nan_r4_sub6 = r4_nan - r4_nan
-!  real(4), parameter :: r_nan_r4_add3 = 0._4 + r4_nan
-!  real(4), parameter :: r_nan_r4_add4 = r4_nan + r4_pmax
-!  real(4), parameter :: r_nan_r4_add5 = r4_nmax + r4_nan
-!  real(4), parameter :: r_nan_r4_add6 = r4_nan + r4_nan
-!
-!  !WARN: overflow on multiplication
-!  logical, parameter :: test_inf_r4_mult1 = (1.5_4*r4_pmax).eq.(r4_pinf)
-!  !WARN: overflow on multiplication
-!  logical, parameter :: test_inf_r4_mult2 = (1.5_4*r4_nmax).eq.(r4_ninf)
-!  !WARN: overflow on division
-!  logical, parameter :: test_inf_r4_div1 = (r4_nmax/(-0.5_4)).eq.(r4_pinf)
-!  !WARN: overflow on division
-!  logical, parameter :: test_inf_r4_div2 = (r4_pmax/(-0.5_4)).eq.(r4_ninf)
-!
-!  ! No warnings expected below (inf propagation).
-!  logical, parameter :: test_inf_r4_mult3 = (r4_pinf*r4_pinf).EQ.(r4_pinf)
-!  logical, parameter :: test_inf_r4_mult4 = (r4_ninf*r4_ninf).EQ.(r4_pinf)
-!  logical, parameter :: test_inf_r4_mult5 = (r4_pinf*0.1_4).EQ.(r4_pinf)
-!  logical, parameter :: test_inf_r4_mult6 = (r4_ninf*r4_nmax).EQ.(r4_pinf)
-!  logical, parameter :: test_inf_r4_div3 = (r4_pinf/0.).EQ.(r4_pinf)
-!  logical, parameter :: test_inf_r4_div4 = (r4_ninf/0.).EQ.(r4_ninf)
-!  logical, parameter :: test_inf_r4_div5 = (0./r4_pinf).EQ.(0.)
-!  logical, parameter :: test_inf_r4_div6 = (0./r4_ninf).EQ.(0.)
-!  logical, parameter :: test_inf_r4_div7 = (r4_pinf/r4_pmax).EQ.(r4_pinf)
-!  logical, parameter :: test_inf_r4_div8 = (r4_pinf/r4_nmax).EQ.(r4_ninf)
-!  logical, parameter :: test_inf_r4_div9 = (r4_nmax/r4_pinf).EQ.(0.)
-!  logical, parameter :: test_inf_r4_div10 = (r4_nmax/r4_ninf).EQ.(0.)
-!
-!  !WARN: invalid argument on division
-!  real(4), parameter :: r_nan_r4_div1 = 0._4/0._4
-!  !WARN: invalid argument on division
-!  real(4), parameter :: r_nan_r4_div2 = r4_ninf/r4_ninf
-!  !WARN: invalid argument on division
-!  real(4), parameter :: r_nan_r4_div3 = r4_ninf/r4_pinf
-!  !WARN: invalid argument on division
-!  real(4), parameter :: r_nan_r4_div4 = r4_pinf/r4_ninf
-!  !WARN: invalid argument on division
-!  real(4), parameter :: r_nan_r4_div5 = r4_pinf/r4_pinf
-!  !WARN: invalid argument on multiplication
-!  real(4), parameter :: r_nan_r4_mult1 = r4_pinf*0._4
-!  !WARN: invalid argument on multiplication
-!  real(4), parameter :: r_nan_r4_mult2 = 0._4*r4_ninf
-!
-!  ! No warnings expected here (quite NaN propagation)
-!  real(4), parameter :: r_nan_r4_div6 = 0._4/r4_nan
-!  real(4), parameter :: r_nan_r4_div7 = r4_nan/r4_nan
-!  real(4), parameter :: r_nan_r4_div8 = r4_nan/0._4
-!  real(4), parameter :: r_nan_r4_div9 = r4_nan/1._4
-!  real(4), parameter :: r_nan_r4_mult3 = r4_nan*1._4
-!  real(4), parameter :: r_nan_r4_mult4 = r4_nan*r4_nan
-!  real(4), parameter :: r_nan_r4_mult5 = 0._4*r4_nan
-!
-!  ! TODO: ** operator folding
-!  !  logical, parameter :: test_inf_r4_exp1 = (r4_pmax**2._4).EQ.(r4_pinf)
-!
-!  ! Relational operator edge cases (No warnings expected?)
-!  logical, parameter :: test_inf_r4_eq1 = r4_pinf.EQ.r4_pinf
-!  logical, parameter :: test_inf_r4_eq2 = r4_ninf.EQ.r4_ninf
-!  logical, parameter :: test_inf_r4_eq3 = .NOT.(r4_pinf.EQ.r4_ninf)
-!  logical, parameter :: test_inf_r4_eq4 = .NOT.(r4_pinf.EQ.r4_pmax)
-!
-!  logical, parameter :: test_inf_r4_ne1 = .NOT.(r4_pinf.NE.r4_pinf)
-!  logical, parameter :: test_inf_r4_ne2 = .NOT.(r4_ninf.NE.r4_ninf)
-!  logical, parameter :: test_inf_r4_ne3 = r4_pinf.NE.r4_ninf
-!  logical, parameter :: test_inf_r4_ne4 = r4_pinf.NE.r4_pmax
-!
-!  logical, parameter :: test_inf_r4_gt1 = .NOT.(r4_pinf.GT.r4_pinf)
-!  logical, parameter :: test_inf_r4_gt2 = .NOT.(r4_ninf.GT.r4_ninf)
-!  logical, parameter :: test_inf_r4_gt3 = r4_pinf.GT.r4_ninf
-!  logical, parameter :: test_inf_r4_gt4 = r4_pinf.GT.r4_pmax
-!
-!  logical, parameter :: test_inf_r4_lt1 = .NOT.(r4_pinf.LT.r4_pinf)
-!  logical, parameter :: test_inf_r4_lt2 = .NOT.(r4_ninf.LT.r4_ninf)
-!  logical, parameter :: test_inf_r4_lt3 = r4_ninf.LT.r4_pinf
-!  logical, parameter :: test_inf_r4_lt4 = r4_pmax.LT.r4_pinf
-!
-!  logical, parameter :: test_inf_r4_ge1 = r4_pinf.GE.r4_pinf
-!  logical, parameter :: test_inf_r4_ge2 = r4_ninf.GE.r4_ninf
-!  logical, parameter :: test_inf_r4_ge3 = .NOT.(r4_ninf.GE.r4_pinf)
-!  logical, parameter :: test_inf_r4_ge4 = .NOT.(r4_pmax.GE.r4_pinf)
-!
-!  logical, parameter :: test_inf_r4_le1 = r4_pinf.LE.r4_pinf
-!  logical, parameter :: test_inf_r4_le2 = r4_ninf.LE.r4_ninf
-!  logical, parameter :: test_inf_r4_le3 = .NOT.(r4_pinf.LE.r4_ninf)
-!  logical, parameter :: test_inf_r4_le4 = .NOT.(r4_pinf.LE.r4_pmax)
-!
-!  ! Invalid relational argument ? Defined behavior to return false ?
-!  logical, parameter :: test_nan_r4_eq1 = .NOT.(r4_nan.EQ.r4_nan)
-!  logical, parameter :: test_nan_r4_ne1 = .NOT.(r4_nan.NE.r4_nan)
-!
-!  !real(4), parameter :: acos_nan_r10 = acos(r4_pinf)
-!
-!  ! logical, parameter :: test_add_overflow = (2147483647_4 + 2_4).EQ.(-2147483647_4)
-!  ! ! logical, parameter :: test_add_overflow2 = .NOT.(2147483647_4 + 2_4).EQ.(+1/0.)
-!  ! real, parameter :: test_error = acos(2.) ! This is NAN. Can we test that ?? ISNAN non standard intrinsic?
-!  ! logical, parameter :: test_host_overflow =  exp(256._4).EQ.(1./0.)
-!  ! logical, parameter :: test_not_host_overflow =  exp(256._8).NE.(1./0.)
-!  
-!  ! TODO: conversions
-!  ! integer(4), parameter :: r4_nan_to_i4 = int(r4_nan, 4)
-!  ! integer(4), parameter :: r4_pinf_to_i4 = int(r4_pinf, 4)
-!  ! integer(4), parameter :: r4_ninf_to_i4 = int(r4_ninf, 4)
-!  !
-!  ! integer(16), parameter :: r4_nan_to_i16 = int(r4_nan, 16)
-!  ! integer(16), parameter :: r4_pinf_to_i16 = int(r4_pinf, 16)
-!  ! integer(16), parameter :: r4_ninf_to_i16 = int(r4_ninf, 16)
-!  !  ! TODO: That seems wrong to me. These should stay what they are
-!  ! real, parameter :: test_conversion_from_nan_to_real = real(test_error, 8)
-!  ! real, parameter :: test_conversion_from_pinf_to_real = real(1._4/0._4, 8)
-!  ! real, parameter :: test_conversion_from_ninf_to_real = real(-1._4/0._4, 8)
-!  ! !real, parameter :: test_error2 = 0./0.
-!  ! !real, parameter :: test_error3 = acos(2.)
-!  ! !integer, parameter :: test_error4 = int(-1./0.)
-!  ! !real(kind=test_error4) y
-!  ! !real(kind=(2147483647_4 - (2147483647_4 + 2_4) + 4_4)) x
-!
-!  ! TODO: character intrinsic folding
-!  !
-!end module
+! Proposal: Make integer divide by zero a fatal error. There is no maths
+! rational to support it and there is no integer NaN to circumvent this.
+! Plus, people ignore warnings ?
 
-! TODO complex tests ?
+
+module integer_tests
+  integer(4), parameter :: i4_pmax = 2147483647_4
+  integer(4), parameter :: i4_nmax = -2147483647_4 - 1_4 ! See TODO above.
+
+  ! integer(4), parameter :: i4_nan = (0_4/0_4).EQ.i4_pmax ! See TODO above.
+
+  !WARN: INTEGER(4) division by zero
+  logical, parameter :: test_pinf = (1_4/0_4).EQ.i4_pmax ! See TODO above
+  ! !WARN: INTEGER(4) division by zero
+  ! logical, parameter :: test_ninf = (-1_4/0_4).EQ.i4_nmax ! See TODO above, plus returns -2147483647_4
+
+  !WARN: INTEGER(4) negation overflowed
+  logical, parameter :: test_overflow_unary_minus1 = (-i4_nmax).EQ.i4_nmax
+  logical, parameter :: test_no_overflow_unary_minus1 = (-i4_pmax).EQ.(i4_nmax+1_4)
+  logical, parameter :: test_no_overflow_unary_plus1 = (+i4_pmax).EQ.i4_pmax
+  logical, parameter :: test_no_overflow_unary_plus2 = (+i4_nmax).EQ.i4_nmax
+
+  !WARN: INTEGER(4) addition overflowed
+  logical, parameter :: test_overflow_add1 = (i4_pmax+1_4).EQ.i4_nmax
+  !WARN: INTEGER(4) addition overflowed
+  logical, parameter :: test_overflow_add2 = (i4_nmax + (-1_4)).EQ.i4_pmax
+  !WARN: INTEGER(4) addition overflowed
+  logical, parameter :: test_overflow_add3 = (i4_pmax + i4_pmax).EQ.(-2_4)
+  !WARN: INTEGER(4) addition overflowed
+  logical, parameter :: test_overflow_add4 = (i4_nmax + i4_nmax).EQ.(0_4)
+  logical, parameter :: test_no_overflow_add1 = (i4_pmax + 0_4).EQ.i4_pmax
+  logical, parameter :: test_no_overflow_add2 = (i4_nmax + (-0_4)).EQ.i4_nmax
+  logical, parameter :: test_no_overflow_add3 = (i4_pmax + i4_nmax).EQ.(-1_4)
+  logical, parameter :: test_no_overflow_add4 = (i4_nmax + i4_pmax).EQ.(-1_4)
+
+  !WARN: INTEGER(4) subtraction overflowed
+  logical, parameter :: test_overflow_sub1 = (i4_nmax - 1_4).EQ.i4_pmax
+  !WARN: INTEGER(4) subtraction overflowed
+  logical, parameter :: test_overflow_sub2 = (i4_pmax - (-1_4)).EQ.i4_nmax
+  !WARN: INTEGER(4) subtraction overflowed
+  logical, parameter :: test_overflow_sub3 = (i4_nmax - i4_pmax).EQ.(1_4)
+  !WARN: INTEGER(4) subtraction overflowed
+  logical, parameter :: test_overflow_sub4 = (i4_pmax - i4_nmax).EQ.(-1_4)
+  logical, parameter :: test_no_overflow_sub1 = (i4_nmax - 0_4).EQ.i4_nmax
+  logical, parameter :: test_no_overflow_sub2 = (i4_pmax - (-0_4)).EQ.i4_pmax
+  logical, parameter :: test_no_overflow_sub3 = (i4_nmax - i4_nmax).EQ.0_4
+  logical, parameter :: test_no_overflow_sub4 = (i4_pmax - i4_pmax).EQ.0_4
+
+
+  !WARN: INTEGER(4) multiplication overflowed
+  logical, parameter :: test_overflow_mult1 = (i4_pmax*2_4).EQ.(-2_4)
+  !WARN: INTEGER(4) multiplication overflowed
+  logical, parameter :: test_overflow_mult2 = (i4_nmax*2_4).EQ.(0_4)
+  !WARN: INTEGER(4) multiplication overflowed
+  logical, parameter :: test_overflow_mult3 = (i4_nmax*i4_nmax).EQ.(0_4)
+  !WARN: INTEGER(4) multiplication overflowed
+  logical, parameter :: test_overflow_mult4 = (i4_pmax*i4_pmax).EQ.(1_4)
+
+  !WARN: INTEGER(4) division overflowed
+  logical, parameter :: test_overflow_div1 = (i4_nmax/(-1_4)).EQ.(i4_nmax)
+  logical, parameter :: test_no_overflow_div1 = (i4_nmax/(-2_4)).EQ.(1_4 + i4_pmax/2_4)
+  logical, parameter :: test_no_overflow_div2 = (i4_nmax/i4_nmax).EQ.(1_4)
+
+  !WARN: INTEGER(4) power overflowed
+  logical, parameter :: test_overflow_pow1 = (i4_pmax**2_4).EQ.(1_4)
+  !WARN: INTEGER(4) power overflowed
+  logical, parameter :: test_overflow_pow3 = (i4_nmax**2_4).EQ.(0_4)
+  logical, parameter :: test_no_overflow_pow1 = ((-1_4)**i4_nmax).EQ.(1_4)
+  logical, parameter :: test_no_overflow_pow2 = ((-1_4)**i4_pmax).EQ.(-1_4)
+
+end module
+
+module real_tests
+  ! Test real(4) operation folding on edge cases (inf and NaN)
+
+  real(4), parameter :: r4_pmax = 3.4028235E38
+  real(4), parameter :: r4_nmax = -3.4028235E38
+  !WARN: invalid argument on division
+  real(4), parameter :: r4_nan = 0._4/0._4
+  TEST_ISNAN(r4_nan)
+  !WARN: division by zero on division
+  real(4), parameter :: r4_pinf = 1._4/0._4
+  !WARN: division by zero on division
+  real(4), parameter :: r4_ninf = -1._4/0._4
+
+  logical, parameter :: test_ra_nan_parentheses1 = .NOT.(((r4_nan)).EQ.r4_nan)
+  logical, parameter :: test_ra_nan_parentheses2 = .NOT.(((r4_nan)).NE.r4_nan)
+  logical, parameter :: test_ra_pinf_parentheses = ((r4_pinf)).EQ.r4_pinf
+  logical, parameter :: test_ra_ninf_parentheses = ((r4_ninf)).EQ.r4_ninf
+
+  ! No warnings expected
+  logical, parameter :: test_r4_negation1 = (-r4_pmax).EQ.r4_nmax
+  logical, parameter :: test_r4_negation2 = (-r4_nmax).EQ.r4_pmax
+  logical, parameter :: test_r4_negation3 = (-r4_pinf).EQ.r4_ninf
+  logical, parameter :: test_r4_negation4 = (-r4_ninf).EQ.r4_pinf
+  logical, parameter :: test_r4_plus1 = (+r4_pmax).EQ.r4_pmax
+  logical, parameter :: test_r4_plus2 = (+r4_nmax).EQ.r4_nmax
+  logical, parameter :: test_r4_plus3 = (+r4_pinf).EQ.r4_pinf
+  logical, parameter :: test_r4_plus4 = (+r4_ninf).EQ.r4_ninf
+  ! NaN propagation , no warnings expected (quiet)
+  real(4), parameter :: r4_nan_minus = (-r4_nan)
+  TEST_ISNAN(r4_nan_minus)
+  real(4), parameter :: r4_nan_plus = (+r4_nan)
+  TEST_ISNAN(r4_nan_plus)
+
+  !WARN: overflow on addition
+  logical, parameter :: test_inf_r4_add9 = (r4_pmax + r4_pmax).eq.(r4_pinf)
+  !WARN: overflow on addition
+  logical, parameter :: test_inf_r4_add10 = (r4_nmax + r4_nmax).eq.(r4_ninf)
+  !WARN: overflow on subtraction
+  logical, parameter :: test_inf_r4_sub9 = (r4_pmax - r4_nmax).eq.(r4_pinf)
+  !WARN: overflow on subtraction
+  logical, parameter :: test_inf_r4_sub10 = (r4_nmax - r4_pmax).eq.(r4_ninf)
+
+  ! No warnings expected below (inf propagation).
+  logical, parameter :: test_inf_r4_add1 = (r4_pinf + r4_pinf).EQ.(r4_pinf)
+  logical, parameter :: test_inf_r4_add2 = (r4_ninf + r4_ninf).EQ.(r4_ninf)
+  logical, parameter :: test_inf_r4_add3 = (r4_pinf + r4_nmax).EQ.(r4_pinf)
+  logical, parameter :: test_inf_r4_add4 = (r4_pinf + r4_pmax).EQ.(r4_pinf)
+  logical, parameter :: test_inf_r4_add5 = (r4_ninf + r4_pmax).EQ.(r4_ninf)
+  logical, parameter :: test_inf_r4_add6 = (r4_ninf + r4_nmax).EQ.(r4_ninf)
+  logical, parameter :: test_inf_r4_add7 = (r4_ninf + 0._4).EQ.(r4_ninf)
+  logical, parameter :: test_inf_r4_add8 = (r4_pinf + 0._4).EQ.(r4_pinf)
+
+  !WARN: invalid argument on subtraction
+  real(4), parameter :: r4_nan_sub1 = r4_pinf - r4_pinf
+  TEST_ISNAN(r4_nan_sub1)
+  !WARN: invalid argument on subtraction
+  real(4), parameter :: r4_nan_sub2 = r4_ninf - r4_ninf
+  TEST_ISNAN(r4_nan_sub2)
+  !WARN: invalid argument on addition
+  real(4), parameter :: r4_nan_add1 = r4_ninf + r4_pinf
+  TEST_ISNAN(r4_nan_add1)
+  !WARN: invalid argument on addition
+  real(4), parameter :: r4_nan_add2 = r4_pinf + r4_ninf
+  TEST_ISNAN(r4_nan_add2)
+
+  ! No warnings expected here (quite NaN propagation)
+  real(4), parameter :: r4_nan_sub3 = 0._4 - r4_nan
+  TEST_ISNAN(r4_nan_sub3)
+  real(4), parameter :: r4_nan_sub4 = r4_nan - r4_pmax
+  TEST_ISNAN(r4_nan_sub4)
+  real(4), parameter :: r4_nan_sub5 = r4_nan - r4_nmax
+  TEST_ISNAN(r4_nan_sub5)
+  real(4), parameter :: r4_nan_sub6 = r4_nan - r4_nan
+  TEST_ISNAN(r4_nan_sub6)
+  real(4), parameter :: r4_nan_add3 = 0._4 + r4_nan
+  TEST_ISNAN(r4_nan_add3)
+  real(4), parameter :: r4_nan_add4 = r4_nan + r4_pmax
+  TEST_ISNAN(r4_nan_add4)
+  real(4), parameter :: r4_nan_add5 = r4_nmax + r4_nan
+  TEST_ISNAN(r4_nan_add5)
+  real(4), parameter :: r4_nan_add6 = r4_nan + r4_nan
+  TEST_ISNAN(r4_nan_add6)
+
+  !WARN: overflow on multiplication
+  logical, parameter :: test_inf_r4_mult1 = (1.5_4*r4_pmax).eq.(r4_pinf)
+  !WARN: overflow on multiplication
+  logical, parameter :: test_inf_r4_mult2 = (1.5_4*r4_nmax).eq.(r4_ninf)
+  !WARN: overflow on division
+  logical, parameter :: test_inf_r4_div1 = (r4_nmax/(-0.5_4)).eq.(r4_pinf)
+  !WARN: overflow on division
+  logical, parameter :: test_inf_r4_div2 = (r4_pmax/(-0.5_4)).eq.(r4_ninf)
+
+  ! No warnings expected below (inf propagation).
+  logical, parameter :: test_inf_r4_mult3 = (r4_pinf*r4_pinf).EQ.(r4_pinf)
+  logical, parameter :: test_inf_r4_mult4 = (r4_ninf*r4_ninf).EQ.(r4_pinf)
+  logical, parameter :: test_inf_r4_mult5 = (r4_pinf*0.1_4).EQ.(r4_pinf)
+  logical, parameter :: test_inf_r4_mult6 = (r4_ninf*r4_nmax).EQ.(r4_pinf)
+  logical, parameter :: test_inf_r4_div3 = (r4_pinf/0.).EQ.(r4_pinf)
+  logical, parameter :: test_inf_r4_div4 = (r4_ninf/0.).EQ.(r4_ninf)
+  logical, parameter :: test_inf_r4_div5 = (0./r4_pinf).EQ.(0.)
+  logical, parameter :: test_inf_r4_div6 = (0./r4_ninf).EQ.(0.)
+  logical, parameter :: test_inf_r4_div7 = (r4_pinf/r4_pmax).EQ.(r4_pinf)
+  logical, parameter :: test_inf_r4_div8 = (r4_pinf/r4_nmax).EQ.(r4_ninf)
+  logical, parameter :: test_inf_r4_div9 = (r4_nmax/r4_pinf).EQ.(0.)
+  logical, parameter :: test_inf_r4_div10 = (r4_nmax/r4_ninf).EQ.(0.)
+
+  !WARN: invalid argument on division
+  real(4), parameter :: r4_nan_div1 = 0._4/0._4
+  TEST_ISNAN(r4_nan_div1)
+  !WARN: invalid argument on division
+  real(4), parameter :: r4_nan_div2 = r4_ninf/r4_ninf
+  TEST_ISNAN(r4_nan_div2)
+  !WARN: invalid argument on division
+  real(4), parameter :: r4_nan_div3 = r4_ninf/r4_pinf
+  TEST_ISNAN(r4_nan_div3)
+  !WARN: invalid argument on division
+  real(4), parameter :: r4_nan_div4 = r4_pinf/r4_ninf
+  TEST_ISNAN(r4_nan_div4)
+  !WARN: invalid argument on division
+  real(4), parameter :: r4_nan_div5 = r4_pinf/r4_pinf
+  TEST_ISNAN(r4_nan_div5)
+  !WARN: invalid argument on multiplication
+  real(4), parameter :: r4_nan_mult1 = r4_pinf*0._4
+  TEST_ISNAN(r4_nan_mult1)
+  !WARN: invalid argument on multiplication
+  real(4), parameter :: r4_nan_mult2 = 0._4*r4_ninf
+  TEST_ISNAN(r4_nan_mult2)
+
+  ! No warnings expected here (quite NaN propagation)
+  real(4), parameter :: r4_nan_div6 = 0._4/r4_nan
+  TEST_ISNAN(r4_nan_div6)
+  real(4), parameter :: r4_nan_div7 = r4_nan/r4_nan
+  TEST_ISNAN(r4_nan_div7)
+  real(4), parameter :: r4_nan_div8 = r4_nan/0._4
+  TEST_ISNAN(r4_nan_div8)
+  real(4), parameter :: r4_nan_div9 = r4_nan/1._4
+  TEST_ISNAN(r4_nan_div9)
+  real(4), parameter :: r4_nan_mult3 = r4_nan*1._4
+  TEST_ISNAN(r4_nan_mult3)
+  real(4), parameter :: r4_nan_mult4 = r4_nan*r4_nan
+  TEST_ISNAN(r4_nan_mult4)
+  real(4), parameter :: r4_nan_mult5 = 0._4*r4_nan
+  TEST_ISNAN(r4_nan_mult5)
+
+  ! TODO: ** operator folding
+  !  logical, parameter :: test_inf_r4_exp1 = (r4_pmax**2._4).EQ.(r4_pinf)
+
+  ! Relational operator edge cases (No warnings expected?)
+  logical, parameter :: test_inf_r4_eq1 = r4_pinf.EQ.r4_pinf
+  logical, parameter :: test_inf_r4_eq2 = r4_ninf.EQ.r4_ninf
+  logical, parameter :: test_inf_r4_eq3 = .NOT.(r4_pinf.EQ.r4_ninf)
+  logical, parameter :: test_inf_r4_eq4 = .NOT.(r4_pinf.EQ.r4_pmax)
+
+  logical, parameter :: test_inf_r4_ne1 = .NOT.(r4_pinf.NE.r4_pinf)
+  logical, parameter :: test_inf_r4_ne2 = .NOT.(r4_ninf.NE.r4_ninf)
+  logical, parameter :: test_inf_r4_ne3 = r4_pinf.NE.r4_ninf
+  logical, parameter :: test_inf_r4_ne4 = r4_pinf.NE.r4_pmax
+
+  logical, parameter :: test_inf_r4_gt1 = .NOT.(r4_pinf.GT.r4_pinf)
+  logical, parameter :: test_inf_r4_gt2 = .NOT.(r4_ninf.GT.r4_ninf)
+  logical, parameter :: test_inf_r4_gt3 = r4_pinf.GT.r4_ninf
+  logical, parameter :: test_inf_r4_gt4 = r4_pinf.GT.r4_pmax
+
+  logical, parameter :: test_inf_r4_lt1 = .NOT.(r4_pinf.LT.r4_pinf)
+  logical, parameter :: test_inf_r4_lt2 = .NOT.(r4_ninf.LT.r4_ninf)
+  logical, parameter :: test_inf_r4_lt3 = r4_ninf.LT.r4_pinf
+  logical, parameter :: test_inf_r4_lt4 = r4_pmax.LT.r4_pinf
+
+  logical, parameter :: test_inf_r4_ge1 = r4_pinf.GE.r4_pinf
+  logical, parameter :: test_inf_r4_ge2 = r4_ninf.GE.r4_ninf
+  logical, parameter :: test_inf_r4_ge3 = .NOT.(r4_ninf.GE.r4_pinf)
+  logical, parameter :: test_inf_r4_ge4 = .NOT.(r4_pmax.GE.r4_pinf)
+
+  logical, parameter :: test_inf_r4_le1 = r4_pinf.LE.r4_pinf
+  logical, parameter :: test_inf_r4_le2 = r4_ninf.LE.r4_ninf
+  logical, parameter :: test_inf_r4_le3 = .NOT.(r4_pinf.LE.r4_ninf)
+  logical, parameter :: test_inf_r4_le4 = .NOT.(r4_pinf.LE.r4_pmax)
+
+  ! Invalid relational argument
+  logical, parameter :: test_nan_r4_eq1 = .NOT.(r4_nan.EQ.r4_nan)
+  logical, parameter :: test_nan_r4_ne1 = .NOT.(r4_nan.NE.r4_nan)
+
+end module
+
+! TODO: edge case conversions
+! TODO: complex tests (or is real tests enough?)
 
 ! Logical operation (with logical arguments) cannot overflow or be invalid.
 ! CHARACTER folding operations may cause host memory exhaustion if the

--- a/test/evaluate/folding03.f90
+++ b/test/evaluate/folding03.f90
@@ -1,0 +1,277 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test operation folding edge case (both expected value and messages)
+! These tests make assumptions regarding real(4) and integer(4) extrema.
+
+program test
+  integer(4), parameter :: i4_neg_max = int(Z'FFFFFFFF')
+  integer(4), parameter :: i4_nmax = -2147483647_4 - 1_4 !TODO bug that -2147483648_4 cannot be written ?
+  integer(4), parameter :: i4_nmax2 = -2147483648_4
+  integer(4), parameter :: i4_pmax1 = 2147483647_4
+  integer(4), parameter :: i4_pmax2 = 2147483648_4
+
+print*, "i4_neg_max ", i4_neg_max
+print*, "i4_nmax ", i4_nmax
+print*, "i4_nmax2 ", i4_nmax2
+print*, "i4_pmax1 ", i4_pmax1
+print*, "i4_pmax2 ", i4_pmax2
+
+end program
+
+!module integer_tests
+  ! These test assume a 
+!  integer(4), parameter :: i4_neg_max = int(Z'FFFFFFFF')
+!  integer(4), parameter :: i4_pmax = 2147483647_4
+!  integer(4), parameter :: i4_nmax = -2147483647_4 - 1_4 !TODO bug that -2147483648_4 cannot be written ?
+! ! Or maybe it is a bug that it -2147483648_4 can be reached because it is not
+! ! representable in the 16.4 bit model... ??
+!
+!  ! TODO: Should we test something for 0/0 hw seems to handle this differently (0 or pinf)?
+!  ! integer(4), parameter :: i4_nan = (0_4/0_4).EQ.i4_pmax ! Very undefined. Looks like this is zero on power
+!
+!  !WARN: INTEGER(4) division by zero
+!  logical, parameter :: test_pinf = (1_4/0_4).EQ.i4_pmax
+!  !WARN: INTEGER(4) division by zero
+!  logical, parameter :: test_ninf = (-1_4/0_4).EQ.i4_nmax ! TODO : should it be -2147483648_4 instead of -2147483647_4 ?
+!
+!  !WARN: INTEGER(4) negation overflowed
+!  logical, parameter :: test_overflow_unary_minus1 = (-i4_nmax).EQ.i4_nmax
+!  logical, parameter :: test_no_overflow_unary_minus1 = (-i4_pmax).EQ.(i4_nmax+1_4)
+!  logical, parameter :: test_no_overflow_unary_plus1 = (+i4_pmax).EQ.i4_pmax
+!  logical, parameter :: test_no_overflow_unary_plus2 = (+i4_nmax).EQ.i4_nmax
+!
+!  !WARN: INTEGER(4) addition overflowed
+!  logical, parameter :: test_overflow_add1 = (i4_pmax+1_4).EQ.i4_nmax
+!  !WARN: INTEGER(4) addition overflowed
+!  logical, parameter :: test_overflow_add2 = (i4_nmax + (-1_4)).EQ.i4_pmax
+!  !WARN: INTEGER(4) addition overflowed
+!  logical, parameter :: test_overflow_add3 = (i4_pmax + i4_pmax).EQ.(-2_4)
+!  !WARN: INTEGER(4) addition overflowed
+!  logical, parameter :: test_overflow_add4 = (i4_nmax + i4_nmax).EQ.(0_4)
+!  logical, parameter :: test_no_overflow_add1 = (i4_pmax + 0_4).EQ.i4_pmax
+!  logical, parameter :: test_no_overflow_add2 = (i4_nmax + (-0_4)).EQ.i4_nmax
+!  logical, parameter :: test_no_overflow_add3 = (i4_pmax + i4_nmax).EQ.(-1_4)
+!  logical, parameter :: test_no_overflow_add4 = (i4_nmax + i4_pmax).EQ.(-1_4)
+!
+!  !WARN: INTEGER(4) subtraction overflowed
+!  logical, parameter :: test_overflow_sub1 = (i4_nmax - 1_4).EQ.i4_pmax
+!  !WARN: INTEGER(4) subtraction overflowed
+!  logical, parameter :: test_overflow_sub2 = (i4_pmax - (-1_4)).EQ.i4_nmax
+!  !WARN: INTEGER(4) subtraction overflowed
+!  logical, parameter :: test_overflow_sub3 = (i4_nmax - i4_pmax).EQ.(1_4)
+!  !WARN: INTEGER(4) subtraction overflowed
+!  logical, parameter :: test_overflow_sub4 = (i4_pmax - i4_nmax).EQ.(-1_4)
+!  logical, parameter :: test_no_overflow_sub1 = (i4_nmax - 0_4).EQ.i4_nmax
+!  logical, parameter :: test_no_overflow_sub2 = (i4_pmax - (-0_4)).EQ.i4_pmax
+!  logical, parameter :: test_no_overflow_sub3 = (i4_nmax - i4_nmax).EQ.0_4
+!  logical, parameter :: test_no_overflow_sub4 = (i4_pmax - i4_pmax).EQ.0_4
+!
+!
+!  !WARN: INTEGER(4) multiplication overflowed
+!  logical, parameter :: test_overflow_mult1 = (i4_pmax*2_4).EQ.(-2_4)
+!  !WARN: INTEGER(4) multiplication overflowed
+!  logical, parameter :: test_overflow_mult2 = (i4_nmax*2_4).EQ.(0_4)
+!  !WARN: INTEGER(4) multiplication overflowed
+!  logical, parameter :: test_overflow_mult3 = (i4_nmax*i4_nmax).EQ.(0_4)
+!  !WARN: INTEGER(4) multiplication overflowed
+!  logical, parameter :: test_overflow_mult4 = (i4_pmax*i4_pmax).EQ.(1_4)
+
+!end module
+
+!module real_tests
+!  ! Test real(4) operation folding on edge cases (inf and NaN)
+!
+!  real(4), parameter :: r4_pmax = 3.4028235E38
+!  real(4), parameter :: r4_nmax = -3.4028235E38
+!  !WARN: invalid argument on division
+!  real(4), parameter :: r4_nan = (0._4/0._4)
+!  !WARN: division by zero on division
+!  real(4), parameter :: r4_pinf = (1._4/0._4)
+!  !WARN: division by zero on division
+!  real(4), parameter :: r4_ninf = (-1._4/0._4)
+!
+!
+!  ! No warnings expected
+!  logical, parameter :: test_r4_negation1 = (-r4_pmax).EQ.r4_nmax
+!  logical, parameter :: test_r4_negation2 = (-r4_nmax).EQ.r4_pmax
+!  logical, parameter :: test_r4_negation3 = (-r4_pinf).EQ.r4_ninf
+!  logical, parameter :: test_r4_negation4 = (-r4_ninf).EQ.r4_pinf
+!  logical, parameter :: test_r4_plus1 = (+r4_pmax).EQ.r4_pmax
+!  logical, parameter :: test_r4_plus2 = (+r4_nmax).EQ.r4_nmax
+!  logical, parameter :: test_r4_plus3 = (+r4_pinf).EQ.r4_pinf
+!  logical, parameter :: test_r4_plus4 = (+r4_ninf).EQ.r4_ninf
+!  ! NaN propagation , no warnings expected (quiet)
+!  real(4), parameter :: r_r4_nan_minus = (-r4_nan)
+!  real(4), parameter :: r_r4_nan_plus = (+r4_nan)
+!
+!  !WARN: overflow on addition
+!  logical, parameter :: test_inf_r4_add9 = (r4_pmax + r4_pmax).eq.(r4_pinf)
+!  !WARN: overflow on addition
+!  logical, parameter :: test_inf_r4_add10 = (r4_nmax + r4_nmax).eq.(r4_ninf)
+!  !WARN: overflow on subtraction
+!  logical, parameter :: test_inf_r4_sub9 = (r4_pmax - r4_nmax).eq.(r4_pinf)
+!  !WARN: overflow on subtraction
+!  logical, parameter :: test_inf_r4_sub10 = (r4_nmax - r4_pmax).eq.(r4_ninf)
+!
+!  ! No warnings expected below (inf propagation).
+!  logical, parameter :: test_inf_r4_add1 = (r4_pinf + r4_pinf).EQ.(r4_pinf)
+!  logical, parameter :: test_inf_r4_add2 = (r4_ninf + r4_ninf).EQ.(r4_ninf)
+!  logical, parameter :: test_inf_r4_add3 = (r4_pinf + r4_nmax).EQ.(r4_pinf)
+!  logical, parameter :: test_inf_r4_add4 = (r4_pinf + r4_pmax).EQ.(r4_pinf)
+!  logical, parameter :: test_inf_r4_add5 = (r4_ninf + r4_pmax).EQ.(r4_ninf)
+!  logical, parameter :: test_inf_r4_add6 = (r4_ninf + r4_nmax).EQ.(r4_ninf)
+!  logical, parameter :: test_inf_r4_add7 = (r4_ninf + 0._4).EQ.(r4_ninf)
+!  logical, parameter :: test_inf_r4_add8 = (r4_pinf + 0._4).EQ.(r4_pinf)
+!
+!  !WARN: invalid argument on subtraction
+!  real(4), parameter :: r_nan_r4_sub1 = r4_pinf - r4_pinf
+!  !WARN: invalid argument on subtraction
+!  real(4), parameter :: r_nan_r4_sub2 = r4_ninf - r4_ninf
+!  !WARN: invalid argument on addition
+!  real(4), parameter :: r_nan_r4_add1 = r4_ninf + r4_pinf
+!  !WARN: invalid argument on addition
+!  real(4), parameter :: r_nan_r4_add2 = r4_pinf + r4_ninf
+!
+!  ! No warnings expected here (quite NaN propagation)
+!  real(4), parameter :: r_nan_r4_sub3 = 0._4 - r4_nan
+!  real(4), parameter :: r_nan_r4_sub4 = r4_nan - r4_pmax
+!  real(4), parameter :: r_nan_r4_sub5 = r4_nan - r4_nmax
+!  real(4), parameter :: r_nan_r4_sub6 = r4_nan - r4_nan
+!  real(4), parameter :: r_nan_r4_add3 = 0._4 + r4_nan
+!  real(4), parameter :: r_nan_r4_add4 = r4_nan + r4_pmax
+!  real(4), parameter :: r_nan_r4_add5 = r4_nmax + r4_nan
+!  real(4), parameter :: r_nan_r4_add6 = r4_nan + r4_nan
+!
+!  !WARN: overflow on multiplication
+!  logical, parameter :: test_inf_r4_mult1 = (1.5_4*r4_pmax).eq.(r4_pinf)
+!  !WARN: overflow on multiplication
+!  logical, parameter :: test_inf_r4_mult2 = (1.5_4*r4_nmax).eq.(r4_ninf)
+!  !WARN: overflow on division
+!  logical, parameter :: test_inf_r4_div1 = (r4_nmax/(-0.5_4)).eq.(r4_pinf)
+!  !WARN: overflow on division
+!  logical, parameter :: test_inf_r4_div2 = (r4_pmax/(-0.5_4)).eq.(r4_ninf)
+!
+!  ! No warnings expected below (inf propagation).
+!  logical, parameter :: test_inf_r4_mult3 = (r4_pinf*r4_pinf).EQ.(r4_pinf)
+!  logical, parameter :: test_inf_r4_mult4 = (r4_ninf*r4_ninf).EQ.(r4_pinf)
+!  logical, parameter :: test_inf_r4_mult5 = (r4_pinf*0.1_4).EQ.(r4_pinf)
+!  logical, parameter :: test_inf_r4_mult6 = (r4_ninf*r4_nmax).EQ.(r4_pinf)
+!  logical, parameter :: test_inf_r4_div3 = (r4_pinf/0.).EQ.(r4_pinf)
+!  logical, parameter :: test_inf_r4_div4 = (r4_ninf/0.).EQ.(r4_ninf)
+!  logical, parameter :: test_inf_r4_div5 = (0./r4_pinf).EQ.(0.)
+!  logical, parameter :: test_inf_r4_div6 = (0./r4_ninf).EQ.(0.)
+!  logical, parameter :: test_inf_r4_div7 = (r4_pinf/r4_pmax).EQ.(r4_pinf)
+!  logical, parameter :: test_inf_r4_div8 = (r4_pinf/r4_nmax).EQ.(r4_ninf)
+!  logical, parameter :: test_inf_r4_div9 = (r4_nmax/r4_pinf).EQ.(0.)
+!  logical, parameter :: test_inf_r4_div10 = (r4_nmax/r4_ninf).EQ.(0.)
+!
+!  !WARN: invalid argument on division
+!  real(4), parameter :: r_nan_r4_div1 = 0._4/0._4
+!  !WARN: invalid argument on division
+!  real(4), parameter :: r_nan_r4_div2 = r4_ninf/r4_ninf
+!  !WARN: invalid argument on division
+!  real(4), parameter :: r_nan_r4_div3 = r4_ninf/r4_pinf
+!  !WARN: invalid argument on division
+!  real(4), parameter :: r_nan_r4_div4 = r4_pinf/r4_ninf
+!  !WARN: invalid argument on division
+!  real(4), parameter :: r_nan_r4_div5 = r4_pinf/r4_pinf
+!  !WARN: invalid argument on multiplication
+!  real(4), parameter :: r_nan_r4_mult1 = r4_pinf*0._4
+!  !WARN: invalid argument on multiplication
+!  real(4), parameter :: r_nan_r4_mult2 = 0._4*r4_ninf
+!
+!  ! No warnings expected here (quite NaN propagation)
+!  real(4), parameter :: r_nan_r4_div6 = 0._4/r4_nan
+!  real(4), parameter :: r_nan_r4_div7 = r4_nan/r4_nan
+!  real(4), parameter :: r_nan_r4_div8 = r4_nan/0._4
+!  real(4), parameter :: r_nan_r4_div9 = r4_nan/1._4
+!  real(4), parameter :: r_nan_r4_mult3 = r4_nan*1._4
+!  real(4), parameter :: r_nan_r4_mult4 = r4_nan*r4_nan
+!  real(4), parameter :: r_nan_r4_mult5 = 0._4*r4_nan
+!
+!  ! TODO: ** operator folding
+!  !  logical, parameter :: test_inf_r4_exp1 = (r4_pmax**2._4).EQ.(r4_pinf)
+!
+!  ! Relational operator edge cases (No warnings expected?)
+!  logical, parameter :: test_inf_r4_eq1 = r4_pinf.EQ.r4_pinf
+!  logical, parameter :: test_inf_r4_eq2 = r4_ninf.EQ.r4_ninf
+!  logical, parameter :: test_inf_r4_eq3 = .NOT.(r4_pinf.EQ.r4_ninf)
+!  logical, parameter :: test_inf_r4_eq4 = .NOT.(r4_pinf.EQ.r4_pmax)
+!
+!  logical, parameter :: test_inf_r4_ne1 = .NOT.(r4_pinf.NE.r4_pinf)
+!  logical, parameter :: test_inf_r4_ne2 = .NOT.(r4_ninf.NE.r4_ninf)
+!  logical, parameter :: test_inf_r4_ne3 = r4_pinf.NE.r4_ninf
+!  logical, parameter :: test_inf_r4_ne4 = r4_pinf.NE.r4_pmax
+!
+!  logical, parameter :: test_inf_r4_gt1 = .NOT.(r4_pinf.GT.r4_pinf)
+!  logical, parameter :: test_inf_r4_gt2 = .NOT.(r4_ninf.GT.r4_ninf)
+!  logical, parameter :: test_inf_r4_gt3 = r4_pinf.GT.r4_ninf
+!  logical, parameter :: test_inf_r4_gt4 = r4_pinf.GT.r4_pmax
+!
+!  logical, parameter :: test_inf_r4_lt1 = .NOT.(r4_pinf.LT.r4_pinf)
+!  logical, parameter :: test_inf_r4_lt2 = .NOT.(r4_ninf.LT.r4_ninf)
+!  logical, parameter :: test_inf_r4_lt3 = r4_ninf.LT.r4_pinf
+!  logical, parameter :: test_inf_r4_lt4 = r4_pmax.LT.r4_pinf
+!
+!  logical, parameter :: test_inf_r4_ge1 = r4_pinf.GE.r4_pinf
+!  logical, parameter :: test_inf_r4_ge2 = r4_ninf.GE.r4_ninf
+!  logical, parameter :: test_inf_r4_ge3 = .NOT.(r4_ninf.GE.r4_pinf)
+!  logical, parameter :: test_inf_r4_ge4 = .NOT.(r4_pmax.GE.r4_pinf)
+!
+!  logical, parameter :: test_inf_r4_le1 = r4_pinf.LE.r4_pinf
+!  logical, parameter :: test_inf_r4_le2 = r4_ninf.LE.r4_ninf
+!  logical, parameter :: test_inf_r4_le3 = .NOT.(r4_pinf.LE.r4_ninf)
+!  logical, parameter :: test_inf_r4_le4 = .NOT.(r4_pinf.LE.r4_pmax)
+!
+!  ! Invalid relational argument ? Defined behavior to return false ?
+!  logical, parameter :: test_nan_r4_eq1 = .NOT.(r4_nan.EQ.r4_nan)
+!  logical, parameter :: test_nan_r4_ne1 = .NOT.(r4_nan.NE.r4_nan)
+!
+!  !real(4), parameter :: acos_nan_r10 = acos(r4_pinf)
+!
+!  ! logical, parameter :: test_add_overflow = (2147483647_4 + 2_4).EQ.(-2147483647_4)
+!  ! ! logical, parameter :: test_add_overflow2 = .NOT.(2147483647_4 + 2_4).EQ.(+1/0.)
+!  ! real, parameter :: test_error = acos(2.) ! This is NAN. Can we test that ?? ISNAN non standard intrinsic?
+!  ! logical, parameter :: test_host_overflow =  exp(256._4).EQ.(1./0.)
+!  ! logical, parameter :: test_not_host_overflow =  exp(256._8).NE.(1./0.)
+!  
+!  ! TODO: conversions
+!  ! integer(4), parameter :: r4_nan_to_i4 = int(r4_nan, 4)
+!  ! integer(4), parameter :: r4_pinf_to_i4 = int(r4_pinf, 4)
+!  ! integer(4), parameter :: r4_ninf_to_i4 = int(r4_ninf, 4)
+!  !
+!  ! integer(16), parameter :: r4_nan_to_i16 = int(r4_nan, 16)
+!  ! integer(16), parameter :: r4_pinf_to_i16 = int(r4_pinf, 16)
+!  ! integer(16), parameter :: r4_ninf_to_i16 = int(r4_ninf, 16)
+!  !  ! TODO: That seems wrong to me. These should stay what they are
+!  ! real, parameter :: test_conversion_from_nan_to_real = real(test_error, 8)
+!  ! real, parameter :: test_conversion_from_pinf_to_real = real(1._4/0._4, 8)
+!  ! real, parameter :: test_conversion_from_ninf_to_real = real(-1._4/0._4, 8)
+!  ! !real, parameter :: test_error2 = 0./0.
+!  ! !real, parameter :: test_error3 = acos(2.)
+!  ! !integer, parameter :: test_error4 = int(-1./0.)
+!  ! !real(kind=test_error4) y
+!  ! !real(kind=(2147483647_4 - (2147483647_4 + 2_4) + 4_4)) x
+!
+!  ! TODO: character intrinsic folding
+!  !
+!end module
+
+! TODO complex tests ?
+
+! Logical operation (with logical arguments) cannot overflow or be invalid.
+! CHARACTER folding operations may cause host memory exhaustion if the
+! string are very large. This will cause a fatal error for the program
+! doing folding (e.g. f18), so there is nothing very interesting to test here.

--- a/test/evaluate/folding04.f90
+++ b/test/evaluate/folding04.f90
@@ -15,8 +15,6 @@
 ! Test intrinsic function folding edge case (both expected value and messages)
 ! These tests make assumptions regarding real(4) extrema.
 
-!end program
-
 #define TEST_ISNAN(v) logical, parameter :: test_##v =.NOT.(v.EQ.v)
 
 

--- a/test/evaluate/folding04.f90
+++ b/test/evaluate/folding04.f90
@@ -1,0 +1,64 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test intrinsic function folding edge case (both expected value and messages)
+! These tests make assumptions regarding real(4) extrema.
+
+!end program
+
+#define TEST_ISNAN(v) logical, parameter :: test_##v =.NOT.(v.EQ.v)
+
+
+module real_tests
+  ! Test real(4) intrinsic folding on edge cases (inf and NaN)
+
+  real(4), parameter :: r4_pmax = 3.4028235E38
+  real(4), parameter :: r4_nmax = -3.4028235E38
+  !WARN: invalid argument on division
+  real(4), parameter :: r4_nan = 0._4/0._4
+  !WARN: division by zero on division
+  real(4), parameter :: r4_pinf = 1._4/0._4
+  !WARN: division by zero on division
+  real(4), parameter :: r4_ninf = -1._4/0._4
+
+  !WARN: invalid argument on folding function with host runtime
+  real(4), parameter :: nan_r4_acos1 = acos(1.1)
+  TEST_ISNAN(nan_r4_acos1)
+  !WARN: invalid argument on folding function with host runtime
+  real(4), parameter :: nan_r4_acos2 = acos(r4_pmax)
+  TEST_ISNAN(nan_r4_acos2)
+  !WARN: invalid argument on folding function with host runtime
+  real(4), parameter :: nan_r4_acos3 = acos(r4_nmax)
+  TEST_ISNAN(nan_r4_acos3)
+  !WARN: invalid argument on folding function with host runtime
+  real(4), parameter :: nan_r4_acos4 = acos(r4_ninf)
+  TEST_ISNAN(nan_r4_acos4)
+  !WARN: invalid argument on folding function with host runtime
+  real(4), parameter :: nan_r4_acos5 = acos(r4_pinf)
+  TEST_ISNAN(nan_r4_acos5)
+  ! No warnings expected for NaN propagation (quiet)
+  real(4), parameter :: nan_r4_acos6 = acos(r4_nan)
+  TEST_ISNAN(nan_r4_acos6)
+
+  !WARN: overflow on folding function with host runtime
+  logical, parameter :: test_exp_overflow = exp(256._4).EQ.r4_pinf
+end module
+
+module parentheses
+  ! Test parentheses in folding (they are kept around constants to keep the
+  ! distinction between variable and expressions and require special care).
+  real(4), parameter :: x_nop = 0.1_4
+  real(4), parameter :: x_p = (x_nop)
+  logical, parameter :: test_parentheses1 = acos(x_p).EQ.acos(x_nop)
+end module

--- a/test/semantics/resolve37.f90
+++ b/test/semantics/resolve37.f90
@@ -35,4 +35,13 @@ real :: u(l*2)
 character(len=l) :: v
 !ERROR: Initialization expression for PARAMETER 'o' (o) cannot be computed as a constant value
 real, parameter ::  o = o
+!ERROR: Must be a constant value
+integer, parameter ::  p = 0/0
+!ERROR: Must be a constant value
+integer, parameter ::  q = 1+2*(1/0)
+!ERROR: Must be a constant value
+integer(kind=2/0) r
+integer, parameter :: sok(:)=[1,2]/[1,2]
+!ERROR: Must be a constant value
+integer, parameter :: snok(:)=[1,2]/[1,0]
 end


### PR DESCRIPTION
So far, non-fatal messages created while folding were printed without location information. This looked weird.

This PR:

- Add location information (simply by setting the context location before calling fold)

- Update parser node typedExpr expressions after folding to avoid doing several times the same work (and generating several times the same warnings...). So far, folding was done at least twice from scratch for all parser::Constant<A> expression.

- Add tests for operation folding "edge cases" (the one that generate warnings). Both checks expected values and warning messages

- Fix parentheses handling in intrinsic function folding (`acos((0.5_4))`) was not folding properly because a bare `UnwrapExpr<Constant<T>>` was used instead of new `GetConstantValue<T>`