### PR TITLE
Compile and install the predefined module files.

### DIFF
--- a/test/evaluate/test_folding.sh
+++ b/test/evaluate/test_folding.sh
@@ -35,7 +35,7 @@
 
 PATH=/usr/bin:/bin
 srcdir=$(dirname $0)
-F18CC=${F18:-../../../tools/f18/f18}
+F18CC=${F18:-../../../tools/f18/bin/f18}
 CMD="$F18CC -fdebug-dump-symbols -fparse-only"
 
 if [[ $# < 1 ]]; then

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -129,11 +129,6 @@ set(ERROR_TESTS
   expr-errors01.f90
   null01.f90
   equivalence01.f90
-  ${PROJECT_SOURCE_DIR}/module/ieee_arithmetic.f90
-  ${PROJECT_SOURCE_DIR}/module/ieee_exceptions.f90
-  ${PROJECT_SOURCE_DIR}/module/ieee_features.f90
-  ${PROJECT_SOURCE_DIR}/module/iso_c_binding.f90
-  ${PROJECT_SOURCE_DIR}/module/iso_fortran_env.f90
 )
 
 # These test files have expected symbols in the source

--- a/test/semantics/test_any.sh
+++ b/test/semantics/test_any.sh
@@ -19,7 +19,7 @@
 # Change the compiler by setting the F18 environment variable.
 PATH=/usr/bin:/bin
 srcdir=$(dirname $0)
-F18=${F18:=../../tools/f18/f18}
+F18=${F18:=../../tools/f18/bin/f18}
 FileCheck=${FileCheck:=internal_check}
 
 function internal_check() {

--- a/test/semantics/test_errors.sh
+++ b/test/semantics/test_errors.sh
@@ -18,7 +18,7 @@
 
 PATH=/usr/bin:/bin
 srcdir=$(dirname $0)
-CMD="${F18:-../../../tools/f18/f18} -fdebug-resolve-names -fparse-only"
+CMD="${F18:-../../../tools/f18/bin/f18} -fdebug-resolve-names -fparse-only"
 
 if [[ $# != 1 ]]; then
   echo "Usage: $0 <fortran-source>"

--- a/test/semantics/test_modfile.sh
+++ b/test/semantics/test_modfile.sh
@@ -18,7 +18,7 @@
 set -e
 PATH=/usr/bin:/bin
 srcdir=$(dirname $0)
-CMD="${F18:-../../../tools/f18/f18} -fdebug-resolve-names -fparse-only"
+CMD="${F18:-../../../tools/f18/bin/f18} -fdebug-resolve-names -fparse-only"
 if [[ $# != 1 ]]; then
   echo "Usage: $0 <fortran-source>"
   exit 1

--- a/test/semantics/test_symbols.sh
+++ b/test/semantics/test_symbols.sh
@@ -20,7 +20,7 @@
 
 PATH=/usr/bin:/bin
 srcdir=$(dirname $0)
-CMD="${F18:-../../../tools/f18/f18} -funparse-with-symbols"
+CMD="${F18:-../../../tools/f18/bin/f18} -funparse-with-symbols"
 
 if [[ $# != 1 ]]; then
   echo "Usage: $0 <fortran-source>"

--- a/tools/f18/CMakeLists.txt
+++ b/tools/f18/CMakeLists.txt
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
+file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")
+
 add_executable(f18
   f18.cc
   dump.cc
@@ -31,5 +34,31 @@ add_executable(f18-parse-demo
 target_link_libraries(f18-parse-demo
   FortranParser
 )
+
+set_target_properties(f18 f18-parse-demo
+  PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin"
+)
+
+set(MODULES
+  "ieee_arithmetic"
+  "ieee_exceptions"
+  "ieee_features"
+  "iso_c_binding"
+  "iso_fortran_env"
+)
+
+# Create module files directly from the top-level module source directory
+foreach(filename ${MODULES})
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.mod
+    COMMAND f18 -fparse-only -fdebug-semantics ${PROJECT_SOURCE_DIR}/module/${filename}.f90
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include"
+    DEPENDS f18 ${PROJECT_SOURCE_DIR}/module/${filename}.f90
+  )
+  list(APPEND MODULE_FILES "${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.mod")
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.mod DESTINATION include)
+endforeach()
+
+add_custom_target(module_files ALL DEPENDS ${MODULE_FILES})
 
 install(TARGETS f18 f18-parse-demo DESTINATION bin)


### PR DESCRIPTION
Change the CMakeFile.txt in tools/f18 to build the predefined modules with the just-built compiler. The mod files are created in the new "include" subdirectory of the binary target directory.  The mod files are installed to ${CMAKE_INSTALL_PREFIX}/include.

The f18 driver is already installed in ${CMAKE_INSTALL_PREFIX}/bin.  This change change the location of the f18 binary build to a sibling directory of "include" called "bin" instead of at the top level of the binary destination directory. This change is in anticipation of changing the driver to find the include directory using a path relative to the location of f18.

Update the test scripts to find f18 in the bin subdirectory.

Remove the simple predefined module tests from test/semantics because they are compiled as part of the build and don't need to be recompiled as part of a test.