### PR TITLE
Prevent possible infinite loop in parameter folding

### DIFF
--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -806,6 +806,9 @@ static std::optional<Expr<T>> GetParameterValue(
           auto converted{ConvertToType(*dyType, common::Clone(*init))};
           semantics::ObjectEntityDetails *mutableObject{
               const_cast<semantics::ObjectEntityDetails *>(object)};
+          // Reset expression now to prevent infinite loops if the init
+          // expression depends on symbol itself.
+          mutableObject->set_init(std::nullopt);
           if (converted.has_value()) {
             *converted = Fold(context, std::move(*converted));
             auto *unwrapped{UnwrapExpr<Expr<T>>(*converted)};
@@ -827,7 +830,6 @@ static std::optional<Expr<T>> GetParameterValue(
                 "Initialization expression for PARAMETER '%s' (%s) cannot be converted to its type (%s)"_err_en_US,
                 symbol->name(), ss.str(), dyType->AsFortran());
           }
-          mutableObject->set_init(std::nullopt);
         }
       }
     }

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -820,7 +820,7 @@ static std::optional<Expr<T>> GetParameterValue(
               std::stringstream ss;
               unwrapped->AsFortran(ss);
               context.messages().Say(symbol->name(),
-                  "Initialization expression for PARAMETER '%s' (%s) cannot computed as a constant value"_err_en_US,
+                  "Initialization expression for PARAMETER '%s' (%s) cannot be computed as a constant value"_err_en_US,
                   symbol->name(), ss.str());
             }
           } else {

--- a/test/semantics/resolve37.f90
+++ b/test/semantics/resolve37.f90
@@ -33,4 +33,6 @@ type(t( &
 real :: u(l*2)
 !ERROR: Must have INTEGER type, but is REAL(4)
 character(len=l) :: v
+!ERROR: Initialization expression for PARAMETER 'o' (o) cannot be computed as a constant value
+real, parameter ::  o = o
 end


### PR DESCRIPTION
The following program creates an infinite loop in folding that segfaults f18:

```
subroutine()
  real, parameter :: x = x
end subroutine 
```

The infinite loop starts in `GetParameterValue` that calls `Fold` on the init expression that ends-up recalling `GetParameterValue` with the same arguments and ...

To avoid this, set the `typeExpr` of the symbol in `GetParameterValue` to `std::nullopt` before calling `Fold` on the init expression.