### PR TITLE
Fix CHECK failure on undeclared type parameter

### DIFF
--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -2883,13 +2883,13 @@ void DeclarationVisitor::Post(const parser::DerivedTypeSpec &x) {
     if (!spec.FindParameter(name)) {
       auto it{std::find_if(parameterDecls.begin(), parameterDecls.end(),
           [&](const Symbol *symbol) { return symbol->name() == name; })};
-      CHECK(it != parameterDecls.end());
-      auto &symbol{**it};
-      const auto *details{symbol.detailsIf<TypeParamDetails>()};
-      if (details == nullptr || !details->init().has_value()) {
-        Say(typeName.source,
-            "Type parameter '%s' lacks a value and has no default"_err_en_US,
-            symbol.name());
+      if (it != parameterDecls.end()) {
+        const auto *details{(*it)->detailsIf<TypeParamDetails>()};
+        if (details == nullptr || !details->init().has_value()) {
+          Say(typeName.source,
+              "Type parameter '%s' lacks a value and has no default"_err_en_US,
+              name);
+        }
       }
     }
   }

--- a/test/semantics/resolve43.f90
+++ b/test/semantics/resolve43.f90
@@ -50,3 +50,10 @@ module module1
     call type2arg(type2(0,0)(type1=type1(0)(),m=2))
   end subroutine errors
 end module module1
+
+module module2
+  !ERROR: No definition found for type parameter 'k'
+  type :: type1(k)
+  end type
+  type(type1):: x
+end module


### PR DESCRIPTION
In the example below, the compiler gets an internal error when
processing the derived-type-spec for the declaration of `x`.
When the search for type parameter `k` fails it means an error
has already occurred and we should skip that parameter.

```
type :: t(k)
end type
type(t):: x
end
```