### PR TITLE
 Loop association between Loop Constructs and do-loops

### DIFF
--- a/lib/parser/openmp-grammar.h
+++ b/lib/parser/openmp-grammar.h
@@ -526,11 +526,13 @@ TYPE_PARSER(startOmpLine >> "END"_tok >>
     construct<OmpEndBlockDirective>(Parser<OmpBlockDirective>{}) / endOmpLine)
 
 // END OMP Loop directives
-TYPE_PARSER(startOmpLine >> "END"_tok >>
-    (construct<OpenMPEndLoopDirective>("DO SIMD" >> Parser<OmpEndDoSimd>{}) ||
-        construct<OpenMPEndLoopDirective>("DO" >> Parser<OmpEndDo>{}) ||
-        construct<OpenMPEndLoopDirective>(Parser<OmpLoopDirective>{}) /
-            endOmpLine))
+TYPE_PARSER(startOmpLine >>
+    sourced("END"_tok >>
+        (construct<OpenMPEndLoopDirective>(
+             "DO SIMD" >> Parser<OmpEndDoSimd>{}) ||
+            construct<OpenMPEndLoopDirective>("DO" >> Parser<OmpEndDo>{}) ||
+            construct<OpenMPEndLoopDirective>(Parser<OmpLoopDirective>{}))) /
+        endOmpLine)
 
 TYPE_PARSER(construct<OpenMPLoopConstruct>(
     Parser<OmpLoopDirective>{}, Parser<OmpClauseList>{} / endOmpLine))

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -3693,6 +3693,7 @@ WRAPPER_CLASS(OmpEndDoSimd, std::optional<OmpNowait>);
 WRAPPER_CLASS(OmpEndDo, std::optional<OmpNowait>);
 struct OpenMPEndLoopDirective {
   UNION_CLASS_BOILERPLATE(OpenMPEndLoopDirective);
+  CharBlock source;
   std::variant<OmpEndDoSimd, OmpEndDo, OmpLoopDirective> u;
 };
 

--- a/test/semantics/omp-clause-validity01.f90
+++ b/test/semantics/omp-clause-validity01.f90
@@ -206,6 +206,26 @@
   do i = 1, N
      a = 3.14
   enddo
+  !$omp end parallel do
+
+! Loop association check
+
+  a = 0.0
+  !ERROR: The END PARALLEL DO must follow the do-loop associated with the loop construct
+  !$omp end parallel do
+  !$omp parallel do private(c)
+  do i = 1, N
+     do j = 1, N
+        !ERROR: do-loop is expected after the PARALLEL DO directive
+        !$omp parallel do shared(b)
+        a = 3.14
+     enddo
+     !ERROR: The END PARALLEL DO must follow the do-loop associated with the loop construct
+     !$omp end parallel do
+  enddo
+  a = 1.414
+  !ERROR: The END PARALLEL DO must follow the do-loop associated with the loop construct
+  !$omp end parallel do
 
 ! 2.8.3 do-simd-clause -> do-clause |
 !                         simd-clause

--- a/test/semantics/omp-clause-validity01.f90
+++ b/test/semantics/omp-clause-validity01.f90
@@ -196,6 +196,18 @@
   enddo
   !$omp end parallel
 
+  !$omp parallel
+  !ERROR: An ORDERED construct with the SIMD clause is the only OpenMP construct that can be encountered during execution of a SIMD region
+  !$omp simd
+  do i = 1, N
+     do j = 1, N
+        !$omp ordered threads
+        a = 3.14
+        !$omp end ordered
+     enddo
+  enddo
+  !$omp end parallel
+
 ! 2.11.1 parallel-do-clause -> parallel-clause |
 !                              do-clause
 


### PR DESCRIPTION
```
!$omp parallel do
do i=1, N
  ...
enddo
[!$omp end parallel do]
```
Here LoopDirective and EndLoopDirective are not wrapped in the same class.
Ideally, it would be `{LoopDirective, ClauseList, DoConstruct, EndLoopDirective}`.
However, to allow different forms of do-loops, OpenMPLoopConstruct is actually
`{LoopDirective, ClauseList}` and the loop association checks are deferred to
Semantics.

In the example, do-loop needs to immediately follow the LoopDirective and
EndLoopDirective needs to immediately follow the ENDDO (`DoConstruct`). Here
the EndLoopdirective is optional because the scope of PARALLEL region is
determined by the scope of the associated do-loop. Unlike BlockDirective,
we pop the context upon the LEAVE of DoConstruct or on the point of failing
to find the associated do-loop.

Note that a new `checkState_` struct was created to hold temporary status.

Msg examples:
```
omp-clause-validity01.f90:220:15: error: do-loop is expected after the PARALLEL DO directive
          !$omp parallel do shared(b)
                ^^^^^^^^^^^
omp-clause-validity01.f90:224:12: error: The END PARALLEL DO must follow the do-loop associated with the loop construct
       !$omp end parallel do
             ^^^^^^^^^^^^^^^
```
Also added simd/ordered constructs example to test the implementation.