### PR TITLE
More fixes from test suite shakedown

### DIFF
--- a/documentation/Extensions.md
+++ b/documentation/Extensions.md
@@ -98,3 +98,10 @@ Extensions and legacy features deliberately not supported
 * Use of host FORMAT labels in internal subprograms (PGI-only feature)
 * ALLOCATE(TYPE(derived)::...) as variant of correct ALLOCATE(derived::...) (PGI only)
 * USE association of a procedure interface within that same procedure's definition
+* After "TYPE,EXTENDS(T1)::T2;...", the nonstandard structure constructor
+  T2(T1(x)) is accepted by PGI/GNU/Intel.  Use T2(T1=T1(x)) or T2(x) instead.
+* NULL() as a structure constructor expression for an ALLOCATABLE component (PGI).
+* Conversion of LOGICAL to INTEGER.
+* IF (integer expression) THEN ... END IF  (PGI/Intel)
+* Comparsion of LOGICAL with ==/.EQ. rather than .EQV. (also .NEQV.) (PGI/Intel)
+* Procedure pointers in COMMON blocks (PGI/Intel)

--- a/lib/evaluate/characteristics.h
+++ b/lib/evaluate/characteristics.h
@@ -52,6 +52,10 @@ public:
   DEFAULT_CONSTRUCTORS_AND_ASSIGNMENTS(TypeAndShape)
 
   DynamicType type() const { return type_; }
+  TypeAndShape &set_type(DynamicType t) {
+    type_ = t;
+    return *this;
+  }
   const Shape &shape() const { return shape_; }
 
   bool operator==(const TypeAndShape &) const;
@@ -159,6 +163,7 @@ struct FunctionResult {
   const TypeAndShape *GetTypeAndShape() const {
     return std::get_if<TypeAndShape>(&u);
   }
+  void SetType(DynamicType t) { std::get<TypeAndShape>(u).set_type(t); }
 
   std::ostream &Dump(std::ostream &) const;
 

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -1422,7 +1422,7 @@ std::optional<SpecificCall> IntrinsicProcTable::Implementation::Probe(
         bool ok{false};
         if (const auto &arg{specificCall->arguments[0]}) {
           if (const auto *expr{arg->UnwrapExpr()}) {
-            if (const Symbol * symbol{IsWholeSymbolDataRef(*expr)}) {
+            if (const Symbol * symbol{UnwrapWholeSymbolDataRef(*expr)}) {
               ok = symbol->attrs().test(semantics::Attr::OPTIONAL);
             }
           }

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -76,11 +76,7 @@ template<typename T> bool IsVariable(const Expr<T> &expr) {
   return std::visit([](const auto &x) { return IsVariable(x); }, expr.u);
 }
 template<typename A> bool IsVariable(const std::optional<A> &x) {
-  if (x.has_value()) {
-    return IsVariable(*x);
-  } else {
-    return false;
-  }
+  return x.has_value() && IsVariable(*x);
 }
 
 // Predicate: true when an expression is assumed-rank
@@ -99,11 +95,7 @@ template<typename T> bool IsAssumedRank(const Expr<T> &expr) {
   return std::visit([](const auto &x) { return IsAssumedRank(x); }, expr.u);
 }
 template<typename A> bool IsAssumedRank(const std::optional<A> &x) {
-  if (x.has_value()) {
-    return IsAssumedRank(*x);
-  } else {
-    return false;
-  }
+  return x.has_value() && IsAssumedRank(*x);
 }
 
 // Generalizing packagers: these take operations and expressions of more
@@ -667,11 +659,7 @@ inline bool IsProcedurePointer(const Expr<SomeType> &expr) {
       [](const auto &x) { return IsProcedurePointer(x); }, expr.u);
 }
 template<typename A> bool IsProcedurePointer(const std::optional<A> &x) {
-  if (x.has_value()) {
-    return IsProcedurePointer(*x);
-  } else {
-    return false;
-  }
+  return x.has_value() && IsProcedurePointer(*x);
 }
 }
 #endif  // FORTRAN_EVALUATE_TOOLS_H_

--- a/lib/parser/parse-tree.cc
+++ b/lib/parser/parse-tree.cc
@@ -207,6 +207,19 @@ Statement<ActionStmt> StmtFunctionStmt::ConvertToAssignment() {
           AssignmentStmt{std::move(variable), std::move(funcExpr)}}}};
 }
 
