### PR TITLE
Dodge a GCC-specific valgrind warning

### DIFF
--- a/lib/parser/basic-parsers.h
+++ b/lib/parser/basic-parsers.h
@@ -76,7 +76,7 @@ public:
   using resultType = A;
   constexpr PureParser(const PureParser &) = default;
   constexpr explicit PureParser(A &&x) : value_(std::move(x)) {}
-  std::optional<A> Parse(ParseState &) const { return {value_}; }
+  std::optional<A> Parse(ParseState &) const { return value_; }
 
 private:
   const A value_;
@@ -126,8 +126,9 @@ public:
     forked.set_deferMessages(true);
     if (parser_.Parse(forked)) {
       return std::nullopt;
+    } else {
+      return Success{};
     }
-    return {Success{}};
   }
 
 private:
@@ -149,7 +150,7 @@ public:
     ParseState forked{state};
     forked.set_deferMessages(true);
     if (parser_.Parse(forked).has_value()) {
-      return {Success{}};
+      return Success{};
     }
     return std::nullopt;
   }
@@ -415,7 +416,7 @@ public:
       }
       at = state.GetLocation();
     }
-    return {std::move(result)};
+    return result;
   }
 
 private:
@@ -445,7 +446,7 @@ public:
       if (state.GetLocation() > start) {
         result.splice(result.end(), many(parser_).Parse(state).value());
       }
-      return {std::move(result)};
+      return result;
     }
     return std::nullopt;
   }
@@ -469,7 +470,7 @@ public:
          parser_.Parse(state) && state.GetLocation() > at;
          at = state.GetLocation()) {
     }
-    return {Success{}};
+    return Success{};
   }
 
 private:
@@ -491,7 +492,7 @@ public:
   std::optional<Success> Parse(ParseState &state) const {
     while (parser_.Parse(state)) {
     }
-    return {Success{}};
+    return Success{};
   }
 
 private:
@@ -513,9 +514,9 @@ public:
   constexpr MaybeParser(PA parser) : parser_{parser} {}
   std::optional<resultType> Parse(ParseState &state) const {
     if (resultType result{parser_.Parse(state)}) {
-      return {std::move(result)};
+      return result;
     }
-    return {resultType{}};
+    return resultType{};
   }
 
 private:
@@ -539,7 +540,7 @@ public:
     if (ax.value().has_value()) {  // maybe() always succeeds
       return std::move(*ax);
     }
-    return {resultType{}};
+    return resultType{};
   }
 
 private:
@@ -610,8 +611,8 @@ public:
     ApplyArgs<PARSER...> results;
     using Sequence = std::index_sequence_for<PARSER...>;
     if (ApplyHelperArgs(parsers_, results, state, Sequence{})) {
-      return {ApplyHelperFunction<FUNCTION, RESULT, PARSER...>(
-          function_, std::move(results), Sequence{})};
+      return ApplyHelperFunction<FUNCTION, RESULT, PARSER...>(
+          function_, std::move(results), Sequence{});
     } else {
       return std::nullopt;
     }
@@ -669,8 +670,8 @@ public:
     using Sequence1 = std::index_sequence_for<OBJPARSER, PARSER...>;
     using Sequence2 = std::index_sequence_for<PARSER...>;
     if (ApplyHelperArgs(parsers_, results, state, Sequence1{})) {
-      return {ApplyHelperMember<OBJPARSER, PARSER...>(
-          function_, std::move(results), Sequence2{})};
+      return ApplyHelperMember<OBJPARSER, PARSER...>(
+          function_, std::move(results), Sequence2{});
     } else {
       return std::nullopt;
     }
@@ -795,7 +796,7 @@ template<bool pass> struct FixedParser {
   constexpr FixedParser() {}
   static constexpr std::optional<Success> Parse(ParseState &) {
     if (pass) {
-      return {Success{}};
+      return Success{};
     }
     return std::nullopt;
   }

--- a/lib/parser/grammar.h
+++ b/lib/parser/grammar.h
@@ -444,10 +444,9 @@ constexpr auto executableConstruct{
 constexpr auto obsoleteExecutionPartConstruct{recovery(ignoredStatementPrefix >>
         fail<ExecutionPartConstruct>(
             "obsolete legacy extension is not supported"_err_en_US),
-    construct<ExecutionPartConstruct>(
+    construct<ExecutionPartConstruct>(construct<ErrorRecovery>(ok /
         statement("REDIMENSION" >> name >>
-            parenthesized(nonemptyList(Parser<AllocateShapeSpec>{})) >> ok) >>
-        construct<ErrorRecovery>()))};
+            parenthesized(nonemptyList(Parser<AllocateShapeSpec>{}))))))};
 
 TYPE_PARSER(recovery(
     withMessage("expected execution part construct"_err_en_US,
@@ -461,8 +460,8 @@ TYPE_PARSER(recovery(
                     statement(indirect(dataStmt))),
                 extension<LanguageFeature::ExecutionPartNamelist>(
                     construct<ExecutionPartConstruct>(
-                        statement(indirect(Parser<NamelistStmt>{}))) ||
-                    obsoleteExecutionPartConstruct)))),
+                        statement(indirect(Parser<NamelistStmt>{})))),
+                obsoleteExecutionPartConstruct))),
     construct<ExecutionPartConstruct>(executionPartErrorRecovery)))
 
 // R509 execution-part -> executable-construct [execution-part-construct]...

--- a/lib/parser/token-parsers.h
+++ b/lib/parser/token-parsers.h
@@ -498,7 +498,7 @@ struct DigitStringIgnoreSpaces {
     if (overflow) {
       state.Say(*firstDigit, "overflow in decimal literal"_err_en_US);
     }
-    return {value};
+    return value;
   }
 };
 

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -30,7 +30,7 @@
 #include <optional>
 #include <set>
 
-#define DUMP_ON_FAILURE 1  // TODO pmk rm
+// #define DUMP_ON_FAILURE 1
 // #define CRASH_ON_FAILURE 1
 #if DUMP_ON_FAILURE
 #include "../parser/dump-parse-tree.h"


### PR DESCRIPTION
When f18 is built with gcc 8.3.0 or 9.1.0 (& possibly others), valgrind detects and warns that a conditional jump or move has been determined from uninitialized data in an instance of `RecoveryParser`, viz. the one built to emit an error and recover if a REDIMENSION statement appears.  I had thought that the problem was peculiar to gcc 9.1.0, but it's not -- I just usually do valgrind testing and performance measurement on f18 as built by clang, and had missed it with earlier versions of gcc.

I tracked it down to the use of a superfluous `>> ok` in the `statement()` parser; when the superfluous term is removed, the valgrind warning goes away.

So here's that change, plus some clean-up that accumulated along the way.