### PR TITLE
Allow forward references to procedure interfaces in derived types (fi…

### DIFF
--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -3941,7 +3941,7 @@ void DeclarationVisitor::CheckExplicitInterface(Symbol &symbol) {
     const Symbol *subp{FindSubprogram(*interface)};
     if (subp == nullptr || !subp->HasExplicitInterface()) {
       Say(symbol.name(),
-          "The interface of '%s' (%s) is not an abstract interface or a "
+          "The interface of '%s' ('%s') is not an abstract interface or a "
           "procedure with an explicit interface"_err_en_US,
           symbol.name(), interface->name());
       context().SetError(symbol);

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -1973,6 +1973,7 @@ void ModuleVisitor::BeginModule(const parser::Name &name, bool isSubmodule) {
   auto &details{symbol.get<ModuleDetails>()};
   PushScope(Scope::Kind::Module, &symbol);
   details.set_scope(&currScope());
+  defaultAccess_ = Attr::PUBLIC;
   prevAccessStmt_ = nullptr;
 }
 

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -541,7 +541,13 @@ public:
             [&](const ProcEntityDetails &x) {
               return attrs_.test(Attr::INTRINSIC) || x.HasExplicitInterface();
             },
+            [](const ProcBindingDetails &x) {
+              return x.symbol().HasExplicitInterface();
+            },
             [](const UseDetails &x) {
+              return x.symbol().HasExplicitInterface();
+            },
+            [](const HostAssocDetails &x) {
               return x.symbol().HasExplicitInterface();
             },
             [](const auto &) { return false; },

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -41,6 +41,8 @@ const Symbol *FindPointerComponent(const Scope &);
 const Symbol *FindPointerComponent(const DerivedTypeSpec &);
 const Symbol *FindPointerComponent(const DeclTypeSpec &);
 const Symbol *FindPointerComponent(const Symbol &);
+const Symbol *FindInterface(const Symbol &);
+const Symbol *FindSubprogram(const Symbol &);
 const Symbol *FindFunctionResult(const Symbol &);
 
 bool IsCommonBlockContaining(const Symbol &block, const Symbol &object);

--- a/test/semantics/resolve20.f90
+++ b/test/semantics/resolve20.f90
@@ -22,20 +22,20 @@ module m
   procedure(integer) :: b
   procedure(foo) :: c
   procedure(bar) :: d
-  !ERROR: The interface of 'e' (missing) is not an abstract interface or a procedure with an explicit interface
+  !ERROR: The interface of 'e' ('missing') is not an abstract interface or a procedure with an explicit interface
   procedure(missing) :: e
-  !ERROR: The interface of 'f' (b) is not an abstract interface or a procedure with an explicit interface
+  !ERROR: The interface of 'f' ('b') is not an abstract interface or a procedure with an explicit interface
   procedure(b) :: f
   procedure(c) :: g
   external :: h
-  !ERROR: The interface of 'i' (h) is not an abstract interface or a procedure with an explicit interface
+  !ERROR: The interface of 'i' ('h') is not an abstract interface or a procedure with an explicit interface
   procedure(h) :: i
   procedure(forward) :: j
-  !ERROR: The interface of 'k1' (bad1) is not an abstract interface or a procedure with an explicit interface
+  !ERROR: The interface of 'k1' ('bad1') is not an abstract interface or a procedure with an explicit interface
   procedure(bad1) :: k1
-  !ERROR: The interface of 'k2' (bad2) is not an abstract interface or a procedure with an explicit interface
+  !ERROR: The interface of 'k2' ('bad2') is not an abstract interface or a procedure with an explicit interface
   procedure(bad2) :: k2
-  !ERROR: The interface of 'k3' (bad3) is not an abstract interface or a procedure with an explicit interface
+  !ERROR: The interface of 'k3' ('bad3') is not an abstract interface or a procedure with an explicit interface
   procedure(bad3) :: k3
 
   abstract interface

--- a/test/semantics/resolve20.f90
+++ b/test/semantics/resolve20.f90
@@ -22,20 +22,20 @@ module m
   procedure(integer) :: b
   procedure(foo) :: c
   procedure(bar) :: d
-  !ERROR: The interface of 'e' is not an abstract interface or a procedure with an explicit interface
+  !ERROR: The interface of 'e' (missing) is not an abstract interface or a procedure with an explicit interface
   procedure(missing) :: e
-  !ERROR: The interface of 'f' is not an abstract interface or a procedure with an explicit interface
+  !ERROR: The interface of 'f' (b) is not an abstract interface or a procedure with an explicit interface
   procedure(b) :: f
   procedure(c) :: g
   external :: h
-  !ERROR: The interface of 'i' is not an abstract interface or a procedure with an explicit interface
+  !ERROR: The interface of 'i' (h) is not an abstract interface or a procedure with an explicit interface
   procedure(h) :: i
   procedure(forward) :: j
-  !ERROR: The interface of 'k1' is not an abstract interface or a procedure with an explicit interface
+  !ERROR: The interface of 'k1' (bad1) is not an abstract interface or a procedure with an explicit interface
   procedure(bad1) :: k1
-  !ERROR: The interface of 'k2' is not an abstract interface or a procedure with an explicit interface
+  !ERROR: The interface of 'k2' (bad2) is not an abstract interface or a procedure with an explicit interface
   procedure(bad2) :: k2
-  !ERROR: The interface of 'k3' is not an abstract interface or a procedure with an explicit interface
+  !ERROR: The interface of 'k3' (bad3) is not an abstract interface or a procedure with an explicit interface
   procedure(bad3) :: k3
 
   abstract interface

--- a/test/semantics/resolve32.f90
+++ b/test/semantics/resolve32.f90
@@ -57,7 +57,7 @@ module m
     procedure(foo), nopass, deferred :: f
     !ERROR: DEFERRED is required when an interface-name is provided
     procedure(foo), nopass :: g
-    !ERROR: 'bar' is not an abstract interface or a procedure with an explicit interface
+    !ERROR: The interface of 'h' (bar) is not an abstract interface or a procedure with an explicit interface
     procedure(bar), nopass, deferred :: h
   end type
   type t2

--- a/test/semantics/resolve32.f90
+++ b/test/semantics/resolve32.f90
@@ -57,7 +57,7 @@ module m
     procedure(foo), nopass, deferred :: f
     !ERROR: DEFERRED is required when an interface-name is provided
     procedure(foo), nopass :: g
-    !ERROR: The interface of 'h' (bar) is not an abstract interface or a procedure with an explicit interface
+    !ERROR: The interface of 'h' ('bar') is not an abstract interface or a procedure with an explicit interface
     procedure(bar), nopass, deferred :: h
   end type
   type t2


### PR DESCRIPTION
…xing #571 more)

An earlier change fixed up forward references in `procedure()` interfaces outside derived types.  This change completes the job so that forward references can also be used within derived types.