### PR TITLE
Check constraints on passed-object dummy argument

### DIFF
--- a/lib/semantics/check-allocate.cc
+++ b/lib/semantics/check-allocate.cc
@@ -556,8 +556,7 @@ bool AllocationCheckerHelper::RunCoarrayRelatedChecks(
                   "Type-Spec in ALLOCATE must not be TEAM_TYPE from ISO_FORTRAN_ENV when an allocatable object is a coarray"_err_en_US)
               .Attach(name_.source, "'%s' is a coarray"_en_US, name_.source);
           return false;
-        } else if (IsDerivedTypeFromModule(derived, "iso_c_binding", "c_ptr") ||
-            IsDerivedTypeFromModule(derived, "iso_c_binding", "c_funptr")) {
+        } else if (IsIsoCType(derived)) {
           context
               .Say(allocateInfo_.typeSpecLoc.value(),
                   "Type-Spec in ALLOCATE must not be C_PTR or C_FUNPTR from ISO_C_BINDING when an allocatable object is a coarray"_err_en_US)
@@ -578,9 +577,7 @@ bool AllocationCheckerHelper::RunCoarrayRelatedChecks(
                   "SOURCE or MOLD expression type must not be TEAM_TYPE from ISO_FORTRAN_ENV when an allocatable object is a coarray"_err_en_US)
               .Attach(name_.source, "'%s' is a coarray"_en_US, name_.source);
           return false;
-        } else if (IsDerivedTypeFromModule(
-                       &derived, "iso_c_binding", "c_ptr") ||
-            IsDerivedTypeFromModule(&derived, "iso_c_binding", "c_funptr")) {
+        } else if (IsIsoCType(&derived)) {
           context
               .Say(allocateInfo_.sourceExprLoc.value(),
                   "SOURCE or MOLD expression type must not be C_PTR or C_FUNPTR from ISO_C_BINDING when an allocatable object is a coarray"_err_en_US)

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -563,9 +563,7 @@ std::ostream &PutLower(std::ostream &os, const Symbol &symbol) {
 }
 
 std::ostream &PutLower(std::ostream &os, const DeclTypeSpec &type) {
-  std::stringstream s;
-  s << type;
-  return PutLower(os, s.str());
+  return PutLower(os, type.AsFortran());
 }
 
 std::ostream &PutLower(std::ostream &os, const std::string &str) {

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -43,7 +43,7 @@ static std::vector<const Symbol *> CollectSymbols(const Scope &);
 static void PutEntity(std::ostream &, const Symbol &);
 static void PutObjectEntity(std::ostream &, const Symbol &);
 static void PutProcEntity(std::ostream &, const Symbol &);
-static void PutPassName(std::ostream &, const std::optional<SourceName> &);
+static void PutPassName(std::ostream &, const SourceName *);
 static void PutTypeParam(std::ostream &, const Symbol &);
 static void PutEntity(std::ostream &, const Symbol &, std::function<void()>);
 static void PutInit(std::ostream &, const MaybeExpr &);
@@ -482,7 +482,7 @@ void PutProcEntity(std::ostream &os, const Symbol &symbol) {
   });
 }
 
