### PR TITLE
2.7.1 DO: Checks about clause arguments that allow Int Expr

### DIFF
--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -162,14 +162,15 @@ void OmpStructureChecker::Leave(const parser::OmpClauseList &) {
           const auto &collapseClause{
               std::get<parser::OmpClause::Collapse>(clause2->u)};
           // ordered and collapse both have parameters
-          const auto orderedValue{GetIntValue(orderedClause.v)};
-          const auto collapseValue{GetIntValue(collapseClause.v)};
-          if (orderedValue && collapseValue && orderedValue.value() > 0 &&
-              collapseValue.value() > 0 &&
-              orderedValue.value() < collapseValue.value()) {
-            context_.Say(clause->source,
-                "The parameter of the ORDERED clause must be greater than or "
-                "equal to the parameter of the COLLAPSE clause"_err_en_US);
+          if (const auto orderedValue{GetIntValue(orderedClause.v)}) {
+            if (const auto collapseValue{GetIntValue(collapseClause.v)}) {
+              if (*orderedValue > 0 && *orderedValue < *collapseValue) {
+                context_.Say(clause->source,
+                    "The parameter of the ORDERED clause must be greater than "
+                    "or "
+                    "equal to the parameter of the COLLAPSE clause"_err_en_US);
+              }
+            }
           }
         }
       }
@@ -205,11 +206,12 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Untied &) {
 void OmpStructureChecker::Enter(const parser::OmpClause::Collapse &x) {
   CheckAllowed(OmpClause::COLLAPSE);
   // collapse clause must have a parameter
-  const auto v{GetIntValue(x.v)};
-  if (v && v.value() <= 0) {
-    context_.Say(GetContext().clauseSource,
-        "The parameter of the COLLAPSE clause must be "
-        "a constant positive integer expression"_err_en_US);
+  if (const auto v{GetIntValue(x.v)}) {
+    if (*v <= 0) {
+      context_.Say(GetContext().clauseSource,
+          "The parameter of the COLLAPSE clause must be "
+          "a constant positive integer expression"_err_en_US);
+    }
   }
 }
 
@@ -248,11 +250,12 @@ void OmpStructureChecker::Enter(const parser::OmpClause::NumTeams &) {
 }
 void OmpStructureChecker::Enter(const parser::OmpClause::NumThreads &x) {
   CheckAllowed(OmpClause::NUM_THREADS);
-  const auto v{GetIntValue(x.v)};
-  if (v && v.value() <= 0) {
-    context_.Say(GetContext().clauseSource,
-        "The parameter of the NUM_THREADS clause must be "
-        "a positive integer expression"_err_en_US);
+  if (const auto v{GetIntValue(x.v)}) {
+    if (*v <= 0) {
+      context_.Say(GetContext().clauseSource,
+          "The parameter of the NUM_THREADS clause must be "
+          "a positive integer expression"_err_en_US);
+    }
   }
   // if parameter is variable, defer to Expression Analysis
 }
@@ -261,11 +264,12 @@ void OmpStructureChecker::Enter(const parser::OmpClause::Ordered &x) {
   CheckAllowed(OmpClause::ORDERED);
   // the parameter of ordered clause is optional
   if (const auto &expr{x.v}) {
-    const auto v{GetIntValue(expr)};
-    if (v && v.value() <= 0) {
-      context_.Say(GetContext().clauseSource,
-          "The parameter of the ORDERED clause must be "
-          "a constant positive integer expression"_err_en_US);
+    if (const auto v{GetIntValue(expr)}) {
+      if (*v <= 0) {
+        context_.Say(GetContext().clauseSource,
+            "The parameter of the ORDERED clause must be "
+            "a constant positive integer expression"_err_en_US);
+      }
     }
   }
 }

--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -166,9 +166,9 @@ void OmpStructureChecker::Leave(const parser::OmpClauseList &) {
             if (const auto collapseValue{GetIntValue(collapseClause.v)}) {
               if (*orderedValue > 0 && *orderedValue < *collapseValue) {
                 context_.Say(clause->source,
-                    "The parameter of the ORDERED clause must be greater than "
-                    "or "
-                    "equal to the parameter of the COLLAPSE clause"_err_en_US);
+                    "The parameter of the ORDERED clause must be "
+                    "greater than or equal to "
+                    "the parameter of the COLLAPSE clause"_err_en_US);
               }
             }
           }

--- a/lib/semantics/check-omp-structure.h
+++ b/lib/semantics/check-omp-structure.h
@@ -149,25 +149,6 @@ private:
     return nullptr;
   }
 
-  template<typename T> std::optional<std::int64_t> GetIntValue(const T &x) {
-    const auto *expr{GetExpr(x)};
-    if (expr && evaluate::ToInt64(*expr).has_value()) {
-      return evaluate::ToInt64(*expr).value();
-    }
-    return std::nullopt;
-  }
-  template<typename T> std::int64_t GetPosIntValue(const T &x) {
-    const auto &v{GetIntValue(x)};
-    return v && v > 0 ? v.value() : 0;
-  }
-  template<typename T> std::int64_t GetConstPosIntValue(const T &x) {
-    const auto *expr{GetExpr(x)};
-    if (expr && IsConstantExpr(*expr)) {
-      return GetPosIntValue(x);
-    }
-    return 0;
-  }
-
   bool CurrentDirectiveIsNested() { return ompContext_.size() > 0; };
   bool HasInvalidWorksharingNesting(
       const parser::CharBlock &, const OmpDirectiveSet &);

--- a/lib/semantics/check-omp-structure.h
+++ b/lib/semantics/check-omp-structure.h
@@ -21,7 +21,9 @@
 #define FORTRAN_SEMANTICS_CHECK_OMP_STRUCTURE_H_
 
 #include "semantics.h"
+#include "tools.h"
 #include "../common/enum-set.h"
+#include "../evaluate/fold.h"
 #include "../parser/parse-tree.h"
 
 namespace Fortran::semantics {
@@ -145,6 +147,25 @@ private:
       return it->second;
     }
     return nullptr;
+  }
+
+  template<typename T> std::optional<std::int64_t> GetIntValue(const T &x) {
+    const auto *expr{GetExpr(x)};
+    if (expr && evaluate::ToInt64(*expr).has_value()) {
+      return evaluate::ToInt64(*expr).value();
+    }
+    return std::nullopt;
+  }
+  template<typename T> std::int64_t GetPosIntValue(const T &x) {
+    const auto &v{GetIntValue(x)};
+    return v && v > 0 ? v.value() : 0;
+  }
+  template<typename T> std::int64_t GetConstPosIntValue(const T &x) {
+    const auto *expr{GetExpr(x)};
+    if (expr && IsConstantExpr(*expr)) {
+      return GetPosIntValue(x);
+    }
+    return 0;
   }
 
   bool CurrentDirectiveIsNested() { return ompContext_.size() > 0; };

--- a/lib/semantics/check-omp-structure.h
+++ b/lib/semantics/check-omp-structure.h
@@ -21,9 +21,7 @@
 #define FORTRAN_SEMANTICS_CHECK_OMP_STRUCTURE_H_
 
 #include "semantics.h"
-#include "tools.h"
 #include "../common/enum-set.h"
-#include "../evaluate/fold.h"
 #include "../parser/parse-tree.h"
 
 namespace Fortran::semantics {

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -168,10 +168,5 @@ template<typename T> std::optional<std::int64_t> GetIntValue(const T &x) {
   }
 }
 
-template<typename T> std::optional<std::int64_t> GetPosIntValue(const T &x) {
-  const auto v{GetIntValue(x)};
-  return v && v.value() > 0 ? v : std::nullopt;
-}
-
 }
 #endif  // FORTRAN_SEMANTICS_TOOLS_H_

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -160,5 +160,18 @@ template<typename T> const SomeExpr *GetExpr(const T &x) {
   return GetExprHelper{}.Get(x);
 }
 
