### PR TITLE
Changes to improve messages for DO semantics

### DIFF
--- a/lib/semantics/check-do.cc
+++ b/lib/semantics/check-do.cc
@@ -513,6 +513,7 @@ private:
       }
     }
   }
+
   void CheckMaskIsPure(const parser::ScalarLogicalExpr &mask) const {
     // C1121 - procedures in mask must be pure
     // TODO - add the name of the impure procedure to the message
@@ -526,30 +527,33 @@ private:
       }
     }
   }
-  void CheckNoCollisions(const CS &containerA, const CS &containerB,
-      const parser::MessageFormattedText &errorMessage) const {
-    for (auto *a : containerA) {
-      for (auto *b : containerB) {
-        if (a == b) {
-          context_.Say(currentStatementSourcePosition_, errorMessage);
+
+  void CheckNoCollisions(const CS &refs, const CS &defs,
+      const parser::MessageFixedText &errorMessage) const {
+    for (const Symbol *ref : refs) {
+      for (const Symbol *def : defs) {
+        if (ref == def) {
+          context_.Say(ref->name(), errorMessage, ref->name());
           return;
         }
       }
     }
   }
+
   void HasNoReferences(
       const CS &indexNames, const parser::ScalarIntExpr &expression) const {
-    CS references{
+    const CS references{
         GatherReferencesFromExpression(expression.thing.thing.value())};
     CheckNoCollisions(references, indexNames,
-        "concurrent-control expression references index-name"_err_en_US);
+        "concurrent-control expression references index-name '%s'"_err_en_US);
   }
+
   void CheckMaskDoesNotReferenceLocal(
       const parser::ScalarLogicalExpr &mask, const CS &symbols) const {
     // C1129
     CheckNoCollisions(GatherReferencesFromExpression(mask.thing.thing.value()),
         symbols,
-        "concurrent-header mask-expr references name"
+        "concurrent-header mask-expr references name '%s'"
         " in locality-spec"_err_en_US);
   }
   void CheckLocalAndLocalInitAttributes(const CS &symbols) const {

--- a/test/semantics/dosemantics04.f90
+++ b/test/semantics/dosemantics04.f90
@@ -28,21 +28,21 @@ PROGRAM dosemantics04
 30 END DO
 
 ! Initial expression
-!ERROR: concurrent-control expression references index-name
+!ERROR: concurrent-control expression references index-name 'j'
   DO CONCURRENT (i = j:3, j=1:3)
   END DO
 
 ! Final expression
-!ERROR: concurrent-control expression references index-name
+!ERROR: concurrent-control expression references index-name 'j'
   DO CONCURRENT (i = 1:j, j=1:3)
   END DO
 
 ! Step expression
-!ERROR: concurrent-control expression references index-name
+!ERROR: concurrent-control expression references index-name 'j'
   DO CONCURRENT (i = 1:3:j, j=1:3)
   END DO
 
-!ERROR: concurrent-control expression references index-name
+!ERROR: concurrent-control expression references index-name 'i'
   DO CONCURRENT (INTEGER*2 :: i = 1:3, j=i:3)
   END DO
 


### PR DESCRIPTION
I changed two things in the messages produced for DO semantic checks --
 - I changed the source location to be specific to where conflicting names are
 declared.
 - I added the conflicting names to the message.