### PR TITLE
A minimal PRINT Enter function requires a minimal PRINT Leave function.

### DIFF
--- a/lib/semantics/check-io.cc
+++ b/lib/semantics/check-io.cc
@@ -497,6 +497,10 @@ void IoChecker::Leave(const parser::OpenStmt &stmt) {
   stmt_ = IoStmtKind::None;
 }
 
+void IoChecker::Leave(const parser::PrintStmt &stmt) {
+  stmt_ = IoStmtKind::None;
+}
+
 void IoChecker::Leave(const parser::ReadStmt &stmt) {
   if (!flags_.test(Flag::IoControlList)) {
     return;

--- a/lib/semantics/check-io.h
+++ b/lib/semantics/check-io.h
@@ -78,6 +78,7 @@ public:
   void Leave(const parser::FlushStmt &);
   void Leave(const parser::InquireStmt &);
   void Leave(const parser::OpenStmt &);
+  void Leave(const parser::PrintStmt &);
   void Leave(const parser::ReadStmt &);
   void Leave(const parser::RewindStmt &);
   void Leave(const parser::WaitStmt &);

--- a/test/semantics/io04.f90
+++ b/test/semantics/io04.f90
@@ -21,6 +21,7 @@
   integer*8 stat8
   integer :: iunit = 10
   integer, parameter :: junit = 11
+  integer, pointer :: a(:)
 
   namelist /nnn/ nn1, nn2
 
@@ -57,6 +58,9 @@
 
   print*
   print*, 'Ok'
+
+  allocate(a(2), stat=stat2)
+  allocate(a(8), stat=stat8)
 
   !ERROR: Duplicate UNIT specifier
   write(internal_file, unit=*)


### PR DESCRIPTION
Fixes #541