+template<typename T> std::optional<std::int64_t> GetIntValue(const T &x) {
+  if (const auto *expr{GetExpr(x)}) {
+    return evaluate::ToInt64(*expr);
+  } else {
+    return std::nullopt;
+  }
+}
+
+template<typename T> std::optional<std::int64_t> GetPosIntValue(const T &x) {
+  const auto v{GetIntValue(x)};
+  return v && v.value() > 0 ? v : std::nullopt;
+}
+
 }
 #endif  // FORTRAN_SEMANTICS_TOOLS_H_

--- a/test/semantics/omp-clause-validity01.f90
+++ b/test/semantics/omp-clause-validity01.f90
@@ -134,10 +134,11 @@
      a = 3.14
   enddo
 
+  !ERROR: The parameter of the ORDERED clause must be a constant positive integer expression
   !ERROR: A loop directive may not have both a LINEAR clause and an ORDERED clause with a parameter
   !ERROR: Internal: no symbol found for 'b'
   !ERROR: Internal: no symbol found for 'a'
-  !$omp do ordered(1) private(b) linear(b) linear(a)
+  !$omp do ordered(1-1) private(b) linear(b) linear(a)
   do i = 1, N
      a = 3.14
   enddo

--- a/test/semantics/omp-clause-validity01.f90
+++ b/test/semantics/omp-clause-validity01.f90
@@ -21,6 +21,7 @@
 !    ...
 
   integer :: b = 128
+  integer, parameter :: num = 16
   N = 1024
 
 ! 2.5 parallel-clause -> if-clause |
@@ -76,6 +77,25 @@
   enddo
   !$omp end parallel
 
+  !ERROR: The parameter of the NUM_THREADS clause must be a positive integer expression
+  !$omp parallel num_threads(1-4)
+  do i = 1, N
+     a = 3.14
+  enddo
+  !$omp end parallel
+
+  !$omp parallel num_threads(num-10)
+  do i = 1, N
+     a = 3.14
+  enddo
+  !$omp end parallel
+
+  !$omp parallel num_threads(b+1)
+  do i = 1, N
+     a = 3.14
+  enddo
+  !$omp end parallel
+
 ! 2.7.1  do-clause -> private-clause |
 !                     firstprivate-clause |
 !                     lastprivate-clause |
@@ -120,5 +140,15 @@
   !$omp do ordered(1) private(b) linear(b) linear(a)
   do i = 1, N
      a = 3.14
+  enddo
+
+  !ERROR: The parameter of the ORDERED clause must be greater than or equal to the parameter of the COLLAPSE clause
+  !$omp do collapse(num) ordered(1+2+3+4)
+  do i = 1, N
+     do j = 1, N
+        do k = 1, N
+           a = 3.14
+        enddo
+     enddo
   enddo
 end


### PR DESCRIPTION
For the clauses allow constant integer expression as an argument, we can check the validity of the evaluated value in the structural checker. If the argument allows integer variables, the analysis will be deferred.

Example:
```
omp-clause-validity01.f90:81:18: error: The parameter of the NUM_THREADS clause must be a positive integer expression
    !$omp parallel num_threads(1-4)
                   ^^^^^^^^^^^^^^^^
omp-clause-validity01.f90:146:26: error: The parameter of the ORDERED clause must be greater than or equal to the parameter of the COLLAPSE clause
    !$omp do collapse(num) ordered(1+2+3+4)
                           ^^^^^^^^^^^^^^^^
```