### PR TITLE
Better name resolution for intrinsics

### DIFF
--- a/lib/evaluate/characteristics.cc
+++ b/lib/evaluate/characteristics.cc
@@ -371,6 +371,10 @@ std::optional<Procedure> Procedure::Characterize(
           },
           [&](const semantics::ProcEntityDetails &proc)
               -> std::optional<Procedure> {
+            if (symbol.attrs().test(semantics::Attr::INTRINSIC)) {
+              return intrinsics.IsUnrestrictedSpecificIntrinsicFunction(
+                  symbol.name().ToString());
+            }
             const semantics::ProcInterface &interface{proc.interface()};
             if (const semantics::Symbol * interfaceSymbol{interface.symbol()}) {
               auto characterized{Characterize(*interfaceSymbol, intrinsics)};
@@ -403,21 +407,11 @@ std::optional<Procedure> Procedure::Characterize(
           [&](const semantics::ProcBindingDetails &binding) {
             return Characterize(binding.symbol(), intrinsics);
           },
-          [&](const semantics::MiscDetails &misc) -> std::optional<Procedure> {
-            if (misc.kind() ==
-                semantics::MiscDetails::Kind::SpecificIntrinsic) {
-              return intrinsics.IsUnrestrictedSpecificIntrinsicFunction(
-                  symbol.name().ToString());
-            } else {
-              return std::nullopt;
-            }
-          },
           [](const semantics::GenericDetails &) -> std::optional<Procedure> {
             return std::nullopt;
           },
-          [](const semantics::GenericBindingDetails &) -> std::optional<Procedure> {
-            return std::nullopt;
-          },
+          [](const semantics::GenericBindingDetails &)
+              -> std::optional<Procedure> { return std::nullopt; },
           [](const auto &) -> std::optional<Procedure> { CRASH_NO_CASE; },
       },
       symbol.details());

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1449,17 +1449,15 @@ auto ExpressionAnalyzer::Procedure(const parser::ProcedureDesignator &pd,
               return std::nullopt;
             }
             const Symbol &symbol{n.symbol->GetUltimate()};
-            if (!symbol.HasExplicitInterface() ||
-                (symbol.has<semantics::MiscDetails>() &&
-                    symbol.get<semantics::MiscDetails>().kind() ==
-                        semantics::MiscDetails::Kind::SpecificIntrinsic)) {
-              // Might be an intrinsic.
+            if (symbol.attrs().test(semantics::Attr::INTRINSIC)) {
               if (std::optional<SpecificCall> specificCall{
                       context_.intrinsics().Probe(CallCharacteristics{n.source},
                           arguments, GetFoldingContext())}) {
                 return CalleeAndArguments{ProcedureDesignator{std::move(
                                               specificCall->specificIntrinsic)},
                     std::move(specificCall->arguments)};
+              } else {
+                return std::nullopt;
               }
             }
             if (symbol.HasExplicitInterface()) {

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -326,8 +326,8 @@ class FinalProcDetails {};
 class MiscDetails {
 public:
   ENUM_CLASS(Kind, None, ConstructName, ScopeName, PassName, ComplexPartRe,
-      ComplexPartIm, KindParamInquiry, LenParamInquiry, SelectTypeAssociateName,
-      SpecificIntrinsic);
+      ComplexPartIm, KindParamInquiry, LenParamInquiry,
+      SelectTypeAssociateName);
   MiscDetails(Kind kind) : kind_{kind} {}
   Kind kind() const { return kind_; }
 
@@ -540,12 +540,11 @@ public:
         common::visitors{
             [](const SubprogramDetails &) { return true; },
             [](const SubprogramNameDetails &) { return true; },
-            [](const ProcEntityDetails &x) { return x.HasExplicitInterface(); },
+            [&](const ProcEntityDetails &x) {
+              return attrs_.test(Attr::INTRINSIC) || x.HasExplicitInterface();
+            },
             [](const UseDetails &x) {
               return x.symbol().HasExplicitInterface();
-            },
-            [](const MiscDetails &x) {
-              return x.kind() == MiscDetails::Kind::SpecificIntrinsic;
             },
             [](const auto &) { return false; },
         },

--- a/test/semantics/procinterface01.f90
+++ b/test/semantics/procinterface01.f90
@@ -66,13 +66,13 @@ module module1
   !DEF: /module1/derived1/p5 NOPASS, POINTER ProcEntity COMPLEX(4)
   !DEF: /module1/nested4 PUBLIC Subprogram COMPLEX(4)
   procedure(complex), pointer, nopass :: p5 => nested4
+  !DEF: /module1/sin INTRINSIC, PUBLIC ProcEntity
   !DEF: /module1/derived1/p6 NOPASS, POINTER ProcEntity
   !REF: /module1/nested1
-  ! NOTE: sin is not dumped as a DEF here because specific
-  ! intrinsic functions are represented with MiscDetails
-  ! and those are omitted from dumping.
   procedure(sin), pointer, nopass :: p6 => nested1
+  !REF: /module1/sin
   !DEF: /module1/derived1/p7 NOPASS, POINTER ProcEntity
+  !DEF: /module1/cos INTRINSIC, PUBLIC ProcEntity
   procedure(sin), pointer, nopass :: p7 => cos
   !REF: /module1/tan
   !DEF: /module1/derived1/p8 NOPASS, POINTER ProcEntity CHARACTER(1_4,1)
@@ -118,7 +118,7 @@ contains
   !REF: /module1/nested4/x
   real, intent(in) :: x
   !DEF: /module1/nested4/nested4 ObjectEntity COMPLEX(4)
-  !DEF: /cmplx EXTERNAL (implicit) ProcEntity REAL(4)
+  !DEF: /cmplx INTRINSIC ProcEntity
   !REF: /module1/nested4/x
   nested4 = cmplx(x+4., 6.)
  end function nested4

--- a/test/semantics/symbol13.f90
+++ b/test/semantics/symbol13.f90
@@ -23,7 +23,7 @@ character*1 function f1(x1, x2)
  !REF: /f1/n
  !REF: /f1/x1
  !REF: /f1/x2
- !DEF: /len EXTERNAL (implicit) ProcEntity INTEGER(4)
+ !DEF: /len INTRINSIC ProcEntity
  character*(n), intent(in) :: x1, x2*(len(x1)+1)
  !DEF: /f1/t DerivedType
  type :: t


### PR DESCRIPTION
Eliminate `semantics::MiscDetails::Kind::SpecificIntrinsic` in favor of representing intrinsic procedures in the symbol table as `ProcEntity`(ie)s with the `INTRINSIC` attr set.  Ensure that `EXTERNAL abs` masks the intrinsic.