### PR TITLE
Fix internal error due to missing type

### DIFF
--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -129,7 +129,7 @@ set(ERROR_TESTS
   expr-errors01.f90
   null01.f90
   equivalence01.f90
-  # ${PROJECT_SOURCE_DIR}/module/ieee_arithmetic.f90 #520
+  ${PROJECT_SOURCE_DIR}/module/ieee_arithmetic.f90
   ${PROJECT_SOURCE_DIR}/module/ieee_exceptions.f90
   ${PROJECT_SOURCE_DIR}/module/ieee_features.f90
   ${PROJECT_SOURCE_DIR}/module/iso_c_binding.f90
@@ -185,6 +185,7 @@ set(MODFILE_TESTS
   modfile26.f90
   modfile27.f90
   modfile28.f90
+  modfile29.f90
 )
 
 set(LABEL_TESTS

--- a/test/semantics/modfile29.f90
+++ b/test/semantics/modfile29.f90
@@ -1,0 +1,30 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Check that implicitly typed entities get a type in the module file.
+
+module m
+  public :: a
+  private :: b
+  protected :: i
+  allocatable :: j
+end
+
+!Expect: m.mod
+!module m
+! real(4)::a
+! real(4),private::b
+! integer(4),protected::i
+! integer(4),allocatable::j
+!end


### PR DESCRIPTION
If a name is declared in a module with just `private :: x`,
we don't know if `x` is supposed to be an object or procedure,
so it ends up not getting an implicit type. This leads to an
internal error when writing the `.mod` file.

The fix requires two changes:
1. Cause all `EntityDetails` to be converted to `ObjectEntityDetails`
   in `ResolveSpecificationParts`. This is done by calling `PopScope()`.
   The reason for not calling it there no longer applies since the
   addition of the `ExecutionPartSkimmer` pass.
2. In the same place, apply the implicit typing rules to every entity
   in the scope.

Fixes #514, fixes #520.