### PR TITLE
Move some functions to semantics/tools.h

### DIFF
--- a/lib/semantics/check-allocate.cc
+++ b/lib/semantics/check-allocate.cc
@@ -353,10 +353,8 @@ static std::optional<std::int64_t> GetTypeParameterInt64Value(
 // type2 (except for kind type parameters)
 static bool HaveCompatibleKindParameters(
     const DerivedTypeSpec &derivedType1, const DerivedTypeSpec &derivedType2) {
-  const DerivedTypeDetails &typeDetails{
-      derivedType1.typeSymbol().get<DerivedTypeDetails>()};
   for (const Symbol *symbol :
-      typeDetails.OrderParameterDeclarations(derivedType1.typeSymbol())) {
+      OrderParameterDeclarations(derivedType1.typeSymbol())) {
     if (symbol->get<TypeParamDetails>().attr() == common::TypeParamAttr::Kind) {
       // At this point, it should have been ensured that these contain integer
       // constants, so die if this is not the case.

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1892,8 +1892,8 @@ static void FixMisparsedFunctionReference(
             CHECK(derivedType->has<semantics::DerivedTypeDetails>());
             auto &scope{context.FindScope(name->source)};
             const semantics::DeclTypeSpec &type{
-                scope.FindOrInstantiateDerivedType(
-                    semantics::DerivedTypeSpec{*derivedType}, context)};
+                semantics::FindOrInstantiateDerivedType(
+                    scope, semantics::DerivedTypeSpec{*derivedType}, context)};
             u = funcRef.ConvertToStructureConstructor(type.derivedTypeSpec());
           } else {
             common::die(

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -2891,9 +2891,8 @@ void DeclarationVisitor::Post(const parser::DerivedTypeSpec &x) {
   // order as "type parameter order" (7.5.3.2).
   // Parameters of the most deeply nested "base class" come first when the
   // derived type is an extension.
-  const DerivedTypeDetails &typeDetails{typeSymbol->get<DerivedTypeDetails>()};
-  auto parameterNames{typeDetails.OrderParameterNames(*typeSymbol)};
-  auto parameterDecls{typeDetails.OrderParameterDeclarations(*typeSymbol)};
+  auto parameterNames{OrderParameterNames(*typeSymbol)};
+  auto parameterDecls{OrderParameterDeclarations(*typeSymbol)};
   auto nextNameIter{parameterNames.begin()};
   bool seenAnyName{false};
   for (const auto &typeParamSpec :

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -1188,11 +1188,12 @@ bool AttrsVisitor::SetPassNameOn(Symbol &symbol) {
   if (!passName_) {
     return false;
   }
-  std::visit(common::visitors{
-                 [&](ProcEntityDetails &x) { x.set_passName(*passName_); },
-                 [&](ProcBindingDetails &x) { x.set_passName(*passName_); },
-                 [](auto &) { common::die("unexpected pass name"); },
-             },
+  std::visit(
+      common::visitors{
+          [&](ProcEntityDetails &x) { x.set_passName(*passName_); },
+          [&](ProcBindingDetails &x) { x.set_passName(*passName_); },
+          [](auto &) { common::die("unexpected pass name"); },
+      },
       symbol.details());
   return true;
 }
@@ -1344,22 +1345,23 @@ void ImplicitRulesVisitor::Post(const parser::ParameterStmt &x) {
 }
 
 bool ImplicitRulesVisitor::Pre(const parser::ImplicitStmt &x) {
-  bool res = std::visit(common::visitors{
-                            [&](const std::list<ImplicitNoneNameSpec> &x) {
-                              return HandleImplicitNone(x);
-                            },
-                            [&](const std::list<parser::ImplicitSpec> &x) {
-                              if (prevImplicitNoneType_) {
-                                Say("IMPLICIT statement after IMPLICIT NONE or "
-                                    "IMPLICIT NONE(TYPE) statement"_err_en_US);
-                                return false;
-                              }
-                              return true;
-                            },
-                        },
-      x.u);
+  bool result{std::visit(
+      common::visitors{
+          [&](const std::list<ImplicitNoneNameSpec> &x) {
+            return HandleImplicitNone(x);
+          },
+          [&](const std::list<parser::ImplicitSpec> &x) {
+            if (prevImplicitNoneType_) {
+              Say("IMPLICIT statement after IMPLICIT NONE or "
+                  "IMPLICIT NONE(TYPE) statement"_err_en_US);
+              return false;
+            }
+            return true;
+          },
+      },
+      x.u)};
   prevImplicit_ = currStmtSource();
-  return res;
+  return result;
 }
 
 bool ImplicitRulesVisitor::Pre(const parser::LetterSpec &x) {
@@ -1688,17 +1690,18 @@ void ScopeHandler::EraseSymbol(const parser::Name &name) {
 
 static bool NeedsType(const Symbol &symbol) {
   return symbol.GetType() == nullptr &&
-      std::visit(common::visitors{
-                     [](const EntityDetails &) { return true; },
-                     [](const ObjectEntityDetails &) { return true; },
-                     [](const AssocEntityDetails &) { return true; },
-                     [&](const ProcEntityDetails &p) {
-                       return symbol.test(Symbol::Flag::Function) &&
-                           p.interface().type() == nullptr &&
-                           p.interface().symbol() == nullptr;
-                     },
-                     [](const auto &) { return false; },
-                 },
+      std::visit(
+          common::visitors{
+              [](const EntityDetails &) { return true; },
+              [](const ObjectEntityDetails &) { return true; },
+              [](const AssocEntityDetails &) { return true; },
+              [&](const ProcEntityDetails &p) {
+                return symbol.test(Symbol::Flag::Function) &&
+                    p.interface().type() == nullptr &&
+                    p.interface().symbol() == nullptr;
+              },
+              [](const auto &) { return false; },
+          },
           symbol.details());
 }
 void ScopeHandler::ApplyImplicitRules(Symbol &symbol) {
@@ -1833,14 +1836,15 @@ void ModuleVisitor::Post(const parser::UseStmt &x) {
     // then add a use for each public name that was not renamed.
     std::set<SourceName> useNames;
     for (const auto &rename : *list) {
-      std::visit(common::visitors{
-                     [&](const parser::Rename::Names &names) {
-                       useNames.insert(std::get<1>(names.t).source);
-                     },
-                     [&](const parser::Rename::Operators &ops) {
-                       useNames.insert(std::get<1>(ops.t).v.source);
-                     },
-                 },
+      std::visit(
+          common::visitors{
+              [&](const parser::Rename::Names &names) {
+                useNames.insert(std::get<1>(names.t).source);
+              },
+              [&](const parser::Rename::Operators &ops) {
+                useNames.insert(std::get<1>(ops.t).v.source);
+              },
+          },
           rename.u);
     }
     for (const auto &[name, symbol] : *useModuleScope_) {
@@ -4147,16 +4151,17 @@ bool ConstructVisitor::Pre(const parser::DataImpliedDo &x) {
 }
 
 bool ConstructVisitor::Pre(const parser::DataStmtObject &x) {
-  std::visit(common::visitors{
-                 [&](const common::Indirection<parser::Variable> &y) {
-                   Walk(y.value());
-                 },
-                 [&](const parser::DataImpliedDo &y) {
-                   PushScope(Scope::Kind::ImpliedDos, nullptr);
-                   Walk(y);
-                   PopScope();
-                 },
-             },
+  std::visit(
+      common::visitors{
+          [&](const common::Indirection<parser::Variable> &y) {
+            Walk(y.value());
+          },
+          [&](const parser::DataImpliedDo &y) {
+            PushScope(Scope::Kind::ImpliedDos, nullptr);
+            Walk(y);
+            PopScope();
+          },
+      },
       x.u);
   return false;
 }
@@ -4374,14 +4379,15 @@ void ConstructVisitor::SetAttrsFromAssociation(Symbol &symbol) {
 
 ConstructVisitor::Selector ConstructVisitor::ResolveSelector(
     const parser::Selector &x) {
-  return std::visit(common::visitors{
-                        [&](const parser::Expr &expr) {
-                          return Selector{expr.source, EvaluateExpr(expr)};
-                        },
-                        [&](const parser::Variable &var) {
-                          return Selector{var.GetSource(), EvaluateExpr(var)};
-                        },
-                    },
+  return std::visit(
+      common::visitors{
+          [&](const parser::Expr &expr) {
+            return Selector{expr.source, EvaluateExpr(expr)};
+          },
+          [&](const parser::Variable &var) {
+            return Selector{var.GetSource(), EvaluateExpr(var)};
+          },
+      },
       x.u);
 }
 
@@ -4511,12 +4517,13 @@ const parser::Name *DeclarationVisitor::ResolveVariable(
           [&](const common::Indirection<parser::FunctionReference> &y) {
             const auto &proc{
                 std::get<parser::ProcedureDesignator>(y.value().v.t)};
-            return std::visit(common::visitors{
-                                  [&](const parser::Name &z) { return &z; },
-                                  [&](const parser::ProcComponentRef &z) {
-                                    return ResolveStructureComponent(z.v.thing);
-                                  },
-                              },
+            return std::visit(
+                common::visitors{
+                    [&](const parser::Name &z) { return &z; },
+                    [&](const parser::ProcComponentRef &z) {
+                      return ResolveStructureComponent(z.v.thing);
+                    },
+                },
                 proc.u);
           },
       },
@@ -4856,15 +4863,16 @@ bool ModuleVisitor::Pre(const parser::AccessStmt &x) {
     defaultAccess_ = accessAttr;
   } else {
     for (const auto &accessId : accessIds) {
-      std::visit(common::visitors{
-                     [=](const parser::Name &y) {
-                       Resolve(y, SetAccess(y.source, accessAttr));
-                     },
-                     [=](const Indirection<parser::GenericSpec> &y) {
-                       auto info{GenericSpecInfo{y.value()}};
-                       info.Resolve(&SetAccess(info.symbolName(), accessAttr));
-                     },
-                 },
+      std::visit(
+          common::visitors{
+              [=](const parser::Name &y) {
+                Resolve(y, SetAccess(y.source, accessAttr));
+              },
+              [=](const Indirection<parser::GenericSpec> &y) {
+                auto info{GenericSpecInfo{y.value()}};
+                info.Resolve(&SetAccess(info.symbolName(), accessAttr));
+              },
+          },
           accessId.u);
     }
   }
@@ -4963,21 +4971,23 @@ bool ResolveNamesVisitor::Pre(const parser::ImplicitStmt &x) {
 }
 
 void ResolveNamesVisitor::Post(const parser::PointerObject &x) {
-  std::visit(common::visitors{
-                 [&](const parser::Name &x) { ResolveName(x); },
-                 [&](const parser::StructureComponent &x) {
-                   ResolveStructureComponent(x);
-                 },
-             },
+  std::visit(
+      common::visitors{
+          [&](const parser::Name &x) { ResolveName(x); },
+          [&](const parser::StructureComponent &x) {
+            ResolveStructureComponent(x);
+          },
+      },
       x.u);
 }
 void ResolveNamesVisitor::Post(const parser::AllocateObject &x) {
-  std::visit(common::visitors{
-                 [&](const parser::Name &x) { ResolveName(x); },
-                 [&](const parser::StructureComponent &x) {
-                   ResolveStructureComponent(x);
-                 },
-             },
+  std::visit(
+      common::visitors{
+          [&](const parser::Name &x) { ResolveName(x); },
+          [&](const parser::StructureComponent &x) {
+            ResolveStructureComponent(x);
+          },
+      },
       x.u);
 }
 

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -2954,7 +2954,7 @@ void DeclarationVisitor::Post(const parser::DerivedTypeSpec &x) {
   }
 
   auto category{GetDeclTypeSpecCategory()};
-  spec.ProcessParameterExpressions(context().foldingContext());
+  ProcessParameterExpressions(spec, context().foldingContext());
   if (const DeclTypeSpec *
       extant{currScope().FindInstantiatedDerivedType(spec, category)}) {
     // This derived type and parameter expressions (if any) are already present
@@ -2973,7 +2973,7 @@ void DeclarationVisitor::Post(const parser::DerivedTypeSpec &x) {
       // clone its contents, specialize them with the actual type parameter
       // values, and check constraints.
       auto save{GetFoldingContext().messages().SetLocation(*currStmtSource())};
-      type.derivedTypeSpec().Instantiate(currScope(), context());
+      InstantiateDerivedType(type.derivedTypeSpec(), currScope(), context());
     }
     SetDeclTypeSpec(type);
   }

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -23,12 +23,12 @@
 #include "../parser/provenance.h"
 #include <list>
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
 
 namespace Fortran::semantics {
 
-class SemanticsContext;
 using namespace parser::literals;
 
 using common::ConstantSubscript;
@@ -162,6 +162,7 @@ public:
   Scope *FindSubmodule(const SourceName &) const;
   bool AddSubmodule(const SourceName &, Scope &);
 
+  const DeclTypeSpec *FindType(const DeclTypeSpec &) const;
   const DeclTypeSpec &MakeNumericType(TypeCategory, KindExpr &&kind);
   const DeclTypeSpec &MakeLogicalType(KindExpr &&kind);
   const DeclTypeSpec &MakeCharacterType(
@@ -202,17 +203,6 @@ public:
   // Attempts to find a match for a derived type instance
   const DeclTypeSpec *FindInstantiatedDerivedType(const DerivedTypeSpec &,
       DeclTypeSpec::Category = DeclTypeSpec::TypeDerived) const;
-
-  // Returns a matching derived type instance if one exists, otherwise
-  // creates one
-  const DeclTypeSpec &FindOrInstantiateDerivedType(DerivedTypeSpec &&,
-      SemanticsContext &, DeclTypeSpec::Category = DeclTypeSpec::TypeDerived);
-
-  // Clones a DerivedType scope for a new instance from the type definition.
-  Scope &InstantiateDerivedType(const Scope &, SemanticsContext &);
-
-  const DeclTypeSpec &InstantiateIntrinsicType(
-      const DeclTypeSpec &, SemanticsContext &);
 
   bool IsModuleFile() const {
     return kind_ == Kind::Module && symbol_ != nullptr &&

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -552,32 +552,6 @@ void DerivedTypeDetails::add_component(const Symbol &symbol) {
   componentNames_.push_back(symbol.name());
 }
 
-std::list<SourceName> DerivedTypeDetails::OrderParameterNames(
-    const Symbol &type) const {
-  std::list<SourceName> result;
-  if (const DerivedTypeSpec * spec{type.GetParentTypeSpec()}) {
-    const DerivedTypeDetails &details{
-        spec->typeSymbol().get<DerivedTypeDetails>()};
-    result = details.OrderParameterNames(spec->typeSymbol());
-  }
-  for (const auto &name : paramNames_) {
-    result.push_back(name);
-  }
-  return result;
-}
-
-SymbolVector DerivedTypeDetails::OrderParameterDeclarations(
-    const Symbol &type) const {
-  SymbolVector result;
-  if (const DerivedTypeSpec * spec{type.GetParentTypeSpec()}) {
-    const DerivedTypeDetails &details{
-        spec->typeSymbol().get<DerivedTypeDetails>()};
-    result = details.OrderParameterDeclarations(spec->typeSymbol());
-  }
-  result.insert(result.end(), paramDecls_.begin(), paramDecls_.end());
-  return result;
-}
-
 SymbolVector DerivedTypeDetails::OrderComponents(const Scope &scope) const {
   SymbolVector result;
   for (SourceName name : componentNames_) {

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -233,15 +233,6 @@ public:
   void add_component(const Symbol &);
   void set_sequence(bool x = true) { sequence_ = x; }
 
-  // Returns the complete list of derived type parameter names in the
-  // order defined by 7.5.3.2.
-  std::list<SourceName> OrderParameterNames(const Symbol &) const;
-
-  // Returns the complete list of derived type parameter symbols in
-  // the order in which their declarations appear in the derived type
-  // definitions (parents first).
-  SymbolVector OrderParameterDeclarations(const Symbol &) const;
-
   // Returns the complete list of derived type components in the order
   // in which their declarations appear in the derived type definitions
   // (parents first).  Parent components appear in the list immediately

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -30,7 +30,6 @@ namespace Fortran::semantics {
 /// *Details classes.
 
 class Scope;
-class SemanticsContext;
 class Symbol;
 
 using SymbolVector = std::vector<const Symbol *>;
@@ -609,9 +608,6 @@ public:
         },
         details_);
   }
-
-  // Clones the Symbol in the context of a parameterized derived type instance
-  Symbol &Instantiate(Scope &, SemanticsContext &) const;
 
   // If there is a parent component, return a pointer to its derived type spec.
   // The Scope * argument defaults to this->scope_ but should be overridden

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -103,6 +103,14 @@ bool IsFinalizable(const Symbol &symbol);
 bool IsCoarray(const Symbol &symbol);
 bool IsAssumedSizeArray(const Symbol &symbol);
 
+// Returns the complete list of derived type parameter symbols in
+// the order in which their declarations appear in the derived type
+// definitions (parents first).
+SymbolVector OrderParameterDeclarations(const Symbol &);
+// Returns the complete list of derived type parameter names in the
+// order defined by 7.5.3.2.
+std::list<SourceName> OrderParameterNames(const Symbol &);
+
 // Create a new instantiation of this parameterized derived type
 // for this particular distinct set of actual parameter values.
 void InstantiateDerivedType(DerivedTypeSpec &, Scope &, SemanticsContext &);

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -103,6 +103,14 @@ bool IsFinalizable(const Symbol &symbol);
 bool IsCoarray(const Symbol &symbol);
 bool IsAssumedSizeArray(const Symbol &symbol);
 
+// Create a new instantiation of this parameterized derived type
+// for this particular distinct set of actual parameter values.
+void InstantiateDerivedType(DerivedTypeSpec &, Scope &, SemanticsContext &);
+// Return an existing or new derived type instance
+const DeclTypeSpec &FindOrInstantiateDerivedType(Scope &, DerivedTypeSpec &&,
+    SemanticsContext &, DeclTypeSpec::Category = DeclTypeSpec::TypeDerived);
+void ProcessParameterExpressions(DerivedTypeSpec &, evaluate::FoldingContext &);
+
 // Determines whether an object might be visible outside a
 // PURE function (C1594); returns a non-null Symbol pointer for
 // diagnostic purposes if so.

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -33,15 +33,10 @@ namespace Fortran::parser {
 struct Expr;
 }
 
-namespace Fortran::evaluate {
-class FoldingContext;
-}
-
 namespace Fortran::semantics {
 
 class Scope;
 class Symbol;
-class SemanticsContext;
 class ExprResolver;
 
 /// A SourceName is a name in the cooked character stream,
@@ -231,6 +226,7 @@ public:
   const Symbol &typeSymbol() const { return typeSymbol_; }
   const Scope *scope() const { return scope_; }
   void set_scope(const Scope &);
+  void ReplaceScope(const Scope &);
   const std::map<SourceName, ParamValue> &parameters() const {
     return parameters_;
   }
@@ -246,8 +242,6 @@ public:
       return nullptr;
     }
   }
-  void ProcessParameterExpressions(evaluate::FoldingContext &);
-  Scope &Instantiate(Scope &, SemanticsContext &);
   bool operator==(const DerivedTypeSpec &that) const {
     return &typeSymbol_ == &that.typeSymbol_ && parameters_ == that.parameters_;
   }


### PR DESCRIPTION
Move some member functions out of symbols.h etc. and into tools.h. This simplifies things a little and reduces dependencies of the symbol table on the rest of semantics.