### PR TITLE
Common descriptor interface in front-end and runtime: RESHAPE example

### DIFF
--- a/lib/common/abstract-descriptor.h
+++ b/lib/common/abstract-descriptor.h
@@ -1,0 +1,269 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FORTRAN_COMMON_ABSTRACT_DESCRIPTOR_H_
+#define FORTRAN_COMMON_ABSTRACT_DESCRIPTOR_H_
+
+#include "constexpr-bitset.h"
+
+namespace Fortran::common {
+
+// DescriptorInterface both serves to describe and validate the interface
+// that descriptor implementations must comply with in order to be used to
+// instantiate Fortran transformational intrinsic abstract implementation.
+// To validate the compliance of a descriptor implementation DESC with the
+// interface, one must compile in a test file:
+//
+//  template class DescriptorInterface<DESC>;
+//  template class Transformational<DescriptorInterface<DESC>>;
+//
+// The first line ensures DESC has all properties required by the descriptor
+// interface. The second line ensures the Abstract Fortran Runtime
+// implementation is only using descriptor properties that are part of the
+// descriptor interface. These are static tests only and it does not validate
+// the descriptor implementation logic.
+// Note that inheritance and abstract functions were not selected to make the
+// interface to avoid runtime overhead with virtual functions.
+
+template<typename DESC> class DescriptorInterface : private DESC {
+public:
+  // A descriptor implementation must define the following type
+
+  // basic integer types
+  using SubscriptValue = typename DESC::SubscriptValue;
+  using SizeValue = typename DESC::SizeValue;  // may or may not be unsigned
+  using Rank = typename DESC::Rank;
+  using Attribute = typename DESC::Attribute;
+
+  // RankedSizedArray<A>(n) are arrays with storage for at least n A elements.
+  // The implementation is free to allocate more memory space than needed.
+  // n must not be greater than maxRank;
+  template<typename A>
+  using RankedSizedArray = typename DESC::template RankedSizedArray<A>;
+
+  // SubscriptArray is an alias for RankedSizedArray<SubscriptValue>
+  using SubscriptArray = typename DESC::SubscriptArray;
+
+  // OwningPointer<A> acts like a A*. When receiving an OwningPointer<A>,
+  // one is responsible to destroy its content. It may be implemented as
+  // a simple A* or something more complex and safer.
+  template<typename A>
+  using OwningPointer = typename DESC::template OwningPointer<A>;
+
+  // TODO: Describe FortranType and Dimension interface or hide them
+  // FortranType holds type information
+  using FortranType = typename DESC::FortranType;
+  // Dimension holds dimension information.
+  using Dimension = typename DESC::Dimension;
+
+  // Constants to be defined by descriptor implementation
+  static constexpr Rank maxRank{DESC::maxRank};
+
+  // A descriptor implementation must provide the following functions:
+
+  Rank rank() const { return DESC::rank(); }
+
+  FortranType type() const { return DESC::type(); }
+
+  Dimension GetDimension(Rank i) const { return DESC::GetDimension(i); }
+
+  // Write lower bounds of the entity describe by the descriptor
+  // into subscripts.
+  void GetLowerBounds(SubscriptArray &subscripts) const {
+    DESC::GetLowerBounds(subscripts);
+  }
+
+  bool HasSameTypeAs(const DescriptorInterface<DESC> &other) const {
+    return DESC::HasSameTypeAs(static_cast<const DESC &>(other));
+  }
+
+  // When the decsriptor describes an array containing integer,
+  // GetSubscriptValueAt extract the element indexed by subscripts and convert
+  // it to a SubscriptValue.
+  SubscriptValue GetSubscriptValueAt(const SubscriptArray &subscripts) const {
+    return DESC::GetSubscriptValueAt(subscripts);
+  }
+
+  // Number of elements
+  SizeValue Elements() const { return DESC::Elements(); }
+
+  // Create a descriptor with the same type (including type parameters if
+  // applicable) as source and the given rank. The data and bounds are left
+  // unset.
+  static OwningPointer<DescriptorInterface<DESC>> CreateWithSameTypeAs(
+      const DescriptorInterface<DESC> &source, Rank rank, Attribute attribute) {
+    return OwningPointer<DescriptorInterface<DESC>>{
+        static_cast<DescriptorInterface<DESC> *>(&(*DESC::CreateWithSameTypeAs(
+            static_cast<const DESC &>(source), rank, attribute)))};
+  }
+
+  // Allocate a descriptor for which the type is fully defined:
+  //  - set bounds information (the lower bounds are set to to 1)
+  //  - get storage for the entity described by the descriptor and
+  //    make it available to the descriptor.
+  //  The data is not initialized (even for derived type).
+  void Allocate(const SubscriptArray &extents) { DESC::Allocate(extents); }
+
+  // Copy count elements from the entity described by source into the entity
+  // describe by the descriptor.
+  // - source and the descriptor must describe entities of the same type. source
+  // must have at least one element.
+  // - For the target, the copy starts at the element indexed by resultSubscript
+  // and resultSubscript are incremented according to the dimension order in
+  // dimOrder.
+  // - For the source, the copy starts at the first element and source elements
+  // are run through in Fortran dimension order. If the end of the source of the
+  // target is reached before count, the copy continues from the first element
+  // of the entity whose last element was reached.
+  SizeValue CopyFrom(const DescriptorInterface<DESC> &source,
+      SubscriptArray &resultSubscripts, SizeValue count,
+      const RankedSizedArray<Rank> *dimOrder) {
+    return DESC::CopyFrom(
+        static_cast<const DESC &>(source), resultSubscripts, count, dimOrder);
+  }
+
+  // Indicate that the descriptor is not describing a user variable (this
+  // information may not be useful and this may be a no-op)
+  void SetCompilerCreatedFlag() { DESC::SetCompilerCreatedFlag(); }
+
+  // TODO: improve interface for attributes
+  static Attribute AllocatableAttribute() {
+    return DESC::AllocatableAttribute();
+  }
+};
+
+namespace safestd {
+// This namespace contains symbols named after C++ standard library that
+// have the same interface as the corresponding STL symbols.
+// It is guaranteed that there usage will not bring
+// dependencies with the C++ runtime library.
+// The purpose is to avoid having the Fortran runtime be dependent upon the
+// C++ runtime while allowing Fortran runtime programmers to use C++ features
+// that they are used to.
+// A symbols can directly be an alias of the corresponding std symbol when its
+// usage is not dependent on the C++ runtime. These independence is determined
+// empirically by testing that the Fortran runtime can be built without linking
+// to the C++ runtime. This has to be shown with all the supported f18 built
+// toolchain.
+// If a C++ standard library feature depends on C++ runtime and is highly
+// desired, a C++ runtime independent implementation will need to be provided
+// here. Similarly, if a new toolchain introduces C++ runtime dependencies for
+// the symbols previously listed here, re-implementation of these features will
+// have to be done as part of the toolchain support introduction.
+
+// Alas, std::bitset comes with C++ exceptions runtime symbols (even with
+// -fno-exceptions).
+template<std::size_t N> using bitset = Fortran::common::BitSet<N>;
+template<typename T> constexpr T min(const T &a, const T &b) {
+  return (a < b ? a : b);
+}
+}
+
+// Transformational contains an implementation of Fortran intrinsic functions
+// operating on descriptors in a descriptor abstracted way. The purpose is that
+// these implementations can be used both in the front-end for folding and the
+// runtime library, by selecting the applicable descriptor. DESC has to comply
+// with the DescriptorInterface above. Because these functions can be
+// instantiated in a runtime library context, their abstract implementations
+// must not use any C++ features that would bring runtime dependencies.
+template<typename DESC> class Transformational {
+  // TODO: abstract error handling and memory allocation
+public:
+  using SubscriptValue = typename DESC::SubscriptValue;
+  using SizeValue = typename DESC::SizeValue;
+  template<typename A>
+  using RankedSizedArray = typename DESC::template RankedSizedArray<A>;
+  using SubscriptArray = typename DESC::SubscriptArray;
+  template<typename A>
+  using OwningPointer = typename DESC::template OwningPointer<A>;
+  using FortranType = typename DESC::FortranType;
+  using Dimension = typename DESC::Dimension;
+  using Attribute = typename DESC::Attribute;
+  using Rank = typename DESC::Rank;
+  static constexpr Rank maxRank{DESC::maxRank};
+
+  static OwningPointer<DESC> RESHAPE(const DESC &source, const DESC &shape,
+      const DESC *pad = nullptr, const DESC *order = nullptr) {
+    // Compute and check the rank of the result.
+    CHECK(shape.rank() == 1);
+    CHECK(shape.type().IsInteger());
+    SubscriptValue resultRank{shape.GetDimension(0).Extent()};
+    CHECK(
+        resultRank >= 0 && resultRank <= static_cast<SubscriptValue>(maxRank));
+
+    // Extract and check the shape of the result; compute its element count.
+    SubscriptArray resultExtent(resultRank);
+    SizeValue resultElements{1};
+    SubscriptArray shapeSubscript(1);
+    shapeSubscript[0] = shape.GetDimension(0).LowerBound();
+    for (SubscriptValue j{0}; j < resultRank; ++j, shapeSubscript[0]++) {
+      resultExtent[j] = shape.GetSubscriptValueAt(shapeSubscript);
+      CHECK(resultExtent[j] >= 0);
+      resultElements *= resultExtent[j];
+    }
+
+    // Check that there are sufficient elements in the SOURCE=, or that
+    // the optional PAD= argument is present and nonempty.
+    SizeValue sourceElements{source.Elements()};
+    SizeValue padElements{pad ? pad->Elements() : 0};
+    if (sourceElements < resultElements) {
+      CHECK(padElements > 0);
+      CHECK(pad->HasSameTypeAs(source));
+    }
+
+    // Extract and check the optional ORDER= argument, which must be a
+    // permutation of [1..resultRank].
+    RankedSizedArray<Rank> dimOrder(resultRank);
+    if (order != nullptr) {
+      CHECK(order->rank() == 1);
+      CHECK(order->type().IsInteger());
+      CHECK(order->GetDimension(0).Extent() == resultRank);
+      safestd::bitset<maxRank> values;
+      SubscriptArray orderSubscript(1);
+      orderSubscript[0] = order->GetDimension(0).LowerBound();
+      for (SubscriptValue j{0}; j < resultRank; ++j, ++orderSubscript[0]) {
+        auto k{order->GetSubscriptValueAt(orderSubscript)};
+        CHECK(k >= 1 && k <= resultRank && !values.test(k - 1));
+        values.set(k - 1);
+        dimOrder[k - 1] = j;
+      }
+    } else {
+      for (Rank j{0}; j < resultRank; ++j) {
+        dimOrder[j] = j;
+      }
+    }
+
+    // Create and populate the result's descriptor.
+    OwningPointer<DESC> result{DESC::CreateWithSameTypeAs(
+        source, resultRank, DESC::AllocatableAttribute())};
+    result->SetCompilerCreatedFlag();
+    result->Allocate(resultExtent);
+    // Copy elements
+    SubscriptArray resultSubscript(resultRank);
+    result->GetLowerBounds(resultSubscript);
+    SizeValue count{safestd::min(sourceElements, resultElements)};
+    SizeValue copied{
+        result->CopyFrom(source, resultSubscript, count, &dimOrder)};
+    if (copied < resultElements) {
+      CHECK(pad);
+      result->CopyFrom(
+          *pad, resultSubscript, resultElements - copied, &dimOrder);
+    }
+    return result;
+  }
+};
+
+}
+
+#endif  // FORTRAN_COMMON_ABSTRACT_DESCRIPTOR_H_

