### PR TITLE
Unparse the typedExpr from semantics

### DIFF
--- a/lib/parser/unparse.h
+++ b/lib/parser/unparse.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,10 @@
 #include <functional>
 #include <iosfwd>
 
+namespace Fortran::evaluate {
+struct GenericExprWrapper;
+}
+
 namespace Fortran::parser {
 
 struct Program;
@@ -28,10 +32,16 @@ struct Program;
 using preStatementType =
     std::function<void(const CharBlock &, std::ostream &, int)>;
 
+// A function to handle unparsing of evaluate::GenericExprWrapper
+// rather than original expression parse trees.
+using TypedExprAsFortran =
+    std::function<void(std::ostream &, const evaluate::GenericExprWrapper &)>;
+
 /// Convert parsed program to out as Fortran.
 void Unparse(std::ostream &out, const Program &program,
     Encoding encoding = Encoding::UTF8, bool capitalizeKeywords = true,
-    bool backslashEscapes = true, preStatementType *preStatement = nullptr);
+    bool backslashEscapes = true, preStatementType *preStatement = nullptr,
+    TypedExprAsFortran *expr = nullptr);
 }
 
 #endif

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -19,6 +19,7 @@
 #include "../../lib/FIR/graph-writer.h"
 #endif
 #include "../../lib/common/default-kinds.h"
+#include "../../lib/evaluate/expression.h"
 #include "../../lib/parser/characters.h"
 #include "../../lib/parser/dump-parse-tree.h"
 #include "../../lib/parser/features.h"
@@ -256,9 +257,18 @@ std::string CompileFortran(std::string path, Fortran::parser::Options options,
     Fortran::parser::DumpTree(std::cout, parseTree);
   }
   if (driver.dumpUnparse) {
+    Fortran::parser::TypedExprAsFortran unparseExpression{
+        [](std::ostream &o, const Fortran::evaluate::GenericExprWrapper &x) {
+          if (x.v.has_value()) {
+            o << *x.v;
+          } else {
+            o << "(bad expression)";
+          }
+        }};
     Unparse(std::cout, parseTree, driver.encoding, true /*capitalize*/,
         options.features.IsEnabled(
-            Fortran::parser::LanguageFeature::BackslashEscapes));
+            Fortran::parser::LanguageFeature::BackslashEscapes),
+        nullptr /* action before each statement */, &unparseExpression);
     return {};
   }
   if (driver.parseOnly) {


### PR DESCRIPTION
Implements a request from sscalpone.

Regeneration of Fortran from the parse tree for "-funparse" output and compilation with another Fortran compiler will use the expression formatting code for typed expressions attached to the parse tree, rather than the original parse tree expressions, when typed expressions are present.

Does not apply to the output of "-funparse-with-symbols", since we don't want to perturb the test files that use that option, and their output needs to match their input source modulo comments.