### PR TITLE
Add DerivedTypeSpec::IsKindCompatibleWith

### DIFF
--- a/lib/common/idioms.h
+++ b/lib/common/idioms.h
@@ -133,6 +133,10 @@ template<typename A> struct ListItemCount {
 // Given a const reference to a value, return a copy of the value.
 template<typename A> A Clone(const A &x) { return x; }
 
+template<typename A> inline bool PointeeComparison(const A *x, const A *y) {
+  return x == y || (x != nullptr && y != nullptr && *x == *y);
+}
+
 // C++ does a weird and dangerous thing when deducing template type parameters
 // from function arguments: lvalue references are allowed to match rvalue
 // reference arguments.  Template function declarations like

--- a/lib/evaluate/type.cc
+++ b/lib/evaluate/type.cc
@@ -93,14 +93,10 @@ bool IsDescriptor(const Symbol &symbol) {
 
 namespace Fortran::evaluate {
 
-template<typename A> inline bool PointeeComparison(const A *x, const A *y) {
-  return x == y || (x != nullptr && y != nullptr && *x == *y);
-}
-
 bool DynamicType::operator==(const DynamicType &that) const {
   return category_ == that.category_ && kind_ == that.kind_ &&
-      PointeeComparison(charLength_, that.charLength_) &&
-      PointeeComparison(derived_, that.derived_);
+      common::PointeeComparison(charLength_, that.charLength_) &&
+      common::PointeeComparison(derived_, that.derived_);
 }
 
 bool DynamicType::IsAssumedLengthCharacter() const {
@@ -146,24 +142,6 @@ bool DynamicType::IsTypeCompatibleWith(const DynamicType &that) const {
           IsAncestorTypeOf(derived_, that.derived_));
 }
 
-// Do the kind type parameters of type1 have the same values as the
-// corresponding kind type parameters of the type2?
-static bool IsKindCompatible(const semantics::DerivedTypeSpec &type1,
-    const semantics::DerivedTypeSpec &type2) {
-  for (const auto &[name, symbol] : *type1.scope()) {
-    if (const auto *details{symbol->detailsIf<semantics::TypeParamDetails>()}) {
-      if (details->attr() == common::TypeParamAttr::Kind) {
-        const semantics::ParamValue *param1{type1.FindParameter(name)};
-        const semantics::ParamValue *param2{type2.FindParameter(name)};
-        if (!PointeeComparison(param1, param2)) {
-          return false;
-        }
-      }
-    }
-  }
-  return true;
-}
-
 bool DynamicType::IsTkCompatibleWith(const DynamicType &that) const {
   if (category_ != TypeCategory::Derived) {
     return category_ == that.category_ && kind_ == that.kind_;
@@ -171,7 +149,7 @@ bool DynamicType::IsTkCompatibleWith(const DynamicType &that) const {
     return true;
   } else if (that.IsUnlimitedPolymorphic()) {
     return false;
-  } else if (!IsKindCompatible(*derived_, *that.derived_)) {
+  } else if (!derived_->IsKindCompatibleWith(*that.derived_)) {
     return false;  // kind params don't match
   } else if (!IsPolymorphic()) {
     return derived_->typeSymbol() == that.derived_->typeSymbol();
@@ -255,7 +233,7 @@ DynamicType DynamicType::ResultTypeForMultiply(const DynamicType &that) const {
 
 bool SomeKind<TypeCategory::Derived>::operator==(
     const SomeKind<TypeCategory::Derived> &that) const {
-  return PointeeComparison(derivedTypeSpec_, that.derivedTypeSpec_);
+  return common::PointeeComparison(derivedTypeSpec_, that.derivedTypeSpec_);
 }
 
 int SelectedCharKind(const std::string &s) {  // 16.9.168

--- a/lib/semantics/check-allocate.cc
+++ b/lib/semantics/check-allocate.cc
@@ -353,10 +353,8 @@ static std::optional<std::int64_t> GetTypeParameterInt64Value(
 // type2 (except for kind type parameters)
 static bool HaveCompatibleKindParameters(
     const DerivedTypeSpec &derivedType1, const DerivedTypeSpec &derivedType2) {
-  const DerivedTypeDetails &typeDetails{
-      derivedType1.typeSymbol().get<DerivedTypeDetails>()};
   for (const Symbol *symbol :
-      typeDetails.OrderParameterDeclarations(derivedType1.typeSymbol())) {
+      OrderParameterDeclarations(derivedType1.typeSymbol())) {
     if (symbol->get<TypeParamDetails>().attr() == common::TypeParamAttr::Kind) {
       // At this point, it should have been ensured that these contain integer
       // constants, so die if this is not the case.

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -2878,9 +2878,8 @@ void DeclarationVisitor::Post(const parser::DerivedTypeSpec &x) {
   // order as "type parameter order" (7.5.3.2).
   // Parameters of the most deeply nested "base class" come first when the
   // derived type is an extension.
-  const DerivedTypeDetails &typeDetails{typeSymbol->get<DerivedTypeDetails>()};
-  auto parameterNames{typeDetails.OrderParameterNames(*typeSymbol)};
-  auto parameterDecls{typeDetails.OrderParameterDeclarations(*typeSymbol)};
+  auto parameterNames{OrderParameterNames(*typeSymbol)};
+  auto parameterDecls{OrderParameterDeclarations(*typeSymbol)};
   auto nextNameIter{parameterNames.begin()};
   bool seenAnyName{false};
   for (const auto &typeParamSpec :

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -641,32 +641,6 @@ void DerivedTypeDetails::add_component(const Symbol &symbol) {
   componentNames_.push_back(symbol.name());
 }
 
-std::list<SourceName> DerivedTypeDetails::OrderParameterNames(
-    const Symbol &type) const {
-  std::list<SourceName> result;
-  if (const DerivedTypeSpec * spec{type.GetParentTypeSpec()}) {
-    const DerivedTypeDetails &details{
-        spec->typeSymbol().get<DerivedTypeDetails>()};
-    result = details.OrderParameterNames(spec->typeSymbol());
-  }
-  for (const auto &name : paramNames_) {
-    result.push_back(name);
-  }
-  return result;
-}
-
-SymbolVector DerivedTypeDetails::OrderParameterDeclarations(
-    const Symbol &type) const {
-  SymbolVector result;
-  if (const DerivedTypeSpec * spec{type.GetParentTypeSpec()}) {
-    const DerivedTypeDetails &details{
-        spec->typeSymbol().get<DerivedTypeDetails>()};
-    result = details.OrderParameterDeclarations(spec->typeSymbol());
-  }
-  result.insert(result.end(), paramDecls_.begin(), paramDecls_.end());
-  return result;
-}
-
 SymbolVector DerivedTypeDetails::OrderComponents(const Scope &scope) const {
   SymbolVector result;
   for (SourceName name : componentNames_) {

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -234,15 +234,6 @@ public:
   void add_component(const Symbol &);
   void set_sequence(bool x = true) { sequence_ = x; }
 
-  // Returns the complete list of derived type parameter names in the
-  // order defined by 7.5.3.2.
-  std::list<SourceName> OrderParameterNames(const Symbol &) const;
-
-  // Returns the complete list of derived type parameter symbols in
-  // the order in which their declarations appear in the derived type
-  // definitions (parents first).
-  SymbolVector OrderParameterDeclarations(const Symbol &) const;
-
   // Returns the complete list of derived type components in the order
   // in which their declarations appear in the derived type definitions
   // (parents first).  Parent components appear in the list immediately

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -387,4 +387,24 @@ const Symbol *FindUltimateComponent(const DerivedTypeSpec &derivedTypeSpec,
   return nullptr;
 }
 
+std::vector<SourceName> OrderParameterNames(const Symbol &typeSymbol) {
+  std::vector<SourceName> result;
+  if (const DerivedTypeSpec * parent{typeSymbol.GetParentTypeSpec()}) {
+    result = OrderParameterNames(parent->typeSymbol());
+  }
+  const auto &paramNames{typeSymbol.get<DerivedTypeDetails>().paramNames()};
+  result.insert(result.end(), paramNames.begin(), paramNames.end());
+  return result;
+}
+
+SymbolVector OrderParameterDeclarations(const Symbol &typeSymbol) {
+  SymbolVector result;
+  if (const DerivedTypeSpec * parent{typeSymbol.GetParentTypeSpec()}) {
+    result = OrderParameterDeclarations(parent->typeSymbol());
+  }
+  const auto &paramDecls{typeSymbol.get<DerivedTypeDetails>().paramDecls()};
+  result.insert(result.end(), paramDecls.begin(), paramDecls.end());
+  return result;
+}
+
 }

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -81,6 +81,15 @@ const Symbol *HasEventOrLockPotentialComponent(const DerivedTypeSpec &);
 const Symbol *FindUltimateComponent(
     const DerivedTypeSpec &type, std::function<bool(const Symbol &)> predicate);
 
+// For a symbol that represents a derived type, return the complete list of
+// derived type parameter names in the order defined by 7.5.3.2.
+std::vector<SourceName> OrderParameterNames(const Symbol &);
+
+// For a symbol that represents a derived type, return the complete list of
+// derived type parameter symbols in the order in which their declarations
+// appear in the derived type definitions (parents first).
+std::vector<const Symbol *> OrderParameterDeclarations(const Symbol &);
+
 inline bool IsPointer(const Symbol &symbol) {
   return symbol.attrs().test(Attr::POINTER);
 }

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -173,6 +173,21 @@ Scope &DerivedTypeSpec::Instantiate(
   return newScope;
 }
 
+bool DerivedTypeSpec::IsKindCompatibleWith(const DerivedTypeSpec &that) const {
+  for (const Symbol *symbol : OrderParameterDeclarations(typeSymbol_)) {
+    if (const auto *details{symbol->detailsIf<TypeParamDetails>()}) {
+      if (details->attr() == common::TypeParamAttr::Kind) {
+        const ParamValue *param1{FindParameter(symbol->name())};
+        const ParamValue *param2{that.FindParameter(symbol->name())};
+        if (!common::PointeeComparison(param1, param2)) {
+          return false;
+        }
+      }
+    }
+  }
+  return true;
+}
+
 std::string DerivedTypeSpec::AsFortran() const {
   std::stringstream ss;
   ss << typeSymbol_.name().ToString();

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -17,6 +17,7 @@
 #include "scope.h"
 #include "semantics.h"
 #include "symbol.h"
+#include "tools.h"
 #include "../common/restorer.h"
 #include "../evaluate/fold.h"
 #include "../evaluate/tools.h"
@@ -56,8 +57,7 @@ ParamValue *DerivedTypeSpec::FindParameter(SourceName target) {
 
 void DerivedTypeSpec::ProcessParameterExpressions(
     evaluate::FoldingContext &foldingContext) {
-  const DerivedTypeDetails &typeDetails{typeSymbol_.get<DerivedTypeDetails>()};
-  auto paramDecls{typeDetails.OrderParameterDeclarations(typeSymbol_)};
+  auto paramDecls{OrderParameterDeclarations(typeSymbol_)};
   // Fold the explicit type parameter value expressions first.  Do not
   // fold them within the scope of the derived type being instantiated;
   // these expressions cannot use its type parameters.  Convert the values
@@ -121,9 +121,7 @@ Scope &DerivedTypeSpec::Instantiate(
   scope_ = &newScope;
   const Scope *typeScope{typeSymbol_.scope()};
   CHECK(typeScope != nullptr);
-  const DerivedTypeDetails &typeDetails{typeSymbol_.get<DerivedTypeDetails>()};
-  for (const Symbol *symbol :
-      typeDetails.OrderParameterDeclarations(typeSymbol_)) {
+  for (const Symbol *symbol : OrderParameterDeclarations(typeSymbol_)) {
     const SourceName &name{symbol->name()};
     if (typeScope->find(symbol->name()) != typeScope->end()) {
       // This type parameter belongs to the derived type itself, not to

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -251,6 +251,10 @@ public:
   bool operator==(const DerivedTypeSpec &that) const {
     return &typeSymbol_ == &that.typeSymbol_ && parameters_ == that.parameters_;
   }
+
+  // Do the kind type parameters of this have the same values as the
+  // corresponding kind type parameters of that?
+  bool IsKindCompatibleWith(const DerivedTypeSpec &) const;
   std::string AsFortran() const;
 
 private:

--- a/test/evaluate/CMakeLists.txt
+++ b/test/evaluate/CMakeLists.txt
@@ -118,6 +118,7 @@ add_executable(folding-test
 
 target_link_libraries(folding-test
   FortranEvaluateTesting
+  FortranSemantics
   FortranEvaluate
 )
 

--- a/test/semantics/resolve53.f90
+++ b/test/semantics/resolve53.f90
@@ -276,6 +276,34 @@ contains
   end
 end
 
+! Types distinguished by kind parameters in parent type
+module m15b
+  type t1(k1)
+    integer, kind :: k1 = 1
+  end type
+  type, extends(t1) :: t2(k2)
+    integer, kind :: k2
+  end type
+  interface g1
+    procedure s1
+    procedure s3
+  end interface
+  interface g2
+    procedure s2
+    procedure s3
+  end interface
+contains
+  subroutine s1(x)
+    type(t2(k1=4, k2=5)) :: x
+  end
+  subroutine s2(x)
+    type(t2(k1=5, k2=4)) :: x
+  end
+  subroutine s3(x)
+    type(t2(k1=5, k2=5)) :: x
+  end
+end
+
 ! Check that specifics for type-bound generics can be distinguished
 module m16
   type :: t


### PR DESCRIPTION
- Share function that checks derived type kind compatibility with `check-allocate.cc`
- Fix a bug in that function
- Move some member functions out of `DerivedTypeDetails`