### PR TITLE
Support Latin-1 source encodings, generally clean up source character processing

### DIFF
--- a/documentation/Parsing.md
+++ b/documentation/Parsing.md
@@ -58,7 +58,8 @@ by a CookedSource class instance, in which:
 * except for the payload in character literals, Hollerith constants,
   and character and Hollerith edit descriptors, all letters have been
   normalized to lower case
-* all non-ASCII characters have been re-encoded in UTF-8.
+* all original non-ASCII characters in character literals have been
+  decoded, converted to UTF-8, and then formatted with escape sequences
 
 Lines in the cooked character stream can be of arbitrary length.
 

--- a/documentation/Parsing.md
+++ b/documentation/Parsing.md
@@ -58,8 +58,8 @@ by a CookedSource class instance, in which:
 * except for the payload in character literals, Hollerith constants,
   and character and Hollerith edit descriptors, all letters have been
   normalized to lower case
-* all original non-ASCII characters in character literals have been
-  decoded, converted to UTF-8, and then formatted with escape sequences
+* all original non-ASCII characters in Hollerith constants have been
+  decoded and re-encoded into UTF-8
 
 Lines in the cooked character stream can be of arbitrary length.
 

--- a/documentation/Parsing.md
+++ b/documentation/Parsing.md
@@ -1,5 +1,5 @@
 <!--
-Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 -->
 
 The F18 Parser
@@ -58,6 +58,7 @@ by a CookedSource class instance, in which:
 * except for the payload in character literals, Hollerith constants,
   and character and Hollerith edit descriptors, all letters have been
   normalized to lower case
+* all non-ASCII characters have been re-encoded in UTF-8.
 
 Lines in the cooked character stream can be of arbitrary length.
 

