### PR TITLE
Changes for constraint C1128

### DIFF
--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1335,7 +1335,7 @@ MaybeExpr ExpressionAnalyzer::Analyze(
                 if (auto *msg{Say(expr.source,
                         "Externally visible object '%s' must not be "
                         "associated with pointer component '%s' in a "
-                        "PURE function"_err_en_US,
+                        "PURE procedure"_err_en_US,
                         object->name(), pointer->name())}) {
                   msg->Attach(object->name(), "Object declaration"_en_US)
                       .Attach(pointer->name(), "Pointer declaration"_en_US);

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1325,13 +1325,13 @@ MaybeExpr ExpressionAnalyzer::Analyze(
         } else if (symbol->has<semantics::ObjectEntityDetails>()) {
           // C1594(4)
           const auto &innermost{context_.FindScope(expr.source)};
-          if (const auto *pureFunc{
-                  semantics::FindPureFunctionContaining(&innermost)}) {
+          if (const auto *pureProc{
+                  semantics::FindPureProcedureContaining(&innermost)}) {
             if (const Symbol *
                 pointer{semantics::FindPointerComponent(*symbol)}) {
               if (const Symbol *
                   object{semantics::FindExternallyVisibleObject(
-                      *value, *pureFunc)}) {
+                      *value, *pureProc)}) {
                 if (auto *msg{Say(expr.source,
                         "Externally visible object '%s' must not be "
                         "associated with pointer component '%s' in a "

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -3804,9 +3804,6 @@ bool DeclarationVisitor::PassesSharedLocalityChecks(
 // Checks for locality-specs LOCAL and LOCAL_INIT
 bool DeclarationVisitor::PassesLocalityChecks(
     const parser::Name &name, Symbol &symbol) {
-  if (!PassesSharedLocalityChecks(name, symbol)) {
-    return false;
-  }
   if (IsAllocatable(symbol)) {  // C1128
     SayWithDecl(name, symbol,
         "ALLOCATABLE variable '%s' not allowed in a locality-spec"_err_en_US);
@@ -3846,7 +3843,15 @@ bool DeclarationVisitor::PassesLocalityChecks(
         "Assumed size array '%s' not allowed in a locality-spec"_err_en_US);
     return false;
   }
-  // TODO: Check to see if the name can appear in a variable definition context
+  if (!IsModifiable(symbol, currScope())) {  // C1128
+    SayWithDecl(name, symbol,
+        "'%s' must be able to appear in a variable definition context to "
+        "appear in a locality-spec"_err_en_US);
+    return false;
+  }
+  if (!PassesSharedLocalityChecks(name, symbol)) {
+    return false;
+  }
   return true;
 }
 

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -3853,8 +3853,8 @@ bool DeclarationVisitor::PassesLocalityChecks(
   if (std::optional<MessageFixedText> msg{
           WhyNotModifiable(symbol, currScope())}) {
     SayWithReason(name, symbol,
-        "'%s' must be able to appear in a variable definition context to "
-        "appear in a locality-spec"_err_en_US,
+        "'%s' may not appear in a locality-spec because it is not "
+        "definable"_err_en_US,
         std::move(*msg));
     return false;
   }

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -501,7 +501,7 @@ public:
   // Can the details of this symbol be replaced with the given details?
   bool CanReplaceDetails(const Details &details) const;
 
-  // Follow use-associations to get the ultimate entity.
+  // Follow use-associations and host-associations to get the ultimate entity.
   Symbol &GetUltimate();
   const Symbol &GetUltimate() const;
 

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -18,6 +18,7 @@
 // Simple predicates and look-up functions that are best defined
 // canonically for use in semantic checking.
 
+#include "attr.h"
 #include "expression.h"
 #include "semantics.h"
 #include "../common/Fortran.h"
@@ -36,7 +37,7 @@ class Symbol;
 const Symbol *FindCommonBlockContaining(const Symbol &object);
 const Scope *FindProgramUnitContaining(const Scope &);
 const Scope *FindProgramUnitContaining(const Symbol &);
-const Scope *FindPureFunctionContaining(const Scope *);
+const Scope *FindPureProcedureContaining(const Scope *);
 const Symbol *FindPointerComponent(const Scope &);
 const Symbol *FindPointerComponent(const DerivedTypeSpec &);
 const Symbol *FindPointerComponent(const DeclTypeSpec &);
@@ -44,6 +45,7 @@ const Symbol *FindPointerComponent(const Symbol &);
 const Symbol *FindInterface(const Symbol &);
 const Symbol *FindSubprogram(const Symbol &);
 const Symbol *FindFunctionResult(const Symbol &);
+const Symbol *GetAssociationRoot(const Symbol &);
 
 bool IsCommonBlockContaining(const Symbol &block, const Symbol &object);
 bool DoesScopeContain(const Scope *maybeAncestor, const Scope &maybeDescendent);
@@ -52,9 +54,10 @@ bool IsUseAssociated(const Symbol *, const Scope &);
 bool IsHostAssociated(const Symbol &, const Scope &);
 bool IsDummy(const Symbol &);
 bool IsPointerDummy(const Symbol &);
+bool IsValueDummy(const Symbol &);
 bool IsFunction(const Symbol &);
-bool IsPureFunction(const Symbol &);
-bool IsPureFunction(const Scope &);
+bool IsPureProcedure(const Symbol &);
+bool IsPureProcedure(const Scope &);
 bool IsProcedure(const Symbol &);
 bool IsProcName(const Symbol &symbol);  // proc-name
 bool IsVariableName(const Symbol &symbol);  // variable-name
@@ -78,6 +81,7 @@ const Symbol *HasCoarrayUltimateComponent(const DerivedTypeSpec &);
 // potential component of EVENT_TYPE or LOCK_TYPE from
 // ISO_FORTRAN_ENV module.
 const Symbol *HasEventOrLockPotentialComponent(const DerivedTypeSpec &);
+bool IsOrContainsEventOrLockComponent(const Symbol &);
 
 // Return an ultimate component of type that matches predicate, or nullptr.
 const Symbol *FindUltimateComponent(
@@ -101,9 +105,15 @@ inline bool IsOptional(const Symbol &symbol) {
 inline bool IsIntentIn(const Symbol &symbol) {
   return symbol.attrs().test(Attr::INTENT_IN);
 }
+inline bool IsProtected(const Symbol &symbol) {
+  return symbol.attrs().test(Attr::PROTECTED);
+}
 bool IsFinalizable(const Symbol &symbol);
 bool IsCoarray(const Symbol &symbol);
 bool IsAssumedSizeArray(const Symbol &symbol);
+// Is the symbol modifiable in this scope
+bool IsModifiable(const Symbol &symbol, const Scope &scope);
+bool IsExternalInPureContext(const Symbol &symbol, const Scope &scope);
 
 // Returns the complete list of derived type parameter symbols in
 // the order in which their declarations appear in the derived type

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -24,6 +24,7 @@
 #include "../common/Fortran.h"
 #include "../evaluate/expression.h"
 #include "../evaluate/variable.h"
+#include "../parser/message.h"
 #include "../parser/parse-tree.h"
 #include <functional>
 
@@ -45,6 +46,7 @@ const Symbol *FindPointerComponent(const Symbol &);
 const Symbol *FindInterface(const Symbol &);
 const Symbol *FindSubprogram(const Symbol &);
 const Symbol *FindFunctionResult(const Symbol &);
+const Symbol *GetAssociatedVariable(const AssocEntityDetails &);
 const Symbol *GetAssociationRoot(const Symbol &);
 
 bool IsCommonBlockContaining(const Symbol &block, const Symbol &object);
@@ -111,6 +113,8 @@ inline bool IsProtected(const Symbol &symbol) {
 bool IsFinalizable(const Symbol &symbol);
 bool IsCoarray(const Symbol &symbol);
 bool IsAssumedSizeArray(const Symbol &symbol);
+std::optional<parser::MessageFixedText> WhyNotModifiable(
+    const Symbol &symbol, const Scope &scope);
 // Is the symbol modifiable in this scope
 bool IsModifiable(const Symbol &symbol, const Scope &scope);
 bool IsExternalInPureContext(const Symbol &symbol, const Scope &scope);

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -46,7 +46,6 @@ const Symbol *FindPointerComponent(const Symbol &);
 const Symbol *FindInterface(const Symbol &);
 const Symbol *FindSubprogram(const Symbol &);
 const Symbol *FindFunctionResult(const Symbol &);
-const Symbol *GetAssociatedVariable(const AssocEntityDetails &);
 const Symbol *GetAssociationRoot(const Symbol &);
 
 bool IsCommonBlockContaining(const Symbol &block, const Symbol &object);
@@ -56,7 +55,6 @@ bool IsUseAssociated(const Symbol *, const Scope &);
 bool IsHostAssociated(const Symbol &, const Scope &);
 bool IsDummy(const Symbol &);
 bool IsPointerDummy(const Symbol &);
-bool IsValueDummy(const Symbol &);
 bool IsFunction(const Symbol &);
 bool IsPureProcedure(const Symbol &);
 bool IsPureProcedure(const Scope &);
@@ -116,7 +114,6 @@ bool IsAssumedSizeArray(const Symbol &symbol);
 std::optional<parser::MessageFixedText> WhyNotModifiable(
     const Symbol &symbol, const Scope &scope);
 // Is the symbol modifiable in this scope
-bool IsModifiable(const Symbol &symbol, const Scope &scope);
 bool IsExternalInPureContext(const Symbol &symbol, const Scope &scope);
 
 // Returns the complete list of derived type parameter symbols in

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -93,6 +93,7 @@ set(ERROR_TESTS
   resolve54.f90
   resolve55.f90
   resolve56.f90
+  resolve57.f90
   stop01.f90
   structconst01.f90
   structconst02.f90

--- a/test/semantics/resolve35.f90
+++ b/test/semantics/resolve35.f90
@@ -119,13 +119,13 @@ subroutine s10
   real, parameter :: bad2 = 1.0
   x = cos(0.)
   do concurrent(i=1:2) &
-    !ERROR: The name 'bad1' must be a variable to appear in a locality-spec
+    !ERROR: 'bad1' must be able to appear in a variable definition context to appear in a locality-spec
     local(bad1) &
-    !ERROR: The name 'bad2' must be a variable to appear in a locality-spec
+    !ERROR: 'bad2' must be able to appear in a variable definition context to appear in a locality-spec
     local(bad2) &
-    !ERROR: The name 'bad3' must be a variable to appear in a locality-spec
+    !ERROR: 'bad3' must be able to appear in a variable definition context to appear in a locality-spec
     local(bad3) &
-    !ERROR: The name 'cos' must be a variable to appear in a locality-spec
+    !ERROR: 'cos' must be able to appear in a variable definition context to appear in a locality-spec
     local(cos)
   end do
   do concurrent(i=1:2) &

--- a/test/semantics/resolve35.f90
+++ b/test/semantics/resolve35.f90
@@ -119,13 +119,13 @@ subroutine s10
   real, parameter :: bad2 = 1.0
   x = cos(0.)
   do concurrent(i=1:2) &
-    !ERROR: 'bad1' must be able to appear in a variable definition context to appear in a locality-spec
+    !ERROR: 'bad1' may not appear in a locality-spec because it is not definable
     local(bad1) &
-    !ERROR: 'bad2' must be able to appear in a variable definition context to appear in a locality-spec
+    !ERROR: 'bad2' may not appear in a locality-spec because it is not definable
     local(bad2) &
-    !ERROR: 'bad3' must be able to appear in a variable definition context to appear in a locality-spec
+    !ERROR: 'bad3' may not appear in a locality-spec because it is not definable
     local(bad3) &
-    !ERROR: 'cos' must be able to appear in a variable definition context to appear in a locality-spec
+    !ERROR: 'cos' may not appear in a locality-spec because it is not definable
     local(cos)
   end do
   do concurrent(i=1:2) &

--- a/test/semantics/resolve57.f90
+++ b/test/semantics/resolve57.f90
@@ -1,0 +1,135 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Tests for the last sentence of C1128:
+!A variable-name that is not permitted to appear in a variable definition
+!context shall not appear in a LOCAL or LOCAL_INIT locality-spec.
+
+subroutine s1(arg)
+  real, intent(in) :: arg
+
+  ! This is not OK because "arg" is "intent(in)"
+!ERROR: INTENT IN argument 'arg' not allowed in a locality-spec
+  do concurrent (i=1:5) local(arg)
+  end do
+end subroutine s1
+
+subroutine s2(arg)
+  real, value, intent(in) :: arg
+
+  ! This is not OK even though "arg" has the "value" attribute.  C1128
+  ! explicitly excludes dummy arguments of INTENT(IN)
+!ERROR: INTENT IN argument 'arg' not allowed in a locality-spec
+  do concurrent (i=1:5) local(arg)
+  end do
+end subroutine s2
+
+module m3
+  real, protected :: prot
+  real var
+
+  contains
+    subroutine sub()
+      ! C857 This is OK because of the "protected" attribute only applies to
+      ! accesses outside the module
+      do concurrent (i=1:5) local(prot)
+      end do
+    end subroutine sub
+endmodule m3
+
+subroutine s4()
+  use m3
+
+  ! C857 This is not OK because of the "protected" attribute
+!ERROR: 'prot' must be able to appear in a variable definition context to appear in a locality-spec
+  do concurrent (i=1:5) local(prot)
+  end do
+
+  ! C857 This is OK because of there's no "protected" attribute
+  do concurrent (i=1:5) local(var)
+  end do
+end subroutine s4
+
+subroutine s5()
+  real :: a, b, c, d, e
+
+  associate (a => b + c, d => e)
+    b = 3.0
+    ! C1101 This is OK because 'd' is associated with a variable
+    do concurrent (i=1:5) local(d)
+    end do
+
+    ! C1101 This is not OK because 'a' is not associated with a variable
+!ERROR: 'a' must be able to appear in a variable definition context to appear in a locality-spec
+    do concurrent (i=1:5) local(a)
+    end do
+  end associate
+end subroutine s5
+
+subroutine s6()
+  type point
+    real :: x, y
+  end type point
+
+  type, extends(point) :: color_point
+    integer :: color
+  end type color_point
+
+  type(point), target :: c, d
+  class(point), pointer :: p_or_c
+
+  p_or_c => c
+  select type ( a => p_or_c )
+  type is ( point )
+    ! C1158 This is OK because 'a' is associated with a variable
+    do concurrent (i=1:5) local(a)
+    end do
+  end select
+
+  select type ( a => func() )
+  type is ( point )
+    ! C1158 This is not OK because 'a' is not associated with a variable
+!ERROR: 'a' must be able to appear in a variable definition context to appear in a locality-spec
+    do concurrent (i=1:5) local(a)
+    end do
+  end select
+
+  contains
+    function func()
+      class(point), pointer :: func
+      func => c
+    end function func
+end subroutine s6
+
+module m4
+  real, protected :: prot
+  real var
+endmodule m4
+
+pure subroutine s7()
+  use m4
+
+  ! C1594 This is not OK because we're in a PURE subroutine
+!ERROR: 'var' must be able to appear in a variable definition context to appear in a locality-spec
+  do concurrent (i=1:5) local(var)
+  end do
+end subroutine s7
+
+subroutine s8()
+  integer, parameter :: iconst = 343
+
+!ERROR: 'iconst' must be able to appear in a variable definition context to appear in a locality-spec
+  do concurrent (i=1:5) local(iconst)
+  end do
+end subroutine s8

--- a/test/semantics/resolve57.f90
+++ b/test/semantics/resolve57.f90
@@ -52,7 +52,7 @@ subroutine s4()
   use m3
 
   ! C857 This is not OK because of the "protected" attribute
-!ERROR: 'prot' must be able to appear in a variable definition context to appear in a locality-spec
+!ERROR: 'prot' may not appear in a locality-spec because it is not definable
   do concurrent (i=1:5) local(prot)
   end do
 
@@ -71,7 +71,7 @@ subroutine s5()
     end do
 
     ! C1101 This is not OK because 'a' is not associated with a variable
-!ERROR: 'a' must be able to appear in a variable definition context to appear in a locality-spec
+!ERROR: 'a' may not appear in a locality-spec because it is not definable
     do concurrent (i=1:5) local(a)
     end do
   end associate
@@ -100,7 +100,7 @@ subroutine s6()
   select type ( a => func() )
   type is ( point )
     ! C1158 This is not OK because 'a' is not associated with a variable
-!ERROR: 'a' must be able to appear in a variable definition context to appear in a locality-spec
+!ERROR: 'a' may not appear in a locality-spec because it is not definable
     do concurrent (i=1:5) local(a)
     end do
   end select
@@ -121,7 +121,7 @@ pure subroutine s7()
   use m4
 
   ! C1594 This is not OK because we're in a PURE subroutine
-!ERROR: 'var' must be able to appear in a variable definition context to appear in a locality-spec
+!ERROR: 'var' may not appear in a locality-spec because it is not definable
   do concurrent (i=1:5) local(var)
   end do
 end subroutine s7
@@ -129,7 +129,7 @@ end subroutine s7
 subroutine s8()
   integer, parameter :: iconst = 343
 
-!ERROR: 'iconst' must be able to appear in a variable definition context to appear in a locality-spec
+!ERROR: 'iconst' may not appear in a locality-spec because it is not definable
   do concurrent (i=1:5) local(iconst)
   end do
 end subroutine s8

--- a/test/semantics/structconst03.f90
+++ b/test/semantics/structconst03.f90
@@ -76,26 +76,26 @@ module module1
     common /cblock/ commonvar1
     pf1 = 0.
     x1 = t1(0)(local1)
-    !ERROR: Externally visible object 'usedfrom1' must not be associated with pointer component 'pt1' in a PURE function
+    !ERROR: Externally visible object 'usedfrom1' must not be associated with pointer component 'pt1' in a PURE procedure
     x1 = t1(0)(usedfrom1)
-    !ERROR: Externally visible object 'modulevar1' must not be associated with pointer component 'pt1' in a PURE function
+    !ERROR: Externally visible object 'modulevar1' must not be associated with pointer component 'pt1' in a PURE procedure
     x1 = t1(0)(modulevar1)
-    !ERROR: Externally visible object 'cblock' must not be associated with pointer component 'pt1' in a PURE function
+    !ERROR: Externally visible object 'cblock' must not be associated with pointer component 'pt1' in a PURE procedure
     x1 = t1(0)(commonvar1)
-    !ERROR: Externally visible object 'dummy1' must not be associated with pointer component 'pt1' in a PURE function
+    !ERROR: Externally visible object 'dummy1' must not be associated with pointer component 'pt1' in a PURE procedure
     x1 = t1(0)(dummy1)
     x1 = t1(0)(dummy2)
-    !ERROR: Externally visible object 'dummy3' must not be associated with pointer component 'pt1' in a PURE function
+    !ERROR: Externally visible object 'dummy3' must not be associated with pointer component 'pt1' in a PURE procedure
     x1 = t1(0)(dummy3)
 ! TODO when semantics handles coindexing:
-! TODO !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+! TODO !ERROR: Externally visible object must not be associated with a pointer in a PURE procedure
 ! TODO x1 = t1(0)(dummy4[0])
     x1 = t1(0)(dummy4)
-    !ERROR: Externally visible object 'modulevar2' must not be associated with pointer component 'ptop' in a PURE function
+    !ERROR: Externally visible object 'modulevar2' must not be associated with pointer component 'ptop' in a PURE procedure
     x2 = t2(0)(modulevar2)
-    !ERROR: Externally visible object 'modulevar3' must not be associated with pointer component 'ptop' in a PURE function
+    !ERROR: Externally visible object 'modulevar3' must not be associated with pointer component 'ptop' in a PURE procedure
     x3 = t3(0)(modulevar3)
-    !ERROR: Externally visible object 'modulevar4' must not be associated with pointer component 'ptop' in a PURE function
+    !ERROR: Externally visible object 'modulevar4' must not be associated with pointer component 'ptop' in a PURE procedure
     x4 = t4(0)(modulevar4)
    contains
     subroutine subr(dummy1a, dummy2a, dummy3a, dummy4a)
@@ -109,30 +109,30 @@ module module1
       real, pointer :: dummy3a
       real, intent(inout), target :: dummy4a[*]
       x1a = t1(0)(local1a)
-      !ERROR: Externally visible object 'usedfrom1' must not be associated with pointer component 'pt1' in a PURE function
+      !ERROR: Externally visible object 'usedfrom1' must not be associated with pointer component 'pt1' in a PURE procedure
       x1a = t1(0)(usedfrom1)
-      !ERROR: Externally visible object 'modulevar1' must not be associated with pointer component 'pt1' in a PURE function
+      !ERROR: Externally visible object 'modulevar1' must not be associated with pointer component 'pt1' in a PURE procedure
       x1a = t1(0)(modulevar1)
-      !ERROR: Externally visible object 'cblock' must not be associated with pointer component 'pt1' in a PURE function
+      !ERROR: Externally visible object 'cblock' must not be associated with pointer component 'pt1' in a PURE procedure
       x1a = t1(0)(commonvar1)
-      !ERROR: Externally visible object 'dummy1' must not be associated with pointer component 'pt1' in a PURE function
+      !ERROR: Externally visible object 'dummy1' must not be associated with pointer component 'pt1' in a PURE procedure
       x1a = t1(0)(dummy1)
-      !ERROR: Externally visible object 'dummy1a' must not be associated with pointer component 'pt1' in a PURE function
+      !ERROR: Externally visible object 'dummy1a' must not be associated with pointer component 'pt1' in a PURE procedure
       x1a = t1(0)(dummy1a)
       x1a = t1(0)(dummy2a)
-      !ERROR: Externally visible object 'dummy3' must not be associated with pointer component 'pt1' in a PURE function
+      !ERROR: Externally visible object 'dummy3' must not be associated with pointer component 'pt1' in a PURE procedure
       x1a = t1(0)(dummy3)
-      !ERROR: Externally visible object 'dummy3a' must not be associated with pointer component 'pt1' in a PURE function
+      !ERROR: Externally visible object 'dummy3a' must not be associated with pointer component 'pt1' in a PURE procedure
       x1a = t1(0)(dummy3a)
 ! TODO when semantics handles coindexing:
-! TODO !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+! TODO !ERROR: Externally visible object must not be associated with a pointer in a PURE procedure
 ! TODO x1a = t1(0)(dummy4a[0])
       x1a = t1(0)(dummy4a)
-      !ERROR: Externally visible object 'modulevar2' must not be associated with pointer component 'ptop' in a PURE function
+      !ERROR: Externally visible object 'modulevar2' must not be associated with pointer component 'ptop' in a PURE procedure
       x2a = t2(0)(modulevar2)
-      !ERROR: Externally visible object 'modulevar3' must not be associated with pointer component 'ptop' in a PURE function
+      !ERROR: Externally visible object 'modulevar3' must not be associated with pointer component 'ptop' in a PURE procedure
       x3a = t3(0)(modulevar3)
-      !ERROR: Externally visible object 'modulevar4' must not be associated with pointer component 'ptop' in a PURE function
+      !ERROR: Externally visible object 'modulevar4' must not be associated with pointer component 'ptop' in a PURE procedure
       x4a = t4(0)(modulevar4)
     end subroutine subr
   end function pf1

--- a/test/semantics/structconst04.f90
+++ b/test/semantics/structconst04.f90
@@ -71,26 +71,26 @@ module module1
     common /cblock/ commonvar1
     pf1 = 0.
     x1 = t1(local1)
-    !ERROR: Externally visible object 'usedfrom1' must not be associated with pointer component 'pt1' in a PURE function
+    !ERROR: Externally visible object 'usedfrom1' must not be associated with pointer component 'pt1' in a PURE procedure
     x1 = t1(usedfrom1)
-    !ERROR: Externally visible object 'modulevar1' must not be associated with pointer component 'pt1' in a PURE function
+    !ERROR: Externally visible object 'modulevar1' must not be associated with pointer component 'pt1' in a PURE procedure
     x1 = t1(modulevar1)
-    !ERROR: Externally visible object 'cblock' must not be associated with pointer component 'pt1' in a PURE function
+    !ERROR: Externally visible object 'cblock' must not be associated with pointer component 'pt1' in a PURE procedure
     x1 = t1(commonvar1)
-    !ERROR: Externally visible object 'dummy1' must not be associated with pointer component 'pt1' in a PURE function
+    !ERROR: Externally visible object 'dummy1' must not be associated with pointer component 'pt1' in a PURE procedure
     x1 = t1(dummy1)
     x1 = t1(dummy2)
-    !ERROR: Externally visible object 'dummy3' must not be associated with pointer component 'pt1' in a PURE function
+    !ERROR: Externally visible object 'dummy3' must not be associated with pointer component 'pt1' in a PURE procedure
     x1 = t1(dummy3)
 ! TODO when semantics handles coindexing:
-! TODO !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+! TODO !ERROR: Externally visible object must not be associated with a pointer in a PURE procedure
 ! TODO x1 = t1(dummy4[0])
     x1 = t1(dummy4)
-    !ERROR: Externally visible object 'modulevar2' must not be associated with pointer component 'ptop' in a PURE function
+    !ERROR: Externally visible object 'modulevar2' must not be associated with pointer component 'ptop' in a PURE procedure
     x2 = t2(modulevar2)
-    !ERROR: Externally visible object 'modulevar3' must not be associated with pointer component 'ptop' in a PURE function
+    !ERROR: Externally visible object 'modulevar3' must not be associated with pointer component 'ptop' in a PURE procedure
     x3 = t3(modulevar3)
-    !ERROR: Externally visible object 'modulevar4' must not be associated with pointer component 'ptop' in a PURE function
+    !ERROR: Externally visible object 'modulevar4' must not be associated with pointer component 'ptop' in a PURE procedure
     x4 = t4(modulevar4)
    contains
     subroutine subr(dummy1a, dummy2a, dummy3a, dummy4a)
@@ -104,30 +104,30 @@ module module1
       real, pointer :: dummy3a
       real, intent(inout), target :: dummy4a[*]
       x1a = t1(local1a)
-      !ERROR: Externally visible object 'usedfrom1' must not be associated with pointer component 'pt1' in a PURE function
+      !ERROR: Externally visible object 'usedfrom1' must not be associated with pointer component 'pt1' in a PURE procedure
       x1a = t1(usedfrom1)
-      !ERROR: Externally visible object 'modulevar1' must not be associated with pointer component 'pt1' in a PURE function
+      !ERROR: Externally visible object 'modulevar1' must not be associated with pointer component 'pt1' in a PURE procedure
       x1a = t1(modulevar1)
-      !ERROR: Externally visible object 'cblock' must not be associated with pointer component 'pt1' in a PURE function
+      !ERROR: Externally visible object 'cblock' must not be associated with pointer component 'pt1' in a PURE procedure
       x1a = t1(commonvar1)
-      !ERROR: Externally visible object 'dummy1' must not be associated with pointer component 'pt1' in a PURE function
+      !ERROR: Externally visible object 'dummy1' must not be associated with pointer component 'pt1' in a PURE procedure
       x1a = t1(dummy1)
-      !ERROR: Externally visible object 'dummy1a' must not be associated with pointer component 'pt1' in a PURE function
+      !ERROR: Externally visible object 'dummy1a' must not be associated with pointer component 'pt1' in a PURE procedure
       x1a = t1(dummy1a)
       x1a = t1(dummy2a)
-      !ERROR: Externally visible object 'dummy3' must not be associated with pointer component 'pt1' in a PURE function
+      !ERROR: Externally visible object 'dummy3' must not be associated with pointer component 'pt1' in a PURE procedure
       x1a = t1(dummy3)
-      !ERROR: Externally visible object 'dummy3a' must not be associated with pointer component 'pt1' in a PURE function
+      !ERROR: Externally visible object 'dummy3a' must not be associated with pointer component 'pt1' in a PURE procedure
       x1a = t1(dummy3a)
 ! TODO when semantics handles coindexing:
-! TODO !ERROR: Externally visible object must not be associated with a pointer in a PURE function
+! TODO !ERROR: Externally visible object must not be associated with a pointer in a PURE procedure
 ! TODO x1a = t1(dummy4a[0])
       x1a = t1(dummy4a)
-      !ERROR: Externally visible object 'modulevar2' must not be associated with pointer component 'ptop' in a PURE function
+      !ERROR: Externally visible object 'modulevar2' must not be associated with pointer component 'ptop' in a PURE procedure
       x2a = t2(modulevar2)
-      !ERROR: Externally visible object 'modulevar3' must not be associated with pointer component 'ptop' in a PURE function
+      !ERROR: Externally visible object 'modulevar3' must not be associated with pointer component 'ptop' in a PURE procedure
       x3a = t3(modulevar3)
-      !ERROR: Externally visible object 'modulevar4' must not be associated with pointer component 'ptop' in a PURE function
+      !ERROR: Externally visible object 'modulevar4' must not be associated with pointer component 'ptop' in a PURE procedure
       x4a = t4(modulevar4)
     end subroutine subr
   end function pf1


### PR DESCRIPTION
Specifically, these changes enforce the last sentence of the constraint, which
prohibits names that cannot appear in a variable definition context from
appearing in a locality-spec.  Here are the details.

 - Created the function "IsModifiableName" to return "true" when its parameter
   is the name of a variable that can appear in a variable definition context.
 - Created the function "GetAssociationRoot" to follow construct associations
   to potentially get to an underlying variable.  This function is similar to
   the existing "GetUltimate" function that follows use associations and host
   associations.  One difference is that "GetAssociationRoot" requires access
   to the types "MaybeExpr" and "SomeExpr", which makes is inappropriate to put
   into symbol.cc, which is where "GetUltimate" lives.  Perhaps we should move
   "GetUltimate" to tools.[h,cc].
 - Generalized the functions "IsPureFunction" to "IsPureProcedure" since either
   a pure function or subroutine can provide a context for variables that
   cannot be modified.  Changed "FindPureFunctionContaining" to
   "FindPureProcedueContaining" to go along with this.
 - Added the function "IsExternalInPureContext" to detect the case where a
   nominally pure procedure potentially modifies a variable.
 - Created the function "IsOrContainsEventOrLockComponent" to detect variables
   that either are of EVENT_TYPE or LOCK_TYPE or contain components of these
   types.  Such variables cannot appear in variable definition contexts.
 - Added the test resolve56.f90 to test most of these conditions.  Note that I
   only tested the new code from the perspective of locality-specs.