### PR TITLE
Prevent segfault in DynamicType::IsTkCompatibleWith

### DIFF
--- a/lib/evaluate/type.cc
+++ b/lib/evaluate/type.cc
@@ -171,7 +171,8 @@ bool DynamicType::IsTkCompatibleWith(const DynamicType &that) const {
     return true;
   } else if (that.IsUnlimitedPolymorphic()) {
     return false;
-  } else if (!IsKindCompatible(*derived_, *that.derived_)) {
+  } else if (!derived_ || !that.derived_ ||
+      !IsKindCompatible(*derived_, *that.derived_)) {
     return false;  // kind params don't match
   } else if (!IsPolymorphic()) {
     return derived_->typeSymbol() == that.derived_->typeSymbol();


### PR DESCRIPTION
Make sure `derived_` is not null before dereferencing it.

This might only happen when there is a previous error. I saw it
compiling a test program where a USEd module was not found.