### PR TITLE
Semantics for LOC() & %LOC()

### DIFF
--- a/documentation/Extensions.md
+++ b/documentation/Extensions.md
@@ -33,7 +33,8 @@ Extensions, deletions, and legacy features supported by default
 * Leading comma allowed before I/O item list
 * Empty parentheses allowed in `PROGRAM P()`
 * Missing parentheses allowed in `FUNCTION F`
-* Cray based `POINTER(p,x)`
+* Cray based `POINTER(p,x)` and `LOC()` intrinsic (with `%LOC()` as
+  an alias)
 * Arithmetic `IF`.  (Which branch should NaN take? Fall through?)
 * `ASSIGN` statement, assigned `GO TO`, and assigned format
 * `PAUSE` statement

--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -397,7 +397,6 @@ std::string DynamicType::AsFortran() const {
   if (derived_ != nullptr) {
     CHECK(category_ == TypeCategory::Derived);
     return DerivedTypeSpecAsFortran(*derived_);
-    // TODO pmk: how to indicate polymorphism?  can't use TYPE() vs CLASS()
   } else if (charLength_ != nullptr) {
     std::string result{"CHARACTER(KIND="s + std::to_string(kind_) + ",LEN="};
     if (charLength_->isAssumed()) {
@@ -410,8 +409,10 @@ std::string DynamicType::AsFortran() const {
       result += ss.str();
     }
     return result + ')';
-  } else if (isPolymorphic_) {
-    return "CLASS(*)";  // not valid, just for debugging
+  } else if (IsUnlimitedPolymorphic()) {
+    return "CLASS(*)";
+  } else if (IsAssumedType()) {
+    return "TYPE(*)";
   } else if (kind_ == 0) {
     return "(typeless intrinsic function argument)";
   } else {

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -612,6 +612,9 @@ struct TypeKindVisitor {
 template<typename A> const semantics::Symbol *GetLastSymbol(const A &) {
   return nullptr;
 }
+template<typename... A> const semantics::Symbol *GetLastSymbol(const std::variant<A...> &);
+template<typename A> const semantics::Symbol *GetLastSymbol(const std::optional<A> &);
+template<typename A> const semantics::Symbol *GetLastSymbol(const A *);
 inline const semantics::Symbol *GetLastSymbol(const Symbol &x) { return &x; }
 inline const semantics::Symbol *GetLastSymbol(const Component &x) {
   return &x.GetLastSymbol();
@@ -639,12 +642,22 @@ inline const semantics::Symbol *GetLastSymbol(const ProcedureRef &x) {
   return GetLastSymbol(x.proc());
 }
 template<typename T> const semantics::Symbol *GetLastSymbol(const Expr<T> &x) {
-  return std::visit([](const auto &y) { return GetLastSymbol(y); }, x.u);
+  return GetLastSymbol(x.u);
+}
+template<typename... A> const semantics::Symbol *GetLastSymbol(const std::variant<A...> &u) {
+  return std::visit([](const auto &x) { return GetLastSymbol(x); }, u);
 }
 template<typename A>
 const semantics::Symbol *GetLastSymbol(const std::optional<A> &x) {
   if (x.has_value()) {
     return GetLastSymbol(*x);
+  } else {
+    return nullptr;
+  }
+}
+template<typename A> const semantics::Symbol *GetLastSymbol(const A *p) {
+  if (p != nullptr) {
+    return GetLastSymbol(*p);
   } else {
     return nullptr;
   }

--- a/lib/evaluate/variable.cc
+++ b/lib/evaluate/variable.cc
@@ -319,8 +319,8 @@ template<typename T> Expr<SubscriptInteger> Designator<T>::LEN() const {
 }
 
 Expr<SubscriptInteger> ProcedureDesignator::LEN() const {
-  // TODO pmk: this needs more thought for assumed-length
-  // character functions, &c.
+  // TODO: this needs more thought for assumed-length
+  // character functions, intrinsics, &c.
   return std::visit(
       common::visitors{
           [](const Symbol *s) { return SymbolLEN(*s); },

--- a/lib/evaluate/variable.cc
+++ b/lib/evaluate/variable.cc
@@ -319,6 +319,8 @@ template<typename T> Expr<SubscriptInteger> Designator<T>::LEN() const {
 }
 
 Expr<SubscriptInteger> ProcedureDesignator::LEN() const {
+  // TODO pmk: this needs more thought for assumed-length
+  // character functions, &c.
   return std::visit(
       common::visitors{
           [](const Symbol *s) { return SymbolLEN(*s); },
@@ -326,7 +328,7 @@ Expr<SubscriptInteger> ProcedureDesignator::LEN() const {
             return c.value().LEN();
           },
           [](const auto &) {
-            // TODO intrinsics?
+            // TODO: intrinsics
             CRASH_NO_CASE;
             return AsExpr(Constant<SubscriptInteger>{0});
           },

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1652,8 +1652,9 @@ MaybeExpr ExpressionAnalyzer::Analyze(const parser::Expr::PercentLoc &x) {
   // Use the actual source for the name of the call for error reporting.
   if (MaybeExpr arg{Analyze(x.v.value())}) {
     parser::CharBlock at{GetContextualMessages().at()};
-    CHECK(at[0] == '%');
-    parser::CharBlock loc{at.begin() + 1, at.end()};
+    CHECK(at.size() >= 4);
+    parser::CharBlock loc{at.begin() + 1, 3};
+    CHECK(loc == "loc");
     return MakeFunctionRef(
         loc, ActualArguments{ActualArgument{std::move(*arg)}});
   }

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -308,9 +308,10 @@ private:
   MaybeExpr TopLevelChecks(DataRef &&);
   std::optional<Expr<SubscriptInteger>> GetSubstringBound(
       const std::optional<parser::ScalarIntExpr> &);
-
   std::optional<ProcedureDesignator> AnalyzeProcedureComponentRef(
       const parser::ProcComponentRef &);
+  std::optional<ActualArgument> AnalyzeActualArgument(const parser::Expr &);
+  std::optional<ActualArgument> AnalyzeActualArgument(const parser::Variable &);
 
   struct CalleeAndArguments {
     ProcedureDesignator procedureDesignator;

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -4272,10 +4272,16 @@ const DeclTypeSpec &ConstructVisitor::ToDeclTypeSpec(
   case common::TypeCategory::Logical:
     return context().MakeLogicalType(type.kind());
   case common::TypeCategory::Derived:
-    return currScope().MakeDerivedType(type.isPolymorphic()
-            ? DeclTypeSpec::ClassDerived
-            : DeclTypeSpec::TypeDerived,
-        DerivedTypeSpec{type.GetDerivedTypeSpec()});
+    if (type.IsAssumedType()) {
+      return currScope().MakeTypeStarType();
+    } else if (type.IsUnlimitedPolymorphic()) {
+      return currScope().MakeClassStarType();
+    } else {
+      return currScope().MakeDerivedType(type.IsPolymorphic()
+              ? DeclTypeSpec::ClassDerived
+              : DeclTypeSpec::TypeDerived,
+          DerivedTypeSpec{type.GetDerivedTypeSpec()});
+    }
   case common::TypeCategory::Character:
   default: CRASH_NO_CASE;
   }

--- a/module/iso_c_binding.f90
+++ b/module/iso_c_binding.f90
@@ -72,7 +72,7 @@ module iso_c_binding
     c_long_double_complex = c_long_double
 
   integer, parameter :: c_bool = 1 ! TODO: or default LOGICAL?
-  integer, parameter :: c_char = 1 ! TODO: Kanji mode
+  integer, parameter :: c_char = 1
 
  contains
 
@@ -96,9 +96,19 @@ module iso_c_binding
     ! TODO: Define, or write in C and change this to an interface
   end subroutine c_f_pointer
 
+  function c_loc(x)
+    type(c_ptr) :: c_loc
+    type(*), intent(in) :: x
+    c_loc = c_ptr(loc(x))
+  end function c_loc
+
+  function c_funloc(x)
+    type(c_funptr) :: c_funloc
+    external :: x
+    c_funloc = c_funptr(loc(x))
+  end function c_funloc
+
   ! TODO c_f_procpointer
-  ! TODO c_funcloc
-  ! TODO c_loc
   ! TODO c_sizeof
 
 end module iso_c_binding


### PR DESCRIPTION
Some regression tests that were mostly fixed last week need the non-standard `LOC` intrinsic function to compile completely.  While here, also implement the legacy variant spelling `%LOC` that is already supported in the parser and parse tree.