### PR TITLE
Fix a couple bugs with SELECT TYPE(p) from regression tests

### DIFF
--- a/documentation/Extensions.md
+++ b/documentation/Extensions.md
@@ -69,6 +69,7 @@ Extensions, deletions, and legacy features supported by default
 * BOZ literals can be used as INTEGER values in contexts where the type is
   unambiguous (including the right hand sides of assigments and initializations
   of INTEGER entities).
+* EQUIVALENCE of numeric and character sequences (a ubiquitous extension)
 
 Extensions supported when enabled by options
 --------------------------------------------

--- a/lib/parser/features.h
+++ b/lib/parser/features.h
@@ -31,7 +31,7 @@ ENUM_CLASS(LanguageFeature, BackslashEscapes, OldDebugLines,
     ProgramParentheses, PercentRefAndVal, OmitFunctionDummies, CrayPointer,
     Hollerith, ArithmeticIF, Assign, AssignedGOTO, Pause, OpenMP,
     CruftAfterAmpersand, ClassicCComments, AdditionalFormats, BigIntLiterals,
-    RealDoControls)
+    RealDoControls, EquivalenceNumericWithCharacter)
 
 using LanguageFeatures =
     common::EnumSet<LanguageFeature, LanguageFeature_enumSize>;

--- a/lib/semantics/resolve-names-utils.cc
+++ b/lib/semantics/resolve-names-utils.cc
@@ -364,12 +364,24 @@ bool EquivalenceSets::CheckCanEquivalence(
     msg = "Equivalence set cannot contain '%s'"
           " with PROTECTED attribute and '%s' without"_err_en_US;
   } else if (isNum1) {
-    if (!isNum2) {  // C8110
+    if (isChar2) {
+      if (context_.ShouldWarn(
+              parser::LanguageFeature::EquivalenceNumericWithCharacter)) {
+        msg = "Equivalence set contains '%s' that is numeric sequence "
+              "type and '%s' that is character"_en_US;
+      }
+    } else if (!isNum2) {  // C8110
       msg = "Equivalence set cannot contain '%s'"
             " that is numeric sequence type and '%s' that is not"_err_en_US;
     }
   } else if (isChar1) {
-    if (!isChar2) {  // C8111
+    if (isNum2) {
+      if (context_.ShouldWarn(
+              parser::LanguageFeature::EquivalenceNumericWithCharacter)) {
+        msg = "Equivalence set contains '%s' that is character sequence "
+              "type and '%s' that is numeric"_en_US;
+      }
+    } else if (!isChar2) {  // C8111
       msg = "Equivalence set cannot contain '%s'"
             " that is character sequence type and '%s' that is not"_err_en_US;
     }

--- a/test/semantics/test_errors.sh
+++ b/test/semantics/test_errors.sh
@@ -18,7 +18,7 @@
 
 PATH=/usr/bin:/bin
 srcdir=$(dirname $0)
-CMD="${F18:-../../../tools/f18/f18} -fdebug-resolve-names -fparse-only"
+CMD="${F18:-../../../tools/f18/f18} -fdebug-resolve-names -fparse-only -Mstandard"
 
 if [[ $# != 1 ]]; then
   echo "Usage: $0 <fortran-source>"

--- a/test/semantics/test_errors.sh
+++ b/test/semantics/test_errors.sh
@@ -18,7 +18,7 @@
 
 PATH=/usr/bin:/bin
 srcdir=$(dirname $0)
-CMD="${F18:-../../../tools/f18/f18} -fdebug-resolve-names -fparse-only -Mstandard"
+CMD="${F18:-../../../tools/f18/f18} -fdebug-resolve-names -fparse-only"
 
 if [[ $# != 1 ]]; then
   echo "Usage: $0 <fortran-source>"


### PR DESCRIPTION
When a variable name appears in `SELECT TYPE` with no `associate-name =>`, the simple whole variable needs to be checked out as a variable (not parameter), converted if necessary to an object from an unknown entity, and then introduced into the per-guard scopes later.