### PR TITLE
Structural checks for DO construct

### DIFF
--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -40,15 +40,14 @@ void OmpStructureChecker::CheckAllowed(const OmpClause &type) {
         parser::ToUpperCaseLetters(GetContext().directiveSource.ToString()));
     return;
   }
-  if (GetContext().allowedOnceClauses.test(type) &&
-      GetContext().seenClauses.test(type)) {
+  if (GetContext().allowedOnceClauses.test(type) && SeenClause(type)) {
     context_.Say(GetContext().clauseSource,
         "At most one %s clause can appear on the %s directive"_err_en_US,
         EnumToString(type),
         parser::ToUpperCaseLetters(GetContext().directiveSource.ToString()));
     return;
   }
-  SetContextSeen(type);
+  SetContextClauseInfo(type);
 }
 
 void OmpStructureChecker::Enter(const parser::OpenMPLoopConstruct &x) {
@@ -114,9 +113,8 @@ void OmpStructureChecker::Enter(const parser::OmpLoopDirective::Do &) {
   // reserve for nesting check
   SetContextDirectiveEnum(OmpDirective::DO);
 
-  OmpClauseSet allowed{OmpClause::PRIVATE, OmpClause::LASTPRIVATE,
-      OmpClause::LINEAR, OmpClause::REDUCTION, OmpClause::SCHEDULE,
-      OmpClause::COLLAPSE, OmpClause::ORDERED};
+  OmpClauseSet allowed{OmpClause::PRIVATE, OmpClause::FIRSTPRIVATE,
+      OmpClause::LASTPRIVATE, OmpClause::LINEAR, OmpClause::REDUCTION};
   SetContextAllowed(allowed);
 
   OmpClauseSet allowedOnce{
@@ -124,8 +122,48 @@ void OmpStructureChecker::Enter(const parser::OmpLoopDirective::Do &) {
   SetContextAllowedOnce(allowedOnce);
 }
 
+void OmpStructureChecker::Leave(const parser::OmpClauseList &) {
+  // 2.7 Loop Construct Restriction
+  if (GetContext().directive == OmpDirective::DO) {
+    if (SeenClause(OmpClause::SCHEDULE)) {
+      // only one schedule clause is allowed
+      auto it{GetContext().clauseInfo.find(OmpClause::SCHEDULE)};
+      auto *clause{it->second};
+      const auto &schedClause{std::get<parser::OmpScheduleClause>(clause->u)};
+      if (ScheduleModifierHasType(schedClause,
+              parser::OmpScheduleModifierType::ModType::Nonmonotonic)) {
+        if (SeenClause(OmpClause::ORDERED)) {
+          context_.Say(clause->source,
+              "The NONMONOTONIC modifier cannot be specified "
+              "if an ORDERED clause is specified"_err_en_US);
+        }
+        if (ScheduleModifierHasType(schedClause,
+                parser::OmpScheduleModifierType::ModType::Monotonic)) {
+          context_.Say(clause->source,
+              "The MONOTONIC and NONMONOTONIC modifiers "
+              "cannot be both specified"_err_en_US);
+        }
+      }
+    }
+
+    if (SeenClause(OmpClause::ORDERED) && SeenClause(OmpClause::LINEAR)) {
+      // only one ordered clause is allowed
+      auto it{GetContext().clauseInfo.find(OmpClause::ORDERED)};
+      auto *clause{it->second};
+      const auto &orderedClause{
+          std::get<parser::OmpClause::Ordered>(clause->u)};
+      if (orderedClause.v.has_value()) {
+        context_.Say(clause->source,
+            "A LINEAR clause or an ORDERED clause with a parameter "
+            "can be specified on a loop directive but not both"_err_en_US);
+      }
+    }
+  }
+}
+
 void OmpStructureChecker::Enter(const parser::OmpClause &x) {
   SetContextClauseSource(x.source);
+  SetContextClause(&x);
 }
 
 void OmpStructureChecker::Enter(const parser::OmpClause::Defaultmap &) {
@@ -234,8 +272,18 @@ void OmpStructureChecker::Enter(const parser::OmpDependClause &) {
 void OmpStructureChecker::Enter(const parser::OmpIfClause &) {
   CheckAllowed(OmpClause::IF);
 }
-void OmpStructureChecker::Enter(const parser::OmpLinearClause &) {
+void OmpStructureChecker::Enter(const parser::OmpLinearClause &x) {
   CheckAllowed(OmpClause::LINEAR);
+
+  // 2.7 Loop Construct Restriction
+  if (GetContext().directive == OmpDirective::DO ||
+      GetContext().directive == OmpDirective::SIMD) {
+    if (std::holds_alternative<parser::OmpLinearClause::WithModifier>(x.u)) {
+      context_.Say(GetContext().clauseSource,
+          "A modifier may not be specified in a LINEAR clause "
+          "on the DO or SIMD directive"_err_en_US);
+    }
+  }
 }
 void OmpStructureChecker::Enter(const parser::OmpMapClause &) {
   CheckAllowed(OmpClause::MAP);
@@ -246,7 +294,47 @@ void OmpStructureChecker::Enter(const parser::OmpProcBindClause &) {
 void OmpStructureChecker::Enter(const parser::OmpReductionClause &) {
   CheckAllowed(OmpClause::REDUCTION);
 }
-void OmpStructureChecker::Enter(const parser::OmpScheduleClause &) {
+
+bool OmpStructureChecker::ScheduleModifierHasType(
+    const parser::OmpScheduleClause &x,
+    const parser::OmpScheduleModifierType::ModType &type) {
+  const auto &modifier{std::get<0>(x.t)};
+  if (modifier.has_value()) {
+    const auto &modType1{std::get<0>(modifier->t)};
+    const auto &modType2{std::get<1>(modifier->t)};
+    if ((modType1.v).v == type ||
+        (modType2.has_value() && (modType2->v).v == type)) {
+      return true;
+    }
+  }
+  return false;
+}
+void OmpStructureChecker::Enter(const parser::OmpScheduleClause &x) {
   CheckAllowed(OmpClause::SCHEDULE);
+
+  // 2.7 Loop Construct Restriction
+  if (GetContext().directive == OmpDirective::DO) {
+    const auto &kind{std::get<1>(x.t)};
+    const auto &chunk{std::get<2>(x.t)};  // chunk_size
+    if ((kind == parser::OmpScheduleClause::ScheduleType::Runtime ||
+            kind == parser::OmpScheduleClause::ScheduleType::Auto) &&
+        chunk.has_value()) {
+      context_.Say(GetContext().clauseSource,
+          "When SCHEDULE(%s) is specified, "
+          "CHUNK_SIZE must not be specified"_err_en_US,
+          parser::ToUpperCaseLetters(
+              parser::OmpScheduleClause::EnumToString(kind)));
+    }
+
+    if (ScheduleModifierHasType(
+            x, parser::OmpScheduleModifierType::ModType::Nonmonotonic)) {
+      if ((kind != parser::OmpScheduleClause::ScheduleType::Dynamic &&
+              kind != parser::OmpScheduleClause::ScheduleType::Guided)) {
+        context_.Say(GetContext().clauseSource,
+            "The NONMONOTONIC modifier can only be specified with "
+            "SCHEDULE(DYNAMIC) or SCHEDULE(GUIDED)"_err_en_US);
+      }
+    }
+  }
 }
 }

--- a/lib/semantics/check-omp-structure.h
+++ b/lib/semantics/check-omp-structure.h
@@ -123,8 +123,9 @@ private:
   void SetContextDirectiveSource(const parser::CharBlock &directive) {
     ompContext_.back().directiveSource = directive;
   }
-  void SetContextClauseSource(const parser::CharBlock &clause) {
-    ompContext_.back().clauseSource = clause;
+  void SetContextClause(const parser::OmpClause &clause) {
+    ompContext_.back().clauseSource = clause.source;
+    ompContext_.back().clause = &clause;
   }
   void SetContextDirectiveEnum(const OmpDirective &dir) {
     ompContext_.back().directive = dir;
@@ -135,14 +136,15 @@ private:
   void SetContextAllowedOnce(const OmpClauseSet &allowedOnce) {
     ompContext_.back().allowedOnceClauses = allowedOnce;
   }
-  void SetContextClause(const parser::OmpClause *clause) {
-    ompContext_.back().clause = clause;
-  }
   void SetContextClauseInfo(const OmpClause &type) {
     ompContext_.back().clauseInfo.emplace(type, ompContext_.back().clause);
   }
-  bool SeenClause(const OmpClause &type) {
-    return GetContext().clauseInfo.find(type) != GetContext().clauseInfo.end();
+  const parser::OmpClause *FindClause(const OmpClause &type) {
+    auto it{GetContext().clauseInfo.find(type)};
+    if (it != GetContext().clauseInfo.end()) {
+      return it->second;
+    }
+    return nullptr;
   }
 
   bool CurrentDirectiveIsNested() { return ompContext_.size() > 0; };

--- a/test/semantics/omp-clause-validity01.f90
+++ b/test/semantics/omp-clause-validity01.f90
@@ -87,9 +87,9 @@
 
 ! TODO: all the internal errors
 
-  !ERROR: When SCHEDULE(AUTO) is specified, CHUNK_SIZE must not be specified
+  !ERROR: When SCHEDULE clause has AUTO specified, it must not have chunk size specified
   !ERROR: At most one SCHEDULE clause can appear on the DO directive
-  !ERROR: When SCHEDULE(RUNTIME) is specified, CHUNK_SIZE must not be specified
+  !ERROR: When SCHEDULE clause has RUNTIME specified, it must not have chunk size specified
   !$omp do schedule(auto, 2) schedule(runtime, 2)
   do i = 1, N
      a = 3.14
@@ -114,7 +114,7 @@
      a = 3.14
   enddo
 
-  !ERROR: A LINEAR clause or an ORDERED clause with a parameter can be specified on a loop directive but not both
+  !ERROR: A loop directive may not have both a LINEAR clause and an ORDERED clause with a parameter
   !ERROR: Internal: no symbol found for 'b'
   !ERROR: Internal: no symbol found for 'a'
   !$omp do ordered(1) private(b) linear(b) linear(a)

--- a/test/semantics/omp-clause-validity01.f90
+++ b/test/semantics/omp-clause-validity01.f90
@@ -17,10 +17,13 @@
 ! Check OpenMP clause validity for the following directives:
 !
 !    2.5 PARALLEL construct
+!    2.7.1 Loop construct
 !    ...
 
-! 2.5 parallel -> PARALLEL [parallel-clause[ [,] parallel-clause]...]
-!     parallel-clause -> if-clause |
+  integer :: b = 128
+  N = 1024
+
+! 2.5 parallel-clause -> if-clause |
 !                        num-threads-clause |
 !                        default-clause |
 !                        private-clause |
@@ -30,7 +33,6 @@
 !                        reduction-clause |
 !                        proc-bind-clause
 
-  N = 1024
   !$omp parallel
   do i = 1, N
      a = 3.14
@@ -73,4 +75,50 @@
      a = 3.14
   enddo
   !$omp end parallel
+
+! 2.7.1  do-clause -> private-clause |
+!                     firstprivate-clause |
+!                     lastprivate-clause |
+!                     linear-clause |
+!                     reduction-clause |
+!                     schedule-clause |
+!                     collapse-clause |
+!                     ordered-clause
+
+! TODO: all the internal errors
+
+  !ERROR: When SCHEDULE(AUTO) is specified, CHUNK_SIZE must not be specified
+  !ERROR: At most one SCHEDULE clause can appear on the DO directive
+  !ERROR: When SCHEDULE(RUNTIME) is specified, CHUNK_SIZE must not be specified
+  !$omp do schedule(auto, 2) schedule(runtime, 2)
+  do i = 1, N
+     a = 3.14
+  enddo
+
+  !ERROR: A modifier may not be specified in a LINEAR clause on the DO or SIMD directive
+  !ERROR: Internal: no symbol found for 'b'
+  !$omp do linear(ref(b))
+  do i = 1, N
+     a = 3.14
+  enddo
+
+  !ERROR: The NONMONOTONIC modifier can only be specified with SCHEDULE(DYNAMIC) or SCHEDULE(GUIDED)
+  !ERROR: The NONMONOTONIC modifier cannot be specified if an ORDERED clause is specified
+  !$omp do schedule(NONMONOTONIC:static) ordered
+  do i = 1, N
+     a = 3.14
+  enddo
+
+  !$omp do schedule(simd, monotonic:dynamic)
+  do i = 1, N
+     a = 3.14
+  enddo
+
+  !ERROR: A LINEAR clause or an ORDERED clause with a parameter can be specified on a loop directive but not both
+  !ERROR: Internal: no symbol found for 'b'
+  !ERROR: Internal: no symbol found for 'a'
+  !$omp do ordered(1) private(b) linear(b) linear(a)
+  do i = 1, N
+     a = 3.14
+  enddo
 end


### PR DESCRIPTION
Most restrictions in 2.7.1 Loop construct, nesting checks are still on TODO list.

`seenClauses` (`EnumSet`) is dropped. A `multimap clauseInfo` is added to save the encountering clause and its parser tree node pointer (`parser::OmpClause`) and to do the checks after walking through all the clauses.

Error msg examples:
```
omp-clause-validity01.f90:93:12: error: When SCHEDULE(AUTO) is specified, CHUNK_SIZE must not be specified
    !$omp do schedule(auto, 2) schedule(runtime, 2)
             ^^^^^^^^^^^^^^^^^
omp-clause-validity01.f90:93:30: error: At most one SCHEDULE clause can appear on the DO directive
    !$omp do schedule(auto, 2) schedule(runtime, 2)
                               ^^^^^^^^^^^^^^^^^^^^
omp-clause-validity01.f90:93:30: error: When SCHEDULE(RUNTIME) is specified, CHUNK_SIZE must not be specified
    !$omp do schedule(auto, 2) schedule(runtime, 2)
                               ^^^^^^^^^^^^^^^^^^^^
omp-clause-validity01.f90:100:12: error: A modifier may not be specified in a LINEAR clause on the DO or SIMD directive
    !$omp do linear(ref(b))
             ^^^^^^^^^^^^^^
omp-clause-validity01.f90:107:12: error: The NONMONOTONIC modifier can only be specified with SCHEDULE(DYNAMIC) or SCHEDULE(GUIDED)
    !$omp do schedule(NONMONOTONIC:static) ordered
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
omp-clause-validity01.f90:107:12: error: The NONMONOTONIC modifier cannot be specified if an ORDERED clause is specified
    !$omp do schedule(NONMONOTONIC:static) ordered
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
omp-clause-validity01.f90:120:12: error: A LINEAR clause or an ORDERED clause with a parameter can be specified on a loop directive but not both
    !$omp do ordered(1) private(b) linear(b) linear(a)
             ^^^^^^^^^^
```