### PR TITLE
Improvements to semantics tests

### DIFF
--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -140,6 +140,9 @@ set(ERROR_TESTS
 #  omp-nested01.f90
   equivalence01.f90
   init01.f90
+  if_arith01.f90
+  if_construct01.f90
+  if_stmt01.f90
 )
 
 # These test files have expected symbols in the source
@@ -211,40 +214,24 @@ set(FORALL_TESTS
   forall*.[Ff]90
 )
 
-set(IF_TESTS
-  if_arith01.f90
-  if_construct01.f90
-  if_stmt01.f90
-)
+set(F18 $<TARGET_FILE:f18>)
 
 foreach(test ${ERROR_TESTS})
-  add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_errors.sh ${test})
+  add_test(NAME ${test}
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_errors.sh ${test} ${F18})
 endforeach()
 
 foreach(test ${SYMBOL_TESTS})
-  add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_symbols.sh ${test})
+  add_test(NAME ${test}
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_symbols.sh ${test} ${F18})
 endforeach()
 
 foreach(test ${MODFILE_TESTS})
-  add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_modfile.sh ${test})
+  add_test(NAME ${test}
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_modfile.sh ${test} ${F18})
 endforeach()
 
-foreach(test ${LABEL_TESTS})
-  add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_any.sh ${test})
-endforeach()
-
-foreach(test ${CANONDO_TESTS})
-  add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_any.sh ${test})
-endforeach()
-
-foreach(test ${DOCONCURRENT_TESTS})
-  add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_any.sh ${test})
-endforeach()
-
-foreach(test ${FORALL_TESTS})
-  add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_any.sh ${test})
-endforeach()
-
-foreach(test ${IF_TESTS})
-  add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_any.sh ${test})
+foreach(test ${LABEL_TESTS} ${CANONDO_TESTS} ${DOCONCURRENT_TESTS} ${FORALL_TESTS})
+  add_test(NAME ${test}
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_any.sh ${test} ${F18})
 endforeach()

--- a/test/semantics/allocate11.f90
+++ b/test/semantics/allocate11.f90
@@ -90,20 +90,6 @@ subroutine C937(var)
   allocate(C:: var)
 end subroutine
 
-module iso_fortran_env
-  type :: team_type
-  end type
-end module
-
-module iso_c_binding
-  type :: c_ptr
-    integer(kind=8) ptr
-  end type
-  type :: c_funptr
-    integer(kind=8) ptr
-  end type
-end module
-
 !TODO: type extending team_type !? subcomponents !?
 
 subroutine C938_C947(var2, ptr, ptr2, fptr, my_team, srca)

--- a/test/semantics/allocate13.f90
+++ b/test/semantics/allocate13.f90
@@ -14,13 +14,6 @@
 
 ! Check for semantic errors in ALLOCATE statements
 
-module iso_fortran_env
-  type event_type
-  end type
-  type lock_type
-  end type
-end module
-
 module not_iso_fortran_env
   type event_type
   end type

--- a/test/semantics/coarrays01.f90
+++ b/test/semantics/coarrays01.f90
@@ -14,12 +14,6 @@
 
 ! Test selector and team-value in CHANGE TEAM statement
 
-! Temporary, until we have real iso_fortran_env
-module iso_fortran_env
-  type :: team_type
-  end type
-end
-
 ! OK
 subroutine s1
   use iso_fortran_env, only: team_type

