### PR TITLE
Fix bug #491 (and replace a misleading name)

### DIFF
--- a/lib/parser/prescan.cc
+++ b/lib/parser/prescan.cc
@@ -304,16 +304,9 @@ void Prescanner::NextChar() {
     } else {
       mightNeedSpace = *at_ == '\n';
     }
-    while (*at_ == '\n' || *at_ == '&') {
-      bool continued{inFixedForm_ ? FixedFormContinuation(mightNeedSpace)
-                                  : FreeFormContinuation()};
-      if (continued) {
-        if (MustSkipToEndOfLine()) {
-          SkipToEndOfLine();
-        }
-        mightNeedSpace = false;
-      } else {
-        break;
+    for (; Continuation(mightNeedSpace); mightNeedSpace = false) {
+      if (MustSkipToEndOfLine()) {
+        SkipToEndOfLine();
       }
     }
     if (*at_ == '\t') {
@@ -953,6 +946,18 @@ bool Prescanner::FreeFormContinuation() {
     }
   } while (SkipCommentLine(ampersand));
   return false;
+}
+
+bool Prescanner::Continuation(bool mightNeedFixedFormSpace) {
+  if (*at_ == '\n' || *at_ == '&') {
+    if (inFixedForm_) {
+      return FixedFormContinuation(mightNeedFixedFormSpace);
+    } else {
+      return FreeFormContinuation();
+    }
+  } else {
+    return false;
+  }
 }
 
 std::optional<Prescanner::LineClassification>

--- a/lib/parser/prescan.h
+++ b/lib/parser/prescan.h
@@ -171,6 +171,7 @@ private:
   const char *FreeFormContinuationLine(bool ampersand);
   bool FixedFormContinuation(bool mightNeedSpace);
   bool FreeFormContinuation();
+  bool Continuation(bool mightNeedFixedFormSpace);
   std::optional<LineClassification> IsFixedFormCompilerDirectiveLine(
       const char *) const;
   std::optional<LineClassification> IsFreeFormCompilerDirectiveLine(

--- a/lib/parser/prescan.h
+++ b/lib/parser/prescan.h
@@ -65,7 +65,7 @@ public:
   void NextLine();
 
   // Callbacks for use by Preprocessor.
-  bool IsAtEnd() const { return lineStart_ >= limit_; }
+  bool IsAtEnd() const { return nextLine_ >= limit_; }
   bool IsNextLinePreprocessorDirective() const;
   TokenSequence TokenizePreprocessorDirective();
   Provenance GetCurrentProvenance() const { return GetProvenance(at_); }
@@ -106,7 +106,7 @@ private:
   }
 
   void BeginSourceLineAndAdvance() {
-    BeginSourceLine(lineStart_);
+    BeginSourceLine(nextLine_);
     NextLine();
   }
 
@@ -149,6 +149,7 @@ private:
 
   void LabelField(TokenSequence &, int outCol = 1);
   void SkipToEndOfLine();
+  bool MustSkipToEndOfLine() const;
   void NextChar();
   void SkipCComments();
   void SkipSpaces();
@@ -191,12 +192,12 @@ private:
   Provenance startProvenance_;
   const char *start_{nullptr};  // beginning of current source file content
   const char *limit_{nullptr};  // first address after end of current source
-  const char *lineStart_{nullptr};  // next line to process; <= limit_
+  const char *nextLine_{nullptr};  // next line to process; <= limit_
   const char *directiveSentinel_{nullptr};  // current compiler directive
 
   // This data members are state for processing the source line containing
-  // "at_", which goes to up to the newline character before "lineStart_".
-  const char *at_{nullptr};  // next character to process; < lineStart_
+  // "at_", which goes to up to the newline character before "nextLine_".
+  const char *at_{nullptr};  // next character to process; < nextLine_
   int column_{1};  // card image column position of next character
   bool tabInCurrentLine_{false};
   bool slashInCurrentLine_{false};


### PR DESCRIPTION
Deal with inline `!` comments in fixed-form source that appear in continuation lines.

Also rename `lineStart_` to `nextLine_` because it (now) always points to the beginning of the *next* line.  This is a clean-up I keep forgetting to do.