--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -56,7 +56,8 @@ std::ostream &ConstantBase<RESULT, VALUE>::AsFortran(std::ostream &o) const {
         Result::category == TypeCategory::Complex) {
       value.AsFortran(o, Result::kind);
     } else if constexpr (Result::category == TypeCategory::Character) {
-      o << Result::kind << '_' << parser::QuoteCharacterLiteral(value);
+      o << Result::kind << '_'
+        << parser::QuoteCharacterLiteral(value, true, false);
     } else if constexpr (Result::category == TypeCategory::Logical) {
       if (value.IsTrue()) {
         o << ".true.";
@@ -92,7 +93,9 @@ std::ostream &Constant<Type<TypeCategory::Character, KIND>>::AsFortran(
     } else if (Rank() == 0) {
       o << Result::kind << '_';
     }
-    o << parser::QuoteCharacterLiteral(value);
+    o << parser::QuoteCharacterLiteral(value, true /* double quotes */,
+        false /* avoid backslash escapes */,
+        parser::Encoding::UTF_8 /* module files are UTF-8 */);
   }
   if (Rank() > 0) {
     o << ']';

--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -92,9 +92,7 @@ std::ostream &Constant<Type<TypeCategory::Character, KIND>>::AsFortran(
     } else if (Rank() == 0) {
       o << Result::kind << '_';
     }
-    o << parser::QuoteCharacterLiteral(value,
-        false /* avoid backslash escapes */,
-        parser::Encoding::UTF_8 /* module files are UTF-8 */);
+    o << parser::QuoteCharacterLiteral(value);
   }
   if (Rank() > 0) {
     o << ']';

--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -56,7 +56,7 @@ std::ostream &ConstantBase<RESULT, VALUE>::AsFortran(std::ostream &o) const {
         Result::category == TypeCategory::Complex) {
       value.AsFortran(o, Result::kind);
     } else if constexpr (Result::category == TypeCategory::Character) {
-      o << Result::kind << '_' << parser::QuoteCharacterLiteral(value, false);
+      o << Result::kind << '_' << parser::QuoteCharacterLiteral(value, true);
     } else if constexpr (Result::category == TypeCategory::Logical) {
       if (value.IsTrue()) {
         o << ".true.";

--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -56,8 +56,7 @@ std::ostream &ConstantBase<RESULT, VALUE>::AsFortran(std::ostream &o) const {
         Result::category == TypeCategory::Complex) {
       value.AsFortran(o, Result::kind);
     } else if constexpr (Result::category == TypeCategory::Character) {
-      o << Result::kind << '_'
-        << parser::QuoteCharacterLiteral(value, true, false);
+      o << Result::kind << '_' << parser::QuoteCharacterLiteral(value, false);
     } else if constexpr (Result::category == TypeCategory::Logical) {
       if (value.IsTrue()) {
         o << ".true.";
@@ -93,7 +92,7 @@ std::ostream &Constant<Type<TypeCategory::Character, KIND>>::AsFortran(
     } else if (Rank() == 0) {
       o << Result::kind << '_';
     }
-    o << parser::QuoteCharacterLiteral(value, true /* double quotes */,
+    o << parser::QuoteCharacterLiteral(value,
         false /* avoid backslash escapes */,
         parser::Encoding::UTF_8 /* module files are UTF-8 */);
   }

--- a/lib/parser/characters.cc
+++ b/lib/parser/characters.cc
@@ -224,9 +224,12 @@ static DecodedCharacter DecodeEscapedCharacter(
       return {static_cast<char32_t>(16 * HexadecimalDigitValue(cp[2]) +
                   HexadecimalDigitValue(cp[3])),
           4};
-    } else {
-      // unknown escape - ignore the '\' (PGI compatibility)
+    } else if (IsLetter(cp[1])) {
+      // Unknown escape - ignore the '\' (PGI compatibility)
       return {static_cast<unsigned char>(cp[1]), 2};
+    } else {
+      // Not an escape character.
+      return {'\\', 1};
     }
   }
   return {static_cast<unsigned char>(cp[0]), 1};

--- a/lib/parser/characters.cc
+++ b/lib/parser/characters.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,27 +13,28 @@
 // limitations under the License.
 
 #include "characters.h"
+#include "../common/idioms.h"
 #include <cstddef>
 #include <optional>
 
 namespace Fortran::parser {
 
-std::optional<int> UTF8CharacterBytes(const char *p) {
+std::optional<int> UTF_8CharacterBytes(const char *p) {
   if ((*p & 0x80) == 0) {
-    return {1};
+    return 1;
   }
   if ((*p & 0xf8) == 0xf0) {
     if ((*p & 0x07) != 0 && (p[1] & 0xc0) == 0x80 && (p[2] & 0xc0) == 0x80 &&
         (p[3] & 0xc0) == 0x80) {
-      return {4};
+      return 4;
     }
   } else if ((*p & 0xf0) == 0xe0) {
     if ((*p & 0x0f) != 0 && (p[1] & 0xc0) == 0x80 && (p[2] & 0xc0) == 0x80) {
-      return {3};
+      return 3;
     }
   } else if ((*p & 0xe0) == 0xc0) {
     if ((*p & 0x1f) != 0 && (p[1] & 0xc0) == 0x80) {
-      return {2};
+      return 2;
     }
   }
   return std::nullopt;
@@ -42,49 +43,68 @@ std::optional<int> UTF8CharacterBytes(const char *p) {
 std::optional<int> EUC_JPCharacterBytes(const char *p) {
   int b1 = *p & 0xff;
   if (b1 <= 0x7f) {
-    return {1};
+    return 1;
   }
   if (b1 >= 0xa1 && b1 <= 0xfe) {
     int b2 = p[1] & 0xff;
     if (b2 >= 0xa1 && b2 <= 0xfe) {
       // JIS X 0208 (code set 1)
-      return {2};
+      return 2;
     }
   } else if (b1 == 0x8e) {
     int b2 = p[1] & 0xff;
     if (b2 >= 0xa1 && b2 <= 0xdf) {
       // upper half JIS 0201 (half-width kana, code set 2)
-      return {2};
+      return 2;
     }
   } else if (b1 == 0x8f) {
     int b2 = p[1] & 0xff;
     int b3 = p[2] & 0xff;
     if (b2 >= 0xa1 && b2 <= 0xfe && b3 >= 0xa1 && b3 <= 0xfe) {
       // JIS X 0212 (code set 3)
-      return {3};
+      return 3;
     }
   }
   return std::nullopt;
 }
 
-std::optional<std::size_t> CountCharacters(
-    const char *p, std::size_t bytes, std::optional<int> (*cbf)(const char *)) {
+static std::optional<int> One(const char *) { return 1; }
+
+static std::optional<int> (*CharacterCounter(Encoding encoding))(const char *) {
+  switch (encoding) {
+  case Encoding::UTF_8: return UTF_8CharacterBytes;
+  case Encoding::EUC_JP: return EUC_JPCharacterBytes;
+  default: return One;
+  }
+}
+
+std::optional<int> CharacterBytes(const char *p, Encoding encoding) {
+  return CharacterCounter(encoding)(p);
+}
+
+std::optional<int> CountCharacters(
+    const char *p, std::size_t bytes, Encoding encoding) {
   std::size_t chars{0};
   const char *limit{p + bytes};
+  std::optional<int> (*cbf)(const char *){CharacterCounter(encoding)};
   while (p < limit) {
-    ++chars;
-    std::optional<int> cb{cbf(p)};
-    if (!cb.has_value()) {
+    if (std::optional<int> cb{cbf(p)}) {
+      p += *cb;
+      ++chars;
+    } else {
       return std::nullopt;
     }
-    p += *cb;
   }
-  return {chars};
+  if (p == limit) {
+    return chars;
+  } else {
+    return std::nullopt;
+  }
 }
 
 template<typename STRING>
-std::string QuoteCharacterLiteralHelper(
-    const STRING &str, bool doubleDoubleQuotes, bool doubleBackslash) {
+std::string QuoteCharacterLiteralHelper(const STRING &str,
+    bool doubleDoubleQuotes, bool doubleBackslash, Encoding encoding) {
   std::string result{'"'};
   const auto emit{[&](char ch) { result += ch; }};
   for (auto ch : str) {
@@ -92,60 +112,198 @@ std::string QuoteCharacterLiteralHelper(
     if constexpr (std::is_same_v<char, CharT>) {
       // char may be signed depending on host.
       char32_t ch32{static_cast<unsigned char>(ch)};
-      EmitQuotedChar(ch32, emit, emit, doubleDoubleQuotes, doubleBackslash);
+      EmitQuotedChar(
+          ch32, emit, emit, doubleDoubleQuotes, doubleBackslash, encoding);
     } else {
       char32_t ch32{ch};
-      EmitQuotedChar(ch32, emit, emit, doubleDoubleQuotes, doubleBackslash);
+      EmitQuotedChar(
+          ch32, emit, emit, doubleDoubleQuotes, doubleBackslash, encoding);
     }
   }
   result += '"';
   return result;
 }
 
-std::string QuoteCharacterLiteral(
-    const std::string &str, bool doubleDoubleQuotes, bool doubleBackslash) {
-  return QuoteCharacterLiteralHelper(str, doubleDoubleQuotes, doubleBackslash);
+std::string QuoteCharacterLiteral(const std::string &str,
+    bool doubleDoubleQuotes, bool doubleBackslash, Encoding encoding) {
+  return QuoteCharacterLiteralHelper(
+      str, doubleDoubleQuotes, doubleBackslash, encoding);
 }
 
-std::string QuoteCharacterLiteral(
-    const std::u16string &str, bool doubleDoubleQuotes, bool doubleBackslash) {
-  return QuoteCharacterLiteralHelper(str, doubleDoubleQuotes, doubleBackslash);
+std::string QuoteCharacterLiteral(const std::u16string &str,
+    bool doubleDoubleQuotes, bool doubleBackslash, Encoding encoding) {
+  return QuoteCharacterLiteralHelper(
+      str, doubleDoubleQuotes, doubleBackslash, encoding);
 }
 
-std::string QuoteCharacterLiteral(
-    const std::u32string &str, bool doubleDoubleQuotes, bool doubleBackslash) {
-  return QuoteCharacterLiteralHelper(str, doubleDoubleQuotes, doubleBackslash);
+std::string QuoteCharacterLiteral(const std::u32string &str,
+    bool doubleDoubleQuotes, bool doubleBackslash, Encoding encoding) {
+  return QuoteCharacterLiteralHelper(
+      str, doubleDoubleQuotes, doubleBackslash, encoding);
 }
 
-std::optional<std::u32string> DecodeUTF8(const std::string &s) {
+EncodedCharacter EncodeLATIN_1(char codepoint) {
+  CHECK(codepoint <= 0xff);
+  EncodedCharacter result;
+  result.buffer[0] = codepoint;
+  result.bytes = 1;
+  return result;
+}
+
+EncodedCharacter EncodeUTF_8(char32_t codepoint) {
+  // N.B. char32_t is unsigned
+  EncodedCharacter result;
+  if (codepoint <= 0x7f) {
+    result.buffer[0] = codepoint;
+    result.bytes = 1;
+  } else if (codepoint <= 0x7ff) {
+    result.buffer[0] = 0xc0 | (codepoint >> 6);
+    result.buffer[1] = 0x80 | (codepoint & 0x3f);
+    result.bytes = 2;
+  } else if (codepoint <= 0xffff) {
+    result.buffer[0] = 0xe0 | (codepoint >> 12);
+    result.buffer[1] = 0x80 | ((codepoint >> 6) & 0x3f);
+    result.buffer[2] = 0x80 | (codepoint & 0x3f);
+    result.bytes = 3;
+  } else {
+    // UCS actually only goes up to 0x10ffff but the
+    // UTF-8 encoding handles 21 bits.
+    CHECK(codepoint <= 0x1fffff);
+    result.buffer[0] = 0xf0 | (codepoint >> 18);
+    result.buffer[1] = 0x80 | ((codepoint >> 12) & 0x3f);
+    result.buffer[2] = 0x80 | ((codepoint >> 6) & 0x3f);
+    result.buffer[3] = 0x80 | (codepoint & 0x3f);
+    result.bytes = 4;
+  }
+  return result;
+}
+
+EncodedCharacter EncodeEUC_JP(char16_t codepoint) {
+  // Assume JIS X 0208 (TODO: others)
+  CHECK(codepoint <= 0x6e6e);
+  EncodedCharacter result;
+  if (codepoint <= 0x7f) {
+    result.buffer[0] = codepoint;
+    result.bytes = 1;
+  } else {
+    result.buffer[0] = 0x80 | (codepoint >> 8);
+    result.buffer[1] = 0x80 | (codepoint & 0x7f);
+    result.bytes = 2;
+  }
+  return result;
+}
+
+EncodedCharacter EncodeCharacter(Encoding encoding, char32_t codepoint) {
+  switch (encoding) {
+  case Encoding::LATIN_1: return EncodeLATIN_1(codepoint);
+  case Encoding::UTF_8: return EncodeUTF_8(codepoint);
+  case Encoding::EUC_JP: return EncodeEUC_JP(codepoint);
+  default: CRASH_NO_CASE;
+  }
+}
+
+DecodedCharacter DecodeUTF_8Character(const char *cp, std::size_t bytes) {
+  auto p{reinterpret_cast<const std::uint8_t *>(cp)};
+  char32_t ch{*p};
+  int charBytes{1};
+  if (ch >= 0x80) {
+    if ((ch & 0xf8) == 0xf0 && bytes >= 4 && ch > 0xf0 &&
+        ((p[1] | p[2] | p[3]) & 0xc0) == 0x80) {
+      charBytes = 4;
+      ch = ((ch & 7) << 6) | (p[1] & 0x3f);
+      ch = (ch << 6) | (p[2] & 0x3f);
+      ch = (ch << 6) | (p[3] & 0x3f);
+    } else if ((ch & 0xf0) == 0xe0 && bytes >= 3 && ch > 0xe0 &&
+        ((p[1] | p[2]) & 0xc0) == 0x80) {
+      charBytes = 3;
+      ch = ((ch & 0xf) << 6) | (p[1] & 0x3f);
+      ch = (ch << 6) | (p[2] & 0x3f);
+    } else if ((ch & 0xe0) == 0xc0 && bytes >= 2 && ch > 0xc0 &&
+        (p[1] & 0xc0) == 0x80) {
+      charBytes = 2;
+      ch = ((ch & 0x1f) << 6) | (p[1] & 0x3f);
+    } else {
+      return {};  // not valid UTF-8
+    }
+  }
+  return {ch, charBytes};
+}
+
+DecodedCharacter DecodeEUC_JPCharacter(const char *cp, std::size_t bytes) {
+  auto p{reinterpret_cast<const std::uint8_t *>(cp)};
+  char32_t ch{*p};
+  int charBytes{1};
+  if (ch >= 0x80) {
+    if (bytes >= 2 && ch == 0x8e && p[1] >= 0xa1 && p[1] <= 0xdf) {
+      charBytes = 2;  // JIS X 0201
+      ch = p[1];
+    } else if (bytes >= 3 && ch == 0x8f && p[1] >= 0xa1 && p[1] <= 0xfe &&
+        p[2] >= 0xa1 && p[2] <= 0xfe) {
+      charBytes = 3;  // JIS X 0212
+      ch = (p[1] & 0x7f) << 8 | (p[1] & 0x7f);
+    } else if (bytes >= 2 && ch >= 0xa1 && ch <= 0xfe && p[1] >= 0x1 &&
+        p[1] <= 0xfe) {
+      charBytes = 2;  // JIS X 0208
+      ch = ((ch & 0x7f) << 8) | (p[1] & 0x7f);
+    } else {
+      return {};
+    }
+  }
+  return {ch, charBytes};
+}
+
+DecodedCharacter DecodeLATIN1Character(const char *cp) {
+  return {*reinterpret_cast<const std::uint8_t *>(cp), 1};
+}
+
+DecodedCharacter DecodeCharacter(
+    Encoding encoding, const char *cp, std::size_t bytes) {
+  switch (encoding) {
+  case Encoding::LATIN_1: return DecodeLATIN1Character(cp);
+  case Encoding::UTF_8: return DecodeUTF_8Character(cp, bytes);
+  case Encoding::EUC_JP: return DecodeEUC_JPCharacter(cp, bytes);
+  default: CRASH_NO_CASE;
+  }
+}
+
+std::u32string DecodeUTF_8(const std::string &s) {
   std::u32string result;
-  const std::uint8_t *p{reinterpret_cast<const std::uint8_t *>(s.data())};
+  const char *p{s.c_str()};
   for (auto bytes{s.size()}; bytes != 0;) {
-    decltype(bytes) charBytes{1};
-    char32_t ch{*p++};
-    if ((ch & 0xc0) > 0x40) {
-      if ((ch & 0xf8) == 0xf0 && bytes >= 4 && ch > 0xf0 &&
-          ((p[0] | p[1] | p[2]) & 0xc0) == 0x80) {
-        charBytes = 4;
-        ch = ((ch & 7) << 6) | (*p++ & 0x3f);
-        ch = (ch << 6) | (*p++ & 0x3f);
-        ch = (ch << 6) | (*p++ & 0x3f);
-      } else if ((ch & 0xf0) == 0xe0 && bytes >= 3 && ch > 0xe0 &&
-          ((p[0] | p[1]) & 0xc0) == 0x80) {
-        charBytes = 3;
-        ch = ((ch & 0xf) << 6) | (*p++ & 0x3f);
-        ch = (ch << 6) | (*p++ & 0x3f);
-      } else if ((ch & 0xe0) == 0xc0 && bytes >= 2 && ch > 0xc0 &&
-          (*p & 0xc0) == 0x80) {
-        charBytes = 2;
-        ch = ((ch & 0x1f) << 6) | (*p++ & 0x3f);
-      } else {
-        return std::nullopt;  // not valid UTF-8
+    DecodedCharacter decoded{DecodeUTF_8Character(p, bytes)};
+    if (decoded.bytes > 0) {
+      if (static_cast<std::size_t>(decoded.bytes) <= bytes) {
+        result.append(1, decoded.unicode);
+        bytes -= decoded.bytes;
+        p += decoded.bytes;
+        continue;
       }
     }
-    result.append(1, ch);
-    bytes -= charBytes;
+    result.append(1, static_cast<uint8_t>(*p));
+    ++p;
+    --bytes;
   }
-  return {result};
+  return result;
 }
+
+std::u16string DecodeEUC_JP(const std::string &s) {
+  std::u16string result;
+  const char *p{s.c_str()};
+  for (auto bytes{s.size()}; bytes != 0;) {
+    DecodedCharacter decoded{DecodeEUC_JPCharacter(p, bytes)};
+    if (decoded.bytes > 0) {
+      if (static_cast<std::size_t>(decoded.bytes) <= bytes) {
+        result.append(1, decoded.unicode);
+        bytes -= decoded.bytes;
+        p += decoded.bytes;
+        continue;
+      }
+    }
+    result.append(1, static_cast<uint8_t>(*p));
+    ++p;
+    --bytes;
+  }
+  return result;
+}
+
 }

--- a/lib/parser/characters.cc
+++ b/lib/parser/characters.cc
@@ -131,12 +131,12 @@ template<> EncodedCharacter EncodeCharacter<Encoding::EUC_JP>(char32_t ucs) {
     result.buffer[0] = ucs;
     result.bytes = 1;
   } else if (ucs <= 0xff) {
-    result.buffer[0] = 0x8e;  // JIS X 0201
+    result.buffer[0] = '\x8e';  // JIS X 0201
     result.buffer[1] = ucs;
     result.bytes = 2;
   } else if (IsUCSJIS_0212(ucs)) {  // JIS X 0212
     char32_t jis{UCSToJIS(ucs)};
-    result.buffer[0] = 0x8f;
+    result.buffer[0] = '\x8f';
     result.buffer[1] = 0x80 ^ (jis >> 8);
     result.buffer[2] = 0x80 ^ jis;
     result.bytes = 3;

--- a/lib/parser/characters.h
+++ b/lib/parser/characters.h
@@ -109,7 +109,7 @@ inline constexpr char HexadecimalDigitValue(char ch) {
 
 inline constexpr std::optional<char> BackslashEscapeValue(char ch) {
   switch (ch) {
-  case 'a': return '\a';
+  case 'a': return std::nullopt;  // '\a';  PGF90 doesn't know \a
   case 'b': return '\b';
   case 'f': return '\f';
   case 'n': return '\n';
@@ -125,7 +125,7 @@ inline constexpr std::optional<char> BackslashEscapeValue(char ch) {
 
 inline constexpr std::optional<char> BackslashEscapeChar(char ch) {
   switch (ch) {
-    //  case '\a': return 'a';  // PGF90 doesn't know \a
+  case '\a': return std::nullopt;  // 'a';  PGF90 doesn't know \a
   case '\b': return 'b';
   case '\f': return 'f';
   case '\n': return 'n';

--- a/lib/parser/characters.h
+++ b/lib/parser/characters.h
@@ -161,13 +161,9 @@ void EmitQuotedChar(char32_t ch, const NORMAL &emit, const INSERTED &insert,
       if (std::optional<char> escape{BackslashEscapeChar(ch)}) {
         emit(*escape);
       } else {
-        // octal escape sequence
-        if (ch > 077) {
-          insert('0' + (ch >> 6));
-        }
-        if (ch > 07) {
-          insert('0' + ((ch >> 3) & 7));
-        }
+        // octal escape sequence; always emit 3 digits to avoid ambiguity
+        insert('0' + (ch >> 6));
+        insert('0' + ((ch >> 3) & 7));
         insert('0' + (ch & 7));
       }
     } else {

--- a/lib/parser/characters.h
+++ b/lib/parser/characters.h
@@ -125,7 +125,7 @@ inline constexpr std::optional<char> BackslashEscapeValue(char ch) {
 
 inline constexpr std::optional<char> BackslashEscapeChar(char ch) {
   switch (ch) {
-  case '\a': return 'a';
+    //  case '\a': return 'a';  // PGF90 doesn't know \a
   case '\b': return 'b';
   case '\f': return 'f';
   case '\n': return 'n';
@@ -140,7 +140,8 @@ inline constexpr std::optional<char> BackslashEscapeChar(char ch) {
 }
 
 struct EncodedCharacter {
-  char buffer[4];
+  static constexpr int maxEncodingBytes{6};
+  char buffer[maxEncodingBytes];
   int bytes{0};
 };
 
@@ -155,7 +156,7 @@ template<typename NORMAL, typename INSERTED>
 void EmitQuotedChar(char32_t ch, const NORMAL &emit, const INSERTED &insert,
     bool backslashEscapes = true, Encoding encoding = Encoding::UTF_8) {
   auto emitOneChar{[&](std::uint8_t ch) {
-    if (ch < ' ' || ch == '\\' || (backslashEscapes && ch >= 0x7f)) {
+    if (ch < ' ' || (backslashEscapes && (ch == '\\' || ch >= 0x7f))) {
       insert('\\');
       if (std::optional<char> escape{BackslashEscapeChar(ch)}) {
         emit(*escape);
@@ -190,9 +191,7 @@ std::string QuoteCharacterLiteral(const std::u16string &,
 std::string QuoteCharacterLiteral(const std::u32string &,
     bool backslashEscapes = true, Encoding = Encoding::UTF_8);
 
-std::optional<int> UTF_8CharacterBytes(const char *);
-std::optional<int> EUC_JPCharacterBytes(const char *);
-std::optional<int> CountCharacters(const char *, std::size_t bytes, Encoding);
+int UTF_8CharacterBytes(const char *);
 
 struct DecodedCharacter {
   char32_t codepoint{0};

--- a/lib/parser/characters.h
+++ b/lib/parser/characters.h
@@ -109,7 +109,7 @@ inline constexpr char HexadecimalDigitValue(char ch) {
 
 inline constexpr std::optional<char> BackslashEscapeValue(char ch) {
   switch (ch) {
-  // case 'a': return '\a';  // pgf90 has no \a
+  case 'a': return '\a';
   case 'b': return '\b';
   case 'f': return '\f';
   case 'n': return '\n';
@@ -125,7 +125,7 @@ inline constexpr std::optional<char> BackslashEscapeValue(char ch) {
 
 inline constexpr std::optional<char> BackslashEscapeChar(char ch) {
   switch (ch) {
-  // case '\a': return 'a';  // pgf90 has no \a
+  case '\a': return 'a';
   case '\b': return 'b';
   case '\f': return 'f';
   case '\n': return 'n';
@@ -153,10 +153,9 @@ EncodedCharacter EncodeCharacter(Encoding, char32_t);
 // bytes of an encoding for a codepoint.
 template<typename NORMAL, typename INSERTED>
 void EmitQuotedChar(char32_t ch, const NORMAL &emit, const INSERTED &insert,
-    bool doubleDoubleQuotes = true, bool backslashEscapes = true,
-    Encoding encoding = Encoding::UTF_8) {
+    bool backslashEscapes = true, Encoding encoding = Encoding::UTF_8) {
   auto emitOneChar{[&](std::uint8_t ch) {
-    if (ch < ' ' || (backslashEscapes && (ch == '\\' || ch >= 0x7f))) {
+    if (ch < ' ' || ch == '\\' || (backslashEscapes && ch >= 0x7f)) {
       insert('\\');
       if (std::optional<char> escape{BackslashEscapeChar(ch)}) {
         emit(*escape);
@@ -174,12 +173,7 @@ void EmitQuotedChar(char32_t ch, const NORMAL &emit, const INSERTED &insert,
       emit(ch);
     }
   }};
-  if (ch == '"') {
-    if (doubleDoubleQuotes) {
-      insert('"');
-    }
-    emit('"');
-  } else if (ch <= 0x7f) {
+  if (ch <= 0x7f) {
     emitOneChar(ch);
   } else {
     EncodedCharacter encoded{EncodeCharacter(encoding, ch)};
@@ -190,21 +184,18 @@ void EmitQuotedChar(char32_t ch, const NORMAL &emit, const INSERTED &insert,
 }
 
 std::string QuoteCharacterLiteral(const std::string &,
-    bool doubleDoubleQuotes = true, bool backslashEscapes = true,
-    Encoding = Encoding::LATIN_1);
+    bool backslashEscapes = true, Encoding = Encoding::LATIN_1);
 std::string QuoteCharacterLiteral(const std::u16string &,
-    bool doubleDoubleQuotes = true, bool backslashEscapes = true,
-    Encoding = Encoding::EUC_JP);
+    bool backslashEscapes = true, Encoding = Encoding::EUC_JP);
 std::string QuoteCharacterLiteral(const std::u32string &,
-    bool doubleDoubleQuotes = true, bool backslashEscapes = true,
-    Encoding = Encoding::UTF_8);
+    bool backslashEscapes = true, Encoding = Encoding::UTF_8);
 
 std::optional<int> UTF_8CharacterBytes(const char *);
 std::optional<int> EUC_JPCharacterBytes(const char *);
 std::optional<int> CountCharacters(const char *, std::size_t bytes, Encoding);
 
 struct DecodedCharacter {
-  char32_t unicode{0};
+  char32_t codepoint{0};
   int bytes{0};  // signifying failure
 };
 

--- a/lib/parser/parse-state.h
+++ b/lib/parser/parse-state.h
@@ -44,7 +44,7 @@ public:
   ParseState(const ParseState &that)
     : p_{that.p_}, limit_{that.limit_}, context_{that.context_},
       userState_{that.userState_}, inFixedForm_{that.inFixedForm_},
-      encoding_{that.encoding_}, anyErrorRecovery_{that.anyErrorRecovery_},
+      anyErrorRecovery_{that.anyErrorRecovery_},
       anyConformanceViolation_{that.anyConformanceViolation_},
       deferMessages_{that.deferMessages_},
       anyDeferredMessages_{that.anyDeferredMessages_},
@@ -52,7 +52,7 @@ public:
   ParseState(ParseState &&that)
     : p_{that.p_}, limit_{that.limit_}, messages_{std::move(that.messages_)},
       context_{std::move(that.context_)}, userState_{that.userState_},
-      inFixedForm_{that.inFixedForm_}, encoding_{that.encoding_},
+      inFixedForm_{that.inFixedForm_},
       anyErrorRecovery_{that.anyErrorRecovery_},
       anyConformanceViolation_{that.anyConformanceViolation_},
       deferMessages_{that.deferMessages_},
@@ -61,7 +61,6 @@ public:
   ParseState &operator=(const ParseState &that) {
     p_ = that.p_, limit_ = that.limit_, context_ = that.context_;
     userState_ = that.userState_, inFixedForm_ = that.inFixedForm_;
-    encoding_ = that.encoding_;
     anyErrorRecovery_ = that.anyErrorRecovery_;
     anyConformanceViolation_ = that.anyConformanceViolation_;
     deferMessages_ = that.deferMessages_;
@@ -73,7 +72,6 @@ public:
     p_ = that.p_, limit_ = that.limit_, messages_ = std::move(that.messages_);
     context_ = std::move(that.context_);
     userState_ = that.userState_, inFixedForm_ = that.inFixedForm_;
-    encoding_ = that.encoding_;
     anyErrorRecovery_ = that.anyErrorRecovery_;
     anyConformanceViolation_ = that.anyConformanceViolation_;
     deferMessages_ = that.deferMessages_;
@@ -103,12 +101,6 @@ public:
   bool inFixedForm() const { return inFixedForm_; }
   ParseState &set_inFixedForm(bool yes = true) {
     inFixedForm_ = yes;
-    return *this;
-  }
-
-  Encoding encoding() const { return encoding_; }
-  ParseState &set_encoding(Encoding encoding) {
-    encoding_ = encoding;
     return *this;
   }
 
@@ -231,7 +223,6 @@ private:
   UserState *userState_{nullptr};
 
   bool inFixedForm_{false};
-  Encoding encoding_{Encoding::UTF_8};
   bool anyErrorRecovery_{false};
   bool anyConformanceViolation_{false};
   bool deferMessages_{false};

--- a/lib/parser/parse-state.h
+++ b/lib/parser/parse-state.h
@@ -185,17 +185,19 @@ public:
   }
 
   std::optional<const char *> GetNextChar() {
-    if (p_ >= limit_) {
+    if (p_ < limit_) {
+      return UncheckedAdvance();
+    } else {
       return std::nullopt;
     }
-    return {UncheckedAdvance()};
   }
 
   std::optional<const char *> PeekAtNextChar() const {
-    if (p_ >= limit_) {
+    if (p_ < limit_) {
+      return p_;
+    } else {
       return std::nullopt;
     }
-    return {p_};
   }
 
   std::size_t BytesRemaining() const {
@@ -229,7 +231,7 @@ private:
   UserState *userState_{nullptr};
 
   bool inFixedForm_{false};
-  Encoding encoding_{Encoding::UTF8};
+  Encoding encoding_{Encoding::UTF_8};
   bool anyErrorRecovery_{false};
   bool anyConformanceViolation_{false};
   bool deferMessages_{false};

--- a/lib/parser/parsing.cc
+++ b/lib/parser/parsing.cc
@@ -69,7 +69,6 @@ void Parsing::Prescan(const std::string &path, Options options) {
   Prescanner prescanner{messages_, cooked_, preprocessor, options.features};
   prescanner.set_fixedForm(options.isFixedForm)
       .set_fixedFormColumnLimit(options.fixedFormColumns)
-      .set_encoding(options.encoding)
       .AddCompilerDirectiveSentinel("dir$");
   if (options.features.IsEnabled(LanguageFeature::OpenMP)) {
     prescanner.AddCompilerDirectiveSentinel("$omp");
@@ -102,9 +101,7 @@ void Parsing::Parse(std::ostream *out) {
       .set_instrumentedParse(options_.instrumentedParse)
       .set_log(&log_);
   ParseState parseState{cooked_};
-  parseState.set_inFixedForm(options_.isFixedForm)
-      .set_encoding(options_.encoding)
-      .set_userState(&userState);
+  parseState.set_inFixedForm(options_.isFixedForm).set_userState(&userState);
   parseTree_ = program.Parse(parseState);
   CHECK(
       !parseState.anyErrorRecovery() || parseState.messages().AnyFatalError());

--- a/lib/parser/parsing.h
+++ b/lib/parser/parsing.h
@@ -37,7 +37,6 @@ struct Options {
   bool isFixedForm{false};
   int fixedFormColumns{72};
   LanguageFeatureControl features;
-  Encoding encoding{Encoding::UTF_8};
   std::vector<std::string> searchDirectories;
   std::vector<Predefinition> predefinitions;
   bool instrumentedParse{false};

--- a/lib/parser/parsing.h
+++ b/lib/parser/parsing.h
@@ -37,7 +37,7 @@ struct Options {
   bool isFixedForm{false};
   int fixedFormColumns{72};
   LanguageFeatureControl features;
-  Encoding encoding{Encoding::UTF8};
+  Encoding encoding{Encoding::UTF_8};
   std::vector<std::string> searchDirectories;
   std::vector<Predefinition> predefinitions;
   bool instrumentedParse{false};

--- a/lib/parser/preprocessor.cc
+++ b/lib/parser/preprocessor.cc
@@ -588,7 +588,9 @@ void Preprocessor::Directive(const TokenSequence &dir, Prescanner *prescanner) {
     } else if (included->bytes() > 0) {
       ProvenanceRange fileRange{
           allSources_.AddIncludedFile(*included, dir.GetProvenanceRange())};
-      Prescanner{*prescanner}.Prescan(fileRange);
+      Prescanner{*prescanner}
+          .set_encoding(included->encoding())
+          .Prescan(fileRange);
     }
   } else {
     prescanner->Say(dir.GetTokenProvenanceRange(dirOffset),

--- a/lib/parser/prescan.cc
+++ b/lib/parser/prescan.cc
@@ -21,7 +21,6 @@
 #include "../common/idioms.h"
 #include <cstddef>
 #include <cstring>
-#include <iostream>  // TODO pmk rm
 #include <sstream>
 #include <utility>
 #include <vector>
@@ -562,6 +561,8 @@ void Prescanner::QuotedCharacterLiteral(
   if (isKanji) {
     // NC'...' - the contents are always decoded as EUC_JP
     encoding = Encoding::EUC_JP;
+  } else if (encoding == Encoding::EUC_JP) {
+    encoding = Encoding::LATIN_1;  // for compatibility with tests
   }
   while (true) {
     DecodedCharacter decoded{DecodeCharacter(

--- a/lib/parser/prescan.cc
+++ b/lib/parser/prescan.cc
@@ -330,7 +330,9 @@ void Prescanner::SkipCComments() {
         nextLine_ = at_ = after;
         NextLine();
       } else {
-        Say(GetProvenance(at_), "unclosed C-style comment"_err_en_US);
+        // Don't emit any messages about unclosed C-style comments, because
+        // the sequence /* can appear legally in a FORMAT statement.  There's
+        // no ambiguity, since the sequence */ cannot appear legally.
         break;
       }
     } else if (inPreprocessorDirective_ && at_[0] == '\\' && at_ + 2 < limit_ &&
@@ -569,7 +571,7 @@ void Prescanner::QuotedCharacterLiteral(
         encoding, at_, static_cast<std::size_t>(limit_ - at_), escapesEnabled)};
     if (decoded.bytes <= 0) {
       Say(GetProvenanceRange(start, at_),
-          "Bad character in character literal"_err_en_US);
+          "Bad character in character literal"_en_US);
       // Just eat a byte and press on.
       decoded.codepoint = static_cast<unsigned char>(*at_);
       decoded.bytes = 1;

--- a/lib/parser/prescan.h
+++ b/lib/parser/prescan.h
@@ -83,6 +83,7 @@ private:
       Comment,
       ConditionalCompilationDirective,
       IncludeDirective,  // #include
+      DefinitionDirective,  // #define & #undef
       PreprocessorDirective,
       IncludeLine,  // Fortran INCLUDE
       CompilerDirective,
@@ -158,8 +159,7 @@ private:
   const char *SkipCComment(const char *) const;
   bool NextToken(TokenSequence &);
   bool ExponentAndKind(TokenSequence &);
-  void QuotedCharacterLiteral(
-      TokenSequence &, const char *start, bool isKanji = false);
+  void QuotedCharacterLiteral(TokenSequence &, const char *start);
   void Hollerith(TokenSequence &, int count, const char *start);
   bool PadOutCharacterLiteral(TokenSequence &);
   bool SkipCommentLine(bool afterAmpersand);

--- a/lib/parser/prescan.h
+++ b/lib/parser/prescan.h
@@ -158,7 +158,8 @@ private:
   const char *SkipCComment(const char *) const;
   bool NextToken(TokenSequence &);
   bool ExponentAndKind(TokenSequence &);
-  void QuotedCharacterLiteral(TokenSequence &, const char *start);
+  void QuotedCharacterLiteral(
+      TokenSequence &, const char *start, bool isKanji = false);
   void Hollerith(TokenSequence &, int count, const char *start);
   bool PadOutCharacterLiteral(TokenSequence &);
   bool SkipCommentLine(bool afterAmpersand);

--- a/lib/parser/prescan.h
+++ b/lib/parser/prescan.h
@@ -186,7 +186,7 @@ private:
   LanguageFeatureControl features_;
   bool inFixedForm_{false};
   int fixedFormColumnLimit_{72};
-  Encoding encoding_{Encoding::UTF8};
+  Encoding encoding_{Encoding::UTF_8};
   int delimiterNesting_{0};
   int prescannerNesting_{0};
 

--- a/lib/parser/provenance.cc
+++ b/lib/parser/provenance.cc
@@ -108,7 +108,7 @@ std::string AllSources::PopSearchPathDirectory() {
 }
 
 const SourceFile *AllSources::Open(std::string path, std::stringstream *error) {
-  std::unique_ptr<SourceFile> source{std::make_unique<SourceFile>()};
+  std::unique_ptr<SourceFile> source{std::make_unique<SourceFile>(encoding_)};
   if (source->Open(LocateSourceFile(path, searchPath_), error)) {
     return ownedSourceFiles_.emplace_back(std::move(source)).get();
   }
@@ -116,7 +116,7 @@ const SourceFile *AllSources::Open(std::string path, std::stringstream *error) {
 }
 
 const SourceFile *AllSources::ReadStandardInput(std::stringstream *error) {
-  std::unique_ptr<SourceFile> source{std::make_unique<SourceFile>()};
+  std::unique_ptr<SourceFile> source{std::make_unique<SourceFile>(encoding_)};
   if (source->ReadStandardInput(error)) {
     return ownedSourceFiles_.emplace_back(std::move(source)).get();
   }

--- a/lib/parser/provenance.h
+++ b/lib/parser/provenance.h
@@ -17,6 +17,7 @@
 
 #include "char-block.h"
 #include "char-buffer.h"
+#include "characters.h"
 #include "source.h"
 #include "../common/idioms.h"
 #include "../common/interval.h"
@@ -117,6 +118,11 @@ public:
 
   std::size_t size() const { return range_.size(); }
   const char &operator[](Provenance) const;
+  Encoding encoding() const { return encoding_; }
+  AllSources &set_encoding(Encoding e) {
+    encoding_ = e;
+    return *this;
+  }
 
   void PushSearchPathDirectory(std::string);
   std::string PopSearchPathDirectory();
@@ -181,6 +187,7 @@ private:
   std::map<char, Provenance> compilerInsertionProvenance_;
   std::vector<std::unique_ptr<SourceFile>> ownedSourceFiles_;
   std::vector<std::string> searchPath_;
+  Encoding encoding_{Encoding::UTF_8};
 };
 
 class CookedSource {

--- a/lib/parser/source.cc
+++ b/lib/parser/source.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -60,17 +60,18 @@ void SourceFile::RecordLineStarts() {
   lineStart_ = FindLineStarts(content_, bytes_);
 }
 
-// Cut down the contiguous content of a source file to skip
-// things like byte order marks.
+// Check for a Unicode byte order mark (BOM).
+// Module files all have one; so can source files.
 void SourceFile::IdentifyPayload() {
   content_ = address_;
   bytes_ = size_;
   if (content_ != nullptr) {
+    static constexpr int BOMBytes{3};
     static const char UTF8_BOM[]{"\xef\xbb\xbf"};
-    if (bytes_ >= sizeof UTF8_BOM &&
-        std::memcmp(content_, UTF8_BOM, sizeof UTF8_BOM) == 0) {
-      content_ += sizeof UTF8_BOM;
-      bytes_ -= sizeof UTF8_BOM;
+    if (bytes_ >= BOMBytes && std::memcmp(content_, UTF8_BOM, BOMBytes) == 0) {
+      content_ += BOMBytes;
+      bytes_ -= BOMBytes;
+      encoding_ = Encoding::UTF_8;
     }
   }
 }

--- a/lib/parser/source.h
+++ b/lib/parser/source.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,7 +18,9 @@
 // Source file content is lightly normalized when the file is read.
 //  - Line ending markers are converted to single newline characters
 //  - A newline character is added to the last line of the file if one is needed
+//  - A Unicode byte order mark is recognized if present.
 
+#include "characters.h"
 #include <cstddef>
 #include <sstream>
 #include <string>
@@ -33,12 +35,13 @@ std::string LocateSourceFile(
 
 class SourceFile {
 public:
-  SourceFile() {}
+  explicit SourceFile(Encoding e) : encoding_{e} {}
   ~SourceFile();
   std::string path() const { return path_; }
   const char *content() const { return content_; }
   std::size_t bytes() const { return bytes_; }
   std::size_t lines() const { return lineStart_.size(); }
+  Encoding encoding() const { return encoding_; }
 
   bool Open(std::string path, std::stringstream *error);
   bool ReadStandardInput(std::stringstream *error);
@@ -62,6 +65,7 @@ private:
   std::size_t bytes_{0};
   std::vector<std::size_t> lineStart_;
   std::string normalized_;
+  Encoding encoding_{Encoding::UTF_8};
 };
 }
 #endif  // FORTRAN_PARSER_SOURCE_H_

--- a/lib/parser/token-parsers.h
+++ b/lib/parser/token-parsers.h
@@ -515,23 +515,18 @@ struct HollerithLiteral {
     }
     std::string content;
     for (auto j{*charCount}; j-- > 0;) {
-      if (std::optional<int> chBytes{
-              UTF_8CharacterBytes(state.GetLocation())}) {
-        for (int bytes{*chBytes}; bytes > 0; --bytes) {
-          if (std::optional<const char *> at{nextCh.Parse(state)}) {
-            if (*chBytes == 1 && !isprint(**at)) {
-              state.Say(start, "Bad character in Hollerith"_err_en_US);
-              return std::nullopt;
-            }
-            content += **at;
-          } else {
-            state.Say(start, "Insufficient characters in Hollerith"_err_en_US);
+      int chBytes{UTF_8CharacterBytes(state.GetLocation())};
+      for (int bytes{chBytes}; bytes > 0; --bytes) {
+        if (std::optional<const char *> at{nextCh.Parse(state)}) {
+          if (chBytes == 1 && !isprint(**at)) {
+            state.Say(start, "Bad character in Hollerith"_err_en_US);
             return std::nullopt;
           }
+          content += **at;
+        } else {
+          state.Say(start, "Insufficient characters in Hollerith"_err_en_US);
+          return std::nullopt;
         }
-      } else {
-        state.Say(start, "Bad multi-byte character in Hollerith"_err_en_US);
-        return std::nullopt;
       }
     }
     return content;

--- a/lib/parser/token-parsers.h
+++ b/lib/parser/token-parsers.h
@@ -207,70 +207,41 @@ template<class PA> inline constexpr auto bracketed(const PA &p) {
 
 // Quoted character literal constants.
 struct CharLiteralChar {
-  struct Result {
-    Result(char c, bool esc) : ch{c}, wasEscaped{esc} {}
-    static Result Bare(char c) { return Result{c, false}; }
-    static Result Escaped(char c) { return Result{c, true}; }
-    char ch;
-    bool wasEscaped;
-  };
-  using resultType = Result;
-  static std::optional<Result> Parse(ParseState &state) {
+  using resultType = char;
+  static std::optional<char> Parse(ParseState &state) {
     auto at{state.GetLocation()};
-    std::optional<const char *> och{nextCh.Parse(state)};
-    if (!och.has_value()) {
-      return std::nullopt;
-    }
-    char ch{**och};
-    if (ch == '\n') {
-      state.Say(CharBlock{at, state.GetLocation()},
-          "unclosed character constant"_err_en_US);
-      return std::nullopt;
-    }
-    if (ch != '\\') {
-      return Result::Bare(ch);
-    }
-    if (!(och = nextCh.Parse(state)).has_value()) {
-      return std::nullopt;
-    }
-    ch = **och;
-    if (ch == '\n') {
-      state.Say(CharBlock{at, state.GetLocation()},
-          "unclosed character constant"_err_en_US);
-      return std::nullopt;
-    }
-    if (std::optional<char> escChar{BackslashEscapeValue(ch)}) {
-      return Result::Escaped(*escChar);
-    }
-    if (IsOctalDigit(ch)) {
-      ch -= '0';
-      for (int j = (ch > 3 ? 1 : 2); j-- > 0;) {
-        static constexpr auto octalDigit{attempt("01234567"_ch)};
-        och = octalDigit.Parse(state);
-        if (och.has_value()) {
-          ch = 8 * ch + **och - '0';
-        } else {
-          break;
-        }
-      }
-    } else if (ch == 'x' || ch == 'X') {
-      ch = 0;
-      static constexpr auto hexDigit{"0123456789abcdefABCDEF"_ch};
-      och = hexDigit.Parse(state);
-      if (och.has_value()) {
-        ch = HexadecimalDigitValue(**och);
-        static constexpr auto hexDigit2{attempt("0123456789abcdefABCDEF"_ch)};
-        och = hexDigit2.Parse(state);
-        if (och.has_value()) {
-          ch = 16 * ch + HexadecimalDigitValue(**och);
-        }
-      } else {
+    if (std::optional<const char *> cp{nextCh.Parse(state)}) {
+      if (**cp == '\n') {
+        state.Say(CharBlock{at, state.GetLocation()},
+            "Unclosed character constant"_err_en_US);
         return std::nullopt;
       }
-    } else {
-      state.Say(at, "bad escaped character"_en_US);
+      if (**cp != '\\') {
+        return **cp;
+      }
+      if (!(cp = nextCh.Parse(state)).has_value()) {
+        state.Say(CharBlock{at, state.GetLocation()},
+            "Unclosed character constant"_err_en_US);
+        return std::nullopt;
+      }
+      if (std::optional<char> escChar{BackslashEscapeValue(**cp)}) {
+        return escChar;
+      }
+      if (IsOctalDigit(**cp)) {
+        int result{**cp - '0'};
+        for (int j = (result > 3 ? 1 : 2); j-- > 0;) {
+          static constexpr auto octalDigit{attempt("01234567"_ch)};
+          if (std::optional<const char *> oct{octalDigit.Parse(state)}) {
+            result = 8 * result + **oct - '0';
+          } else {
+            break;
+          }
+        }
+        return result;
+      }
+      state.Say(at, "Bad escaped character"_err_en_US);
     }
-    return {Result::Escaped(ch)};
+    return std::nullopt;
   }
 };
 
@@ -279,14 +250,14 @@ template<char quote> struct CharLiteral {
   static std::optional<std::string> Parse(ParseState &state) {
     std::string str;
     static constexpr auto nextch{attempt(CharLiteralChar{})};
-    while (std::optional<CharLiteralChar::Result> ch{nextch.Parse(state)}) {
-      if (ch->ch == quote && !ch->wasEscaped) {
+    while (std::optional<char> ch{nextch.Parse(state)}) {
+      if (*ch == quote) {
         static constexpr auto doubled{attempt(AnyOfChars{SetOfChars{quote}})};
         if (!doubled.Parse(state).has_value()) {
           return str;
         }
       }
-      str += ch->ch;
+      str += *ch;
     }
     return std::nullopt;
   }
@@ -544,7 +515,7 @@ struct HollerithLiteral {
     std::string content;
     for (auto j{*charCount}; j-- > 0;) {
       if (std::optional<int> chBytes{
-              CharacterBytes(state.GetLocation(), state.encoding())}) {
+              UTF_8CharacterBytes(state.GetLocation())}) {
         for (int bytes{*chBytes}; bytes > 0; --bytes) {
           if (std::optional<const char *> at{nextCh.Parse(state)}) {
             if (*chBytes == 1 && !isprint(**at)) {

--- a/lib/parser/token-sequence.cc
+++ b/lib/parser/token-sequence.cc
@@ -61,6 +61,16 @@ std::size_t TokenSequence::SkipBlanks(std::size_t at) const {
   return tokens;  // even if at > tokens
 }
 
+void TokenSequence::RemoveLastToken() {
+  CHECK(!start_.empty());
+  CHECK(nextStart_ > start_.back());
+  std::size_t bytes{nextStart_ - start_.back()};
+  nextStart_ = start_.back();
+  start_.pop_back();
+  char_.erase(char_.begin() + nextStart_, char_.end());
+  provenances_.RemoveLastBytes(bytes);
+}
+
 void TokenSequence::Put(const TokenSequence &that) {
   if (nextStart_ < char_.size()) {
     start_.push_back(nextStart_);

--- a/lib/parser/token-sequence.h
+++ b/lib/parser/token-sequence.h
@@ -68,6 +68,9 @@ public:
     return {&char_[start_.at(token)], TokenBytes(token)};
   }
   char CharAt(std::size_t j) const { return char_.at(j); }
+  CharBlock CurrentOpenToken() const {
+    return {&char_[nextStart_], char_.size() - nextStart_};
+  }
 
   std::size_t SkipBlanks(std::size_t) const;
 

--- a/lib/parser/token-sequence.h
+++ b/lib/parser/token-sequence.h
@@ -89,6 +89,8 @@ public:
     start_.pop_back();
   }
 
+  void RemoveLastToken();
+
   void Put(const TokenSequence &);
   void Put(const TokenSequence &, ProvenanceRange);
   void Put(const TokenSequence &, std::size_t at, std::size_t tokens = 1);

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -189,16 +189,18 @@ public:
     if (const auto &k{std::get<std::optional<KindParam>>(x.t)}) {
       if (std::holds_alternative<KindParam::Kanji>(k->u)) {
         Word("NC");
-        Put(QuoteCharacterLiteral(std::get<std::string>(x.t), true,
-            backslashEscapes_, Encoding::EUC_JP));
+        std::u16string jis;
+        for (char32_t ch : DecodeUTF_8(std::get<std::string>(x.t))) {
+          jis += static_cast<char16_t>(ch);
+        }
+        Put(QuoteCharacterLiteral(jis, backslashEscapes_, Encoding::EUC_JP));
       } else {
         Walk(*k), Put('_');
         Put(QuoteCharacterLiteral(
-            std::get<std::string>(x.t), true, backslashEscapes_));
+            std::get<std::string>(x.t), backslashEscapes_));
       }
     } else {
-      Put(QuoteCharacterLiteral(
-          std::get<std::string>(x.t), true, backslashEscapes_));
+      Put(QuoteCharacterLiteral(std::get<std::string>(x.t), backslashEscapes_));
     }
   }
   void Before(const HollerithLiteralConstant &x) {
@@ -1433,7 +1435,7 @@ public:
     std::visit(
         common::visitors{
             [&](const std::string &y) {
-              Put(QuoteCharacterLiteral(y, true, backslashEscapes_));
+              Put(QuoteCharacterLiteral(y, backslashEscapes_));
             },
             [&](const std::list<format::FormatItem> &y) {
               Walk("(", y, ",", ")");

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -186,17 +186,15 @@ public:
         x.u);
   }
   void Unparse(const CharLiteralConstant &x) {  // R724
-    Encoding encoding{Encoding::LATIN_1};
     if (const auto &k{std::get<std::optional<KindParam>>(x.t)}) {
       if (std::holds_alternative<KindParam::Kanji>(k->u)) {
         Word("NC");
-        encoding = Encoding::EUC_JP;
       } else {
         Walk(*k), Put('_');
       }
     }
     Put(QuoteCharacterLiteral(
-        DecodeUTF_8(std::get<std::string>(x.t)), backslashEscapes_, encoding));
+        std::get<std::string>(x.t), backslashEscapes_, Encoding::LATIN_1));
   }
   void Unparse(const HollerithLiteralConstant &x) {
     std::u32string ucs{DecodeUTF_8(x.v)};

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -186,7 +186,7 @@ public:
         x.u);
   }
   void Unparse(const CharLiteralConstant &x) {  // R724
-    Encoding encoding{encoding_};
+    Encoding encoding{Encoding::LATIN_1};
     if (const auto &k{std::get<std::optional<KindParam>>(x.t)}) {
       if (std::holds_alternative<KindParam::Kanji>(k->u)) {
         Word("NC");

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -189,18 +189,21 @@ public:
     if (const auto &k{std::get<std::optional<KindParam>>(x.t)}) {
       if (std::holds_alternative<KindParam::Kanji>(k->u)) {
         Word("NC");
+        Put(QuoteCharacterLiteral(std::get<std::string>(x.t), true,
+            backslashEscapes_, Encoding::EUC_JP));
       } else {
         Walk(*k), Put('_');
+        Put(QuoteCharacterLiteral(
+            std::get<std::string>(x.t), true, backslashEscapes_));
       }
+    } else {
+      Put(QuoteCharacterLiteral(
+          std::get<std::string>(x.t), true, backslashEscapes_));
     }
-    Put(QuoteCharacterLiteral(
-        std::get<std::string>(x.t), true, backslashEscapes_));
   }
   void Before(const HollerithLiteralConstant &x) {
-    std::optional<std::size_t> chars{CountCharacters(x.v.data(), x.v.size(),
-        encoding_ == Encoding::EUC_JP ? EUC_JPCharacterBytes
-                                      : UTF8CharacterBytes)};
-    if (chars.has_value()) {
+    if (std::optional<std::size_t> chars{
+            CountCharacters(x.v.data(), x.v.size(), encoding_)}) {
       Unparse(*chars);
     } else {
       Unparse(x.v.size());
@@ -2575,7 +2578,7 @@ private:
   int column_{1};
   const int maxColumns_{80};
   std::set<CharBlock> structureComponents_;
-  Encoding encoding_{Encoding::UTF8};
+  Encoding encoding_{Encoding::UTF_8};
   bool capitalizeKeywords_{true};
   bool openmpDirective_{false};
   bool backslashEscapes_{false};

--- a/lib/parser/unparse.h
+++ b/lib/parser/unparse.h
@@ -37,7 +37,7 @@ using preStatementType =
 using TypedExprAsFortran =
     std::function<void(std::ostream &, const evaluate::GenericExprWrapper &)>;
 
-/// Convert parsed program to out as Fortran.
+// Converts parsed program to out as Fortran.
 void Unparse(std::ostream &out, const Program &program,
     Encoding encoding = Encoding::UTF_8, bool capitalizeKeywords = true,
     bool backslashEscapes = true, preStatementType *preStatement = nullptr,

--- a/lib/parser/unparse.h
+++ b/lib/parser/unparse.h
@@ -39,7 +39,7 @@ using TypedExprAsFortran =
 
 /// Convert parsed program to out as Fortran.
 void Unparse(std::ostream &out, const Program &program,
-    Encoding encoding = Encoding::UTF8, bool capitalizeKeywords = true,
+    Encoding encoding = Encoding::UTF_8, bool capitalizeKeywords = true,
     bool backslashEscapes = true, preStatementType *preStatement = nullptr,
     TypedExprAsFortran *expr = nullptr);
 }

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -519,16 +519,17 @@ MaybeExpr ExpressionAnalyzer::AnalyzeString(std::string &&string, int kind) {
   if (!CheckIntrinsicKind(TypeCategory::Character, kind)) {
     return std::nullopt;
   }
-  if (kind == 1) {
-    return AsGenericExpr(
-        Constant<Type<TypeCategory::Character, 1>>{std::move(string)});
-  } else if (kind == 2) {
+  switch (kind) {
+  case 1:
+    return AsGenericExpr(Constant<Type<TypeCategory::Character, 1>>{
+        parser::DecodeString<parser::Encoding::LATIN_1>(string, true)});
+  case 2:
     return AsGenericExpr(Constant<Type<TypeCategory::Character, 2>>{
-        parser::DecodeEUC_JP(string)});
-  } else {
-    CHECK(kind == 4);
+        parser::DecodeString<parser::Encoding::EUC_JP>(string, true)});
+  case 4:
     return AsGenericExpr(Constant<Type<TypeCategory::Character, 4>>{
-        parser::DecodeUTF_8(string)});
+        parser::DecodeString<parser::Encoding::UTF_8>(string, true)});
+  default: CRASH_NO_CASE;
   }
 }
 

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -519,10 +519,10 @@ MaybeExpr ExpressionAnalyzer::AnalyzeString(std::string &&string, int kind) {
   if (!CheckIntrinsicKind(TypeCategory::Character, kind)) {
     return std::nullopt;
   }
-  std::u32string unicode{parser::DecodeUTF_8(string)};
+  std::u32string codepoint{parser::DecodeUTF_8(string)};
   if (kind == 1) {
     std::string result;
-    for (const char32_t &ch : unicode) {
+    for (char32_t ch : codepoint) {
       if (ch <= 0xff) {
         result += static_cast<char>(ch);
       } else {
@@ -537,7 +537,7 @@ MaybeExpr ExpressionAnalyzer::AnalyzeString(std::string &&string, int kind) {
         Constant<Type<TypeCategory::Character, 1>>{std::move(result)});
   } else if (kind == 2) {
     std::u16string result;
-    for (const char32_t &ch : unicode) {
+    for (char32_t ch : codepoint) {
       if (ch > 0xffff) {
         Say("Bad character in CHARACTER(KIND=2) literal"_err_en_US);
         return std::nullopt;
@@ -549,7 +549,7 @@ MaybeExpr ExpressionAnalyzer::AnalyzeString(std::string &&string, int kind) {
   } else {
     CHECK(kind == 4);
     return AsGenericExpr(
-        Constant<Type<TypeCategory::Character, 4>>{std::move(unicode)});
+        Constant<Type<TypeCategory::Character, 4>>{std::move(codepoint)});
   }
 }
 

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -31,7 +31,10 @@ namespace Fortran::semantics {
 using namespace parser::literals;
 
 // The initial characters of a file that identify it as a .mod file.
-static constexpr auto magic{"!mod$ v1 sum:"};
+// The first three bytes are a Unicode byte order mark that ensures
+// that the module file is decoded as UTF-8 even if source files
+// are using another encoding.
+static constexpr auto magic{"\xef\xbb\xbf!mod$ v1 sum:"};
 
 static const SourceName *GetSubmoduleParent(const parser::Program &);
 static std::string ModFilePath(const std::string &dir, const SourceName &,

--- a/lib/semantics/unparse-with-symbols.h
+++ b/lib/semantics/unparse-with-symbols.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ struct Program;
 
 namespace Fortran::semantics {
 void UnparseWithSymbols(std::ostream &, const parser::Program &,
-    parser::Encoding encoding = parser::Encoding::UTF8);
+    parser::Encoding encoding = parser::Encoding::UTF_8);
 }
 
 #endif  // FORTRAN_SEMANTICS_UNPARSE_WITH_SYMBOLS_H_

--- a/test/semantics/modfile28.f90
+++ b/test/semantics/modfile28.f90
@@ -29,9 +29,9 @@ end module m
 
 !Expect: m.mod
 !module m
-!character(:,4),parameter::c4=4_"Hi! 你好!"
-!character(:,1),parameter::c1=1_"Hi! ä½ å¥½!"
-!character(:,4),parameter::c4a(1_8:)=[CHARACTER(KIND=4,LEN=1)::"一","二","三","四","五"]
+!character(:,4),parameter::c4=4_"Hi! \344\275\240\345\245\275!"
+!character(:,1),parameter::c1=1_"Hi! \344\275\240\345\245\275!"
+!character(:,4),parameter::c4a(1_8:)=[CHARACTER(KIND=4,LEN=1)::"\344\270\200","\344\272\214","\344\270\211","\345\233\233","\344\272\224"]
 !integer(4),parameter::lc4=7_4
 !integer(4),parameter::lc1=11_4
 !end

--- a/test/semantics/modfile28.f90
+++ b/test/semantics/modfile28.f90
@@ -15,9 +15,12 @@
 
 ! Test UTF-8 support in character literals
 ! TODO: test EUC-JP
+! Note: Module files are encoded in UTF-8.
 
 module m
 character(kind=4,len=:), parameter :: c4 = 4_"Hi! 你好!"
+! In CHARACTER(1) literals, codepoints > 0xff are serialized into UTF-8;
+! each of those bytes then gets encoded into UTF-8 for the module file.
 character(kind=1,len=:), parameter :: c1 = 1_"Hi! 你好!"
 character(kind=4,len=:), parameter :: c4a(:) = [4_"一", 4_"二", 4_"三", 4_"四", 4_"五"]
 integer, parameter :: lc4 = len(c4)
@@ -27,7 +30,7 @@ end module m
 !Expect: m.mod
 !module m
 !character(:,4),parameter::c4=4_"Hi! 你好!"
-!character(:,1),parameter::c1=1_"Hi! \344\275\240\345\245\275!"
+!character(:,1),parameter::c1=1_"Hi! ä½ å¥½!"
 !character(:,4),parameter::c4a(1_8:)=[CHARACTER(KIND=4,LEN=1)::"一","二","三","四","五"]
 !integer(4),parameter::lc4=7_4
 !integer(4),parameter::lc1=11_4

--- a/test/semantics/test_modfile.sh
+++ b/test/semantics/test_modfile.sh
@@ -59,7 +59,8 @@ for src in "$@"; do
       echo FAIL
       exit 1
     fi
-    sed '/^!mod\$/d' $temp/$mod > $actual
+    # The first three bytes of the file are a UTF-8 BOM
+    sed '/^.!mod\$/d' $temp/$mod > $actual
     sed '1,/^!Expect: '"$mod"'/d' $src | sed -e '/^$/,$d' -e 's/^! *//' > $expect
     if ! diff -U999999 $expect $actual > $diffs; then
       echo "Module file $mod differs from expected:"

--- a/tools/f18/f18-parse-demo.cc
+++ b/tools/f18/f18-parse-demo.cc
@@ -446,7 +446,6 @@ int main(int argc, char *const argv[]) {
       }
     }
   }
-  driver.encoding = options.encoding;
 
   if (driver.warnOnNonstandardUsage) {
     options.features.WarnOnAllNonstandard();

--- a/tools/f18/f18-parse-demo.cc
+++ b/tools/f18/f18-parse-demo.cc
@@ -92,7 +92,7 @@ struct DriverOptions {
   bool forcedForm{false};  // -Mfixed or -Mfree appeared
   bool warnOnNonstandardUsage{false};  // -Mstandard
   bool warningsAreErrors{false};  // -Werror
-  Fortran::parser::Encoding encoding{Fortran::parser::Encoding::UTF8};
+  Fortran::parser::Encoding encoding{Fortran::parser::Encoding::UTF_8};
   bool parseOnly{false};
   bool dumpProvenance{false};
   bool dumpCookedChars{false};

--- a/tools/f18/f18-parse-demo.cc
+++ b/tools/f18/f18-parse-demo.cc
@@ -92,7 +92,7 @@ struct DriverOptions {
   bool forcedForm{false};  // -Mfixed or -Mfree appeared
   bool warnOnNonstandardUsage{false};  // -Mstandard
   bool warningsAreErrors{false};  // -Werror
-  Fortran::parser::Encoding encoding{Fortran::parser::Encoding::UTF_8};
+  Fortran::parser::Encoding encoding{Fortran::parser::Encoding::LATIN_1};
   bool parseOnly{false};
   bool dumpProvenance{false};
   bool dumpCookedChars{false};

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -451,8 +451,13 @@ int main(int argc, char *const argv[]) {
     } else if (arg == "-module-suffix") {
       driver.moduleFileSuffix = args.front();
       args.pop_front();
-    } else if (arg == "-fno-utf-8") {
+    } else if (arg == "-futf-8") {
+      driver.encoding = Fortran::parser::Encoding::UTF_8;
+    } else if (arg == "-flatin") {
       driver.encoding = Fortran::parser::Encoding::LATIN_1;
+    } else if (arg == "-fkanji") {
+      driver.encoding = Fortran::parser::Encoding::EUC_JP;
+      driver.pgf90Args.push_back("-Mx,125,4");  // PGI "Kanji" mode
     } else if (arg == "-help" || arg == "--help" || arg == "-?") {
       std::cerr
           << "f18 options:\n"
@@ -467,6 +472,10 @@ int main(int argc, char *const argv[]) {
           << "  -ed                  enable fixed form D lines\n"
           << "  -E                   prescan & preprocess only\n"
           << "  -module dir          module output directory (default .)\n"
+          << "  -fkanji              interpret source as EUC_JP rather than "
+             "UTF-8\n"
+          << "  -flatin              interpret source as Latin-1 (ISO 8859-1) "
+             "rather than UTF-8\n"
           << "  -fparse-only         parse only, no output except messages\n"
           << "  -funparse            parse & reformat only, no code "
              "generation\n"

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -452,7 +452,7 @@ int main(int argc, char *const argv[]) {
       driver.moduleFileSuffix = args.front();
       args.pop_front();
     } else if (arg == "-fno-utf-8") {
-      options.encoding = Fortran::parser::Encoding::LATIN_1;
+      driver.encoding = Fortran::parser::Encoding::LATIN_1;
     } else if (arg == "-help" || arg == "--help" || arg == "-?") {
       std::cerr
           << "f18 options:\n"
@@ -496,11 +496,10 @@ int main(int argc, char *const argv[]) {
       } else if (arg.substr(0, 2) == "-I") {
         driver.searchDirectories.push_back(arg.substr(2));
       } else if (arg == "-Mx,125,4") {  // PGI "all Kanji" mode
-        options.encoding = Fortran::parser::Encoding::EUC_JP;
+        driver.encoding = Fortran::parser::Encoding::EUC_JP;
       }
     }
   }
-  driver.encoding = options.encoding;
 
   if (driver.warnOnNonstandardUsage) {
     options.features.WarnOnAllNonstandard();
@@ -514,6 +513,7 @@ int main(int argc, char *const argv[]) {
   }
 
   Fortran::parser::AllSources allSources;
+  allSources.set_encoding(driver.encoding);
   Fortran::semantics::SemanticsContext semanticsContext{
       defaultKinds, options.features, allSources};
   semanticsContext.set_moduleDirectory(driver.moduleDirectory)

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -513,10 +513,6 @@ int main(int argc, char *const argv[]) {
   if (driver.warnOnNonstandardUsage) {
     options.features.WarnOnAllNonstandard();
   }
-  if (!options.features.IsEnabled(
-          Fortran::parser::LanguageFeature::BackslashEscapes)) {
-    driver.pgf90Args.push_back("-Mbackslash");
-  }
   if (options.features.IsEnabled(Fortran::parser::LanguageFeature::OpenMP)) {
     driver.pgf90Args.push_back("-mp");
   }

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -87,7 +87,7 @@ struct DriverOptions {
   bool forcedForm{false};  // -Mfixed or -Mfree appeared
   bool warnOnNonstandardUsage{false};  // -Mstandard
   bool warningsAreErrors{false};  // -Werror
-  Fortran::parser::Encoding encoding{Fortran::parser::Encoding::UTF8};
+  Fortran::parser::Encoding encoding{Fortran::parser::Encoding::UTF_8};
   bool parseOnly{false};
   bool dumpProvenance{false};
   bool dumpCookedChars{false};
@@ -451,6 +451,8 @@ int main(int argc, char *const argv[]) {
     } else if (arg == "-module-suffix") {
       driver.moduleFileSuffix = args.front();
       args.pop_front();
+    } else if (arg == "-fno-utf-8") {
+      options.encoding = Fortran::parser::Encoding::LATIN_1;
     } else if (arg == "-help" || arg == "--help" || arg == "-?") {
       std::cerr
           << "f18 options:\n"


### PR DESCRIPTION
These changes make f18 more serious about its support for various character sets and their encodings in source files, specifically in character literals and Hollerith.

Add Latin-1 (ISO 8859-1) to the supported character sets and their encodings for source files.  (Other character sets with one-byte encodings will probably work for source files too so long as they don't try to use non-ASCII in CHARACTER(KIND=4) literals.)

Make character encodings particular to each source file, including modules.  Support auto-detection of UTF-8 byte order marks in source files.  Add these BOMs to module files and always use UTF-8 for them.

Further, always use UTF-8 for Hollerith in the cooked character stream  This simplifies the parser proper somewhat.  Character literals are left undecoded until expression semantics, but their contents are encoded with escape sequences for bytes that are not printable ASCII.
