### PR TITLE
Fix issue #582: implicit ac-do-variable kind in expressions

### DIFF
--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1079,10 +1079,10 @@ void ArrayConstructorContext::Add(const parser::AcValue &x) {
                 std::get<parser::AcImpliedDoControl::Bounds>(control.t)};
             Analyze(bounds.name);
             parser::CharBlock name{bounds.name.thing.thing.source};
+            const Symbol *symbol{bounds.name.thing.thing.symbol};
             int kind{IntType::kind};
-            if (auto &its{std::get<std::optional<parser::IntegerTypeSpec>>(
-                    control.t)}) {
-              kind = IntegerTypeSpecKind(*its);
+            if (const auto dynamicType{DynamicType::From(symbol)}) {
+              kind = dynamicType->kind();
             }
             bool inserted{AddAcImpliedDo(name, kind)};
             if (!inserted) {

--- a/test/semantics/allocate09.f90
+++ b/test/semantics/allocate09.f90
@@ -62,6 +62,7 @@ subroutine C946(param_ca_4_assumed, param_ta_4_assumed, param_ca_4_deferred)
   type(WithParam(4, :)), allocatable :: param_ta_4_deferred
   class(WithParam(4, :)), pointer :: param_ca_4_deferred
   class(WithParam), allocatable :: param_defaulted
+  integer, allocatable :: integer_default(:)
 
   type(WithParamExtent2(k1=4, l1=:, k2=5, l2=:, l3=8 )), pointer :: extended2
 
@@ -87,6 +88,8 @@ subroutine C946(param_ca_4_assumed, param_ta_4_assumed, param_ca_4_deferred)
   allocate(param_defaulted, source=WithParam(k1=1)(x=5))
   allocate(param_defaulted, mold=src_c_1_2_5_6_5_8)
   allocate(whatever, source=src_c_1_2_5_6_5_8)
+
+  allocate(integer_default, source=[(i,i=0,9)])
 
 
   !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
@@ -133,4 +136,6 @@ subroutine C946(param_ca_4_assumed, param_ta_4_assumed, param_ca_4_deferred)
   allocate(param_defaulted, mold=WithParam(k1=2)(x=5))
   !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
   allocate(param_defaulted, source=src_c_5_2_5_6_5_8)
+  !ERROR: Kind type parameters of allocatable object must be the same as the corresponding ones of SOURCE or MOLD expression
+  allocate(integer_default, source=[(i, integer(8)::i=0,9)])
 end subroutine


### PR DESCRIPTION
Apply first proposed solution for issue #582: use previously resolved type of `ac-do-variable` from the symbol table when analyzing array constructor with `AcImpliedDo`. The symbol type resolution is compliant with 19.4 point 5 requirements.