### PR TITLE
Enforce constraint C1128 for DO CONCURRENT locality-spec's

### DIFF
--- a/lib/semantics/check-allocate.cc
+++ b/lib/semantics/check-allocate.cc
@@ -532,13 +532,6 @@ bool AllocationCheckerHelper::RunChecks(SemanticsContext &context) {
   return RunCoarrayRelatedChecks(context);
 }
 
-static bool IsCoarray(const Symbol &symbol) {
-  if (const auto *objectDetails{symbol.detailsIf<ObjectEntityDetails>()}) {
-    return objectDetails->IsCoarray();
-  }
-  return false;
-}
-
 bool AllocationCheckerHelper::RunCoarrayRelatedChecks(
     SemanticsContext &context) const {
   if (symbol_ == nullptr) {

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -3753,10 +3753,9 @@ bool DeclarationVisitor::PassesLocalityChecks(
         name, symbol, "Coarray '%s' not allowed in a locality-spec"_err_en_US);
     return false;
   }
-  const DeclTypeSpec *type{symbol.GetType()};
-  if (type) {
+  if (const DeclTypeSpec * type{symbol.GetType()}) {
     if (type->IsPolymorphic() && symbol.IsDummy() &&
-        (!IsPointer(symbol))) {  // C1128
+        !IsPointer(symbol)) {  // C1128
       SayWithDecl(name, symbol,
           "Nonpointer polymorphic argument '%s' not allowed in a "
           "locality-spec"_err_en_US);

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -386,12 +386,9 @@ const Symbol *FindUltimateComponent(const DerivedTypeSpec &derivedTypeSpec,
 }
 
 bool IsFinalizable(const Symbol &symbol) {
-  const DeclTypeSpec *type{symbol.GetType()};
-  if (type) {
-    const DerivedTypeSpec *derived{type->AsDerived()};
-    if (derived) {
-      const Scope *scope{derived->scope()};
-      if (scope) {
+  if (const DeclTypeSpec * type{symbol.GetType()}) {
+    if (const DerivedTypeSpec * derived{type->AsDerived()}) {
+      if (const Scope * scope{derived->scope()}) {
         for (auto &pair : *scope) {
           Symbol &symbol{*pair.second};
           if (symbol.has<FinalProcDetails>()) {

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -402,8 +402,7 @@ bool IsFinalizable(const Symbol &symbol) {
 }
 
 bool IsCoarray(const Symbol &symbol) {
-  const auto *details{symbol.detailsIf<ObjectEntityDetails>()};
-  return details && details->IsCoarray();
+  return symbol.Corank() > 0;
 }
 
 bool IsAssumedSizeArray(const Symbol &symbol) {

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -319,8 +319,6 @@ bool IsTeamType(const DerivedTypeSpec *derived) {
   return IsDerivedTypeFromModule(derived, "iso_fortran_env", "team_type");
 }
 
-bool IsCoarray(const Symbol &symbol) { return symbol.Corank() > 0; }
-
 const Symbol *HasCoarrayUltimateComponent(
     const DerivedTypeSpec &derivedTypeSpec) {
   return FindUltimateComponent(derivedTypeSpec, IsCoarray);
@@ -385,6 +383,35 @@ const Symbol *FindUltimateComponent(const DerivedTypeSpec &derivedTypeSpec,
     }
   }
   return nullptr;
+}
+
+bool IsFinalizable(const Symbol &symbol) {
+  const DeclTypeSpec *type{symbol.GetType()};
+  if (type) {
+    const DerivedTypeSpec *derived{type->AsDerived()};
+    if (derived) {
+      const Scope *scope{derived->scope()};
+      if (scope) {
+        for (auto &pair : *scope) {
+          Symbol &symbol{*pair.second};
+          if (symbol.has<FinalProcDetails>()) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
+bool IsCoarray(const Symbol &symbol) {
+  const auto *details{symbol.detailsIf<ObjectEntityDetails>()};
+  return details && details->IsCoarray();
+}
+
+bool IsAssumedSizeArray(const Symbol &symbol) {
+  const auto *details{symbol.detailsIf<ObjectEntityDetails>()};
+  return details && details->IsAssumedSize();
 }
 
 }

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -93,6 +93,15 @@ inline bool IsAllocatableOrPointer(const Symbol &symbol) {
 inline bool IsParameter(const Symbol &symbol) {
   return symbol.attrs().test(Attr::PARAMETER);
 }
+inline bool IsOptional(const Symbol &symbol) {
+  return symbol.attrs().test(Attr::OPTIONAL);
+}
+inline bool IsIntentIn(const Symbol &symbol) {
+  return symbol.attrs().test(Attr::INTENT_IN);
+}
+bool IsFinalizable(const Symbol &symbol);
+bool IsCoarray(const Symbol &symbol);
+bool IsAssumedSizeArray(const Symbol &symbol);
 
 // Determines whether an object might be visible outside a
 // PURE function (C1594); returns a non-null Symbol pointer for

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -91,6 +91,7 @@ set(ERROR_TESTS
   resolve52.f90
   resolve53.f90
   resolve54.f90
+  resolve55.f90
   stop01.f90
   structconst01.f90
   structconst02.f90

--- a/test/semantics/resolve35.f90
+++ b/test/semantics/resolve35.f90
@@ -120,23 +120,23 @@ subroutine s10
   real, parameter :: bad2 = 1.0
   x = cos(0.)
   do concurrent(i=1:2) &
-    !ERROR: Locality attribute not allowed on 'bad1'
+    !ERROR: The name 'bad1' must be a variable to appear in a locality-spec
     local(bad1) &
-    !ERROR: Locality attribute not allowed on 'bad2'
+    !ERROR: The name 'bad2' must be a variable to appear in a locality-spec
     local(bad2) &
-    !ERROR: Locality attribute not allowed on 'bad3'
+    !ERROR: The name 'bad3' must be a variable to appear in a locality-spec
     local(bad3) &
-    !ERROR: Locality attribute not allowed on 'cos'
+    !ERROR: The name 'cos' must be a variable to appear in a locality-spec
     local(cos)
   end do
   do concurrent(i=1:2) &
-    !ERROR: Locality attribute not allowed on 'bad1'
+    !ERROR: The name 'bad1' must be a variable to appear in a locality-spec
     shared(bad1) &
-    !ERROR: Locality attribute not allowed on 'bad2'
+    !ERROR: The name 'bad2' must be a variable to appear in a locality-spec
     shared(bad2) &
-    !ERROR: Locality attribute not allowed on 'bad3'
+    !ERROR: The name 'bad3' must be a variable to appear in a locality-spec
     shared(bad3) &
-    !ERROR: Locality attribute not allowed on 'cos'
+    !ERROR: The name 'cos' must be a variable to appear in a locality-spec
     shared(cos)
   end do
 contains

--- a/test/semantics/resolve55.f90
+++ b/test/semantics/resolve55.f90
@@ -1,0 +1,107 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Tests for C1128:
+! A variable-name that appears in a LOCAL or LOCAL_INIT locality-spec shall not
+! have the ALLOCATABLE; INTENT (IN); or OPTIONAL attribute; shall not be of
+! finalizable type; shall not be a nonpointer polymorphic dummy argument; and
+! shall not be a coarray or an assumed-size array.
+
+subroutine s1()
+! Cannot have ALLOCATABLE variable in a locality spec
+  integer, allocatable :: k
+!ERROR: ALLOCATABLE variable 'k' not allowed in a locality-spec
+  do concurrent(i=1:5) local(k)
+  end do
+end subroutine s1
+
+subroutine s2(arg)
+! Cannot have a dummy OPTIONAL in a locality spec
+  integer, optional :: arg
+!ERROR: OPTIONAL argument 'arg' not allowed in a locality-spec
+  do concurrent(i=1:5) local(arg)
+  end do
+end subroutine s2
+
+subroutine s3(arg)
+! This is OK
+  real :: arg
+  do concurrent(i=1:5) local(arg)
+  end do
+end subroutine s3
+
+subroutine s4(arg)
+! Cannot have a dummy INTENT(IN) in a locality spec
+  real, intent(in) :: arg
+!ERROR: INTENT IN argument 'arg' not allowed in a locality-spec
+  do concurrent(i=1:5) local(arg)
+  end do
+end subroutine s4
+
+subroutine s5()
+! Cannot have a variable of a finalizable type in a locality spec
+  type t1
+    integer :: i
+  contains
+    final :: f
+  end type t1
+
+  type(t1) :: var
+
+!ERROR: Finalizable variable 'var' not allowed in a locality-spec
+  do concurrent(i=1:5) local(var)
+  end do
+
+contains
+  subroutine f(x)
+    type(t1) :: x
+  end subroutine f
+end subroutine s5
+
+subroutine s6
+! Cannot have a nonpointer polymorphic dummy argument in a locality spec
+  type :: t
+    integer :: field
+  end type t
+contains
+  subroutine s(x, y)
+    class(t), pointer :: x
+    class(t) :: y
+
+! This is allowed
+    do concurrent(i=1:5) local(x)
+    end do
+
+! This is not allowed
+!ERROR: Nonpointer polymorphic argument 'y' not allowed in a locality-spec
+    do concurrent(i=1:5) local(y)
+    end do
+  end subroutine s
+end subroutine s6
+
+subroutine s7()
+! Cannot have a coarray
+  integer, codimension[*] :: coarray_var
+!ERROR: Coarray 'coarray_var' not allowed in a locality-spec
+  do concurrent(i=1:5) local(coarray_var)
+  end do
+end subroutine s7
+
+subroutine s8(arg)
+! Cannot have an assumed size array
+  integer, dimension(*) :: arg
+!ERROR: Assumed size array 'arg' not allowed in a locality-spec
+  do concurrent(i=1:5) local(arg)
+  end do
+end subroutine s8


### PR DESCRIPTION
These changes implement most of the requirements for C1128, which says: "A
variable-name that appears in a LOCAL or LOCAL_INIT locality-spec shall not
have the ALLOCATABLE; INTENT (IN); or OPTIONAL attribute; shall not be of
finalizable type; shall not be a nonpointer polymorphic dummy argument; and
shall not be a coarray or an assumed-size array.  A variable-name that is not
permitted to appear in a variable definition context shall not appear in a
LOCAL or LOCAL_INIT locality-spec."

The changes do not implement the checking required to determine whether a
variable can appear in a "variable definition context".

Here's a summary of the changes:
 - I created the function 'PassesLocalityChecks()' to enforce C1128 along with
   C1124, C1125, and C1126.
 - I cleaned up the code to check if a type or symbol is a coarray.
 - I added functions to tools.[h,cc] to test if a symbol is OPTIONAL, INTENT
   IN, finalizable, a coarray, or an assumed size array.  Should these be
   member functions of the type "Symbol"?
 - Since I changed one of the locality related error messages, I needed to
   change the test resolve35.f90.
 - I added the test resolve55.f90 to test all of the checks implemented in this
   update.