### PR TITLE
Initialize PRINT semantics.  Fixes #516

### DIFF
--- a/lib/semantics/check-io.h
+++ b/lib/semantics/check-io.h
@@ -35,6 +35,7 @@ public:
   void Enter(const parser::FlushStmt &) { Init(IoStmtKind::Flush); }
   void Enter(const parser::InquireStmt &) { Init(IoStmtKind::Inquire); }
   void Enter(const parser::OpenStmt &) { Init(IoStmtKind::Open); }
+  void Enter(const parser::PrintStmt &) { Init(IoStmtKind::Print); }
   void Enter(const parser::ReadStmt &) { Init(IoStmtKind::Read); }
   void Enter(const parser::RewindStmt &) { Init(IoStmtKind::Rewind); }
   void Enter(const parser::WaitStmt &) { Init(IoStmtKind::Wait); }

--- a/test/semantics/io03.f90
+++ b/test/semantics/io03.f90
@@ -31,6 +31,7 @@
   open(10)
 
   read*
+  print*, 'Ok'
   read(*)
   read*, jj
   read(*, *) jj


### PR DESCRIPTION
There are no Clause 12 constraints to check for PRINT, but PRINT does share
FMT specifier processing with READ and WRITE.  To avoid interactions between
these I/O statements, reset IoChecker values for PRINT.