### PR TITLE
Prevent .mod files from being left by tests

### DIFF
--- a/test/evaluate/test_folding.sh
+++ b/test/evaluate/test_folding.sh
@@ -35,7 +35,7 @@
 
 PATH=/usr/bin:/bin
 srcdir=$(dirname $0)
-F18CC=${F18:-../../tools/f18/f18}
+F18CC=${F18:-../../../tools/f18/f18}
 CMD="$F18CC -fdebug-dump-symbols -fparse-only"
 
 if [[ $# < 1 ]]; then
@@ -66,10 +66,11 @@ actual_warnings=$temp/actwarnings.log
 expected_warnings=$temp/expwarnings.log
 warning_diffs=$temp/warnings.diff
 
-if $CMD $src > $src1 2> $messages # compile, dumping symbols
-then :
-else echo FAIL compilation
-     exit 1
+if ! ( cd $temp; $CMD $src ) > $src1 2> $messages # compile, dumping symbols
+then
+  cat $messages
+  echo FAIL compilation
+  exit 1
 fi
 
 # Get all PARAMETER declarations

--- a/test/semantics/test_symbols.sh
+++ b/test/semantics/test_symbols.sh
@@ -20,7 +20,7 @@
 
 PATH=/usr/bin:/bin
 srcdir=$(dirname $0)
-CMD="${F18:-../../tools/f18/f18} -funparse-with-symbols"
+CMD="${F18:-../../../tools/f18/f18} -funparse-with-symbols"
 
 if [[ $# != 1 ]]; then
   echo "Usage: $0 <fortran-source>"
@@ -44,7 +44,7 @@ sed -e 's/!\([DR]EF:\)/KEEP \1/' \
   -e 's/!.*//' -e 's/ *$//' -e '/^$/d' -e 's/KEEP \([DR]EF:\)/!\1/' \
   $src > $src1
 egrep -v '^ *!' $src1 > $src2  # strip out meaningful comments
-$CMD $src2 > $src3  # compile, inserting comments for symbols
+( cd $temp; $CMD $(basename $src2) ) > $src3  # compile, inserting comments for symbols
 
 if diff -w -U999999 $src1 $src3 > $diffs; then
   echo PASS


### PR DESCRIPTION
`test_symbols.sh` and `test_folding.sh` were running the compiler in the
test directory (e.g. `<build>/test/semantics`). This meant that `.mod`
files were being left there because they weren't cleaned up.

Change to run the compiler in the temp directory created for each test.
It is deleted at the end so files aren't left behind.