### PR TITLE
Use passed-object dummy in distinguishability checks

### DIFF
--- a/lib/evaluate/characteristics.h
+++ b/lib/evaluate/characteristics.h
@@ -145,9 +145,10 @@ struct DummyArgument {
   bool IsOptional() const;
   void SetOptional(bool = true);
   std::ostream &Dump(std::ostream &) const;
-  // name is not a characteristic and so does not participate in operator==
-  // but it is needed to determine if procedures are distinguishable
+  // name and pass are not a characteristics and so does not participate in
+  // operator== but are needed to determine if procedures are distinguishable
   std::string name;
+  bool pass{false};  // is this the PASS argument of its procedure
   std::variant<DummyDataObject, DummyProcedure, AlternateReturn> u;
 };
 

--- a/lib/semantics/check-return.cc
+++ b/lib/semantics/check-return.cc
@@ -22,7 +22,7 @@ namespace Fortran::semantics {
 
 const Scope *FindContainingSubprogram(const Scope &start) {
   const Scope *scope{&start};
-  while (scope->kind() != Scope::Kind::Global) {
+  while (!scope->IsGlobal()) {
     switch (scope->kind()) {
     case Scope::Kind::MainProgram:
     case Scope::Kind::Subprogram: return scope;

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -174,7 +174,7 @@ void ModFileWriter::PutSymbols(const Scope &scope) {
     PutSymbol(typeBindings, symbol);
   }
   if (auto str{typeBindings.str()}; !str.empty()) {
-    CHECK(scope.kind() == Scope::Kind::DerivedType);
+    CHECK(scope.IsDerivedType());
     decls_ << "contains\n" << str;
   }
 }
@@ -806,7 +806,7 @@ void SubprogramSymbolCollector::Collect() {
 // Do symbols this one depends on; then add to need_
 void SubprogramSymbolCollector::DoSymbol(const Symbol &symbol) {
   const auto &scope{symbol.owner()};
-  if (scope != scope_ && scope.kind() != Scope::Kind::DerivedType) {
+  if (scope != scope_ && !scope.IsDerivedType()) {
     if (scope != scope_.parent()) {
       useSet_.insert(&symbol);
     } else if (isInterface_) {
@@ -843,7 +843,7 @@ void SubprogramSymbolCollector::DoSymbol(const Symbol &symbol) {
   if (!symbol.has<UseDetails>()) {
     DoType(symbol.GetType());
   }
-  if (scope.kind() != Scope::Kind::DerivedType) {
+  if (!scope.IsDerivedType()) {
     need_.push_back(&symbol);
   }
 }

--- a/lib/semantics/resolve-names-utils.cc
+++ b/lib/semantics/resolve-names-utils.cc
@@ -510,7 +510,7 @@ bool EquivalenceSets::CheckObject(const parser::Name &name) {
   currObject_.symbol = name.symbol;
   parser::MessageFixedText msg{"", 0};
   const Symbol &symbol{*name.symbol};
-  if (symbol.owner().kind() == Scope::Kind::DerivedType) {  // C8107
+  if (symbol.owner().IsDerivedType()) {  // C8107
     msg = "Derived type component '%s'"
           " is not allowed in an equivalence set"_err_en_US;
   } else if (symbol.IsDummy()) {  // C8106

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -79,7 +79,9 @@ public:
     return parent_;
   }
   Kind kind() const { return kind_; }
+  bool IsGlobal() const { return kind_ == Kind::Global; }
   bool IsModule() const;  // only module, not submodule
+  bool IsDerivedType() const { return kind_ == Kind::DerivedType; }
   bool IsParameterizedDerivedType() const;
   Symbol *symbol() { return symbol_; }
   const Symbol *symbol() const { return symbol_; }

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -311,8 +311,7 @@ bool Symbol::IsSeparateModuleProc() const {
 
 bool Symbol::IsFromModFile() const {
   return test(Flag::ModFile) ||
-      (owner_->kind() != Scope::Kind::Global &&
-          owner_->symbol()->IsFromModFile());
+      (!owner_->IsGlobal() && owner_->symbol()->IsFromModFile());
 }
 
 ObjectEntityDetails::ObjectEntityDetails(EntityDetails &&d)
@@ -483,7 +482,7 @@ std::ostream &operator<<(std::ostream &os, const Symbol &symbol) {
 // parent scopes. For scopes without corresponding symbols, use the kind
 // with an index (e.g. Block1, Block2, etc.).
 static void DumpUniqueName(std::ostream &os, const Scope &scope) {
-  if (scope.kind() != Scope::Kind::Global) {
+  if (!scope.IsGlobal()) {
     DumpUniqueName(os, scope.parent());
     os << '/';
     if (auto *scopeSymbol{scope.symbol()};

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -190,16 +190,17 @@ private:
 };
 
 // Mixin for details with passed-object dummy argument.
+// passIndex is set based on passName or the PASS attr.
 class WithPassArg {
 public:
   const SourceName *passName() const { return passName_; }
   void set_passName(const SourceName &passName) { passName_ = &passName; }
-  const Symbol *passArg() const { return passArg_; }
-  void set_passArg(const Symbol *passArg) { passArg_ = passArg; }
+  std::optional<int> passIndex() const { return passIndex_; }
+  void set_passIndex(int index) { passIndex_ = index; }
 
 private:
   const SourceName *passName_{nullptr};
-  const Symbol *passArg_{nullptr};
+  std::optional<int> passIndex_;
 };
 
 // A procedure pointer, dummy procedure, or external procedure

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -39,8 +39,8 @@ static const Symbol *FindCommonBlockInScope(
 }
 
 const Symbol *FindCommonBlockContaining(const Symbol &object) {
-  for (const Scope *scope{&object.owner()};
-       scope->kind() != Scope::Kind::Global; scope = &scope->parent()) {
+  for (const Scope *scope{&object.owner()}; !scope->IsGlobal();
+       scope = &scope->parent()) {
     if (const Symbol * block{FindCommonBlockInScope(*scope, object)}) {
       return block;
     }
@@ -96,7 +96,7 @@ bool DoesScopeContain(
     const Scope *maybeAncestor, const Scope &maybeDescendent) {
   if (maybeAncestor != nullptr) {
     const Scope *scope{&maybeDescendent};
-    while (scope->kind() != Scope::Kind::Global) {
+    while (!scope->IsGlobal()) {
       scope = &scope->parent();
       if (scope == maybeAncestor) {
         return true;
@@ -188,7 +188,7 @@ bool IsProcedurePointer(const Symbol &symbol) {
 
 static const Symbol *FindPointerComponent(
     const Scope &scope, std::set<const Scope *> &visited) {
-  if (scope.kind() != Scope::Kind::DerivedType) {
+  if (!scope.IsDerivedType()) {
     return nullptr;
   }
   if (!visited.insert(&scope).second) {
@@ -450,7 +450,7 @@ static const DeclTypeSpec *FindInstantiatedDerivedType(const Scope &scope,
   DeclTypeSpec type{category, spec};
   if (const auto *found{scope.FindType(type)}) {
     return found;
-  } else if (scope.kind() == Scope::Kind::Global) {
+  } else if (scope.IsGlobal()) {
     return nullptr;
   } else {
     return FindInstantiatedDerivedType(scope.parent(), spec, category);

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -36,7 +36,7 @@ void DerivedTypeSpec::set_scope(const Scope &scope) {
   ReplaceScope(scope);
 }
 void DerivedTypeSpec::ReplaceScope(const Scope &scope) {
-  CHECK(scope.kind() == Scope::Kind::DerivedType);
+  CHECK(scope.IsDerivedType());
   scope_ = &scope;
 }
 

--- a/test/semantics/resolve53.f90
+++ b/test/semantics/resolve53.f90
@@ -357,3 +357,23 @@ contains
     type(*) :: x
   end
 end
+
+! Test C1514 rule 3 -- distinguishable passed-object dummy arguments
+module m18
+  type :: t(k)
+    integer, kind :: k
+  contains
+    procedure, pass(x) :: p1 => s
+    procedure, pass    :: p2 => s
+    procedure          :: p3 => s
+    procedure, pass(y) :: p4 => s
+    generic :: g1 => p1, p4
+    generic :: g2 => p2, p4
+    generic :: g3 => p3, p4
+  end type
+contains
+  subroutine s(x, y)
+    class(t(1)) :: x
+    class(t(2)) :: y
+  end
+end


### PR DESCRIPTION
Complete the checks for distinguishable specifics procedure in a generic
by considering any passed-object dummy arguments.

C1514 rule 3 is implemented and the checks for the other rules are
extended to consider the PASS attribute, including the concept of the
"effective" position of an argument in an argument list, computed by
ignoring passed-object arguments.

Add `pass` to `characteristics::DummyArgument` to mark each
passed-object dummy argument.

Change symbols to store the index of the passed-object dummy argument
rather than its symbol.

Check that specifics of a type-bound generic are distinguishable only
after all of the procedure bindings have been processed. They don't have
to be before the generic.