+CharBlock Variable::GetSource() const {
+  return std::visit(
+      common::visitors{
+          [&](const common::Indirection<Designator> &des) {
+            return des.value().source;
+          },
+          [&](const common::Indirection<parser::FunctionReference> &call) {
+            return call.value().v.source;
+          },
+      },
+      u);
+}
+
 std::ostream &operator<<(std::ostream &os, const Name &x) {
   return os << x.ToString();
 }

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -1773,6 +1773,7 @@ struct Designator {
 struct Variable {
   UNION_CLASS_BOILERPLATE(Variable);
   mutable Expr::TypedExpr typedExpr;
+  parser::CharBlock GetSource() const;
   std::variant<common::Indirection<Designator>,
       common::Indirection<FunctionReference>>
       u;

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1436,7 +1436,7 @@ auto ExpressionAnalyzer::Procedure(const parser::ProcedureDesignator &pd,
             if (context_.HasError(n.symbol)) {
               return std::nullopt;
             }
-            const Symbol &symbol{*n.symbol};
+            const Symbol &symbol{n.symbol->GetUltimate()};
             if (!symbol.HasExplicitInterface() ||
                 (symbol.has<semantics::MiscDetails>() &&
                     symbol.get<semantics::MiscDetails>().kind() ==

--- a/test/evaluate/intrinsics.cc
+++ b/test/evaluate/intrinsics.cc
@@ -200,21 +200,23 @@ void TestIntrinsics() {
   TestCall{table, "abs"}.Push(Const(Scalar<Char>{})).DoCall();
   TestCall{table, "abs"}.Push(Const(Scalar<Log4>{})).DoCall();
 
-  TestCall maxCall{table, "max"}, max0Call{table, "max0"},
-      max1Call{table, "max1"};
-  TestCall amin0Call{table, "amin0"}, amin1Call{table, "amin1"};
+  TestCall maxCallR{table, "max"}, maxCallI{table, "min"},
+      max0Call{table, "max0"}, max1Call{table, "max1"},
+      amin0Call{table, "amin0"}, amin1Call{table, "amin1"};
   for (int j{0}; j < 10; ++j) {
-    maxCall.Push(Const(Scalar<Real4>{}));
+    maxCallR.Push(Const(Scalar<Real4>{}));
+    maxCallI.Push(Const(Scalar<Int4>{}));
     max0Call.Push(Const(Scalar<Real4>{}));
     max1Call.Push(Const(Scalar<Real4>{}));
     amin0Call.Push(Const(Scalar<Int4>{}));
     amin1Call.Push(Const(Scalar<Int4>{}));
   }
-  maxCall.DoCall(Real4::GetType());
-  max0Call.DoCall();
+  maxCallR.DoCall(Real4::GetType());
+  maxCallI.DoCall(Int4::GetType());
+  max0Call.DoCall(Int4::GetType());
   max1Call.DoCall(Int4::GetType());
   amin0Call.DoCall(Real4::GetType());
-  amin1Call.DoCall();
+  amin1Call.DoCall(Real4::GetType());
 
   // TODO: test other intrinsics
 }


### PR DESCRIPTION
Calls to intrinsic functions that resolved to what Fortran calls "specific" intrinsics were being overly strict in their argument checks.

Expressions & variables appearing as selectors in `associate` and `select type/rank` statements are now processed using tools from the evaluate library.  This dodges a segfault that affected all the tests for these constructs.  (They still don't build due to a still-missing intrinsic.)

The order of processing for name resolution has been tweaked again, along with the conversion of unknown entities to objects, so that `associate(x => internalFunction())` now works (this was the original impetus for the program tree based processing order).