### PR TITLE
Avoid interference between different construct association in name resolutions

### DIFF
--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -4441,7 +4441,7 @@ ConstructVisitor::Selector ConstructVisitor::ResolveSelector(
 }
 
 ConstructVisitor::Association &ConstructVisitor::GetCurrentAssociation() {
-  CHECK(associationStack_.size());
+  CHECK(!associationStack_.empty());
   return associationStack_.back();
 }
 
@@ -4450,7 +4450,7 @@ void ConstructVisitor::PushAssociation() {
 }
 
 void ConstructVisitor::PopAssociation() {
-  CHECK(associationStack_.size());
+  CHECK(!associationStack_.empty());
   associationStack_.pop_back();
 }
 

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -92,6 +92,7 @@ set(ERROR_TESTS
   resolve53.f90
   resolve54.f90
   resolve55.f90
+  resolve56.f90
   stop01.f90
   structconst01.f90
   structconst02.f90

--- a/test/semantics/resolve56.f90
+++ b/test/semantics/resolve56.f90
@@ -1,0 +1,80 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test that associations constructs can be correctly combined. The intrinsic
+! functions are not what is tested here, they are only use to reveal the types
+! of local variables.
+
+  implicit none
+  real res
+  complex zres
+  integer ires
+  class(*), allocatable :: a, b
+  select type(a)
+    type is (integer)
+      select type(b)
+        type is (integer)
+          ires = selected_int_kind(b)
+          ires = selected_int_kind(a)
+      end select
+    type is (real)
+     res = acos(a)
+     !ERROR: Actual argument for 'x=' has bad type 'CLASS(*)'
+     res = acos(b)
+  end select
+
+  select type(c => a)
+    type is (real)
+     res = acos(c)
+    class default
+     !ERROR: Actual argument for 'x=' has bad type 'CLASS(*)'
+     res = acos(c)
+  end select
+  select type(a)
+    type is (integer)
+     !ERROR: Actual argument for 'x=' has bad type 'Integer(4)'
+     res = acos(a)
+  end select
+
+  select type(b)
+    type is (integer)
+      associate(y=>1.0, x=>1, z=>(1.0,2.3))
+        ires = selected_int_kind(x)
+        select type(a)
+          type is (real)
+            res = acos(a)
+            res = acos(y)
+            !ERROR: Actual argument for 'x=' has bad type 'Integer(4)'
+            res = acos(b)
+          type is (integer)
+            ires = selected_int_kind(b)
+            zres = acos(z)
+           !ERROR: Actual argument for 'x=' has bad type 'Integer(4)'
+           res = acos(a)
+        end select
+      end associate
+      ires = selected_int_kind(b)
+      !ERROR: No explicit type declared for 'c'
+      ires = selected_int_kind(c)
+      !ERROR: Actual argument for 'x=' has bad type 'CLASS(*)'
+      res = acos(a)
+    class default
+      !ERROR: Actual argument for 'r=' has bad type 'CLASS(*)'
+      ires = selected_int_kind(b)
+  end select
+  !ERROR: Actual argument for 'r=' has bad type 'CLASS(*)'
+  ires = selected_int_kind(a)
+  !ERROR: Actual argument for 'x=' has bad type 'CLASS(*)'
+  res = acos(b)
+end


### PR DESCRIPTION
Fix #598 and similar issues.
Transform `resolve-names.cc` `ConstructVisitor` `association_` member into a stack so that different association construct (select-type, select-rank, change-team, associate) imbrication/succession do not interfere with each other leading to erroneous symbol resolution.