-void PutPassName(std::ostream &os, const std::optional<SourceName> &passName) {
+void PutPassName(std::ostream &os, const SourceName *passName) {
   if (passName) {
     PutLower(os << ",pass(", passName->ToString()) << ')';
   }

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -270,7 +270,7 @@ protected:
 
 private:
   MaybeExpr bindName_;  // from BIND(C, NAME="...")
-  std::optional<SourceName> passName_;  // from PASS(...)
+  const SourceName *passName_{nullptr};  // from PASS(...)
 };
 
 // Find and create types from declaration-type-spec nodes.
@@ -1159,10 +1159,9 @@ Attrs AttrsVisitor::GetAttrs() {
   return *attrs_;
 }
 Attrs AttrsVisitor::EndAttrs() {
-  CHECK(attrs_);
-  Attrs result{*attrs_};
+  Attrs result{GetAttrs()};
   attrs_.reset();
-  passName_.reset();
+  passName_ = nullptr;
   bindName_.reset();
   return result;
 }
@@ -1216,7 +1215,7 @@ bool AttrsVisitor::Pre(const parser::IntentSpec &x) {
 }
 bool AttrsVisitor::Pre(const parser::Pass &x) {
   if (x.v) {
-    passName_ = x.v->source;
+    passName_ = &x.v->source;
     MakePlaceholder(*x.v, MiscDetails::Kind::PassName);
   } else {
     attrs_->set(Attr::PASS);

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -107,9 +107,10 @@ public:
   // Emit a message about a SourceName
   Message &Say(const SourceName &, MessageFixedText &&);
   // Emit a formatted message associated with a source location.
-  Message &Say(const SourceName &, MessageFixedText &&, const SourceName &);
-  Message &Say(const SourceName &, MessageFixedText &&, const SourceName &,
-      const SourceName &);
+  template<typename... A>
+  Message &Say(const SourceName &source, MessageFixedText &&msg, A &&... args) {
+    return context_->Say(source, std::move(msg), std::forward<A>(args)...);
+  }
 
 private:
   SemanticsContext *context_{nullptr};
@@ -1047,6 +1048,10 @@ private:
   void AddSubpNames(const ProgramTree &);
   bool BeginScope(const ProgramTree &);
   void ResolveSpecificationParts(ProgramTree &);
+  void FinishSpecificationParts(const ProgramTree &);
+  void FinishDerivedType(Scope &);
+  const Symbol *CheckPassArg(
+      const Symbol &, const Symbol *, const SourceName *);
 };
 
 // ImplicitRules implementation
@@ -1318,14 +1323,6 @@ Message &MessageHandler::Say(MessageFormattedText &&msg) {
 }
 Message &MessageHandler::Say(const SourceName &name, MessageFixedText &&msg) {
   return Say(name, std::move(msg), name);
-}
-Message &MessageHandler::Say(const SourceName &location, MessageFixedText &&msg,
-    const SourceName &arg1) {
-  return context_->Say(location, std::move(msg), arg1);
-}
-Message &MessageHandler::Say(const SourceName &location, MessageFixedText &&msg,
-    const SourceName &arg1, const SourceName &arg2) {
-  return context_->Say(location, std::move(msg), arg1, arg2);
 }
 
 // ImplicitRulesVisitor implementation
@@ -4734,6 +4731,7 @@ bool ResolveNamesVisitor::Pre(const parser::ProgramUnit &x) {
   auto root{ProgramTree::Build(x)};
   SetScope(context().globalScope());
   ResolveSpecificationParts(root);
+  FinishSpecificationParts(root);
   SetScope(context().globalScope());
   ResolveExecutionParts(root);
   return false;
@@ -4847,6 +4845,146 @@ bool ResolveNamesVisitor::BeginScope(const ProgramTree &node) {
     return BeginSubmodule(node.name(), node.GetParentId());
   default: CRASH_NO_CASE;
   }
+}
+
+// Perform checks that need to happen after all of the specification parts
+// but before any of the execution parts.
+void ResolveNamesVisitor::FinishSpecificationParts(const ProgramTree &node) {
+  if (!node.scope()) {
+    return;  // error occurred creating scope
+  }
+  SetScope(*node.scope());
+  for (Scope &childScope : currScope().children()) {
+    if (childScope.kind() == Scope::Kind::DerivedType && childScope.symbol()) {
+      FinishDerivedType(childScope);
+    }
+  }
+  for (const auto &child : node.children()) {
+    FinishSpecificationParts(child);
+  }
+}
+
+static int FindIndexOfName(
+    const SourceName &name, std::vector<Symbol *> symbols) {
+  for (std::size_t i{0}; i < symbols.size(); ++i) {
+    if (symbols[i] && symbols[i]->name() == name) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+// Perform checks on procedure bindings of this type
+void ResolveNamesVisitor::FinishDerivedType(Scope &scope) {
+  CHECK(scope.kind() == Scope::Kind::DerivedType);
+  for (auto &pair : scope) {
+    Symbol &comp{*pair.second};
+    std::visit(
+        common::visitors{
+            [&](ProcEntityDetails &x) {
+              x.set_passArg(
+                  CheckPassArg(comp, x.interface().symbol(), x.passName()));
+            },
+            [&](ProcBindingDetails &x) {
+              x.set_passArg(CheckPassArg(comp, &x.symbol(), x.passName()));
+            },
+            [](auto &x) {},
+        },
+        comp.details());
+  }
+}
+
+// Check C760, constraints on the passed-object dummy argument
+// If they all pass, return the Symbol for that argument.
+const Symbol *ResolveNamesVisitor::CheckPassArg(
+    const Symbol &proc, const Symbol *interface, const SourceName *passName) {
+  if (proc.attrs().test(Attr::NOPASS)) {
+    return nullptr;
+  }
+  const auto &name{proc.name()};
+  if (!interface) {
+    Say(name,
+        "Procedure component '%s' must have NOPASS attribute or explicit interface"_err_en_US,
+        name);
+    return nullptr;
+  }
+  const auto &dummyArgs{interface->get<SubprogramDetails>().dummyArgs()};
+  if (!passName && dummyArgs.empty()) {
+    Say(name,
+        proc.has<ProcEntityDetails>()
+            ? "Procedure component '%s' with no dummy arguments"
+              " must have NOPASS attribute"_err_en_US
+            : "Procedure binding '%s' with no dummy arguments"
+              " must have NOPASS attribute"_err_en_US,
+        name);
+    return nullptr;
+  }
+  int passArgIndex{0};
+  if (!passName) {
+    passName = &dummyArgs[0]->name();
+  } else {
+    passArgIndex = FindIndexOfName(*passName, dummyArgs);
+    if (passArgIndex < 0) {
+      Say(*passName,
+          "'%s' is not a dummy argument of procedure interface '%s'"_err_en_US,
+          *passName, interface->name());
+      return nullptr;
+    }
+  }
+  const Symbol &passArg{*dummyArgs[passArgIndex]};
+  std::optional<MessageFixedText> msg;
+  if (!passArg.has<ObjectEntityDetails>()) {
+    msg = "Passed-object dummy argument '%s' of procedure '%s'"
+          " must be a data object"_err_en_US;
+  } else if (passArg.attrs().test(Attr::POINTER)) {
+    msg = "Passed-object dummy argument '%s' of procedure '%s'"
+          " may not have the POINTER attribute"_err_en_US;
+  } else if (passArg.attrs().test(Attr::ALLOCATABLE)) {
+    msg = "Passed-object dummy argument '%s' of procedure '%s'"
+          " may not have the ALLOCATABLE attribute"_err_en_US;
+  } else if (passArg.attrs().test(Attr::VALUE)) {
+    msg = "Passed-object dummy argument '%s' of procedure '%s'"
+          " may not have the VALUE attribute"_err_en_US;
+  } else if (passArg.Rank() > 0) {
+    msg = "Passed-object dummy argument '%s' of procedure '%s'"
+          " must be scalar"_err_en_US;
+  }
+  if (msg) {
+    Say(name, std::move(*msg), *passName, name);
+    return nullptr;
+  }
+  const DeclTypeSpec *type{passArg.GetType()};
+  if (!type) {
+    return nullptr;  // an error already occurred
+  }
+  const Symbol &typeSymbol{*proc.owner().GetSymbol()};
+  const DerivedTypeSpec *derived{type->AsDerived()};
+  if (!derived || derived->typeSymbol() != typeSymbol) {
+    Say(name,
+        "Passed-object dummy argument '%s' of procedure '%s'"
+        " must be of type '%s' but is '%s'"_err_en_US,
+        *passName, name, typeSymbol.name(), type->AsFortran());
+    return nullptr;
+  }
+  if (IsExtensibleType(derived) != type->IsPolymorphic()) {
+    Say(name,
+        type->IsPolymorphic()
+            ? "Passed-object dummy argument '%s' of procedure '%s'"
+              " must not be polymorphic because '%s' is not extensible"_err_en_US
+            : "Passed-object dummy argument '%s' of procedure '%s'"
+              " must polymorphic because '%s' is extensible"_err_en_US,
+        *passName, name, typeSymbol.name());
+    return nullptr;
+  }
+  for (const auto &[paramName, paramValue] : derived->parameters()) {
+    if (paramValue.isLen() && !paramValue.isAssumed()) {
+      Say(name,
+          "Passed-object dummy argument '%s' of procedure '%s'"
+          " has non-assumed length parameter '%s'"_err_en_US,
+          *passName, name, paramName);
+    }
+  }
+  return &passArg;
 }
 
 // Resolve names in the execution part of this node and its children

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -27,8 +27,7 @@ std::ostream &operator<<(std::ostream &os, const parser::CharBlock &name) {
 }
 
 template<typename T>
-static void DumpOptional(
-    std::ostream &os, const char *label, const std::optional<T> &x) {
+static void DumpOptional(std::ostream &os, const char *label, const T &x) {
   if (x) {
     os << ' ' << label << ':' << *x;
   }
@@ -435,9 +434,7 @@ std::ostream &operator<<(std::ostream &os, const Details &details) {
           },
           [&](const FinalProcDetails &) {},
           [&](const TypeParamDetails &x) {
-            if (x.type()) {
-              os << ' ' << *x.type();
-            }
+            DumpOptional(os, "type", x.type());
             os << ' ' << common::EnumToString(x.attr());
             DumpOptional(os, "init", x.init());
           },

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -189,8 +189,21 @@ private:
   friend std::ostream &operator<<(std::ostream &, const ObjectEntityDetails &);
 };
 
+// Mixin for details with passed-object dummy argument.
+class WithPassArg {
+public:
+  const SourceName *passName() const { return passName_; }
+  void set_passName(const SourceName &passName) { passName_ = &passName; }
+  const Symbol *passArg() const { return passArg_; }
+  void set_passArg(const Symbol *passArg) { passArg_ = passArg; }
+
+private:
+  const SourceName *passName_{nullptr};
+  const Symbol *passArg_{nullptr};
+};
+
 // A procedure pointer, dummy procedure, or external procedure
-class ProcEntityDetails : public EntityDetails {
+class ProcEntityDetails : public EntityDetails, public WithPassArg {
 public:
   ProcEntityDetails() = default;
   explicit ProcEntityDetails(EntityDetails &&d);
@@ -198,13 +211,10 @@ public:
   const ProcInterface &interface() const { return interface_; }
   ProcInterface &interface() { return interface_; }
   void set_interface(const ProcInterface &interface) { interface_ = interface; }
-  const std::optional<SourceName> &passName() const { return passName_; }
-  void set_passName(const SourceName &passName) { passName_ = passName; }
   inline bool HasExplicitInterface() const;
 
 private:
   ProcInterface interface_;
-  std::optional<SourceName> passName_;
   friend std::ostream &operator<<(std::ostream &, const ProcEntityDetails &);
 };
 
@@ -263,16 +273,13 @@ private:
   friend std::ostream &operator<<(std::ostream &, const DerivedTypeDetails &);
 };
 
-class ProcBindingDetails {
+class ProcBindingDetails : public WithPassArg {
 public:
   explicit ProcBindingDetails(const Symbol &symbol) : symbol_{&symbol} {}
   const Symbol &symbol() const { return *symbol_; }
-  std::optional<SourceName> passName() const { return passName_; }
-  void set_passName(const SourceName &passName) { passName_ = passName; }
 
 private:
   const Symbol *symbol_;  // procedure bound to
-  std::optional<SourceName> passName_;  // name in PASS attribute
 };
 
 ENUM_CLASS(GenericKind,  // Kinds of generic-spec

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -21,6 +21,7 @@
 #include <functional>
 #include <list>
 #include <optional>
+#include <vector>
 
 namespace Fortran::semantics {
 
@@ -73,14 +74,14 @@ public:
     CHECK(result_ == nullptr);
     result_ = &result;
   }
-  const std::list<Symbol *> &dummyArgs() const { return dummyArgs_; }
+  const std::vector<Symbol *> &dummyArgs() const { return dummyArgs_; }
   void add_dummyArg(Symbol &symbol) { dummyArgs_.push_back(&symbol); }
   void add_alternateReturn() { dummyArgs_.push_back(nullptr); }
 
 private:
   bool isInterface_{false};  // true if this represents an interface-body
   MaybeExpr bindName_;
-  std::list<Symbol *> dummyArgs_;  // nullptr -> alternate return indicator
+  std::vector<Symbol *> dummyArgs_;  // nullptr -> alternate return indicator
   Symbol *result_{nullptr};
   friend std::ostream &operator<<(std::ostream &, const SubprogramDetails &);
 };

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -304,6 +304,11 @@ bool IsDerivedTypeFromModule(
   }
 }
 
+bool IsIsoCType(const DerivedTypeSpec *derived) {
+  return IsDerivedTypeFromModule(derived, "iso_c_binding", "c_ptr") ||
+      IsDerivedTypeFromModule(derived, "iso_c_binding", "c_funptr");
+}
+
 bool IsTeamType(const DerivedTypeSpec *derived) {
   return IsDerivedTypeFromModule(derived, "iso_fortran_env", "team_type");
 }

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -293,6 +293,12 @@ const Symbol *FindFunctionResult(const Symbol &symbol) {
   return nullptr;
 }
 
+bool IsExtensibleType(const DerivedTypeSpec *derived) {
+  return derived && !IsIsoCType(derived) &&
+      !derived->typeSymbol().attrs().test(Attr::BIND_C) &&
+      !derived->typeSymbol().get<DerivedTypeDetails>().sequence();
+}
+
 bool IsDerivedTypeFromModule(
     const DerivedTypeSpec *derived, const char *module, const char *name) {
   if (!derived) {

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -57,6 +57,7 @@ bool IsProcedure(const Symbol &);
 bool IsProcName(const Symbol &symbol);  // proc-name
 bool IsVariableName(const Symbol &symbol);  // variable-name
 bool IsProcedurePointer(const Symbol &);
+bool IsExtensibleType(const DerivedTypeSpec *);
 // Is this a derived type from module with this name?
 bool IsDerivedTypeFromModule(
     const DerivedTypeSpec *derived, const char *module, const char *name);

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -60,7 +60,10 @@ bool IsProcedurePointer(const Symbol &);
 // Is this a derived type from module with this name?
 bool IsDerivedTypeFromModule(
     const DerivedTypeSpec *derived, const char *module, const char *name);
-bool IsTeamType(const DerivedTypeSpec *derived);
+// Is this derived type TEAM_TYPE from module ISO_FORTRAN_ENV
+bool IsTeamType(const DerivedTypeSpec *);
+// Is this derived type either C_PTR or C_FUNPTR from module ISO_C_BINDING
+bool IsIsoCType(const DerivedTypeSpec *);
 const bool IsEventTypeOrLockType(const DerivedTypeSpec *);
 // Returns an ultimate component symbol that is a
 // coarray or nullptr if there are no such component.

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -130,8 +130,9 @@ Scope &DerivedTypeSpec::Instantiate(
       // one of its parents.  Put the type parameter expression value
       // into the new scope as the initialization value for the parameter.
       if (ParamValue * paramValue{FindParameter(name)}) {
+        const TypeParamDetails &details{symbol->get<TypeParamDetails>()};
+        paramValue->set_attr(details.attr());
         if (MaybeIntExpr expr{paramValue->GetExplicit()}) {
-          const TypeParamDetails &details{symbol->get<TypeParamDetails>()};
           // Ensure that any kind type parameters with values are
           // constant by now.
           if (details.attr() == common::TypeParamAttr::Kind) {

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -104,6 +104,7 @@ public:
   bool operator==(const ParamValue &that) const {
     return category_ == that.category_ && expr_ == that.expr_;
   }
+  std::string AsFortran() const;
 
 private:
   enum class Category { Explicit, Deferred, Assumed };
@@ -121,6 +122,7 @@ public:
     return category_ == x.category_ && kind_ == x.kind_;
   }
   bool operator!=(const IntrinsicTypeSpec &x) const { return !operator==(x); }
+  std::string AsFortran() const;
 
 protected:
   IntrinsicTypeSpec(TypeCategory, KindExpr &&);
@@ -151,6 +153,7 @@ public:
     : IntrinsicTypeSpec(TypeCategory::Character, std::move(kind)),
       length_{std::move(length)} {}
   const ParamValue &length() const { return length_; }
+  std::string AsFortran() const;
 
 private:
   ParamValue length_;
@@ -244,6 +247,7 @@ public:
   bool operator==(const DerivedTypeSpec &that) const {
     return &typeSymbol_ == &that.typeSymbol_ && parameters_ == that.parameters_;
   }
+  std::string AsFortran() const;
 
 private:
   const Symbol &typeSymbol_;
@@ -314,6 +318,8 @@ public:
     default: return nullptr;
     }
   }
+
+  std::string AsFortran() const;
 
 private:
   Category category_;

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -101,6 +101,9 @@ public:
   bool isDeferred() const { return category_ == Category::Deferred; }
   const MaybeIntExpr &GetExplicit() const { return expr_; }
   void SetExplicit(SomeIntExpr &&);
+  bool isKind() const { return attr_ == common::TypeParamAttr::Kind; }
+  bool isLen() const { return attr_ == common::TypeParamAttr::Len; }
+  void set_attr(common::TypeParamAttr attr) { attr_ = attr; }
   bool operator==(const ParamValue &that) const {
     return category_ == that.category_ && expr_ == that.expr_;
   }
@@ -110,6 +113,7 @@ private:
   enum class Category { Explicit, Deferred, Assumed };
   ParamValue(Category category) : category_{category} {}
   Category category_{Category::Explicit};
+  common::TypeParamAttr attr_{common::TypeParamAttr::Kind};
   MaybeIntExpr expr_;
   friend std::ostream &operator<<(std::ostream &, const ParamValue &);
 };
@@ -285,6 +289,12 @@ public:
 
   Category category() const { return category_; }
   void set_category(Category category) { category_ = category; }
+  bool IsPolymorphic() const {
+    return category_ == ClassDerived || IsUnlimitedPolymorphic();
+  }
+  bool IsUnlimitedPolymorphic() const {
+    return category_ == TypeStar || category_ == ClassStar;
+  }
   bool IsNumeric(TypeCategory) const;
   const NumericTypeSpec &numericTypeSpec() const;
   const LogicalTypeSpec &logicalTypeSpec() const;

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -84,6 +84,7 @@ set(ERROR_TESTS
   resolve49.f90
   resolve50.f90
   resolve51.f90
+  resolve52.f90
   stop01.f90
   structconst01.f90
   structconst02.f90

--- a/test/semantics/allocate01.f90
+++ b/test/semantics/allocate01.f90
@@ -31,12 +31,10 @@ module m
 contains
   function mfoo(x)
     class(a_type) :: foo, x
-    allocatable :: x
     foo = x
   end function
   subroutine mbar(x)
-    class(a_type), allocatable :: x
-    allocate(x)
+    class(a_type) :: x
   end subroutine
 end module
 

--- a/test/semantics/expr-errors01.f90
+++ b/test/semantics/expr-errors01.f90
@@ -15,7 +15,7 @@
 ! C1003 - can't parenthesize function call returning procedure pointer
 module m1
   type :: dt
-    procedure(frpp), pointer :: pp
+    procedure(frpp), pointer, nopass :: pp
   end type dt
  contains
   subroutine boring

--- a/test/semantics/null01.f90
+++ b/test/semantics/null01.f90
@@ -45,10 +45,10 @@ subroutine test
     integer, pointer :: ip1(:)
   end type dt1
   type :: dt2
-    procedure(s0), pointer :: pps0
+    procedure(s0), pointer, nopass :: pps0
   end type dt2
   type :: dt3
-    procedure(s1), pointer :: pps1
+    procedure(s1), pointer, nopass :: pps1
   end type dt3
   integer :: j
   type(dt0) :: dt0x

--- a/test/semantics/resolve52.f90
+++ b/test/semantics/resolve52.f90
@@ -1,0 +1,145 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Tests for C760:
+! The passed-object dummy argument shall be a scalar, nonpointer, nonallocatable
+! dummy data object with the same declared type as the type being defined;
+! all of its length type parameters shall be assumed; it shall be polymorphic
+! (7.3.2.3) if and only if the type being defined is extensible (7.5.7).
+! It shall not have the VALUE attribute.
+
+module m1
+  type :: t
+    procedure(real), pointer, nopass :: a
+    !ERROR: Procedure component 'b' must have NOPASS attribute or explicit interface
+    procedure(real), pointer :: b
+  end type
+end
+
+module m2
+  type :: t
+    !ERROR: Procedure component 'a' with no dummy arguments must have NOPASS attribute
+    procedure(s1), pointer :: a
+    !ERROR: Procedure component 'b' with no dummy arguments must have NOPASS attribute
+    procedure(s1), pointer, pass :: b
+  contains
+    !ERROR: Procedure binding 'p1' with no dummy arguments must have NOPASS attribute
+    procedure :: p1 => s1
+    !ERROR: Procedure binding 'p2' with no dummy arguments must have NOPASS attribute
+    procedure, pass :: p2 => s1
+  end type
+contains
+  subroutine s1()
+  end
+end
+
+module m3
+  type :: t
+    !ERROR: 'y' is not a dummy argument of procedure interface 's'
+    procedure(s), pointer, pass(y) :: a
+  contains
+    !ERROR: 'z' is not a dummy argument of procedure interface 's'
+    procedure, pass(z) :: p => s
+  end type
+contains
+  subroutine s(x)
+    class(t) :: x
+  end
+end
+
+module m4
+  type :: t
+    !ERROR: Passed-object dummy argument 'x' of procedure 'a' may not have the POINTER attribute
+    procedure(s1), pointer :: a
+    !ERROR: Passed-object dummy argument 'x' of procedure 'b' may not have the ALLOCATABLE attribute
+    procedure(s2), pointer, pass(x) :: b
+    !ERROR: Passed-object dummy argument 'f' of procedure 'c' must be a data object
+    procedure(s3), pointer, pass :: c
+    !ERROR: Passed-object dummy argument 'x' of procedure 'd' must be scalar
+    procedure(s4), pointer, pass :: d
+  end type
+contains
+  subroutine s1(x)
+    class(t), pointer :: x
+  end
+  subroutine s2(w, x)
+    real :: x
+    !ERROR: The type of 'x' has already been declared
+    class(t), allocatable :: x
+  end
+  subroutine s3(f)
+    interface
+      real function f()
+      end function
+    end interface
+  end
+  subroutine s4(x)
+    class(t) :: x(10)
+  end
+end
+
+module m5
+  type :: t1
+    sequence
+    !ERROR: Passed-object dummy argument 'x' of procedure 'a' must be of type 't1' but is 'REAL(4)'
+    procedure(s), pointer :: a
+  end type
+  type :: t2
+  contains
+    !ERROR: Passed-object dummy argument 'y' of procedure 's' must be of type 't2' but is 'TYPE(t1)'
+    procedure, pass(y) :: s
+  end type
+contains
+  subroutine s(x, y)
+    real :: x
+    type(t1) :: y
+  end
+end
+
+module m6
+  type :: t(k, l)
+    integer, kind :: k
+    integer, len :: l
+    !ERROR: Passed-object dummy argument 'x' of procedure 'a' has non-assumed length parameter 'l'
+    procedure(s1), pointer :: a
+  end type
+contains
+  subroutine s1(x)
+    class(t(1, 2)) :: x
+  end
+end
+
+module m7
+  type :: t
+    sequence  ! t is not extensible
+    !ERROR: Passed-object dummy argument 'x' of procedure 'a' must not be polymorphic because 't' is not extensible
+    procedure(s), pointer :: a
+  end type
+contains
+  subroutine s(x)
+    class(t) :: x
+  end
+end
+
+module m8
+  type :: t
+  contains
+    !ERROR: Passed-object dummy argument 'x' of procedure 's' must polymorphic because 't' is extensible
+    procedure :: s
+  end type
+contains
+  subroutine s(x)
+    type(t) :: x  ! x is not polymorphic
+  end
+end

--- a/test/semantics/structconst02.f90
+++ b/test/semantics/structconst02.f90
@@ -30,8 +30,8 @@ module module1
     character(kind=ck,len=len) :: cx = ' '
     logical(kind=lk) :: lx = .false.
     real(kind=rk), pointer :: rp = NULL()
-    procedure(realfunc), pointer :: rfp1 => NULL()
-    procedure(real), pointer :: rfp2 => NULL()
+    procedure(realfunc), pointer, nopass :: rfp1 => NULL()
+    procedure(real), pointer, nopass :: rfp2 => NULL()
   end type scalar
  contains
   subroutine scalararg(x)


### PR DESCRIPTION
The passed-object dummy argument cannot be checked until the
interfaces of contained subprograms are known. To accomplish this,
add `FinishSpecificationPart` pass to run after all specification
parts have been analyzed but before any of the execution parts.
This visits all derived types defined in each scope and performs
the checks on each procedure component and procedure binding.

Add a flag to `ParamValue` to distinguish kind from len parameters.

Fix some tests that had errors we now detect.
