### PR TITLE
Fix a couple things, support ALLOCATED

### DIFF
--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -1418,7 +1418,7 @@ static bool ApplySpecificChecks(
     }
   }
   return ok;
-};
+}
 
 // Probe the configured intrinsic procedure pattern tables in search of a
 // match for a given procedure reference.

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1613,8 +1613,6 @@ MaybeExpr ExpressionAnalyzer::Analyze(const parser::Expr::NOT &x) {
               return {AsGenericExpr(LogicalNegation(std::move(lx)))};
             },
             [&](auto &&) -> MaybeExpr {
-              // TODO: accept INTEGER operand and maybe typeless
-              // if not overridden
               Say("Operand of .NOT. must be LOGICAL"_err_en_US);
               return std::nullopt;
             },
@@ -1871,7 +1869,7 @@ MaybeExpr ExpressionAnalyzer::ExprOrVariable(const PARSED &x) {
     if constexpr (std::is_same_v<PARSED, parser::Expr>) {
       // Analyze the expression in a specified source position context for
       // better error reporting.
-      auto save{GetFoldingContext().messages().SetLocation(x.source)};
+      auto save{GetContextualMessages().SetLocation(x.source)};
       result = Analyze(x.u);
     } else {
       result = Analyze(x.u);

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -185,10 +185,10 @@ public:
     return result;
   }
   template<typename A> MaybeExpr Analyze(const parser::Constant<A> &x) {
+    auto save{
+        GetFoldingContext().messages().SetLocation(FindSourceLocation(x))};
     auto result{Analyze(x.thing)};
     if (result.has_value()) {
-      auto save{
-          GetFoldingContext().messages().SetLocation(FindSourceLocation(x))};
       *result = Fold(GetFoldingContext(), std::move(*result));
       if (!IsConstantExpr(*result)) {
         SayAt(x, "Must be a constant value"_err_en_US);

--- a/test/semantics/test_modfile.sh
+++ b/test/semantics/test_modfile.sh
@@ -60,7 +60,7 @@ for src in "$@"; do
       exit 1
     fi
     # The first three bytes of the file are a UTF-8 BOM
-    sed '/^.!mod\$/d' $temp/$mod > $actual
+    sed '/^[^!]*!mod\$/d' $temp/$mod > $actual
     sed '1,/^!Expect: '"$mod"'/d' $src | sed -e '/^$/,$d' -e 's/^! *//' > $expect
     if ! diff -U999999 $expect $actual > $diffs; then
       echo "Module file $mod differs from expected:"


### PR DESCRIPTION
Tweak the sed regular expression in `test_modfile.sh` to make it insensitive to the locale.

Fix source provenances on logical `.NOT.` expression parse trees.

Support the `ALLOCATED` intrinsic.