### PR TITLE
Fix FINDLOC for Character data

### DIFF
--- a/lib/parser/message.cc
+++ b/lib/parser/message.cc
@@ -270,6 +270,11 @@ bool Message::AtSameLocation(const Message &that) const {
       location_, that.location_);
 }
 
+void Messages::clear() {
+  messages_.clear();
+  ResetLastPointer();
+}
+
 bool Messages::Merge(const Message &msg) {
   if (msg.IsMergeable()) {
     for (auto &m : messages_) {

--- a/lib/parser/message.h
+++ b/lib/parser/message.h
@@ -237,6 +237,7 @@ public:
   }
 
   bool empty() const { return messages_.empty(); }
+  void clear();
 
   template<typename... A> Message &Say(A &&... args) {
     last_ = messages_.emplace_after(last_, std::forward<A>(args)...);

--- a/lib/parser/parse-tree.cc
+++ b/lib/parser/parse-tree.cc
@@ -215,6 +215,10 @@ Statement<ActionStmt> StmtFunctionStmt::ConvertToAssignment() {
     source.ExtendToCover(arg.source);
   }
   // extend source to include closing paren
+  if (funcArgs.empty()) {
+    CHECK(*source.end() == '(');
+    source = CharBlock{source.begin(), source.end() + 1};
+  }
   CHECK(*source.end() == ')');
   source = CharBlock{source.begin(), source.end() + 1};
   auto variable{Variable{common::Indirection{WithSource(


### PR DESCRIPTION
Use a better type compatibility test for arguments to intrinsic functions that are required to have the same type, now that Tim has written one (thanks!).  This makes FINDLOC and probably other intrinsics work with character data -- the old type compatibility check would produce false negatives.

Also limit the cascade of error messages on bad intrinsic function calls that can be generated when an intrinsic like FINDLOC has multiple entries in the intrinsic table -- it's more confusing that it's worth.