### PR TITLE
[OpenMP] Add Sections and Single Construct check

### DIFF
--- a/lib/parser/openmp-grammar.h
+++ b/lib/parser/openmp-grammar.h
@@ -491,10 +491,9 @@ TYPE_PARSER(startOmpLine >> "END SECTIONS"_tok >>
 TYPE_PARSER(construct<OpenMPSectionsConstruct>(verbatim("SECTIONS"_tok),
     Parser<OmpClauseList>{} / endOmpLine, block, Parser<OmpEndSections>{}))
 
-// OMP END PARALLEL SECTIONS [NOWAIT]
-TYPE_PARSER(startOmpLine >> "END PARALLEL SECTIONS"_tok >>
-    construct<OmpEndParallelSections>(
-        maybe("NOWAIT" >> construct<OmpNowait>()) / endOmpLine))
+// OMP END PARALLEL SECTIONS
+TYPE_PARSER(construct<OmpEndParallelSections>(
+    startOmpLine >> "END PARALLEL SECTIONS"_tok / endOmpLine))
 
 // OMP PARALLEL SECTIONS
 TYPE_PARSER(construct<OpenMPParallelSectionsConstruct>(

--- a/lib/parser/openmp-grammar.h
+++ b/lib/parser/openmp-grammar.h
@@ -463,8 +463,9 @@ TYPE_PARSER(construct<OpenMPStandaloneConstruct>(
     Parser<OmpStandaloneDirective>{}, Parser<OmpClauseList>{} / endOmpLine))
 
 // OMP SINGLE
-TYPE_PARSER(startOmpLine >> "END"_tok >>
-    construct<OmpEndSingle>("SINGLE" >> Parser<OmpClauseList>{}) / endOmpLine)
+TYPE_PARSER(startOmpLine >> construct<OmpEndSingle>(verbatim("END SINGLE"_tok),
+                                Parser<OmpClauseList>{}) /
+        endOmpLine)
 
 TYPE_PARSER(construct<OpenMPSingleConstruct>(verbatim("SINGLE"_tok),
     Parser<OmpClauseList>{} / endOmpLine, block, Parser<OmpEndSingle>{}))

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -3490,7 +3490,10 @@ struct OpenMPWorkshareConstruct {
 };
 
 // SINGLE
-WRAPPER_CLASS(OmpEndSingle, OmpClauseList);
+struct OmpEndSingle {
+  TUPLE_CLASS_BOILERPLATE(OmpEndSingle);
+  std::tuple<Verbatim, OmpClauseList> t;
+};
 struct OpenMPSingleConstruct {
   TUPLE_CLASS_BOILERPLATE(OpenMPSingleConstruct);
   std::tuple<Verbatim, OmpClauseList, Block, OmpEndSingle> t;

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -3470,14 +3470,13 @@ struct OmpClauseList {
 
 // SECTIONS, PARALLEL SECTIONS
 WRAPPER_CLASS(OmpEndSections, std::optional<OmpNowait>);
-WRAPPER_CLASS(OmpEndParallelSections, std::optional<OmpNowait>);
 WRAPPER_CLASS(OmpSection, Verbatim);
-
 struct OpenMPSectionsConstruct {
   TUPLE_CLASS_BOILERPLATE(OpenMPSectionsConstruct);
   std::tuple<Verbatim, OmpClauseList, Block, OmpEndSections> t;
 };
 
+EMPTY_CLASS(OmpEndParallelSections);
 struct OpenMPParallelSectionsConstruct {
   TUPLE_CLASS_BOILERPLATE(OpenMPParallelSectionsConstruct);
   std::tuple<Verbatim, OmpClauseList, Block, OmpEndParallelSections> t;

--- a/lib/semantics/check-omp-structure.h
+++ b/lib/semantics/check-omp-structure.h
@@ -26,14 +26,14 @@
 
 namespace Fortran::semantics {
 
-ENUM_CLASS(OmpDirective, PARALLEL, DO, SECTIONS, SECTION, SINGLE, WORKSHARE,
-    SIMD, DECLARE_SIMD, DO_SIMD, TASK, TASKLOOP, TASKLOOP_SIMD, TASKYIELD,
-    TARGET_DATA, TARGET_ENTER_DATA, TARGET_EXIT_DATA, TARGET, TARGET_UPDATE,
-    DECLARE_TARGET, TEAMS, DISTRIBUTE, DISTRIBUTE_SIMD, DISTRIBUTE_PARALLEL_DO,
-    DISTRIBUTE_PARALLEL_DO_SIMD, PARALLEL_DO, PARALLEL_SECTIONS,
-    PARALLEL_WORKSHARE, PARALLEL_DO_SIMD, TARGET_PARALLEL, TARGET_PARALLEL_DO,
-    TARGET_PARALLEL_DO_SIMD, TARGET_SIMD, TARGET_TEAMS, TEAMS_DISTRIBUTE,
-    TEAMS_DISTRIBUTE_SIMD, TARGET_TEAMS_DISTRIBUTE,
+ENUM_CLASS(OmpDirective, PARALLEL, DO, SECTIONS, SECTION, SINGLE, END_SINGLE,
+    WORKSHARE, SIMD, DECLARE_SIMD, DO_SIMD, TASK, TASKLOOP, TASKLOOP_SIMD,
+    TASKYIELD, TARGET_DATA, TARGET_ENTER_DATA, TARGET_EXIT_DATA, TARGET,
+    TARGET_UPDATE, DECLARE_TARGET, TEAMS, DISTRIBUTE, DISTRIBUTE_SIMD,
+    DISTRIBUTE_PARALLEL_DO, DISTRIBUTE_PARALLEL_DO_SIMD, PARALLEL_DO,
+    PARALLEL_SECTIONS, PARALLEL_WORKSHARE, PARALLEL_DO_SIMD, TARGET_PARALLEL,
+    TARGET_PARALLEL_DO, TARGET_PARALLEL_DO_SIMD, TARGET_SIMD, TARGET_TEAMS,
+    TEAMS_DISTRIBUTE, TEAMS_DISTRIBUTE_SIMD, TARGET_TEAMS_DISTRIBUTE,
     TARGET_TEAMS_DISTRIBUTE_SIMD, TEAMS_DISTRIBUTE_PARALLEL_DO,
     TARGET_TEAMS_DISTRIBUTE_PARALLEL_DO, TEAMS_DISTRIBUTE_PARALLEL_DO_SIMD,
     TARGET_TEAMS_DISTRIBUTE_PARALLEL_DO_SIMD, MASTER, CRITICAL, BARRIER,
@@ -64,8 +64,19 @@ public:
   void Leave(const parser::OpenMPBlockConstruct &);
   void Enter(const parser::OmpBlockDirective &);
 
+  void Enter(const parser::OpenMPSectionsConstruct &);
+  void Leave(const parser::OpenMPSectionsConstruct &);
+  void Enter(const parser::OmpSection &);
+  void Leave(const parser::OmpSection &);
+
+  void Enter(const parser::OpenMPSingleConstruct &x);
+  void Leave(const parser::OpenMPSingleConstruct &x);
+  void Enter(const parser::OmpEndSingle &x);
+  void Leave(const parser::OmpEndSingle &x);
+
   void Leave(const parser::OmpClauseList &);
   void Enter(const parser::OmpClause &);
+  void Enter(const parser::OmpNowait &);
   void Enter(const parser::OmpClause::Defaultmap &);
   void Enter(const parser::OmpClause::Inbranch &);
   void Enter(const parser::OmpClause::Mergeable &);
@@ -121,6 +132,7 @@ private:
   };
   // back() is the top of the stack
   const OmpContext &GetContext() const { return ompContext_.back(); }
+  const OmpContext &GetPrevContext() const { return ompContext_.rbegin()[1]; }
   void SetContextDirectiveSource(const parser::CharBlock &directive) {
     ompContext_.back().directiveSource = directive;
   }

--- a/lib/semantics/check-omp-structure.h
+++ b/lib/semantics/check-omp-structure.h
@@ -133,29 +133,28 @@ private:
     std::multimap<OmpClause, const parser::OmpClause *> clauseInfo;
   };
   // back() is the top of the stack
-  // TODO: remove CHECK after all directives/clauses are checked
-  const OmpContext &GetContext() const {
+  OmpContext &GetContext() {
     CHECK(!ompContext_.empty());
     return ompContext_.back();
   }
   void SetContextDirectiveSource(const parser::CharBlock &directive) {
-    ompContext_.back().directiveSource = directive;
+    GetContext().directiveSource = directive;
   }
   void SetContextClause(const parser::OmpClause &clause) {
-    ompContext_.back().clauseSource = clause.source;
-    ompContext_.back().clause = &clause;
+    GetContext().clauseSource = clause.source;
+    GetContext().clause = &clause;
   }
   void SetContextDirectiveEnum(const OmpDirective &dir) {
-    ompContext_.back().directive = dir;
+    GetContext().directive = dir;
   }
   void SetContextAllowed(const OmpClauseSet &allowed) {
-    ompContext_.back().allowedClauses = allowed;
+    GetContext().allowedClauses = allowed;
   }
   void SetContextAllowedOnce(const OmpClauseSet &allowedOnce) {
-    ompContext_.back().allowedOnceClauses = allowedOnce;
+    GetContext().allowedOnceClauses = allowedOnce;
   }
   void SetContextClauseInfo(const OmpClause &type) {
-    ompContext_.back().clauseInfo.emplace(type, ompContext_.back().clause);
+    GetContext().clauseInfo.emplace(type, GetContext().clause);
   }
   const parser::OmpClause *FindClause(const OmpClause &type) {
     auto it{GetContext().clauseInfo.find(type)};

--- a/test/semantics/omp-clause-validity01.f90
+++ b/test/semantics/omp-clause-validity01.f90
@@ -165,10 +165,10 @@
   a = 0.0
   !$omp section
   b = 1
-  !$omp end sections
+  !$omp end sections nowait
   !$omp end parallel
 
-  !ERROR: Orphaned SECTION directive is prohibited
+  !ERROR: SECTION directive must appear within the SECTIONS construct
   !$omp section
   a = 0.0
   !$omp parallel
@@ -191,6 +191,14 @@
   !ERROR: At most one NOWAIT clause can appear on the END SINGLE directive
   !$omp end single copyprivate(a) nowait nowait
   c = 2
+  !$omp end parallel
+
+! 2.7.4 workshare
+
+  !$omp parallel
+  !$omp workshare
+  a = 1.0
+  !$omp end workshare nowait
   !$omp end parallel
 
 ! 2.8.1 simd-clause -> safelen-clause |

--- a/test/semantics/omp-clause-validity01.f90
+++ b/test/semantics/omp-clause-validity01.f90
@@ -154,6 +154,45 @@
      enddo
   enddo
 
+! 2.7.2 sections-clause -> private-clause |
+!                         firstprivate-clause |
+!                         lastprivate-clause |
+!                         reduction-clause
+
+  !$omp parallel
+  !$omp sections
+  !$omp section
+  a = 0.0
+  !$omp section
+  b = 1
+  !$omp end sections
+  !$omp end parallel
+
+  !ERROR: Orphaned SECTION directive is prohibited
+  !$omp section
+  a = 0.0
+  !$omp parallel
+  !ERROR: SECTION directive must appear within the SECTIONS construct
+  !$omp section
+  a = 3.14
+  !$omp end parallel
+
+! 2.7.3 single-clause -> private-clause |
+!                        firstprivate-clause
+!   end-single-clause -> copyprivate-clause |
+!                        nowait-clause
+
+  !$omp parallel
+  b = 1
+  !ERROR: LASTPRIVATE clause is not allowed on the SINGLE directive
+  !$omp single private(a) lastprivate(a)
+  a = 3.14
+  !ERROR: The COPYPRIVATE clause must not be used with the NOWAIT clause
+  !ERROR: At most one NOWAIT clause can appear on the END SINGLE directive
+  !$omp end single copyprivate(a) nowait nowait
+  c = 2
+  !$omp end parallel
+
 ! 2.8.1 simd-clause -> safelen-clause |
 !                      simdlen-clause |
 !                      linear-clause |


### PR DESCRIPTION
Parse tree for OmpEndSingle needs to be modified to save the provenance of END SINGLE directive and check its own clauses