### PR TITLE
Fixes for DO constraint C1124

### DIFF
--- a/lib/semantics/check-do.cc
+++ b/lib/semantics/check-do.cc
@@ -481,11 +481,6 @@ private:
     EnforceConcurrentLoopControl(concurrent);
   }
 
-  bool InnermostEnclosingScope(const semantics::Symbol &symbol) const {
-    // TODO - implement
-    return true;
-  }
-
   void CheckZeroOrOneDefaultNone(
       const std::list<parser::LocalitySpec> &localitySpecs) const {
     // C1127
@@ -498,18 +493,6 @@ private:
               "only one DEFAULT(NONE) may appear"_en_US);
           return;
         }
-      }
-    }
-  }
-
-  void CheckScopingConstraints(const CS &symbols) const {
-    // C1124
-    for (auto *symbol : symbols) {
-      if (!InnermostEnclosingScope(*symbol)) {
-        context_.Say(currentStatementSourcePosition_,
-            "variable in locality-spec must be in innermost"
-            " scoping unit"_err_en_US);
-        return;
       }
     }
   }
@@ -600,7 +583,6 @@ private:
     }
     auto variableNames{
         GatherVariables(localitySpecs, GatherWhichVariables::All)};
-    CheckScopingConstraints(variableNames);
     CheckZeroOrOneDefaultNone(localitySpecs);
     CheckLocalAndLocalInitAttributes(
         GatherVariables(localitySpecs, GatherWhichVariables::NotShared));

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -3982,17 +3982,13 @@ bool ConstructVisitor::Pre(const parser::LocalitySpec::Shared &x) {
       Say(name, "Variable '%s' not found"_err_en_US);
       context().SetError(
           MakeSymbol(name, ObjectEntityDetails{EntityDetails{}}));
-    } else {
-      if (prev->owner() == currScope()) {
+    } else if (prev->owner() == currScope()) {
         SayAlreadyDeclared(name, *prev);  // C1125 and C1126
-      } else {
-        if (!IsVariableName(*prev)) {
-          SayBadLocality(name, *prev);  // C1124
-        } else {
-          auto &symbol{MakeSymbol(name, HostAssocDetails{*prev})};
-          symbol.set(Symbol::Flag::LocalityShared);
-        }
-      }
+    } else if (!IsVariableName(*prev)) {
+        SayBadLocality(name, *prev);  // C1124
+    } else {
+      auto &symbol{MakeSymbol(name, HostAssocDetails{*prev})};
+      symbol.set(Symbol::Flag::LocalityShared);
     }
   }
   return false;

--- a/test/semantics/resolve35.f90
+++ b/test/semantics/resolve35.f90
@@ -106,6 +106,16 @@ subroutine s8
 end
 
 subroutine s9
+  integer :: j
+  !ERROR: 'i' is already declared in this scoping unit
+  do concurrent(integer::i=1:5) shared(i) &
+      shared(j) &
+      !ERROR: 'j' is already declared in this scoping unit
+      shared(j)
+  end do
+end
+
+subroutine s10
   external bad1
   real, parameter :: bad2 = 1.0
   x = cos(0.)
@@ -118,6 +128,16 @@ subroutine s9
     local(bad3) &
     !ERROR: Locality attribute not allowed on 'cos'
     local(cos)
+  end do
+  do concurrent(i=1:2) &
+    !ERROR: Locality attribute not allowed on 'bad1'
+    shared(bad1) &
+    !ERROR: Locality attribute not allowed on 'bad2'
+    shared(bad2) &
+    !ERROR: Locality attribute not allowed on 'bad3'
+    shared(bad3) &
+    !ERROR: Locality attribute not allowed on 'cos'
+    shared(cos)
   end do
 contains
   subroutine bad3


### PR DESCRIPTION
The constraint says that a variable-name in a locality-spec shall be the name
of a variable in the innermost executable construct or scoping unit that
includes the DO CONCURRENT statement.  This check was already being made in
resolve-names.cc for LOCAL and LOCAL_INIT locality specs but not for the
SHARED locality spec.  Also, there was some code in check-do.cc that was
intended to be used to enforce this constraint at some time in the future.

I added code to resolve-names.cc to extend the checking to the SHARED locality
spec and removed the unused code from check-do.cc.  I also extended the
existing tests in resolve35.f90 to exercise the new code.