### PR TITLE
Handle nested interface blocks

### DIFF
--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -235,7 +235,7 @@ bool Symbol::CanReplaceDetails(const Details &details) const {
             [=](const ObjectEntityDetails &) { return has<EntityDetails>(); },
             [=](const ProcEntityDetails &) { return has<EntityDetails>(); },
             [=](const SubprogramDetails &) {
-              return has<SubprogramNameDetails>();
+              return has<SubprogramNameDetails>() || has<EntityDetails>();
             },
             [](const auto &) { return false; },
         },

--- a/test/semantics/modfile07.f90
+++ b/test/semantics/modfile07.f90
@@ -43,20 +43,6 @@ contains
     integer x,y
   end function
 end
-
-module m2
-  interface foo
-    procedure foo
-  end interface
-  type :: foo
-    real :: x
-  end type
-contains
-  complex function foo()
-    foo = 1.0
-  end
-end
-
 !Expect: m.mod
 !module m
 ! generic::foo=>s1,s2
@@ -90,6 +76,18 @@ end
 ! end
 !end
 
+module m2
+  interface foo
+    procedure foo
+  end interface
+  type :: foo
+    real :: x
+  end type
+contains
+  complex function foo()
+    foo = 1.0
+  end
+end
 !Expect: m2.mod
 !module m2
 ! generic::foo=>foo
@@ -100,4 +98,37 @@ end
 ! function foo()
 !  complex(4)::foo
 ! end
+!end
+
+! Test interface nested inside another interface
+module m3
+  interface g
+    subroutine s1(f)
+      interface
+        real function f(x)
+          interface
+            subroutine x()
+            end subroutine
+          end interface
+        end function
+      end interface
+    end subroutine
+  end interface
+end
+!Expect: m3.mod
+!module m3
+! generic::g=>s1
+! interface
+!  subroutine s1(f)
+!   interface
+!    function f(x)
+!     real(4)::f
+!     interface
+!      subroutine x()
+!      end
+!     end interface
+!    end
+!   end interface
+!  end
+! end interface
 !end


### PR DESCRIPTION
Interface blocks can be nested if one of the interface bodies
declares a subprogram with a dummy procedure that is specified
by an interface block. See the addition to `modfile07.f90` for
and example.

This didn't work because there was only one copy of each of
`inInterfaceBlock_`, `isAbstract_`, and `genericSymbol_`.
We need these for each active interface block, so replace these
with a stack. A new entry is pushed on the stack when we enter
an `InterfaceStmt` or `GenericStmt` and popped when we leave.

Also in the same example, when declaring the dummy procedure, the
dummy argument is initially an `EntityDetails` but it is replaced
by a `SubprogramDetails` when it is specified by the interface.