### PR TITLE
Roll up some fixes and extensions

### DIFF
--- a/documentation/Extensions.md
+++ b/documentation/Extensions.md
@@ -135,6 +135,10 @@ Extensions and legacy features deliberately not supported
 * Mixing INTEGER types as operands to bit intrinsics (e.g., IAND); only two
   compilers support it, and they disagree on sign extension.
 * Module & program names that conflict with an object inside the unit (PGI only).
+* When the same name is brought into scope via USE association from
+  multiple modules, the name must refer to a generic interface; PGI
+  allows a name to be a procedure from one module and a generic interface
+  from another.
 
 Preprocessing behavior
 ======================

--- a/documentation/Extensions.md
+++ b/documentation/Extensions.md
@@ -82,6 +82,8 @@ Extensions, deletions, and legacy features supported by default
   of INTEGER entities, and as actual arguments to a few intrinsic functions
   (ACHAR, BTEST, CHAR).  But they cannot be used if the type would not
   be known (e.g., `IAND(X'1',X'2')`).
+* BOZ literals can also be used as REAL values in some contexts where the
+  type is unambiguous, such as initializations of REAL parameters.
 * EQUIVALENCE of numeric and character sequences (a ubiquitous extension)
 * Values for whole anonymous parent components in structure constructors
   (e.g., `EXTENDEDTYPE(PARENTTYPE(1,2,3))` rather than `EXTENDEDTYPE(1,2,3)`

--- a/documentation/Extensions.md
+++ b/documentation/Extensions.md
@@ -134,6 +134,7 @@ Extensions and legacy features deliberately not supported
 * Using non-integer expressions for array bounds (e.g., REAL A(3.14159)) (PGI/Intel)
 * Mixing INTEGER types as operands to bit intrinsics (e.g., IAND); only two
   compilers support it, and they disagree on sign extension.
+* Module & program names that conflict with an object inside the unit (PGI only).
 
 Preprocessing behavior
 ======================

--- a/documentation/Extensions.md
+++ b/documentation/Extensions.md
@@ -19,9 +19,9 @@ Intentional violations of the standard
   `REAL` is of course 32-bit IEEE-754 floating-point today.  This legacy
   rule imposes an artificially small constraint in some cases
   where Fortran mandates that something have the default `INTEGER`
-  type: array bounds, `CHARACTER` length, subscripts, and the results
-  of intrinsic function references that return such things.  We
-  use `INTEGER(KIND=8)` for such things.
+  type: specifically, the results of references to the intrinsic functions
+  `LEN`, `SIZE`, `LBOUND`, `UBOUND`, and `SHAPE`.  We return
+  `INTEGER(KIND=8)` in these cases.
 
 Extensions, deletions, and legacy features supported by default
 ===============================================================
@@ -80,11 +80,18 @@ Extensions, deletions, and legacy features supported by default
 * BOZ literals can be used as INTEGER values in contexts where the type is
   unambiguous: the right hand sides of assigments and initializations
   of INTEGER entities, and as actual arguments to a few intrinsic functions
-  (ACHAR, BTEST, CHAR).
+  (ACHAR, BTEST, CHAR).  But they cannot be used if the type would not
+  be known (e.g., `IAND(X'1',X'2')`).
 * EQUIVALENCE of numeric and character sequences (a ubiquitous extension)
 * Values for whole anonymous parent components in structure constructors
   (e.g., `EXTENDEDTYPE(PARENTTYPE(1,2,3))` rather than `EXTENDEDTYPE(1,2,3)`
    or `EXTENDEDTYPE(PARENTTYPE=PARENTTYPE(1,2,3))`).
+* Some intrinsic functions are specified in the standard as requiring the
+  same type and kind for their arguments (viz., ATAN with two arguments,
+  ATAN2, DIM, HYPOT, MAX, MIN, MOD, and MODULO);
+  we allow distinct types to be used, promoting
+  the arguments as if they were operands to an intrinsic `+` operator,
+  and defining the result type accordingly.
 
 Extensions supported when enabled by options
 --------------------------------------------

--- a/lib/evaluate/common.h
+++ b/lib/evaluate/common.h
@@ -207,21 +207,26 @@ template<typename A> class Expr;
 
 class FoldingContext {
 public:
-  FoldingContext() = default;
-  explicit FoldingContext(const parser::ContextualMessages &m,
+  explicit FoldingContext(const common::IntrinsicTypeDefaultKinds &d)
+    : defaults_{d} {}
+  FoldingContext(const parser::ContextualMessages &m,
+      const common::IntrinsicTypeDefaultKinds &d,
       Rounding round = defaultRounding, bool flush = false)
-    : messages_{m}, rounding_{round}, flushSubnormalsToZero_{flush} {}
+    : messages_{m}, defaults_{d}, rounding_{round}, flushSubnormalsToZero_{
+                                                        flush} {}
   FoldingContext(const FoldingContext &that)
-    : messages_{that.messages_}, rounding_{that.rounding_},
+    : messages_{that.messages_}, defaults_{that.defaults_},
+      rounding_{that.rounding_},
       flushSubnormalsToZero_{that.flushSubnormalsToZero_},
       pdtInstance_{that.pdtInstance_}, impliedDos_{that.impliedDos_} {}
   FoldingContext(
       const FoldingContext &that, const parser::ContextualMessages &m)
-    : messages_{m}, rounding_{that.rounding_},
+    : messages_{m}, defaults_{that.defaults_}, rounding_{that.rounding_},
       flushSubnormalsToZero_{that.flushSubnormalsToZero_},
       pdtInstance_{that.pdtInstance_}, impliedDos_{that.impliedDos_} {}
 
   parser::ContextualMessages &messages() { return messages_; }
+  const common::IntrinsicTypeDefaultKinds &defaults() { return defaults_; }
   Rounding rounding() const { return rounding_; }
   bool flushSubnormalsToZero() const { return flushSubnormalsToZero_; }
   bool bigEndian() const { return bigEndian_; }
@@ -245,6 +250,7 @@ public:
 
 private:
   parser::ContextualMessages messages_;
+  const common::IntrinsicTypeDefaultKinds &defaults_;
   Rounding rounding_{defaultRounding};
   bool flushSubnormalsToZero_{false};
   bool bigEndian_{false};

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -549,7 +549,12 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldOperation(FoldingContext &context,
       if (const auto *chCon{
               UnwrapExpr<Constant<TypeOf<std::string>>>(args[0])}) {
         if (std::optional<std::string> value{chCon->GetScalarValue()}) {
-          return Expr<T>{SelectedCharKind(*value)};
+          if (*value == "default") {
+            return Expr<T>{
+                context.defaults().GetDefaultKind(TypeCategory::Character)};
+          } else {
+            return Expr<T>{SelectedCharKind(*value)};
+          }
         }
       }
     } else if (name == "selected_int_kind") {

--- a/lib/evaluate/integer.h
+++ b/lib/evaluate/integer.h
@@ -296,10 +296,10 @@ public:
       if (that.IsNegative()) {
         result.value = result.value.IOR(MASKL(bits - FROM::bits));
       }
+      result.overflow = false;
     } else if constexpr (bits < FROM::bits) {
       auto back{FROM::template ConvertSigned(result.value)};
-      result.overflow |=
-          back.overflow || back.value.CompareUnsigned(that) != Ordering::Equal;
+      result.overflow = back.value.CompareUnsigned(that) != Ordering::Equal;
     }
     return result;
   }

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -1203,13 +1203,8 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
       break;
     case KindCode::operand:
       CHECK(operandArg != nullptr);
-      if (std::optional<DynamicType> aType{operandArg->GetType()}) {
-        if (result.categorySet.test(aType->category())) {
-          resultType = *aType;
-        } else {
-          resultType = DynamicType{*category, aType->kind()};
-        }
-      }
+      resultType = operandArg->GetType();
+      CHECK(!resultType || result.categorySet.test(resultType->category()));
       break;
     case KindCode::effectiveKind:
       CHECK(kindDummyArg != nullptr);

--- a/lib/evaluate/shape.cc
+++ b/lib/evaluate/shape.cc
@@ -101,7 +101,8 @@ std::optional<ExtentExpr> AsExtentArrayExpr(const Shape &shape) {
 
 std::optional<Constant<ExtentType>> AsConstantShape(const Shape &shape) {
   if (auto shapeArray{AsExtentArrayExpr(shape)}) {
-    FoldingContext noFoldingContext;
+    common::IntrinsicTypeDefaultKinds defaults;
+    FoldingContext noFoldingContext{defaults};
     auto folded{Fold(noFoldingContext, std::move(*shapeArray))};
     if (auto *p{UnwrapConstantValue<ExtentType>(folded)}) {
       return std::move(*p);
@@ -143,7 +144,8 @@ static ExtentExpr ComputeTripCount(
       std::move(stride)};
   ExtentExpr extent{
       Extremum<ExtentType>{std::move(span), ExtentExpr{0}, Ordering::Greater}};
-  FoldingContext noFoldingContext;
+  common::IntrinsicTypeDefaultKinds defaults;
+  FoldingContext noFoldingContext{defaults};
   return Fold(noFoldingContext, std::move(extent));
 }
 

--- a/lib/evaluate/tools.cc
+++ b/lib/evaluate/tools.cc
@@ -535,6 +535,10 @@ std::optional<Expr<SomeType>> ConvertToType(
     }
     return ConvertToNumeric<TypeCategory::Integer>(type.kind(), std::move(x));
   case TypeCategory::Real:
+    if (auto *boz{std::get_if<BOZLiteralConstant>(&x.u)}) {
+      return Expr<SomeType>{
+          ConvertToKind<TypeCategory::Real>(type.kind(), std::move(*boz))};
+    }
     return ConvertToNumeric<TypeCategory::Real>(type.kind(), std::move(x));
   case TypeCategory::Complex:
     return ConvertToNumeric<TypeCategory::Complex>(type.kind(), std::move(x));

--- a/lib/parser/message.h
+++ b/lib/parser/message.h
@@ -277,6 +277,7 @@ class ContextualMessages {
 public:
   ContextualMessages() = default;
   ContextualMessages(CharBlock at, Messages *m) : at_{at}, messages_{m} {}
+  explicit ContextualMessages(Messages *m) : messages_{m} {}
   ContextualMessages(const ContextualMessages &that)
     : at_{that.at_}, messages_{that.messages_} {}
 

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1357,6 +1357,9 @@ MaybeExpr ExpressionAnalyzer::Analyze(
         } else if (MaybeExpr converted{
                        ConvertToType(*symbol, std::move(*value))}) {
           result.Add(*symbol, std::move(*converted));
+        } else if (IsAllocatable(*symbol) &&
+            std::holds_alternative<NullPointer>(value->u)) {
+          // NULL() with no arguments allowed by 7.5.10 para 6 for ALLOCATABLE
         } else if (auto symType{DynamicType::From(symbol)}) {
           if (valueType.has_value()) {
             if (auto *msg{Say(expr.source,

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -101,8 +101,7 @@ SemanticsContext::SemanticsContext(
   : defaultKinds_{defaultKinds}, languageFeatures_{languageFeatures},
     allSources_{allSources},
     intrinsics_{evaluate::IntrinsicProcTable::Configure(defaultKinds)},
-    foldingContext_{evaluate::FoldingContext{
-        parser::ContextualMessages{parser::CharBlock{}, &messages_}}} {}
+    foldingContext_{parser::ContextualMessages{&messages_}, defaultKinds} {}
 
 SemanticsContext::~SemanticsContext() {}
 

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -132,7 +132,7 @@ private:
   const evaluate::IntrinsicProcTable intrinsics_;
   Scope globalScope_;
   parser::Messages messages_;
-  evaluate::FoldingContext foldingContext_;
+  evaluate::FoldingContext foldingContext_{defaultKinds_};
 
   bool CheckError(bool);
 };

--- a/test/evaluate/expression.cc
+++ b/test/evaluate/expression.cc
@@ -38,9 +38,9 @@ int main() {
   auto ex1{
       DefaultIntegerExpr{2} + DefaultIntegerExpr{3} * -DefaultIntegerExpr{4}};
   MATCH("2_4+3_4*(-4_4)", AsFortran(ex1));
-  Fortran::parser::CharBlock src;
-  Fortran::parser::ContextualMessages messages{src, nullptr};
-  FoldingContext context{messages};
+  Fortran::common::IntrinsicTypeDefaultKinds defaults;
+  FoldingContext context{
+      Fortran::parser::ContextualMessages{nullptr}, defaults};
   ex1 = Fold(context, std::move(ex1));
   MATCH("-10_4", AsFortran(ex1));
   MATCH("1_4/2_4", AsFortran(DefaultIntegerExpr{1} / DefaultIntegerExpr{2}));

--- a/test/evaluate/folding.cc
+++ b/test/evaluate/folding.cc
@@ -71,8 +71,10 @@ void TestHostRuntimeSubnormalFlushing() {
   if constexpr (std::is_same_v<host::HostType<R4>, float>) {
     Fortran::parser::CharBlock src;
     Fortran::parser::ContextualMessages messages{src, nullptr};
-    FoldingContext flushingContext{messages, defaultRounding, true};
-    FoldingContext noFlushingContext{messages, defaultRounding, false};
+    Fortran::common::IntrinsicTypeDefaultKinds defaults;
+    FoldingContext flushingContext{messages, defaults, defaultRounding, true};
+    FoldingContext noFlushingContext{
+        messages, defaults, defaultRounding, false};
 
     HostIntrinsicProceduresLibrary lib;
     lib.AddProcedure(HostRuntimeIntrinsicProcedure{

--- a/test/evaluate/intrinsics.cc
+++ b/test/evaluate/intrinsics.cc
@@ -113,7 +113,8 @@ struct TestCall {
     std::cout << ')' << std::endl;
     CallCharacteristics call{fName};
     auto messages{strings.Messages(buffer)};
-    FoldingContext context{messages};
+    common::IntrinsicTypeDefaultKinds defaults;
+    FoldingContext context{messages, defaults};
     std::optional<SpecificCall> si{table.Probe(call, args, context)};
     if (resultType.has_value()) {
       TEST(si.has_value());


### PR DESCRIPTION
Allow arguments of distinct types &/or kinds to some multi-argument intrinsics (e.g., `MOD`).

Fix a spurious integer overflow warning.

Allow BOZ initializers for REAL parameters.

Support `SELECTED_CHAR_KIND("DEFAULT")`.

Documentation.