### PR TITLE
Fix two bugs

### DIFF
--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -3384,8 +3384,7 @@ void DeclarationVisitor::Post(const parser::CommonBlockObject &x) {
     return;  // error was reported
   }
   commonBlockInfo_.curr->get<CommonBlockDetails>().add_object(symbol);
-  if (!symbol.attrs().HasAny({Attr::POINTER, Attr::ALLOCATABLE}) &&
-      !IsExplicit(details->shape())) {
+  if (!IsAllocatableOrPointer(symbol) && !IsExplicit(details->shape())) {
     Say(name,
         "The shape of common block object '%s' must be explicit"_err_en_US);
     return;

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -3384,7 +3384,8 @@ void DeclarationVisitor::Post(const parser::CommonBlockObject &x) {
     return;  // error was reported
   }
   commonBlockInfo_.curr->get<CommonBlockDetails>().add_object(symbol);
-  if (!IsExplicit(details->shape())) {
+  if (!symbol.attrs().HasAny({Attr::POINTER, Attr::ALLOCATABLE}) &&
+      !IsExplicit(details->shape())) {
     Say(name,
         "The shape of common block object '%s' must be explicit"_err_en_US);
     return;


### PR DESCRIPTION
Don't require explicit shapes on objects in COMMON blocks when the objects are pointers or allocatables.

Perform semantics checks in ALLOCATABLE statements on the ultimate symbols found by USE association, if any.

These two bugs came up in the same regression test, and each affects several tests.