### PR TITLE
Fix issue #482 related to folding warnings

### DIFF
--- a/lib/evaluate/host.h
+++ b/lib/evaluate/host.h
@@ -39,14 +39,18 @@ class HostFloatingPointEnvironment {
 public:
   void SetUpHostFloatingPointEnvironment(FoldingContext &);
   void CheckAndRestoreFloatingPointEnvironment(FoldingContext &);
-  bool hasSubnormalFlushingHardwareControl() {
+  bool hasSubnormalFlushingHardwareControl() const {
     return hasSubnormalFlushingHardwareControl_;
   }
+  void SetFlag(RealFlag flag) { flags_.set(flag); }
+  bool hardwareFlagsAreReliable() const { return hardwareFlagsAreReliable_; }
 
 private:
   std::fenv_t originalFenv_;
   std::fenv_t currentFenv_;
+  RealFlags flags_;
   bool hasSubnormalFlushingHardwareControl_{false};
+  bool hardwareFlagsAreReliable_{true};
 };
 
 // Type mapping from F18 types to host types

--- a/test/evaluate/CMakeLists.txt
+++ b/test/evaluate/CMakeLists.txt
@@ -139,7 +139,7 @@ set(TEST_LIBPGMATH "-pgmath=false")
 if (LIBPGMATH_DIR)
   find_library(LIBPGMATH pgmath PATHS ${LIBPGMATH_DIR})
   if(LIBPGMATH)
-  set(TEST_LIBPGMATH "-pgmath=true")
+    set(TEST_LIBPGMATH "-pgmath=true")
   endif()
 endif()
 

--- a/test/evaluate/CMakeLists.txt
+++ b/test/evaluate/CMakeLists.txt
@@ -135,6 +135,15 @@ add_test(RESHAPE reshape-test)
 add_test(ISO-binding ISO-Fortran-binding-test)
 add_test(folding folding-test)
 
+set(TEST_LIBPGMATH "-pgmath=false")
+if (LIBPGMATH_DIR)
+  find_library(LIBPGMATH pgmath PATHS ${LIBPGMATH_DIR})
+  if(LIBPGMATH)
+  set(TEST_LIBPGMATH "-pgmath=true")
+  endif()
+endif()
+
 foreach(test ${FOLDING_TESTS})
-  add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_folding.sh ${test})
+  add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_folding.sh
+    ${test} ${TEST_LIBPGMATH})
 endforeach()

--- a/test/evaluate/folding04.f90
+++ b/test/evaluate/folding04.f90
@@ -30,26 +30,23 @@ module real_tests
   !WARN: division by zero on division
   real(4), parameter :: r4_ninf = -1._4/0._4
 
-  !WARN: invalid argument on folding function with host runtime
+  !WARN: invalid argument on intrinsic function
   real(4), parameter :: nan_r4_acos1 = acos(1.1)
   TEST_ISNAN(nan_r4_acos1)
-  !WARN: invalid argument on folding function with host runtime
+  !WARN: invalid argument on intrinsic function
   real(4), parameter :: nan_r4_acos2 = acos(r4_pmax)
   TEST_ISNAN(nan_r4_acos2)
-  !WARN: invalid argument on folding function with host runtime
+  !WARN: invalid argument on intrinsic function
   real(4), parameter :: nan_r4_acos3 = acos(r4_nmax)
   TEST_ISNAN(nan_r4_acos3)
-  !WARN: invalid argument on folding function with host runtime
+  !WARN: invalid argument on intrinsic function
   real(4), parameter :: nan_r4_acos4 = acos(r4_ninf)
   TEST_ISNAN(nan_r4_acos4)
-  !WARN: invalid argument on folding function with host runtime
+  !WARN: invalid argument on intrinsic function
   real(4), parameter :: nan_r4_acos5 = acos(r4_pinf)
   TEST_ISNAN(nan_r4_acos5)
-  ! No warnings expected for NaN propagation (quiet)
-  real(4), parameter :: nan_r4_acos6 = acos(r4_nan)
-  TEST_ISNAN(nan_r4_acos6)
 
-  !WARN: overflow on folding function with host runtime
+  !WARN: overflow on intrinsic function
   logical, parameter :: test_exp_overflow = exp(256._4).EQ.r4_pinf
 end module
 


### PR DESCRIPTION
**Fixes:**
- This PR fixes #482 by removing floating point status flag check in constant folding when compiling f18 with clang (justification below). Instead, the floating point results are checked for issues.

- It also removes the OS dependent check in `test_folding.sh` and uses cmake instead to convey if folding test should assumes `libpgmath` is used for constant folding or not. This is to avoid having to modify this script every-time f18 is build with a new OS.

**Detail regarding #482 (actually not linked to OpenBSD, but related to clang++ -02 and libc++):**

The issue was that intrinsic function folding with host run-time function was always checking `<cfenv>` floating point environment flags to emit warnings regarding invalid arguments, overflow, div by zero.... 
These flags are meaningless when `lib/evaluate` is compiled with clang++ because clang++ optimizations are not guaranteed to be consistent regarding the floating point environment.
For instance, when compiling f18 with clang++, libc++ (and no libpgmath support) in release mode on X86, a division by zero/invalid arg flag was signalling after valid calls to `std::comple<float>` `tan`and `tanh`. This is because clang vectorizes a division without masking the insignificant `xmm` slots that were set to zero (hence the div by zero hardware status flag).

