### PR TITLE
RESHAPE without shared runtime/front-end descriptor API

### DIFF
--- a/lib/common/Fortran.h
+++ b/lib/common/Fortran.h
@@ -53,5 +53,7 @@ ENUM_CLASS(IoSpecKind, Access, Action, Advance, Asynchronous, Blank, Decimal,
     Convert,  // nonstandard
     Dispose,  // nonstandard
 )
+
+static constexpr int maxRank{15};
 }
 #endif  // FORTRAN_COMMON_FORTRAN_H_

--- a/lib/common/Fortran.h
+++ b/lib/common/Fortran.h
@@ -54,6 +54,7 @@ ENUM_CLASS(IoSpecKind, Access, Action, Advance, Asynchronous, Blank, Decimal,
     Dispose,  // nonstandard
 )
 
+// Fortran arrays may have up to 15 dimensions (See Fortran 2018 section 5.4.6).
 static constexpr int maxRank{15};
 }
 #endif  // FORTRAN_COMMON_FORTRAN_H_

--- a/lib/evaluate/constant.cc
+++ b/lib/evaluate/constant.cc
@@ -50,18 +50,13 @@ bool IncrementSubscripts(ConstantSubscripts &indices,
   return false;  // all done
 }
 
-std::optional<std::vector<int>> IsValidDimensionOrder(
-    int rank, const std::optional<std::vector<int>> &order) {
+std::optional<std::vector<int>> ValidateDimensionOrder(
+    int rank, const std::vector<int> &order) {
   std::vector<int> dimOrder(rank);
-  if (!order.has_value()) {
-    for (int j{0}; j < rank; ++j) {
-      dimOrder[j] = j;
-    }
-    return dimOrder;
-  } else if (static_cast<int>(order.value().size()) == rank) {
+  if (static_cast<int>(order.size()) == rank) {
     std::bitset<common::maxRank> seenDimensions;
     for (int j{0}; j < rank; ++j) {
-      int dim{order.value()[j]};
+      int dim{order[j]};
       if (dim < 1 || dim > rank || seenDimensions.test(dim - 1)) {
         return std::nullopt;
       }

--- a/lib/evaluate/constant.cc
+++ b/lib/evaluate/constant.cc
@@ -33,6 +33,7 @@ bool IncrementSubscripts(ConstantSubscripts &indices,
     const ConstantSubscripts &shape, const ConstantSubscripts &lbound) {
   int rank{GetRank(shape)};
   CHECK(GetRank(indices) == rank);
+  CHECK(GetRank(lbound) == rank);
   for (int j{0}; j < rank; ++j) {
     auto lb{lbound[j]};
     CHECK(indices[j] >= lb);
@@ -44,6 +45,64 @@ bool IncrementSubscripts(ConstantSubscripts &indices,
     }
   }
   return false;  // all done
+}
+
+bool IncrementSubscripts(ConstantSubscripts &indices,
+    const ConstantSubscripts &shape, const ConstantSubscripts &lbound,
+    const std::vector<int> &dimOrder) {
+  int rank{GetRank(shape)};
+  CHECK(GetRank(indices) == rank);
+  CHECK(GetRank(lbound) == rank);
+  CHECK(static_cast<int>(dimOrder.size()) == rank);
+  for (int j{0}; j < rank; ++j) {
+    auto lb{lbound[j]};
+    ConstantSubscript k{dimOrder[j]};
+    CHECK(indices[k] >= lb);
+    if (++indices[k] < lb + shape[k]) {
+      return true;
+    } else {
+      CHECK(indices[k] == shape[k] + lb);
+      indices[k] = lb;
+    }
+  }
+  return false;  // all done
+}
+
+std::optional<std::vector<int>> IsValidDimensionOrder(
+    int rank, const std::optional<std::vector<int>> &order) {
+  if (!order.has_value()) {
+    std::vector<int> result;
+    for (int j{0}; j < rank; ++j) {
+      result.push_back(j);
+    }
+    return {std::move(result)};
+  }
+  if (static_cast<int>(order.value().size()) == rank) {
+    std::vector<int> dimOrder(rank);
+    std::bitset<common::maxRank> seenDimensions;
+    for (int j{0}; j < rank; ++j) {
+      int dim{order.value()[j]};
+      if (dim < 1 || dim > rank || seenDimensions.test(dim - 1)) {
+        return std::nullopt;
+      }
+      dimOrder[dim - 1] = j;
+      seenDimensions.set(dim - 1);
+    }
+    return {std::move(dimOrder)};
+  }
+  return std::nullopt;
+}
+
+bool IsValidShape(const ConstantSubscripts &shape) {
+  if (shape.size() > common::maxRank) {
+    return false;
+  }
+  for (ConstantSubscript extent : shape) {
+    if (extent < 0) {
+      return false;
+    }
+  }
+  return true;
 }
 
 template<typename RESULT, typename ELEMENT>
@@ -104,6 +163,27 @@ auto ConstantBase<RESULT, ELEMENT>::Reshape(
   return elements;
 }
 
+template<typename RESULT, typename ELEMENT>
+std::size_t ConstantBase<RESULT, ELEMENT>::CopyFrom(
+    const ConstantBase<RESULT, ELEMENT> &source, std::size_t count,
+    ConstantSubscripts &resultSubscripts, const std::vector<int> *dimOrder) {
+  std::size_t copied{0};
+  ConstantSubscripts sourceSubscripts{source.lbounds_};
+  while (copied < count) {
+    values_.at(SubscriptsToOffset(resultSubscripts, shape_, lbounds_)) =
+        source.values_.at(SubscriptsToOffset(
+            sourceSubscripts, source.shape_, source.lbounds_));
+    copied++;
+    IncrementSubscripts(sourceSubscripts, source.shape_, source.lbounds_);
+    if (dimOrder) {
+      IncrementSubscripts(resultSubscripts, shape_, lbounds_, *dimOrder);
+    } else {
+      IncrementSubscripts(resultSubscripts, shape_, lbounds_);
+    }
+  }
+  return copied;
+}
+
 template<typename T>
 auto Constant<T>::At(const ConstantSubscripts &index) const -> Element {
   return Base::values_.at(
@@ -113,6 +193,12 @@ auto Constant<T>::At(const ConstantSubscripts &index) const -> Element {
 template<typename T>
 auto Constant<T>::Reshape(ConstantSubscripts &&dims) const -> Constant {
   return {Base::Reshape(dims), std::move(dims)};
+}
+
+template<typename T>
+std::size_t Constant<T>::CopyFrom(const Constant<T> &source, std::size_t count,
+    ConstantSubscripts &resultSubscripts, const std::vector<int> *dimOrder) {
+  return Base::CopyFrom(source, count, resultSubscripts, dimOrder);
 }
 
 // Constant<Type<TypeCategory::Character, KIND> specializations
@@ -200,6 +286,33 @@ Constant<Type<TypeCategory::Character, KIND>>::SHAPE() const {
   return AsConstantShape(shape_);
 }
 
+template<int KIND>
+std::size_t Constant<Type<TypeCategory::Character, KIND>>::CopyFrom(
+    const Constant<Type<TypeCategory::Character, KIND>> &source,
+    std::size_t count, ConstantSubscripts &resultSubscripts,
+    const std::vector<int> *dimOrder) {
+  CHECK(length_ == source.length_);
+  std::size_t copied{0};
+  std::size_t elementBytes{length_ * sizeof(decltype(values_[0]))};
+  ConstantSubscripts sourceSubscripts{source.lbounds_};
+  while (copied < count) {
+    auto *dest{&values_.at(
+        SubscriptsToOffset(resultSubscripts, shape_, lbounds_) * length_)};
+    const auto *src{&source.values_.at(
+        SubscriptsToOffset(sourceSubscripts, source.shape_, source.lbounds_) *
+        length_)};
+    std::memcpy(dest, src, elementBytes);
+    copied++;
+    IncrementSubscripts(sourceSubscripts, source.shape_, source.lbounds_);
+    if (dimOrder) {
+      IncrementSubscripts(resultSubscripts, shape_, lbounds_, *dimOrder);
+    } else {
+      IncrementSubscripts(resultSubscripts, shape_, lbounds_);
+    }
+  }
+  return copied;
+}
+
 // Constant<SomeDerived> specialization
 Constant<SomeDerived>::Constant(const StructureConstructor &x)
   : Base{x.values(), Result{x.derivedTypeSpec()}} {}
@@ -242,6 +355,12 @@ StructureConstructor Constant<SomeDerived>::At(
 auto Constant<SomeDerived>::Reshape(ConstantSubscripts &&dims) const
     -> Constant {
   return {result().derivedTypeSpec(), Base::Reshape(dims), std::move(dims)};
+}
+
+std::size_t Constant<SomeDerived>::CopyFrom(const Constant<SomeDerived> &source,
+    std::size_t count, ConstantSubscripts &resultSubscripts,
+    const std::vector<int> *dimOrder) {
+  return Base::CopyFrom(source, count, resultSubscripts, dimOrder);
 }
 
 INSTANTIATE_CONSTANT_TEMPLATES

--- a/lib/evaluate/constant.h
+++ b/lib/evaluate/constant.h
@@ -43,12 +43,14 @@ inline int GetRank(const ConstantSubscripts &s) {
 
 std::size_t TotalElementCount(const ConstantSubscripts &);
 
-// Increments a vector of subscripts in Fortran array order (first dimension
-// varying most quickly).  Returns false when last element was visited.
+// If no optional dimension order argument is passed, increments a vector of
+// subscripts in Fortran array order (first dimension varying most quickly).
+// Otherwise, increments the vector of subscripts according to the given
+// dimension order (dimension dimOrder[0] varying most quickly. Dimensions
+// indexing is zero based here.) Returns false when last element was visited.
 bool IncrementSubscripts(ConstantSubscripts &, const ConstantSubscripts &shape,
-    const ConstantSubscripts &lbound);
-bool IncrementSubscripts(ConstantSubscripts &, const ConstantSubscripts &shape,
-    const ConstantSubscripts &lbound, const std::vector<int> &dimOrder);
+    const ConstantSubscripts &lbound,
+    const std::vector<int> *dimOrder = nullptr);
 
 // Validate dimension re-ordering like ORDER in RESHAPE.
 // On success, return a vector that can be used as dimOrder in

--- a/lib/evaluate/constant.h
+++ b/lib/evaluate/constant.h
@@ -55,9 +55,8 @@ bool IncrementSubscripts(ConstantSubscripts &, const ConstantSubscripts &shape,
 // Validate dimension re-ordering like ORDER in RESHAPE.
 // On success, return a vector that can be used as dimOrder in
 // IncrementSubscripts.
-// If order argument is nullopt, returns Fortran dimension order.
-std::optional<std::vector<int>> IsValidDimensionOrder(
-    int rank, const std::optional<std::vector<int>> &order);
+std::optional<std::vector<int>> ValidateDimensionOrder(
+    int rank, const std::vector<int> &order);
 
 bool IsValidShape(const ConstantSubscripts &);
 

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -116,16 +116,16 @@ Triplet FoldOperation(FoldingContext &context, Triplet &&triplet) {
 }
 
 Subscript FoldOperation(FoldingContext &context, Subscript &&subscript) {
-  return std::visit(common::visitors{
-                        [&](IndirectSubscriptIntegerExpr &&expr) {
-                          expr.value() = Fold(context, std::move(expr.value()));
-                          return Subscript(std::move(expr));
-                        },
-                        [&](Triplet &&triplet) {
-                          return Subscript(
-                              FoldOperation(context, std::move(triplet)));
-                        },
-                    },
+  return std::visit(
+      common::visitors{
+          [&](IndirectSubscriptIntegerExpr &&expr) {
+            expr.value() = Fold(context, std::move(expr.value()));
+            return Subscript(std::move(expr));
+          },
+          [&](Triplet &&triplet) {
+            return Subscript(FoldOperation(context, std::move(triplet)));
+          },
+      },
       std::move(subscript.u));
 }
 
@@ -159,12 +159,13 @@ CoarrayRef FoldOperation(FoldingContext &context, CoarrayRef &&coarrayRef) {
 }
 
 DataRef FoldOperation(FoldingContext &context, DataRef &&dataRef) {
-  return std::visit(common::visitors{
-                        [&](const Symbol *symbol) { return DataRef{*symbol}; },
-                        [&](auto &&x) {
-                          return DataRef{FoldOperation(context, std::move(x))};
-                        },
-                    },
+  return std::visit(
+      common::visitors{
+          [&](const Symbol *symbol) { return DataRef{*symbol}; },
+          [&](auto &&x) {
+            return DataRef{FoldOperation(context, std::move(x))};
+          },
+      },
       std::move(dataRef.u));
 }
 
@@ -2378,13 +2379,13 @@ bool IsInitialDataTarget(const Triplet &x) {
   return IsConstantExpr(x.stride());
 }
 bool IsInitialDataTarget(const Subscript &x) {
-  return std::visit(common::visitors{
-                        [](const Triplet &t) { return IsInitialDataTarget(t); },
-                        [&](const auto &y) {
-                          return y.value().Rank() == 0 &&
-                              IsConstantExpr(y.value());
-                        },
-                    },
+  return std::visit(
+      common::visitors{
+          [](const Triplet &t) { return IsInitialDataTarget(t); },
+          [&](const auto &y) {
+            return y.value().Rank() == 0 && IsConstantExpr(y.value());
+          },
+      },
       x.u);
 }
 bool IsInitialDataTarget(const ArrayRef &x) {

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -67,19 +67,22 @@ static CoarrayRef FoldOperation(FoldingContext &, CoarrayRef &&);
 static DataRef FoldOperation(FoldingContext &, DataRef &&);
 static Substring FoldOperation(FoldingContext &, Substring &&);
 static ComplexPart FoldOperation(FoldingContext &, ComplexPart &&);
+template<typename T>
+Expr<T> FoldOperation(FoldingContext &context, FunctionRef<T> &&);
 template<int KIND>
-Expr<Type<TypeCategory::Integer, KIND>> FoldOperation(
+Expr<Type<TypeCategory::Integer, KIND>> FoldIntrinsicFunction(
     FoldingContext &context, FunctionRef<Type<TypeCategory::Integer, KIND>> &&);
 template<int KIND>
-Expr<Type<TypeCategory::Real, KIND>> FoldOperation(
+Expr<Type<TypeCategory::Real, KIND>> FoldIntrinsicFunction(
     FoldingContext &context, FunctionRef<Type<TypeCategory::Real, KIND>> &&);
 template<int KIND>
-Expr<Type<TypeCategory::Complex, KIND>> FoldOperation(
+Expr<Type<TypeCategory::Complex, KIND>> FoldIntrinsicFunction(
     FoldingContext &context, FunctionRef<Type<TypeCategory::Complex, KIND>> &&);
 template<int KIND>
-Expr<Type<TypeCategory::Logical, KIND>> FoldOperation(
+Expr<Type<TypeCategory::Logical, KIND>> FoldIntrinsicFunction(
     FoldingContext &context, FunctionRef<Type<TypeCategory::Logical, KIND>> &&);
 template<typename T> Expr<T> FoldOperation(FoldingContext &, Designator<T> &&);
+
 template<int KIND>
 Expr<Type<TypeCategory::Integer, KIND>> FoldOperation(
     FoldingContext &, TypeParamInquiry<KIND> &&);
@@ -113,16 +116,16 @@ Triplet FoldOperation(FoldingContext &context, Triplet &&triplet) {
 }
 
 Subscript FoldOperation(FoldingContext &context, Subscript &&subscript) {
-  return std::visit(
-      common::visitors{
-          [&](IndirectSubscriptIntegerExpr &&expr) {
-            expr.value() = Fold(context, std::move(expr.value()));
-            return Subscript(std::move(expr));
-          },
-          [&](Triplet &&triplet) {
-            return Subscript(FoldOperation(context, std::move(triplet)));
-          },
-      },
+  return std::visit(common::visitors{
+                        [&](IndirectSubscriptIntegerExpr &&expr) {
+                          expr.value() = Fold(context, std::move(expr.value()));
+                          return Subscript(std::move(expr));
+                        },
+                        [&](Triplet &&triplet) {
+                          return Subscript(
+                              FoldOperation(context, std::move(triplet)));
+                        },
+                    },
       std::move(subscript.u));
 }
 
@@ -156,13 +159,12 @@ CoarrayRef FoldOperation(FoldingContext &context, CoarrayRef &&coarrayRef) {
 }
 
 DataRef FoldOperation(FoldingContext &context, DataRef &&dataRef) {
-  return std::visit(
-      common::visitors{
-          [&](const Symbol *symbol) { return DataRef{*symbol}; },
-          [&](auto &&x) {
-            return DataRef{FoldOperation(context, std::move(x))};
-          },
-      },
+  return std::visit(common::visitors{
+                        [&](const Symbol *symbol) { return DataRef{*symbol}; },
+                        [&](auto &&x) {
+                          return DataRef{FoldOperation(context, std::move(x))};
+                        },
+                    },
       std::move(dataRef.u));
 }
 
@@ -336,9 +338,20 @@ std::optional<std::vector<A>> GetIntegerVector(const B &x) {
   return std::nullopt;
 }
 
+// Transform an intrinsic function reference that contains user errors
+// into an intrinsic with the same characteristic but the "invalid" name.
+// This to prevent generating warnings over and over if the expression
+// gets re-folded.
+template<typename T> Expr<T> MakeInvalidIntrinsic(FunctionRef<T> &&funcRef) {
+  SpecificIntrinsic invalid{std::get<SpecificIntrinsic>(funcRef.proc().u)};
+  invalid.name = "invalid";
+  return Expr<T>{FunctionRef<T>{
+      ProcedureDesignator{std::move(invalid)}, std::move(funcRef.arguments())}};
+}
+
 template<typename T>
-std::optional<Constant<T>> Reshape(
-    FoldingContext &context, const ActualArguments &args) {
+Expr<T> Reshape(FoldingContext &context, FunctionRef<T> &&funcRef) {
+  auto args{funcRef.arguments()};
   CHECK(args.size() == 4);
   const auto *source{UnwrapConstantValue<T>(args[0])};
   const auto *pad{UnwrapConstantValue<T>(args[2])};
@@ -364,7 +377,7 @@ std::optional<Constant<T>> Reshape(
                 *pad, resultElements - copied, subscripts, &dimOrder.value());
           }
           CHECK(copied == resultElements);
-          return result;
+          return Expr<T>{std::move(result)};
         } else {
           context.messages().Say(
               "Too few SOURCE elements in RESHAPE and PAD is not present or has null size"_en_US);
@@ -375,304 +388,306 @@ std::optional<Constant<T>> Reshape(
     } else {
       context.messages().Say("Invalid SHAPE in RESHAPE"_en_US);
     }
-  }  // non-constant arguments
-  return std::nullopt;
+    // Invalid, prevent re-folding
+    return MakeInvalidIntrinsic(std::move(funcRef));
+  }  // Non-constant arguments
+  return Expr<T>{std::move(funcRef)};
 }
 
 template<typename T>
-ActualArguments &FoldArguments(
-    FoldingContext &context, FunctionRef<T> &funcRef) {
+Expr<T> FoldOperation(FoldingContext &context, FunctionRef<T> &&funcRef) {
   ActualArguments &args{funcRef.arguments()};
   for (std::optional<ActualArgument> &arg : args) {
     if (auto *expr{UnwrapExpr<Expr<SomeType>>(arg)}) {
       *expr = Fold(context, std::move(*expr));
     }
   }
-  return args;
+  if (auto *intrinsic{std::get_if<SpecificIntrinsic>(&funcRef.proc().u)}) {
+    const std::string name{intrinsic->name};
+    if (name == "reshape") {
+      return Reshape(context, std::move(funcRef));
+    }
+    // TODO: other type independent transformational
+    if constexpr (!std::is_same_v<T, SomeDerived>) {
+      return FoldIntrinsicFunction(context, std::move(funcRef));
+    }
+  }
+  return Expr<T>{std::move(funcRef)};
 }
 
 template<int KIND>
-Expr<Type<TypeCategory::Integer, KIND>> FoldOperation(FoldingContext &context,
+Expr<Type<TypeCategory::Integer, KIND>> FoldIntrinsicFunction(
+    FoldingContext &context,
     FunctionRef<Type<TypeCategory::Integer, KIND>> &&funcRef) {
   using T = Type<TypeCategory::Integer, KIND>;
-  ActualArguments &args{FoldArguments(context, funcRef)};
-  if (auto *intrinsic{std::get_if<SpecificIntrinsic>(&funcRef.proc().u)}) {
-    const std::string name{intrinsic->name};
-    if (name == "abs") {
-      return FoldElementalIntrinsic<T, T>(context, std::move(funcRef),
-          ScalarFunc<T, T>([&context](const Scalar<T> &i) -> Scalar<T> {
-            typename Scalar<T>::ValueWithOverflow j{i.ABS()};
-            if (j.overflow) {
-              context.messages().Say(
-                  "abs(integer(kind=%d)) folding overflowed"_en_US, KIND);
-            }
-            return j.value;
-          }));
-    } else if (name == "dim") {
-      return FoldElementalIntrinsic<T, T, T>(
-          context, std::move(funcRef), &Scalar<T>::DIM);
-    } else if (name == "dshiftl" || name == "dshiftr") {
-      using Int4 = Type<TypeCategory::Integer, 4>;
-      const auto fptr{
-          name == "dshiftl" ? &Scalar<T>::DSHIFTL : &Scalar<T>::DSHIFTR};
-      // Third argument can be of any kind. However, it must be smaller or equal
-      // than BIT_SIZE. It can be converted to Int4 to simplify.
-      return FoldElementalIntrinsic<T, T, T, Int4>(context, std::move(funcRef),
-          ScalarFunc<T, T, T, Int4>(
-              [&fptr](const Scalar<T> &i, const Scalar<T> &j,
-                  const Scalar<Int4> &shift) -> Scalar<T> {
-                return std::invoke(
-                    fptr, i, j, static_cast<int>(shift.ToInt64()));
-              }));
-    } else if (name == "exponent") {
-      if (auto *sx{UnwrapExpr<Expr<SomeReal>>(args[0])}) {
+  using Int4 = Type<TypeCategory::Integer, 4>;
+  ActualArguments &args{funcRef.arguments()};
+  auto *intrinsic{std::get_if<SpecificIntrinsic>(&funcRef.proc().u)};
+  CHECK(intrinsic);
+  std::string name{intrinsic->name};
+  if (name == "abs") {
+    return FoldElementalIntrinsic<T, T>(context, std::move(funcRef),
+        ScalarFunc<T, T>([&context](const Scalar<T> &i) -> Scalar<T> {
+          typename Scalar<T>::ValueWithOverflow j{i.ABS()};
+          if (j.overflow) {
+            context.messages().Say(
+                "abs(integer(kind=%d)) folding overflowed"_en_US, KIND);
+          }
+          return j.value;
+        }));
+  } else if (name == "dim") {
+    return FoldElementalIntrinsic<T, T, T>(
+        context, std::move(funcRef), &Scalar<T>::DIM);
+  } else if (name == "dshiftl" || name == "dshiftr") {
+    const auto fptr{
+        name == "dshiftl" ? &Scalar<T>::DSHIFTL : &Scalar<T>::DSHIFTR};
+    // Third argument can be of any kind. However, it must be smaller or equal
+    // than BIT_SIZE. It can be converted to Int4 to simplify.
+    return FoldElementalIntrinsic<T, T, T, Int4>(context, std::move(funcRef),
+        ScalarFunc<T, T, T, Int4>(
+            [&fptr](const Scalar<T> &i, const Scalar<T> &j,
+                const Scalar<Int4> &shift) -> Scalar<T> {
+              return std::invoke(fptr, i, j, static_cast<int>(shift.ToInt64()));
+            }));
+  } else if (name == "exponent") {
+    if (auto *sx{UnwrapExpr<Expr<SomeReal>>(args[0])}) {
+      return std::visit(
+          [&funcRef, &context](const auto &x) -> Expr<T> {
+            using TR = typename std::decay_t<decltype(x)>::Result;
+            return FoldElementalIntrinsic<T, TR>(context, std::move(funcRef),
+                &Scalar<TR>::template EXPONENT<Scalar<T>>);
+          },
+          sx->u);
+    } else {
+      common::die("exponent argument must be real");
+    }
+  } else if (name == "iachar" || name == "ichar") {
+    auto *someChar{UnwrapExpr<Expr<SomeCharacter>>(args[0])};
+    CHECK(someChar != nullptr);
+    if (auto len{ToInt64(someChar->LEN())}) {
+      if (len.value() != 1) {
+        // Do not die, this was not checked before
+        context.messages().Say(
+            "Character in intrinsic function %s must have length one"_en_US,
+            name);
+      } else {
         return std::visit(
-            [&funcRef, &context](const auto &x) -> Expr<T> {
-              using TR = typename std::decay_t<decltype(x)>::Result;
-              return FoldElementalIntrinsic<T, TR>(context, std::move(funcRef),
-                  &Scalar<TR>::template EXPONENT<Scalar<T>>);
-            },
-            sx->u);
-      } else {
-        common::die("exponent argument must be real");
-      }
-    } else if (name == "iachar" || name == "ichar") {
-      auto *someChar{UnwrapExpr<Expr<SomeCharacter>>(args[0])};
-      CHECK(someChar != nullptr);
-      if (auto len{ToInt64(someChar->LEN())}) {
-        if (len.value() != 1) {
-          // Do not die, this was not checked before
-          context.messages().Say(
-              "Character in intrinsic function %s must have length one"_en_US,
-              name);
-        } else {
-          return std::visit(
-              [&funcRef, &context](const auto &str) -> Expr<T> {
-                using Char = typename std::decay_t<decltype(str)>::Result;
-                return FoldElementalIntrinsic<T, Char>(context,
-                    std::move(funcRef),
-                    ScalarFunc<T, Char>([](const Scalar<Char> &c) {
-                      return Scalar<T>{CharacterUtils<Char::kind>::ICHAR(c)};
-                    }));
-              },
-              someChar->u);
-        }
-      }
-    } else if (name == "iand" || name == "ior" || name == "ieor") {
-      auto fptr{&Scalar<T>::IAND};
-      if (name == "iand") {  // done in fptr declaration
-      } else if (name == "ior") {
-        fptr = &Scalar<T>::IOR;
-      } else if (name == "ieor") {
-        fptr = &Scalar<T>::IEOR;
-      } else {
-        common::die("missing case to fold intrinsic function %s", name.c_str());
-      }
-      return FoldElementalIntrinsic<T, T, T>(
-          context, std::move(funcRef), ScalarFunc<T, T, T>(fptr));
-    } else if (name == "ibclr" || name == "ibset" || name == "ishft" ||
-        name == "shifta" || name == "shiftr" || name == "shiftl") {
-      // Second argument can be of any kind. However, it must be smaller or
-      // equal than BIT_SIZE. It can be converted to Int4 to simplify.
-      using Int4 = Type<TypeCategory::Integer, 4>;
-      auto fptr{&Scalar<T>::IBCLR};
-      if (name == "ibclr") {  // done in fprt definition
-      } else if (name == "ibset") {
-        fptr = &Scalar<T>::IBSET;
-      } else if (name == "ishft") {
-        fptr = &Scalar<T>::ISHFT;
-      } else if (name == "shifta") {
-        fptr = &Scalar<T>::SHIFTA;
-      } else if (name == "shiftr") {
-        fptr = &Scalar<T>::SHIFTR;
-      } else if (name == "shiftl") {
-        fptr = &Scalar<T>::SHIFTL;
-      } else {
-        common::die("missing case to fold intrinsic function %s", name.c_str());
-      }
-      return FoldElementalIntrinsic<T, T, Int4>(context, std::move(funcRef),
-          ScalarFunc<T, T, Int4>([&fptr](const Scalar<T> &i,
-                                     const Scalar<Int4> &pos) -> Scalar<T> {
-            return std::invoke(fptr, i, static_cast<int>(pos.ToInt64()));
-          }));
-    } else if (name == "int") {
-      if (auto *expr{args[0].value().UnwrapExpr()}) {
-        return std::visit(
-            [&](auto &&x) -> Expr<T> {
-              using From = std::decay_t<decltype(x)>;
-              if constexpr (std::is_same_v<From, BOZLiteralConstant> ||
-                  IsNumericCategoryExpr<From>()) {
-                return Fold(context, ConvertToType<T>(std::move(x)));
-              }
-              common::die("int() argument type not valid");
-            },
-            std::move(expr->u));
-      }
-    } else if (name == "kind") {
-      if constexpr (common::HasMember<T, IntegerTypes>) {
-        return Expr<T>{args[0].value().GetType()->kind()};
-      } else {
-        common::die("kind() result not integral");
-      }
-    } else if (name == "leadz" || name == "trailz" || name == "poppar" ||
-        name == "popcnt") {
-      if (auto *sn{UnwrapExpr<Expr<SomeInteger>>(args[0])}) {
-        return std::visit(
-            [&funcRef, &context, &name](const auto &n) -> Expr<T> {
-              using TI = typename std::decay_t<decltype(n)>::Result;
-              if (name == "poppar") {
-                return FoldElementalIntrinsic<T, TI>(context,
-                    std::move(funcRef),
-                    ScalarFunc<T, TI>([](const Scalar<TI> &i) -> Scalar<T> {
-                      return Scalar<T>{i.POPPAR() ? 1 : 0};
-                    }));
-              }
-              auto fptr{&Scalar<TI>::LEADZ};
-              if (name == "leadz") {  // done in fprt definition
-              } else if (name == "trailz") {
-                fptr = &Scalar<TI>::TRAILZ;
-              } else if (name == "popcnt") {
-                fptr = &Scalar<TI>::POPCNT;
-              } else {
-                common::die(
-                    "missing case to fold intrinsic function %s", name.c_str());
-              }
-              return FoldElementalIntrinsic<T, TI>(context, std::move(funcRef),
-                  ScalarFunc<T, TI>([&fptr](const Scalar<TI> &i) -> Scalar<T> {
-                    return Scalar<T>{std::invoke(fptr, i)};
+            [&funcRef, &context](const auto &str) -> Expr<T> {
+              using Char = typename std::decay_t<decltype(str)>::Result;
+              return FoldElementalIntrinsic<T, Char>(context,
+                  std::move(funcRef),
+                  ScalarFunc<T, Char>([](const Scalar<Char> &c) {
+                    return Scalar<T>{CharacterUtils<Char::kind>::ICHAR(c)};
                   }));
             },
-            sn->u);
-      } else {
-        common::die("leadz argument must be integer");
+            someChar->u);
       }
-    } else if (name == "len") {
-      if (auto *charExpr{UnwrapExpr<Expr<SomeCharacter>>(args[0])}) {
-        return std::visit(
-            [&](auto &kx) {
-              if (auto len{kx.LEN()}) {
-                return Fold(context, ConvertToType<T>(*std::move(len)));
-              } else {
-                return Expr<T>{std::move(funcRef)};
-              }
-            },
-            charExpr->u);
-      } else {
-        common::die("len() argument must be of character type");
-      }
-    } else if (name == "maskl" || name == "maskr") {
-      // Argument can be of any kind but value has to be smaller than bit_size.
-      // It can be safely converted to Int4 to simplify.
-      using Int4 = Type<TypeCategory::Integer, 4>;
-      const auto fptr{name == "maskl" ? &Scalar<T>::MASKL : &Scalar<T>::MASKR};
-      return FoldElementalIntrinsic<T, Int4>(context, std::move(funcRef),
-          ScalarFunc<T, Int4>([&fptr](const Scalar<Int4> &places) -> Scalar<T> {
-            return fptr(static_cast<int>(places.ToInt64()));
-          }));
-    } else if (name == "merge_bits") {
-      return FoldElementalIntrinsic<T, T, T, T>(
-          context, std::move(funcRef), &Scalar<T>::MERGE_BITS);
-    } else if (name == "precision") {
-      if (const auto *cx{UnwrapExpr<Expr<SomeReal>>(args[0])}) {
-        return Expr<T>{std::visit(
-            [](const auto &kx) {
-              return Scalar<ResultType<decltype(kx)>>::PRECISION;
-            },
-            cx->u)};
-      } else if (const auto *cx{UnwrapExpr<Expr<SomeComplex>>(args[0])}) {
-        return Expr<T>{std::visit(
-            [](const auto &kx) {
-              return Scalar<typename ResultType<decltype(kx)>::Part>::PRECISION;
-            },
-            cx->u)};
-      }
-    } else if (name == "radix") {
-      return Expr<T>{2};
-    } else if (name == "range") {
-      if (const auto *cx{UnwrapExpr<Expr<SomeInteger>>(args[0])}) {
-        return Expr<T>{std::visit(
-            [](const auto &kx) {
-              return Scalar<ResultType<decltype(kx)>>::RANGE;
-            },
-            cx->u)};
-      } else if (const auto *cx{UnwrapExpr<Expr<SomeReal>>(args[0])}) {
-        return Expr<T>{std::visit(
-            [](const auto &kx) {
-              return Scalar<ResultType<decltype(kx)>>::RANGE;
-            },
-            cx->u)};
-      } else if (const auto *cx{UnwrapExpr<Expr<SomeComplex>>(args[0])}) {
-        return Expr<T>{std::visit(
-            [](const auto &kx) {
-              return Scalar<typename ResultType<decltype(kx)>::Part>::RANGE;
-            },
-            cx->u)};
-      }
-    } else if (name == "rank") {
-      // TODO assumed-rank dummy argument
-      return Expr<T>{args[0].value().Rank()};
-    } else if (name == "reshape") {
-      if (auto maybeConstant{Reshape<T>(context, args)}) {
-        return Expr<T>{std::move(maybeConstant.value())};
-      }
-    } else if (name == "selected_char_kind") {
-      if (const auto *chCon{
-              UnwrapExpr<Constant<TypeOf<std::string>>>(args[0])}) {
-        if (std::optional<std::string> value{chCon->GetScalarValue()}) {
-          return Expr<T>{SelectedCharKind(*value)};
-        }
-      }
-    } else if (name == "selected_int_kind") {
-      if (auto p{GetInt64Arg(args[0])}) {
-        return Expr<T>{SelectedIntKind(*p)};
-      }
-    } else if (name == "selected_real_kind") {
-      if (auto p{GetInt64ArgOr(args[0], 0)}) {
-        if (auto r{GetInt64ArgOr(args[1], 0)}) {
-          if (auto radix{GetInt64ArgOr(args[2], 2)}) {
-            return Expr<T>{SelectedRealKind(*p, *r, *radix)};
-          }
-        }
-      }
-    } else if (name == "shape") {
-      if (auto shape{GetShape(context, args[0].value())}) {
-        if (auto shapeExpr{AsExtentArrayExpr(*shape)}) {
-          return Fold(context, ConvertToType<T>(std::move(*shapeExpr)));
-        }
-      }
-    } else if (name == "size") {
-      if (auto shape{GetShape(context, args[0].value())}) {
-        if (auto &dimArg{args[1]}) {  // DIM= is present, get one extent
-          if (auto dim{GetInt64Arg(args[1])}) {
-            int rank = GetRank(*shape);
-            if (*dim >= 1 && *dim <= rank) {
-              if (auto &extent{shape->at(*dim - 1)}) {
-                return Fold(context, ConvertToType<T>(std::move(*extent)));
-              }
-            } else {
-              context.messages().Say(
-                  "size(array,dim=%jd) dimension is out of range for rank-%d array"_en_US,
-                  static_cast<std::intmax_t>(*dim), static_cast<int>(rank));
+    }
+  } else if (name == "iand" || name == "ior" || name == "ieor") {
+    auto fptr{&Scalar<T>::IAND};
+    if (name == "iand") {  // done in fptr declaration
+    } else if (name == "ior") {
+      fptr = &Scalar<T>::IOR;
+    } else if (name == "ieor") {
+      fptr = &Scalar<T>::IEOR;
+    } else {
+      common::die("missing case to fold intrinsic function %s", name.c_str());
+    }
+    return FoldElementalIntrinsic<T, T, T>(
+        context, std::move(funcRef), ScalarFunc<T, T, T>(fptr));
+  } else if (name == "ibclr" || name == "ibset" || name == "ishft" ||
+      name == "shifta" || name == "shiftr" || name == "shiftl") {
+    // Second argument can be of any kind. However, it must be smaller or
+    // equal than BIT_SIZE. It can be converted to Int4 to simplify.
+    auto fptr{&Scalar<T>::IBCLR};
+    if (name == "ibclr") {  // done in fprt definition
+    } else if (name == "ibset") {
+      fptr = &Scalar<T>::IBSET;
+    } else if (name == "ishft") {
+      fptr = &Scalar<T>::ISHFT;
+    } else if (name == "shifta") {
+      fptr = &Scalar<T>::SHIFTA;
+    } else if (name == "shiftr") {
+      fptr = &Scalar<T>::SHIFTR;
+    } else if (name == "shiftl") {
+      fptr = &Scalar<T>::SHIFTL;
+    } else {
+      common::die("missing case to fold intrinsic function %s", name.c_str());
+    }
+    return FoldElementalIntrinsic<T, T, Int4>(context, std::move(funcRef),
+        ScalarFunc<T, T, Int4>(
+            [&fptr](const Scalar<T> &i, const Scalar<Int4> &pos) -> Scalar<T> {
+              return std::invoke(fptr, i, static_cast<int>(pos.ToInt64()));
+            }));
+  } else if (name == "int") {
+    if (auto *expr{args[0].value().UnwrapExpr()}) {
+      return std::visit(
+          [&](auto &&x) -> Expr<T> {
+            using From = std::decay_t<decltype(x)>;
+            if constexpr (std::is_same_v<From, BOZLiteralConstant> ||
+                IsNumericCategoryExpr<From>()) {
+              return Fold(context, ConvertToType<T>(std::move(x)));
             }
-          }
-        } else if (auto extents{
-                       common::AllElementsPresent(std::move(*shape))}) {
-          // DIM= is absent; compute PRODUCT(SHAPE())
-          ExtentExpr product{1};
-          for (auto &&extent : std::move(*extents)) {
-            product = std::move(product) * std::move(extent);
-          }
-          return Expr<T>{ConvertToType<T>(Fold(context, std::move(product)))};
+            common::die("int() argument type not valid");
+          },
+          std::move(expr->u));
+    }
+  } else if (name == "kind") {
+    if constexpr (common::HasMember<T, IntegerTypes>) {
+      return Expr<T>{args[0].value().GetType()->kind()};
+    } else {
+      common::die("kind() result not integral");
+    }
+  } else if (name == "leadz" || name == "trailz" || name == "poppar" ||
+      name == "popcnt") {
+    if (auto *sn{UnwrapExpr<Expr<SomeInteger>>(args[0])}) {
+      return std::visit(
+          [&funcRef, &context, &name](const auto &n) -> Expr<T> {
+            using TI = typename std::decay_t<decltype(n)>::Result;
+            if (name == "poppar") {
+              return FoldElementalIntrinsic<T, TI>(context, std::move(funcRef),
+                  ScalarFunc<T, TI>([](const Scalar<TI> &i) -> Scalar<T> {
+                    return Scalar<T>{i.POPPAR() ? 1 : 0};
+                  }));
+            }
+            auto fptr{&Scalar<TI>::LEADZ};
+            if (name == "leadz") {  // done in fprt definition
+            } else if (name == "trailz") {
+              fptr = &Scalar<TI>::TRAILZ;
+            } else if (name == "popcnt") {
+              fptr = &Scalar<TI>::POPCNT;
+            } else {
+              common::die(
+                  "missing case to fold intrinsic function %s", name.c_str());
+            }
+            return FoldElementalIntrinsic<T, TI>(context, std::move(funcRef),
+                ScalarFunc<T, TI>([&fptr](const Scalar<TI> &i) -> Scalar<T> {
+                  return Scalar<T>{std::invoke(fptr, i)};
+                }));
+          },
+          sn->u);
+    } else {
+      common::die("leadz argument must be integer");
+    }
+  } else if (name == "len") {
+    if (auto *charExpr{UnwrapExpr<Expr<SomeCharacter>>(args[0])}) {
+      return std::visit(
+          [&](auto &kx) {
+            if (auto len{kx.LEN()}) {
+              return Fold(context, ConvertToType<T>(*std::move(len)));
+            } else {
+              return Expr<T>{std::move(funcRef)};
+            }
+          },
+          charExpr->u);
+    } else {
+      common::die("len() argument must be of character type");
+    }
+  } else if (name == "maskl" || name == "maskr") {
+    // Argument can be of any kind but value has to be smaller than bit_size.
+    // It can be safely converted to Int4 to simplify.
+    const auto fptr{name == "maskl" ? &Scalar<T>::MASKL : &Scalar<T>::MASKR};
+    return FoldElementalIntrinsic<T, Int4>(context, std::move(funcRef),
+        ScalarFunc<T, Int4>([&fptr](const Scalar<Int4> &places) -> Scalar<T> {
+          return fptr(static_cast<int>(places.ToInt64()));
+        }));
+  } else if (name == "merge_bits") {
+    return FoldElementalIntrinsic<T, T, T, T>(
+        context, std::move(funcRef), &Scalar<T>::MERGE_BITS);
+  } else if (name == "precision") {
+    if (const auto *cx{UnwrapExpr<Expr<SomeReal>>(args[0])}) {
+      return Expr<T>{std::visit(
+          [](const auto &kx) {
+            return Scalar<ResultType<decltype(kx)>>::PRECISION;
+          },
+          cx->u)};
+    } else if (const auto *cx{UnwrapExpr<Expr<SomeComplex>>(args[0])}) {
+      return Expr<T>{std::visit(
+          [](const auto &kx) {
+            return Scalar<typename ResultType<decltype(kx)>::Part>::PRECISION;
+          },
+          cx->u)};
+    }
+  } else if (name == "radix") {
+    return Expr<T>{2};
+  } else if (name == "range") {
+    if (const auto *cx{UnwrapExpr<Expr<SomeInteger>>(args[0])}) {
+      return Expr<T>{std::visit(
+          [](const auto &kx) {
+            return Scalar<ResultType<decltype(kx)>>::RANGE;
+          },
+          cx->u)};
+    } else if (const auto *cx{UnwrapExpr<Expr<SomeReal>>(args[0])}) {
+      return Expr<T>{std::visit(
+          [](const auto &kx) {
+            return Scalar<ResultType<decltype(kx)>>::RANGE;
+          },
+          cx->u)};
+    } else if (const auto *cx{UnwrapExpr<Expr<SomeComplex>>(args[0])}) {
+      return Expr<T>{std::visit(
+          [](const auto &kx) {
+            return Scalar<typename ResultType<decltype(kx)>::Part>::RANGE;
+          },
+          cx->u)};
+    }
+  } else if (name == "rank") {
+    // TODO assumed-rank dummy argument
+    return Expr<T>{args[0].value().Rank()};
+  } else if (name == "selected_char_kind") {
+    if (const auto *chCon{UnwrapExpr<Constant<TypeOf<std::string>>>(args[0])}) {
+      if (std::optional<std::string> value{chCon->GetScalarValue()}) {
+        return Expr<T>{SelectedCharKind(*value)};
+      }
+    }
+  } else if (name == "selected_int_kind") {
+    if (auto p{GetInt64Arg(args[0])}) {
+      return Expr<T>{SelectedIntKind(*p)};
+    }
+  } else if (name == "selected_real_kind") {
+    if (auto p{GetInt64ArgOr(args[0], 0)}) {
+      if (auto r{GetInt64ArgOr(args[1], 0)}) {
+        if (auto radix{GetInt64ArgOr(args[2], 2)}) {
+          return Expr<T>{SelectedRealKind(*p, *r, *radix)};
         }
       }
     }
-    // TODO:
-    // ceiling, count, cshift, dot_product, eoshift,
-    // findloc, floor, iall, iany, iparity, ibits, image_status, index, ishftc,
-    // lbound, len_trim, matmul, max, maxloc, maxval, merge, min,
-    // minloc, minval, mod, modulo, nint, not, pack, product, reduce,
-    // scan, sign, spread, sum, transfer, transpose, ubound, unpack, verify
+  } else if (name == "shape") {
+    if (auto shape{GetShape(context, args[0].value())}) {
+      if (auto shapeExpr{AsExtentArrayExpr(*shape)}) {
+        return Fold(context, ConvertToType<T>(std::move(*shapeExpr)));
+      }
+    }
+  } else if (name == "size") {
+    if (auto shape{GetShape(context, args[0].value())}) {
+      if (auto &dimArg{args[1]}) {  // DIM= is present, get one extent
+        if (auto dim{GetInt64Arg(args[1])}) {
+          int rank = GetRank(*shape);
+          if (*dim >= 1 && *dim <= rank) {
+            if (auto &extent{shape->at(*dim - 1)}) {
+              return Fold(context, ConvertToType<T>(std::move(*extent)));
+            }
+          } else {
+            context.messages().Say(
+                "size(array,dim=%jd) dimension is out of range for rank-%d array"_en_US,
+                static_cast<std::intmax_t>(*dim), static_cast<int>(rank));
+          }
+        }
+      } else if (auto extents{common::AllElementsPresent(std::move(*shape))}) {
+        // DIM= is absent; compute PRODUCT(SHAPE())
+        ExtentExpr product{1};
+        for (auto &&extent : std::move(*extents)) {
+          product = std::move(product) * std::move(extent);
+        }
+        return Expr<T>{ConvertToType<T>(Fold(context, std::move(product)))};
+      }
+    }
   }
+  // TODO:
+  // ceiling, count, cshift, dot_product, eoshift,
+  // findloc, floor, iall, iany, iparity, ibits, image_status, index, ishftc,
+  // lbound, len_trim, matmul, max, maxloc, maxval, merge, min,
+  // minloc, minval, mod, modulo, nint, not, pack, product, reduce,
+  // scan, sign, spread, sum, transfer, transpose, ubound, unpack, verify
   return Expr<T>{std::move(funcRef)};
 }
 
@@ -707,295 +722,262 @@ Expr<Type<TypeCategory::Real, KIND>> ToReal(
 }
 
 template<int KIND>
-Expr<Type<TypeCategory::Real, KIND>> FoldOperation(FoldingContext &context,
+Expr<Type<TypeCategory::Real, KIND>> FoldIntrinsicFunction(
+    FoldingContext &context,
     FunctionRef<Type<TypeCategory::Real, KIND>> &&funcRef) {
   using T = Type<TypeCategory::Real, KIND>;
   using ComplexT = Type<TypeCategory::Complex, KIND>;
-  ActualArguments &args{FoldArguments(context, funcRef)};
-  if (auto *intrinsic{std::get_if<SpecificIntrinsic>(&funcRef.proc().u)}) {
-    const std::string name{intrinsic->name};
-    if (name == "acos" || name == "acosh" || name == "asin" ||
-        name == "asinh" || (name == "atan" && args.size() == 1) ||
-        name == "atanh" || name == "bessel_j0" || name == "bessel_j1" ||
-        name == "bessel_y0" || name == "bessel_y1" || name == "cos" ||
-        name == "cosh" || name == "erf" || name == "erfc" ||
-        name == "erfc_scaled" || name == "exp" || name == "gamma" ||
-        name == "log" || name == "log10" || name == "log_gamma" ||
-        name == "sin" || name == "sinh" || name == "sqrt" || name == "tan" ||
-        name == "tanh") {
-      CHECK(args.size() == 1);
-      if (auto callable{context.hostIntrinsicsLibrary()
-                            .GetHostProcedureWrapper<Scalar, T, T>(name)}) {
-        return FoldElementalIntrinsic<T, T>(
-            context, std::move(funcRef), *callable);
-      } else {
-        context.messages().Say(
-            "%s(real(kind=%d)) cannot be folded on host"_en_US, name, KIND);
-      }
+  ActualArguments &args{funcRef.arguments()};
+  auto *intrinsic{std::get_if<SpecificIntrinsic>(&funcRef.proc().u)};
+  CHECK(intrinsic);
+  std::string name{intrinsic->name};
+  if (name == "acos" || name == "acosh" || name == "asin" || name == "asinh" ||
+      (name == "atan" && args.size() == 1) || name == "atanh" ||
+      name == "bessel_j0" || name == "bessel_j1" || name == "bessel_y0" ||
+      name == "bessel_y1" || name == "cos" || name == "cosh" || name == "erf" ||
+      name == "erfc" || name == "erfc_scaled" || name == "exp" ||
+      name == "gamma" || name == "log" || name == "log10" ||
+      name == "log_gamma" || name == "sin" || name == "sinh" ||
+      name == "sqrt" || name == "tan" || name == "tanh") {
+    CHECK(args.size() == 1);
+    if (auto callable{context.hostIntrinsicsLibrary()
+                          .GetHostProcedureWrapper<Scalar, T, T>(name)}) {
+      return FoldElementalIntrinsic<T, T>(
+          context, std::move(funcRef), *callable);
+    } else {
+      context.messages().Say(
+          "%s(real(kind=%d)) cannot be folded on host"_en_US, name, KIND);
     }
-    if (name == "atan" || name == "atan2" || name == "hypot" || name == "mod") {
-      std::string localName{name == "atan2" ? "atan" : name};
-      CHECK(args.size() == 2);
+  }
+  if (name == "atan" || name == "atan2" || name == "hypot" || name == "mod") {
+    std::string localName{name == "atan2" ? "atan" : name};
+    CHECK(args.size() == 2);
+    if (auto callable{
+            context.hostIntrinsicsLibrary()
+                .GetHostProcedureWrapper<Scalar, T, T, T>(localName)}) {
+      return FoldElementalIntrinsic<T, T, T>(
+          context, std::move(funcRef), *callable);
+    } else {
+      context.messages().Say(
+          "%s(real(kind=%d), real(kind%d)) cannot be folded on host"_en_US,
+          name, KIND, KIND);
+    }
+  } else if (name == "bessel_jn" || name == "bessel_yn") {
+    if (args.size() == 2) {  // elemental
+      // runtime functions use int arg
+      using Int4 = Type<TypeCategory::Integer, 4>;
       if (auto callable{
               context.hostIntrinsicsLibrary()
-                  .GetHostProcedureWrapper<Scalar, T, T, T>(localName)}) {
-        return FoldElementalIntrinsic<T, T, T>(
+                  .GetHostProcedureWrapper<Scalar, T, Int4, T>(name)}) {
+        return FoldElementalIntrinsic<T, Int4, T>(
             context, std::move(funcRef), *callable);
       } else {
         context.messages().Say(
-            "%s(real(kind=%d), real(kind%d)) cannot be folded on host"_en_US,
-            name, KIND, KIND);
-      }
-    } else if (name == "bessel_jn" || name == "bessel_yn") {
-      if (args.size() == 2) {  // elemental
-        // runtime functions use int arg
-        using Int4 = Type<TypeCategory::Integer, 4>;
-        if (auto callable{
-                context.hostIntrinsicsLibrary()
-                    .GetHostProcedureWrapper<Scalar, T, Int4, T>(name)}) {
-          return FoldElementalIntrinsic<T, Int4, T>(
-              context, std::move(funcRef), *callable);
-        } else {
-          context.messages().Say(
-              "%s(integer(kind=4), real(kind=%d)) cannot be folded on host"_en_US,
-              name, KIND);
-        }
-      }
-    } else if (name == "abs") {
-      // Argument can be complex or real
-      if (auto *x{UnwrapExpr<Expr<SomeReal>>(args[0])}) {
-        return FoldElementalIntrinsic<T, T>(
-            context, std::move(funcRef), &Scalar<T>::ABS);
-      } else if (auto *z{UnwrapExpr<Expr<SomeComplex>>(args[0])}) {
-        if (auto callable{
-                context.hostIntrinsicsLibrary()
-                    .GetHostProcedureWrapper<Scalar, T, ComplexT>("abs")}) {
-          return FoldElementalIntrinsic<T, ComplexT>(
-              context, std::move(funcRef), *callable);
-        } else {
-          context.messages().Say(
-              "abs(complex(kind=%d)) cannot be folded on host"_en_US, KIND);
-        }
-      } else {
-        common::die(" unexpected argument type inside abs");
-      }
-    } else if (name == "aimag") {
-      return FoldElementalIntrinsic<T, ComplexT>(
-          context, std::move(funcRef), &Scalar<ComplexT>::AIMAG);
-    } else if (name == "aint") {
-      return FoldElementalIntrinsic<T, T>(context, std::move(funcRef),
-          ScalarFunc<T, T>([&name, &context](const Scalar<T> &x) -> Scalar<T> {
-            ValueWithRealFlags<Scalar<T>> y{x.AINT()};
-            if (y.flags.test(RealFlag::Overflow)) {
-              context.messages().Say(
-                  "%s intrinsic folding overflow"_en_US, name);
-            }
-            return y.value;
-          }));
-    } else if (name == "dprod") {
-      if (auto *x{UnwrapExpr<Expr<SomeReal>>(args[0])}) {
-        if (auto *y{UnwrapExpr<Expr<SomeReal>>(args[1])}) {
-          return Fold(context,
-              Expr<T>{Multiply<T>{ConvertToType<T>(std::move(*x)),
-                  ConvertToType<T>(std::move(*y))}});
-        }
-      }
-      common::die("Wrong argument type in dprod()");
-    } else if (name == "epsilon") {
-      return Expr<T>{Constant<T>{Scalar<T>::EPSILON()}};
-    } else if (name == "real") {
-      if (auto *expr{args[0].value().UnwrapExpr()}) {
-        return ToReal<KIND>(context, std::move(*expr));
-      }
-    } else if (name == "reshape") {
-      if (auto maybeConstant{Reshape<T>(context, args)}) {
-        return Expr<T>{std::move(maybeConstant.value())};
+            "%s(integer(kind=4), real(kind=%d)) cannot be folded on host"_en_US,
+            name, KIND);
       }
     }
-    // TODO: anint, cshift, dim, dot_product, eoshift, fraction, huge, matmul,
-    // max, maxval, merge, min, minval, modulo, nearest, norm2, pack, product,
-    // reduce, rrspacing, scale, set_exponent, sign, spacing, spread,
-    // sum, tiny, transfer, transpose, unpack, bessel_jn (transformational) and
-    // bessel_yn (transformational)
+  } else if (name == "abs") {
+    // Argument can be complex or real
+    if (auto *x{UnwrapExpr<Expr<SomeReal>>(args[0])}) {
+      return FoldElementalIntrinsic<T, T>(
+          context, std::move(funcRef), &Scalar<T>::ABS);
+    } else if (auto *z{UnwrapExpr<Expr<SomeComplex>>(args[0])}) {
+      if (auto callable{
+              context.hostIntrinsicsLibrary()
+                  .GetHostProcedureWrapper<Scalar, T, ComplexT>("abs")}) {
+        return FoldElementalIntrinsic<T, ComplexT>(
+            context, std::move(funcRef), *callable);
+      } else {
+        context.messages().Say(
+            "abs(complex(kind=%d)) cannot be folded on host"_en_US, KIND);
+      }
+    } else {
+      common::die(" unexpected argument type inside abs");
+    }
+  } else if (name == "aimag") {
+    return FoldElementalIntrinsic<T, ComplexT>(
+        context, std::move(funcRef), &Scalar<ComplexT>::AIMAG);
+  } else if (name == "aint") {
+    return FoldElementalIntrinsic<T, T>(context, std::move(funcRef),
+        ScalarFunc<T, T>([&name, &context](const Scalar<T> &x) -> Scalar<T> {
+          ValueWithRealFlags<Scalar<T>> y{x.AINT()};
+          if (y.flags.test(RealFlag::Overflow)) {
+            context.messages().Say("%s intrinsic folding overflow"_en_US, name);
+          }
+          return y.value;
+        }));
+  } else if (name == "dprod") {
+    if (auto *x{UnwrapExpr<Expr<SomeReal>>(args[0])}) {
+      if (auto *y{UnwrapExpr<Expr<SomeReal>>(args[1])}) {
+        return Fold(context,
+            Expr<T>{Multiply<T>{ConvertToType<T>(std::move(*x)),
+                ConvertToType<T>(std::move(*y))}});
+      }
+    }
+    common::die("Wrong argument type in dprod()");
+  } else if (name == "epsilon") {
+    return Expr<T>{Constant<T>{Scalar<T>::EPSILON()}};
+  } else if (name == "real") {
+    if (auto *expr{args[0].value().UnwrapExpr()}) {
+      return ToReal<KIND>(context, std::move(*expr));
+    }
   }
+  // TODO: anint, cshift, dim, dot_product, eoshift, fraction, huge, matmul,
+  // max, maxval, merge, min, minval, modulo, nearest, norm2, pack, product,
+  // reduce, rrspacing, scale, set_exponent, sign, spacing, spread,
+  // sum, tiny, transfer, transpose, unpack, bessel_jn (transformational) and
+  // bessel_yn (transformational)
   return Expr<T>{std::move(funcRef)};
 }
 
 template<int KIND>
-Expr<Type<TypeCategory::Complex, KIND>> FoldOperation(FoldingContext &context,
+Expr<Type<TypeCategory::Complex, KIND>> FoldIntrinsicFunction(
+    FoldingContext &context,
     FunctionRef<Type<TypeCategory::Complex, KIND>> &&funcRef) {
   using T = Type<TypeCategory::Complex, KIND>;
-  ActualArguments &args{FoldArguments(context, funcRef)};
-  if (auto *intrinsic{std::get_if<SpecificIntrinsic>(&funcRef.proc().u)}) {
-    const std::string name{intrinsic->name};
-    if (name == "acos" || name == "acosh" || name == "asin" ||
-        name == "asinh" || name == "atan" || name == "atanh" || name == "cos" ||
-        name == "cosh" || name == "exp" || name == "log" || name == "sin" ||
-        name == "sinh" || name == "sqrt" || name == "tan" || name == "tanh") {
-      if (auto callable{context.hostIntrinsicsLibrary()
-                            .GetHostProcedureWrapper<Scalar, T, T>(name)}) {
-        return FoldElementalIntrinsic<T, T>(
-            context, std::move(funcRef), *callable);
-      } else {
-        context.messages().Say(
-            "%s(complex(kind=%d)) cannot be folded on host"_en_US, name, KIND);
-      }
-    } else if (name == "conjg") {
+  ActualArguments &args{funcRef.arguments()};
+  auto *intrinsic{std::get_if<SpecificIntrinsic>(&funcRef.proc().u)};
+  CHECK(intrinsic);
+  std::string name{intrinsic->name};
+  if (name == "acos" || name == "acosh" || name == "asin" || name == "asinh" ||
+      name == "atan" || name == "atanh" || name == "cos" || name == "cosh" ||
+      name == "exp" || name == "log" || name == "sin" || name == "sinh" ||
+      name == "sqrt" || name == "tan" || name == "tanh") {
+    if (auto callable{context.hostIntrinsicsLibrary()
+                          .GetHostProcedureWrapper<Scalar, T, T>(name)}) {
       return FoldElementalIntrinsic<T, T>(
-          context, std::move(funcRef), &Scalar<T>::CONJG);
-    } else if (name == "cmplx") {
-      if (args.size() == 2) {
-        if (auto *x{UnwrapExpr<Expr<SomeComplex>>(args[0])}) {
-          return Fold(context, ConvertToType<T>(std::move(*x)));
-        } else {
-          common::die("x must be complex in cmplx(x[, kind])");
-        }
-      } else {
-        CHECK(args.size() == 3);
-        using Part = typename T::Part;
-        Expr<SomeType> re{std::move(*args[0].value().UnwrapExpr())};
-        Expr<SomeType> im{args[1].has_value()
-                ? std::move(*args[1].value().UnwrapExpr())
-                : AsGenericExpr(Constant<Part>{Scalar<Part>{}})};
-        return Fold(context,
-            Expr<T>{
-                ComplexConstructor<KIND>{ToReal<KIND>(context, std::move(re)),
-                    ToReal<KIND>(context, std::move(im))}});
-      }
-    } else if (name == "reshape") {
-      if (auto maybeConstant{Reshape<T>(context, args)}) {
-        return Expr<T>{std::move(maybeConstant.value())};
-      }
+          context, std::move(funcRef), *callable);
+    } else {
+      context.messages().Say(
+          "%s(complex(kind=%d)) cannot be folded on host"_en_US, name, KIND);
     }
-    // TODO: cshift, dot_product, eoshift, matmul, merge, pack, product,
-    // reduce, spread, sum, transfer, transpose, unpack
+  } else if (name == "conjg") {
+    return FoldElementalIntrinsic<T, T>(
+        context, std::move(funcRef), &Scalar<T>::CONJG);
+  } else if (name == "cmplx") {
+    if (args.size() == 2) {
+      if (auto *x{UnwrapExpr<Expr<SomeComplex>>(args[0])}) {
+        return Fold(context, ConvertToType<T>(std::move(*x)));
+      } else {
+        common::die("x must be complex in cmplx(x[, kind])");
+      }
+    } else {
+      CHECK(args.size() == 3);
+      using Part = typename T::Part;
+      Expr<SomeType> re{std::move(*args[0].value().UnwrapExpr())};
+      Expr<SomeType> im{args[1].has_value()
+              ? std::move(*args[1].value().UnwrapExpr())
+              : AsGenericExpr(Constant<Part>{Scalar<Part>{}})};
+      return Fold(context,
+          Expr<T>{ComplexConstructor<KIND>{ToReal<KIND>(context, std::move(re)),
+              ToReal<KIND>(context, std::move(im))}});
+    }
   }
+  // TODO: cshift, dot_product, eoshift, matmul, merge, pack, product,
+  // reduce, spread, sum, transfer, transpose, unpack
   return Expr<T>{std::move(funcRef)};
 }
 
 template<int KIND>
-Expr<Type<TypeCategory::Logical, KIND>> FoldOperation(FoldingContext &context,
+Expr<Type<TypeCategory::Logical, KIND>> FoldIntrinsicFunction(
+    FoldingContext &context,
     FunctionRef<Type<TypeCategory::Logical, KIND>> &&funcRef) {
   using T = Type<TypeCategory::Logical, KIND>;
-  ActualArguments &args{FoldArguments(context, funcRef)};
-  if (auto *intrinsic{std::get_if<SpecificIntrinsic>(&funcRef.proc().u)}) {
-    std::string name{intrinsic->name};
-    if (name == "all") {
-      if (!args[1].has_value()) {  // TODO: ALL(x,DIM=d)
-        if (const auto *constant{UnwrapConstantValue<T>(args[0])}) {
-          bool result{true};
-          for (const auto &element : constant->values()) {
-            if (!element.IsTrue()) {
-              result = false;
-              break;
-            }
+  ActualArguments &args{funcRef.arguments()};
+  auto *intrinsic{std::get_if<SpecificIntrinsic>(&funcRef.proc().u)};
+  CHECK(intrinsic);
+  std::string name{intrinsic->name};
+  if (name == "all") {
+    if (!args[1].has_value()) {  // TODO: ALL(x,DIM=d)
+      if (const auto *constant{UnwrapConstantValue<T>(args[0])}) {
+        bool result{true};
+        for (const auto &element : constant->values()) {
+          if (!element.IsTrue()) {
+            result = false;
+            break;
           }
-          return Expr<T>{result};
         }
-      }
-    } else if (name == "any") {
-      if (!args[1].has_value()) {  // TODO: ANY(x,DIM=d)
-        if (const auto *constant{UnwrapConstantValue<T>(args[0])}) {
-          bool result{false};
-          for (const auto &element : constant->values()) {
-            if (element.IsTrue()) {
-              result = true;
-              break;
-            }
-          }
-          return Expr<T>{result};
-        }
-      }
-    } else if (name == "bge" || name == "bgt" || name == "ble" ||
-        name == "blt") {
-      using LargestInt = Type<TypeCategory::Integer, 16>;
-      static_assert(std::is_same_v<Scalar<LargestInt>, BOZLiteralConstant>);
-      // Arguments do not have to be of the same integer type. Convert all
-      // arguments to the biggest integer type before comparing them to
-      // simplify.
-      for (int i{0}; i <= 1; ++i) {
-        if (auto *x{UnwrapExpr<Expr<SomeInteger>>(args[i])}) {
-          *args[i] = AsGenericExpr(
-              Fold(context, ConvertToType<LargestInt>(std::move(*x))));
-        } else if (auto *x{UnwrapExpr<BOZLiteralConstant>(args[i])}) {
-          *args[i] = AsGenericExpr(Constant<LargestInt>{std::move(*x)});
-        }
-      }
-      auto fptr{&Scalar<LargestInt>::BGE};
-      if (name == "bge") {  // done in fptr declaration
-      } else if (name == "bgt") {
-        fptr = &Scalar<LargestInt>::BGT;
-      } else if (name == "ble") {
-        fptr = &Scalar<LargestInt>::BLE;
-      } else if (name == "blt") {
-        fptr = &Scalar<LargestInt>::BLT;
-      } else {
-        common::die("missing case to fold intrinsic function %s", name.c_str());
-      }
-      return FoldElementalIntrinsic<T, LargestInt, LargestInt>(context,
-          std::move(funcRef),
-          ScalarFunc<T, LargestInt, LargestInt>(
-              [&fptr](
-                  const Scalar<LargestInt> &i, const Scalar<LargestInt> &j) {
-                return Scalar<T>{std::invoke(fptr, i, j)};
-              }));
-    } else if (name == "reshape") {
-      if (auto maybeConstant{Reshape<T>(context, args)}) {
-        return Expr<T>{std::move(maybeConstant.value())};
+        return Expr<T>{result};
       }
     }
-    // TODO: btest, cshift, dot_product, eoshift, is_iostat_end,
-    // is_iostat_eor, lge, lgt, lle, llt, logical, matmul, merge, out_of_range,
-    // pack, parity, reduce, spread, transfer, transpose, unpack
+  } else if (name == "any") {
+    if (!args[1].has_value()) {  // TODO: ANY(x,DIM=d)
+      if (const auto *constant{UnwrapConstantValue<T>(args[0])}) {
+        bool result{false};
+        for (const auto &element : constant->values()) {
+          if (element.IsTrue()) {
+            result = true;
+            break;
+          }
+        }
+        return Expr<T>{result};
+      }
+    }
+  } else if (name == "bge" || name == "bgt" || name == "ble" || name == "blt") {
+    using LargestInt = Type<TypeCategory::Integer, 16>;
+    static_assert(std::is_same_v<Scalar<LargestInt>, BOZLiteralConstant>);
+    // Arguments do not have to be of the same integer type. Convert all
+    // arguments to the biggest integer type before comparing them to
+    // simplify.
+    for (int i{0}; i <= 1; ++i) {
+      if (auto *x{UnwrapExpr<Expr<SomeInteger>>(args[i])}) {
+        *args[i] = AsGenericExpr(
+            Fold(context, ConvertToType<LargestInt>(std::move(*x))));
+      } else if (auto *x{UnwrapExpr<BOZLiteralConstant>(args[i])}) {
+        *args[i] = AsGenericExpr(Constant<LargestInt>{std::move(*x)});
+      }
+    }
+    auto fptr{&Scalar<LargestInt>::BGE};
+    if (name == "bge") {  // done in fptr declaration
+    } else if (name == "bgt") {
+      fptr = &Scalar<LargestInt>::BGT;
+    } else if (name == "ble") {
+      fptr = &Scalar<LargestInt>::BLE;
+    } else if (name == "blt") {
+      fptr = &Scalar<LargestInt>::BLT;
+    } else {
+      common::die("missing case to fold intrinsic function %s", name.c_str());
+    }
+    return FoldElementalIntrinsic<T, LargestInt, LargestInt>(context,
+        std::move(funcRef),
+        ScalarFunc<T, LargestInt, LargestInt>(
+            [&fptr](const Scalar<LargestInt> &i, const Scalar<LargestInt> &j) {
+              return Scalar<T>{std::invoke(fptr, i, j)};
+            }));
   }
+  // TODO: btest, cshift, dot_product, eoshift, is_iostat_end,
+  // is_iostat_eor, lge, lgt, lle, llt, logical, matmul, merge, out_of_range,
+  // pack, parity, reduce, spread, transfer, transpose, unpack
   return Expr<T>{std::move(funcRef)};
 }
 
 template<int KIND>
-Expr<Type<TypeCategory::Character, KIND>> FoldOperation(FoldingContext &context,
+Expr<Type<TypeCategory::Character, KIND>> FoldIntrinsicFunction(
+    FoldingContext &context,
     FunctionRef<Type<TypeCategory::Character, KIND>> &&funcRef) {
   using T = Type<TypeCategory::Character, KIND>;
-  FoldArguments(context, funcRef);
-  if (auto *intrinsic{std::get_if<SpecificIntrinsic>(&funcRef.proc().u)}) {
-    std::string name{intrinsic->name};
-    if (name == "achar" || name == "char") {
-      using IntT = SubscriptInteger;
-      return FoldElementalIntrinsic<T, IntT>(context, std::move(funcRef),
-          ScalarFunc<T, IntT>([](const Scalar<IntT> &i) {
-            return CharacterUtils<KIND>::CHAR(i.ToUInt64());
-          }));
-    } else if (name == "adjustl") {
-      return FoldElementalIntrinsic<T, T>(
-          context, std::move(funcRef), CharacterUtils<KIND>::ADJUSTL);
-    } else if (name == "adjustr") {
-      return FoldElementalIntrinsic<T, T>(
-          context, std::move(funcRef), CharacterUtils<KIND>::ADJUSTR);
-    } else if (name == "new_line") {
-      return Expr<T>{Constant<T>{CharacterUtils<KIND>::NEW_LINE()}};
-    } else if (name == "reshape") {
-      if (auto maybeConstant{Reshape<T>(context, args)}) {
-        return Expr<T>{std::move(maybeConstant.value())};
-      }
-    }
-    // TODO: cshift, eoshift, max, maxval, merge, min, minval, pack, reduce,
-    // repeat, spread, transfer, transpose, trim, unpack
+  auto *intrinsic{std::get_if<SpecificIntrinsic>(&funcRef.proc().u)};
+  CHECK(intrinsic);
+  std::string name{intrinsic->name};
+  if (name == "achar" || name == "char") {
+    using IntT = SubscriptInteger;
+    return FoldElementalIntrinsic<T, IntT>(context, std::move(funcRef),
+        ScalarFunc<T, IntT>([](const Scalar<IntT> &i) {
+          return CharacterUtils<KIND>::CHAR(i.ToUInt64());
+        }));
+  } else if (name == "adjustl") {
+    return FoldElementalIntrinsic<T, T>(
+        context, std::move(funcRef), CharacterUtils<KIND>::ADJUSTL);
+  } else if (name == "adjustr") {
+    return FoldElementalIntrinsic<T, T>(
+        context, std::move(funcRef), CharacterUtils<KIND>::ADJUSTR);
+  } else if (name == "new_line") {
+    return Expr<T>{Constant<T>{CharacterUtils<KIND>::NEW_LINE()}};
   }
+  // TODO: cshift, eoshift, max, maxval, merge, min, minval, pack, reduce,
+  // repeat, spread, transfer, transpose, trim, unpack
   return Expr<T>{std::move(funcRef)};
-}
-
-Expr<SomeDerived> FoldOperation(
-    FoldingContext &context, FunctionRef<SomeDerived> &&funcRef) {
-  ActualArguments &args{FoldArguments(context, funcRef)};
-  if (auto *intrinsic{std::get_if<SpecificIntrinsic>(&funcRef.proc().u)}) {
-    std::string name{intrinsic->name};
-    if (name == "reshape") {
-      if (auto maybeConstant{Reshape<SomeDerived>(context, args)}) {
-        return Expr<SomeDerived>{std::move(maybeConstant.value())};
-      }
-    }
-  }
-  return Expr<SomeDerived>{std::move(funcRef)};
-  // TODO: other intrinsics operating on Derived types
 }
 
 // Get the value of a PARAMETER
@@ -2396,13 +2378,13 @@ bool IsInitialDataTarget(const Triplet &x) {
   return IsConstantExpr(x.stride());
 }
 bool IsInitialDataTarget(const Subscript &x) {
-  return std::visit(
-      common::visitors{
-          [](const Triplet &t) { return IsInitialDataTarget(t); },
-          [&](const auto &y) {
-            return y.value().Rank() == 0 && IsConstantExpr(y.value());
-          },
-      },
+  return std::visit(common::visitors{
+                        [](const Triplet &t) { return IsInitialDataTarget(t); },
+                        [&](const auto &y) {
+                          return y.value().Rank() == 0 &&
+                              IsConstantExpr(y.value());
+                        },
+                    },
       x.u);
 }
 bool IsInitialDataTarget(const ArrayRef &x) {

--- a/test/evaluate/CMakeLists.txt
+++ b/test/evaluate/CMakeLists.txt
@@ -127,6 +127,7 @@ set(FOLDING_TESTS
   folding03.f90
   folding04.f90
   folding05.f90
+  folding06.f90
 )
 
 

--- a/test/evaluate/folding06.f90
+++ b/test/evaluate/folding06.f90
@@ -1,0 +1,68 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+! implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test transformational intrinsic function folding
+
+module m
+
+  type A
+    real(4) x
+    integer(8) i
+  end type
+
+  integer(8), parameter :: new_shape(:) = [2, 4]
+  integer(4), parameter :: order(2) = [2, 1]
+
+
+  ! Testing integers (similar to real and complex)
+  integer(4), parameter :: int_source(:) = [1, 2, 3, 4, 5, 6]
+  integer(4), parameter :: int_pad(2) = [7, 8]
+  integer(4), parameter :: int_expected_result(:, :) = reshape([1, 5, 2, 6, 3, 7, 4, 8], new_shape)
+  integer(4), parameter :: int_result(:, :) = reshape(int_source, new_shape, int_pad, order)
+  logical, parameter :: test_reshape_integer_1 = all(int_expected_result == int_result)
+  logical, parameter :: test_reshape_integer_2 = all(shape(int_result, 8).EQ.new_shape)
+
+
+  ! Testing characters
+  character(kind=1, len=3), parameter ::char_source(:) = ["abc", "def", "ghi", "jkl", "mno", "pqr"]
+  character(kind=1,len=3), parameter :: char_pad(2) = ["stu", "vxy"]
+
+  character(kind=1, len=3), parameter :: char_expected_result(:, :) = &
+    reshape(["abc", "mno", "def", "pqr", "ghi", "stu", "jkl", "vxy"], new_shape)
+
+  character(kind=1, len=3), parameter :: char_result(:, :) = &
+    reshape(char_source, new_shape, char_pad, order)
+
+  logical, parameter :: test_reshape_char_1 = all(char_result == char_expected_result)
+  logical, parameter :: test_reshape_char_2 = all(shape(char_result, 8).EQ.new_shape)
+
+
+  ! Testing derived types
+  type(A), parameter :: derived_source(:) = &
+    [A(x=1.5, i=1), A(x=2.5, i=2), A(x=3.5, i=3), A(x=4.5, i=4), A(x=5.5, i=5), A(x=6.5, i=6)]
+
+  type(A), parameter :: derived_pad(2) = [A(x=7.5, i=7), A(x=8.5, i=8)]
+
+  type(A), parameter :: derived_expected_result(:, :) = &
+    reshape([a::a(x=1.5_4,i=1_8),a(x=5.5_4,i=5_8),a(x=2.5_4,i=2_8), a(x=6.5_4,i=6_8), &
+      a(x=3.5_4,i=3_8),a(x=7.5_4,i=7_8),a(x=4.5_4,i=4_8),a(x=8.5_4,i=8_8)], new_shape)
+
+  type(A), parameter :: derived_result(:, :) = reshape(derived_source, new_shape, derived_pad, order)
+
+  logical, parameter :: test_reshape_derived_1 = all((derived_result%x.EQ.derived_expected_result%x) &
+      .AND.(derived_result%i.EQ.derived_expected_result%i))
+
+  logical, parameter :: test_reshape_derived_2 = all(shape(derived_result).EQ.new_shape)
+end module


### PR DESCRIPTION
**EDIT**: 
PR #530 was closed and folding of transformational intrinsic functions will be implemented as done here.
This PR:
- Adds a few helper member functions on `Constant<T>`
- refactors folding to have a common path to all types in `FunctionRef` `FoldOperation` to avoid duplication (its not a big functional change, but this make a big git diff).
- Implements RESHAPE folding in `fold.cc` (because it may emits different user warning messages, it does not really belong as a `Constant<T>` member function).
- Returns a dummy "invalid" intrinsic function reference if user errors prevented folding so that the expression will not get re-folded (which would re-emit error message )
- Adds a note regarding issue #527 workaround (that does not apply in this PR , but was discussed in previous review)