--- a/lib/common/abstract-descriptor.h
+++ b/lib/common/abstract-descriptor.h
@@ -43,7 +43,6 @@ public:
   // basic integer types
   using SubscriptValue = typename DESC::SubscriptValue;
   using SizeValue = typename DESC::SizeValue;  // may or may not be unsigned
-  using Rank = typename DESC::Rank;
   using Attribute = typename DESC::Attribute;
 
   // RankedSizedArray<A>(n) are arrays with storage for at least n A elements.
@@ -68,15 +67,15 @@ public:
   using Dimension = typename DESC::Dimension;
 
   // Constants to be defined by descriptor implementation
-  static constexpr Rank maxRank{DESC::maxRank};
+  static constexpr int maxRank{DESC::maxRank};
 
   // A descriptor implementation must provide the following functions:
 
-  Rank rank() const { return DESC::rank(); }
+  int rank() const { return DESC::rank(); }
 
   FortranType type() const { return DESC::type(); }
 
-  Dimension GetDimension(Rank i) const { return DESC::GetDimension(i); }
+  Dimension GetDimension(int i) const { return DESC::GetDimension(i); }
 
   // Write lower bounds of the entity describe by the descriptor
   // into subscripts.
@@ -102,7 +101,7 @@ public:
   // applicable) as source and the given rank. The data and bounds are left
   // unset.
   static OwningPointer<DescriptorInterface<DESC>> CreateWithSameTypeAs(
-      const DescriptorInterface<DESC> &source, Rank rank, Attribute attribute) {
+      const DescriptorInterface<DESC> &source, int rank, Attribute attribute) {
     return OwningPointer<DescriptorInterface<DESC>>{
         static_cast<DescriptorInterface<DESC> *>(&(*DESC::CreateWithSameTypeAs(
             static_cast<const DESC &>(source), rank, attribute)))};
@@ -128,7 +127,7 @@ public:
   // of the entity whose last element was reached.
   SizeValue CopyFrom(const DescriptorInterface<DESC> &source,
       SubscriptArray &resultSubscripts, SizeValue count,
-      const RankedSizedArray<Rank> *dimOrder) {
+      const RankedSizedArray<int> *dimOrder) {
     return DESC::CopyFrom(
         static_cast<const DESC &>(source), resultSubscripts, count, dimOrder);
   }
@@ -190,8 +189,7 @@ public:
   using FortranType = typename DESC::FortranType;
   using Dimension = typename DESC::Dimension;
   using Attribute = typename DESC::Attribute;
-  using Rank = typename DESC::Rank;
-  static constexpr Rank maxRank{DESC::maxRank};
+  static constexpr int maxRank{DESC::maxRank};
 
   static OwningPointer<DESC> RESHAPE(const DESC &source, const DESC &shape,
       const DESC *pad = nullptr, const DESC *order = nullptr) {
@@ -224,7 +222,7 @@ public:
 
     // Extract and check the optional ORDER= argument, which must be a
     // permutation of [1..resultRank].
-    RankedSizedArray<Rank> dimOrder(resultRank);
+    RankedSizedArray<int> dimOrder(resultRank);
     if (order != nullptr) {
       CHECK(order->rank() == 1);
       CHECK(order->type().IsInteger());
@@ -239,7 +237,7 @@ public:
         dimOrder[k - 1] = j;
       }
     } else {
-      for (Rank j{0}; j < resultRank; ++j) {
+      for (int j{0}; j < resultRank; ++j) {
         dimOrder[j] = j;
       }
     }

--- a/lib/evaluate/constant.h
+++ b/lib/evaluate/constant.h
@@ -17,6 +17,7 @@
 
 #include "formatting.h"
 #include "type.h"
+#include "../common/abstract-descriptor.h"
 #include "../common/default-kinds.h"
 #include <map>
 #include <ostream>
@@ -53,6 +54,11 @@ inline ConstantSubscripts InitialSubscripts(const ConstantSubscripts &shape) {
 // Increments a vector of subscripts in Fortran array order (first dimension
 // varying most quickly).  Returns false when last element was visited.
 bool IncrementSubscripts(ConstantSubscripts &, const ConstantSubscripts &shape);
+// Increments a vector of subscripts according to given dimension order
+bool IncrementSubscripts(ConstantSubscripts &, const ConstantSubscripts &shape,
+    const std::vector<int> &dimOrder);
+
+class ConstantDescriptor;
 
 // Constant<> is specialized for Character kinds and SomeDerived.
 // The non-Character intrinsic types, and SomeDerived, share enough
@@ -60,6 +66,7 @@ bool IncrementSubscripts(ConstantSubscripts &, const ConstantSubscripts &shape);
 template<typename RESULT, typename ELEMENT = Scalar<RESULT>>
 class ConstantBase {
   static_assert(RESULT::category != TypeCategory::Character);
+  friend ConstantDescriptor;
 
 public:
   using Result = RESULT;
@@ -120,6 +127,8 @@ public:
 };
 
 template<int KIND> class Constant<Type<TypeCategory::Character, KIND>> {
+  friend ConstantDescriptor;
+
 public:
   using Result = Type<TypeCategory::Character, KIND>;
   using Element = Scalar<Result>;
@@ -198,5 +207,157 @@ FOR_EACH_INTRINSIC_KIND(extern template class Constant, )
   FOR_EACH_LENGTHLESS_INTRINSIC_KIND(template class ConstantBase, ) \
   template class ConstantBase<SomeDerived, StructureConstructorValues>; \
   FOR_EACH_INTRINSIC_KIND(template class Constant, )
+
+// ConstantDescriptor is a descriptor that wraps a Constant<T> and is compliant
+// with DescriptorInterface. It can be used for folding with the
+// transformational intrinsic function implementation taking a descriptor type
+// as template argument.
+class ConstantDescriptor {
+public:
+  using SubscriptValue = ConstantSubscript;
+  using SizeValue = std::size_t;
+  using Attribute = int;
+  using Rank = int;
+
+  template<typename A> using RankedSizedArray = std::vector<A>;
+  using SubscriptArray = RankedSizedArray<SubscriptValue>;
+  template<typename A> using OwningPointer = std::unique_ptr<A>;
+
+  struct FortranType {
+    bool IsInteger() const { return type.category() == TypeCategory::Integer; }
+    bool operator==(const FortranType &that) const { return type == that.type; }
+    bool operator!=(const FortranType &that) const { return !(*this == that); }
+    DynamicType type;
+  };
+  struct Dimension {
+    constexpr SubscriptValue LowerBound() const { return 1; }
+    constexpr SubscriptValue UpperBound() const { return extent; }
+    SubscriptValue Extent() const { return extent; };
+    SubscriptValue extent;
+  };
+  static constexpr Rank maxRank{15};
+
+  template<typename T>
+  ConstantDescriptor(const Constant<T> &constant)
+    : type_{constant.GetType()}, rank_{constant.Rank()},
+      elementBytes_{ElementBytes(constant)}, someConstant_{
+                                                 AllocatableConstant<T>{
+                                                     constant}} {}
+  template<typename T>
+  ConstantDescriptor(Constant<T> &&constant)
+    : type_{constant.GetType()}, rank_{constant.Rank()},
+      elementBytes_{ElementBytes(constant)}, someConstant_{
+                                                 AllocatableConstant<T>{
+                                                     std::move(constant)}} {}
+  template<typename T>
+  ConstantDescriptor(
+      const DynamicType &type, int rank, SizeValue elementBytes, const T &)
+    : type_{std::move(type)}, rank_{rank}, elementBytes_{elementBytes},
+      someConstant_{AllocatableConstant<T>{std::nullopt}} {}
+
+  int rank() const { return rank_; }
+  FortranType type() const { return FortranType{type_}; }
+  Dimension GetDimension(int i) const {
+    CHECK(i < rank_);
+    return std::visit(
+        [&](const auto &optionalConstant) -> Dimension {
+          return Dimension{optionalConstant.value().shape()[i]};
+        },
+        someConstant_);
+  }
+  void GetLowerBounds(SubscriptArray &subscripts) const {
+    for (int i{0}; i < rank(); ++i) {
+      subscripts[i] = 1;
+    }
+  }
+  bool HasSameTypeAs(const ConstantDescriptor &other) const {
+    return type() == other.type();
+  }
+  SizeValue Elements() const {
+    return std::visit(
+        [&](const auto &optionalConstant) -> SizeValue {
+          return Elements(optionalConstant.value().shape());
+        },
+        someConstant_);
+  }
+  constexpr void SetCompilerCreatedFlag() { /* no-op in front-end */
+  }
+  SubscriptValue GetSubscriptValueAt(const SubscriptArray &subscripts) const;
+  static OwningPointer<ConstantDescriptor> CreateWithSameTypeAs(
+      const ConstantDescriptor &source, int rank, Attribute);
+  void Allocate(const SubscriptArray &extents);
+  // Copies are only allowed when the underlying type is the same in source
+  SizeValue CopyFrom(const ConstantDescriptor &source,
+      SubscriptArray &resultSubscripts, SizeValue count,
+      const RankedSizedArray<int> *dimOrder);
+
+  template<typename T> Constant<T> ReleaseConstant() {
+    auto &optConstant = std::get<AllocatableConstant<T>>(someConstant_);
+    CHECK(optConstant.has_value());
+    return std::move(optConstant.value());
+  }
+  constexpr static Attribute AllocatableAttribute() {
+    // ConstantDescriptor only acts as a descriptor for allocatable, so this
+    // does not really matter
+    return 0;
+  }
+
+private:
+  static SizeValue Elements(const SubscriptArray &shape) {
+    SizeValue elements{1};
+    for (auto i : shape) {
+      elements *= static_cast<SizeValue>(i);
+    }
+    return elements;
+  }
+  template<typename T>
+  static SizeValue ElementBytes(const Constant<T> &constant) {
+    return sizeof(typename Constant<T>::Element);
+  }
+  template<int KIND>
+  static SizeValue ElementBytes(
+      const Constant<Type<TypeCategory::Character, KIND>> &constant) {
+    return sizeof(typename Scalar<
+               Type<TypeCategory::Character, KIND>>::value_type) *
+        constant.LEN();
+  }
+  template<typename T>
+  static SizeValue Offset(
+      const Constant<T> &constant, const SubscriptArray &subscripts) {
+    SizeValue offset{0};
+    SizeValue stride{ElementBytes(constant)};
+    for (int i{0}; i < constant.Rank(); ++i) {
+      offset += (subscripts[i] - 1) * stride;
+      stride *= constant.shape()[i];
+    }
+    return offset;
+  }
+  template<typename T, typename A>
+  static A *Element(Constant<T> &constant, const SubscriptArray &subscripts) {
+    return reinterpret_cast<A *>(
+        reinterpret_cast<char *>(&constant.values_[0]) +
+        Offset(constant, subscripts));
+  }
+  template<typename T, typename A>
+  static const A *Element(
+      const Constant<T> &constant, const SubscriptArray &subscripts) {
+    return reinterpret_cast<const A *>(
+        reinterpret_cast<const char *>(&constant.values_[0]) +
+        Offset(constant, subscripts));
+  }
+
+  template<typename T> using AllocatableConstant = std::optional<Constant<T>>;
+
+  DynamicType type_;
+  int rank_;
+  SizeValue elementBytes_;
+  Fortran::common::MapTemplate<AllocatableConstant, AllTypes> someConstant_;
+};
+
 }
+
+namespace Fortran::common {
+extern template class Transformational<evaluate::ConstantDescriptor>;
+}
+
 #endif  // FORTRAN_EVALUATE_CONSTANT_H_

--- a/lib/evaluate/constant.h
+++ b/lib/evaluate/constant.h
@@ -217,7 +217,6 @@ public:
   using SubscriptValue = ConstantSubscript;
   using SizeValue = std::size_t;
   using Attribute = int;
-  using Rank = int;
 
   template<typename A> using RankedSizedArray = std::vector<A>;
   using SubscriptArray = RankedSizedArray<SubscriptValue>;
@@ -235,7 +234,7 @@ public:
     SubscriptValue Extent() const { return extent; };
     SubscriptValue extent;
   };
-  static constexpr Rank maxRank{15};
+  static constexpr int maxRank{15};
 
   template<typename T>
   ConstantDescriptor(const Constant<T> &constant)

--- a/runtime/descriptor.h
+++ b/runtime/descriptor.h
@@ -142,13 +142,12 @@ public:
   using SubscriptValue = ISO::CFI_index_t;
   using SizeValue = std::size_t;
   using Attribute = ISO::CFI_attribute_t;
-  using Rank = int;
   template<typename A> using RankedSizedArray = CRankedSizedArray<A>;
   using SubscriptArray = RankedSizedArray<SubscriptValue>;
   template<typename A> using OwningPointer = A *;
   using Dimension = Fortran::runtime::Dimension;
   using FortranType = TypeCode;
-  static constexpr Rank maxRank{Fortran::runtime::maxRank};
+  static constexpr int maxRank{Fortran::runtime::maxRank};
 
   Descriptor() {
     // Minimal initialization to prevent the destructor from running amuck

--- a/runtime/type-code.h
+++ b/runtime/type-code.h
@@ -27,6 +27,12 @@ public:
   TypeCode() {}
   explicit TypeCode(ISO::CFI_type_t t) : raw_{t} {}
   TypeCode(TypeCategory, int);
+  constexpr bool operator==(const TypeCode& other) const {
+    return raw_ == other.raw_;
+  }
+  constexpr bool operator!=(const TypeCode& other) const {
+    return !(*this == other);
+  }
 
   int raw() const { return raw_; }
 

--- a/test/evaluate/CMakeLists.txt
+++ b/test/evaluate/CMakeLists.txt
@@ -127,6 +127,7 @@ set(FOLDING_TESTS
   folding03.f90
   folding04.f90
   folding05.f90
+  folding06.f90
 )
 
 

--- a/test/evaluate/folding06.f90
+++ b/test/evaluate/folding06.f90
@@ -1,0 +1,67 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test transformational intrinsic function folding
+
+module m
+
+  type A
+    real(4) x
+    integer(8) i
+  end type
+
+  integer(8), parameter :: new_shape(2) = [2, 4]
+  integer(4), parameter :: order(2) = [2, 1]
+
+
+  ! Testing integers (similar to real and complex)
+  integer(4), parameter :: int_source(:) = [1, 2, 3, 4, 5, 6]
+  integer(4), parameter :: int_pad(2) = [7, 8]
+  integer(4), parameter :: int_expected_result(:, :) = reshape([1, 5, 2, 6, 3, 7, 4, 8], new_shape)
+  integer(4), parameter :: int_result(:, :) = reshape(int_source, new_shape, int_pad, order)
+  logical, parameter :: test_reshape_integer_1 = all(int_expected_result == int_result)
+  logical, parameter :: test_reshape_integer_2 = all(shape(int_result, 8).EQ.new_shape)
+
+
+  ! Testing characters
+  character(kind=1, len=3), parameter ::char_source(:) = ["abc", "def", "ghi", "jkl", "mno", "pqr"]
+  character(kind=1,len=3), parameter :: char_pad(2) = ["stu", "vxy"]
+
+  character(kind=1, len=3), parameter :: char_expected_result(:, :) = &
+    reshape(["abc", "mno", "def", "pqr", "ghi", "stu", "jkl", "vxy"], new_shape)
+
+  character(kind=1, len=3), parameter :: char_result(:, :) = &
+    reshape(char_source, new_shape, char_pad, order)
+
+  logical, parameter :: test_reshape_char_1 = all(char_result == char_expected_result)
+  logical, parameter :: test_reshape_char_2 = all(shape(char_result, 8).EQ.new_shape)
+
+
+  ! Testing derived types
+  type(A), parameter :: derived_source(:) = &
+    [A(x=1.5, i=1), A(x=2.5, i=2), A(x=3.5, i=3), A(x=4.5, i=4), A(x=5.5, i=5), A(x=6.5, i=6)]
+
+  type(A), parameter :: derived_pad(2) = [A(x=7.5, i=7), A(x=8.5, i=8)]
+
+  type(A), parameter :: derived_expected_result(:, :) = &
+    reshape([a::a(x=1.5_4,i=1_8),a(x=5.5_4,i=5_8),a(x=2.5_4,i=2_8), a(x=6.5_4,i=6_8), &
+      a(x=3.5_4,i=3_8),a(x=7.5_4,i=7_8),a(x=4.5_4,i=4_8),a(x=8.5_4,i=8_8)], new_shape)
+
+  type(A), parameter :: derived_result(:, :) = reshape(derived_source, new_shape, derived_pad, order)
+
+  logical, parameter :: test_reshape_derived_1 = all((derived_result%x.EQ.derived_expected_result%x) &
+      .AND.(derived_result%i.EQ.derived_expected_result%i))
+
+  logical, parameter :: test_reshape_derived_2 = all(shape(derived_result).EQ.new_shape)
+end module

--- a/test/evaluate/reshape.cc
+++ b/test/evaluate/reshape.cc
@@ -14,11 +14,15 @@
 
 #include "testing.h"
 #include "../../runtime/descriptor.h"
-#include "../../runtime/transformational.h"
 #include <cinttypes>
 
 using namespace Fortran::common;
 using namespace Fortran::runtime;
+
+namespace Fortran::common {
+template class DescriptorInterface<Descriptor>;
+template class Transformational<DescriptorInterface<Descriptor>>;
+}
 
 int main() {
   static const SubscriptValue ones[]{1, 1, 1};
@@ -68,7 +72,8 @@ int main() {
   MATCH(2, pad.GetDimension(1).Extent());
   MATCH(3, pad.GetDimension(2).Extent());
 
-  std::unique_ptr<Descriptor> result{RESHAPE(*source, *shape, &pad)};
+  std::unique_ptr<Descriptor> result{
+      Transformational<Descriptor>::RESHAPE(*source, *shape, &pad)};
 
   TEST(result.get() != nullptr);
   result->Check();


### PR DESCRIPTION
Define an interface for descriptors and modify RESHAPE implementation to be templatized with a descriptor type compliant with this interface.
The interface comprises both types, functions and constants to be defined by descriptor implementations.
The purpose is to share the implementation of these intrinsic function between the front-end and the runtime by instantiating them with the relevant descriptor. It is also a goal to have an interface that is high level enough to make future changes in the runtime descriptor format easier. 

In the evaluate library, a `ConstantDescriptor` class is added to wrap `Constant<T>` with the descriptor interface.
The runtime `Descriptor` class is extended to provide the new descriptor interface.

The interface is not enforced through inheritance to avoid virtual functions, however, a validation class `DescriptorInterface` is added to both describe and validate the compliance of a descriptor implementation to this interface.