--- a/test/semantics/common.sh
+++ b/test/semantics/common.sh
@@ -1,0 +1,39 @@
+# Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Common functionality for test scripts
+# Process arguments, expecting source file as 1st; optional path to f18 as 2nd
+# Set: $F18 to the path to f18; $temp to an empty temp directory; and $src
+# to the full path of the single source argument
+
+PATH=/usr/bin:/bin
+
+function die {
+  echo "$(basename $0): $*" >&2
+  exit 1
+}
+
+case $# in
+  (1) ;;
+  (2) F18=$2 ;;
+  (*) echo "Usage: $(basename $0) <fortran-source> [<f18-executable>]"; exit 1
+esac
+[[ -z ${F18+x} ]] && die "Path to f18 must be second argument or in F18 environment variable"
+[[ ! -f $F18 ]] && die "f18 executable not found: $F18"
+case $1 in
+  (/*) src=$1 ;;
+  (*) src=$(dirname $0)/$1 ;;
+esac
+temp=`mktemp -d ./tmp.XXXXXX`
+[[ $KEEP ]] || trap "rm -rf $temp" EXIT

--- a/test/semantics/resolve50.f90
+++ b/test/semantics/resolve50.f90
@@ -14,11 +14,6 @@
 
 ! Test coarray association in CHANGE TEAM statement
 
-module iso_fortran_env
-  type :: team_type
-  end type
-end
-
 subroutine s1
   use iso_fortran_env
   type(team_type) :: t

--- a/test/semantics/test_any.sh
+++ b/test/semantics/test_any.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,9 +17,10 @@
 # we get the right symbols in the output, i.e. the output should be
 # the same as the input, except for the copyright comment.
 # Change the compiler by setting the F18 environment variable.
-PATH=/usr/bin:/bin
+
 srcdir=$(dirname $0)
-F18=${F18:=../../tools/f18/bin/f18}
+source $srcdir/common.sh
+
 FileCheck=${FileCheck:=internal_check}
 
 function internal_check() {
@@ -50,11 +51,9 @@ function internal_check() {
 
 gr=0
 for input in ${srcdir}/$*; do
-  lr=true
   CMD=$(cat ${input} | egrep '^[[:space:]]*![[:space:]]*RUN:[[:space:]]*' | sed -e 's/^[[:space:]]*![[:space:]]*RUN:[[:space:]]*//')
   CMD=$(echo ${CMD} | sed -e "s:%s:${input}:g")
-  $(eval $CMD) || lr=false
-  if $lr; then
+  if $(eval $CMD); then
     echo "PASS  ${input}"
   else
     echo "FAIL  ${input}"

--- a/test/semantics/test_modfile.sh
+++ b/test/semantics/test_modfile.sh
@@ -16,19 +16,10 @@
 # Compile a source file and compare generated .mod files against expected.
 
 set -e
-PATH=/usr/bin:/bin
+F18_OPTIONS="-fdebug-resolve-names -fparse-only"
 srcdir=$(dirname $0)
-CMD="${F18:-../../../tools/f18/bin/f18} -fdebug-resolve-names -fparse-only"
-if [[ $# != 1 ]]; then
-  echo "Usage: $0 <fortran-source>"
-  exit 1
-fi
-src=$srcdir/$1
+source $srcdir/common.sh
 
-temp=temp-$1
-rm -rf $temp
-mkdir $temp
-[[ $KEEP ]] || trap "rm -rf $temp" EXIT
 actual=$temp/actual.mod
 expect=$temp/expect.mod
 actual_files=$temp/actual_files
@@ -43,7 +34,7 @@ for src in "$@"; do
   (
     cd $temp
     ls -1 *.mod > prev_files
-    $CMD $src
+    $F18 $F18_OPTIONS $src
     ls -1 *.mod | comm -13 prev_files -
   ) > $actual_files
   expected_files=$(sed -n 's/^!Expect: \(.*\)/\1/p' $src | sort)

--- a/test/semantics/test_symbols.sh
+++ b/test/semantics/test_symbols.sh
@@ -18,21 +18,10 @@
 # the same as the input, except for the copyright comment.
 # Change the compiler by setting the F18 environment variable.
 
-PATH=/usr/bin:/bin
+F18_OPTIONS="-funparse-with-symbols"
 srcdir=$(dirname $0)
-CMD="${F18:-../../../tools/f18/bin/f18} -funparse-with-symbols"
-
-if [[ $# != 1 ]]; then
-  echo "Usage: $0 <fortran-source>"
-  exit 1
-fi
-src=$srcdir/$1
+source $srcdir/common.sh
 [[ ! -f $src ]] && echo "File not found: $src" && exit 1
-
-temp=temp-$1
-rm -rf $temp
-mkdir $temp
-[[ $KEEP ]] || trap "rm -rf $temp" EXIT
 
 src1=$temp/1.f90
 src2=$temp/2.f90
@@ -44,7 +33,8 @@ sed -e 's/!\([DR]EF:\)/KEEP \1/' \
   -e 's/!.*//' -e 's/ *$//' -e '/^$/d' -e 's/KEEP \([DR]EF:\)/!\1/' \
   $src > $src1
 egrep -v '^ *!' $src1 > $src2  # strip out meaningful comments
-( cd $temp; $CMD $(basename $src2) ) > $src3  # compile, inserting comments for symbols
+# compile, inserting comments for symbols:
+( cd $temp; $F18 $F18_OPTIONS $(basename $src2) ) > $src3
 
 if diff -w -U999999 $src1 $src3 > $diffs; then
   echo PASS


### PR DESCRIPTION
Change test scripts so that cmake passes in the path to the `f18`
that it just built. They no longer have to use relative paths.

Simplify argument passing in test scripts by sharing it in `common.sh`.

Move `if_arith01.f90`, `if_construct01.f90`, `if_stmt01.f90` to `ERROR_TESTS`.
As it was, nothing was being tested on them.

For `test_error.sh`, find the include directory relative to `f18` and
pass that in with a `-I` option. Eliminate the temporary definitions of
`iso_fortran_env`, `iso_c_binding`, `ieee_exceptions` in the tests
because the "real" ones are now available.

The tests that are run with `test_any.sh` could probably have similar
changes, but they are not part of this commit.