### PR TITLE
Add a set of tests which compile the predefined module files.

### DIFF
--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -129,6 +129,11 @@ set(ERROR_TESTS
   expr-errors01.f90
   null01.f90
   equivalence01.f90
+  # ${PROJECT_SOURCE_DIR}/module/ieee_arithmetic.f90 #520
+  ${PROJECT_SOURCE_DIR}/module/ieee_exceptions.f90
+  ${PROJECT_SOURCE_DIR}/module/ieee_features.f90
+  ${PROJECT_SOURCE_DIR}/module/iso_c_binding.f90
+  ${PROJECT_SOURCE_DIR}/module/iso_fortran_env.f90
 )
 
 # These test files have expected symbols in the source

--- a/test/semantics/test_errors.sh
+++ b/test/semantics/test_errors.sh
@@ -24,12 +24,13 @@ if [[ $# != 1 ]]; then
   echo "Usage: $0 <fortran-source>"
   exit 1
 fi
-src=$srcdir/$1
+case $1 in
+(/*) src=$1 ;;
+(*) src=$srcdir/$1 ;;
+esac
 [[ ! -f $src ]] && echo "File not found: $src" && exit 1
 
-temp=temp-$1
-rm -rf $temp
-mkdir $temp
+temp=`mktemp -d -p .`
 [[ $KEEP ]] || trap "rm -rf $temp" EXIT
 
 log=$temp/log

--- a/test/semantics/test_errors.sh
+++ b/test/semantics/test_errors.sh
@@ -30,7 +30,7 @@ case $1 in
 esac
 [[ ! -f $src ]] && echo "File not found: $src" && exit 1
 
-temp=`mktemp -d -p .`
+temp=`mktemp -d ./tmp.XXXXXX`
 [[ $KEEP ]] || trap "rm -rf $temp" EXIT
 
 log=$temp/log


### PR DESCRIPTION
Each test simply tries to compile the module source file. Modify the script test_errors.sh to work with a source file that is specified as a full path. Also, change how the test temp directory is created to use a random name in case any of the source file base names are duplicated.