### PR TITLE
Fix legal pointer target test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+Debug
+Release
+MinSizeRel
 build
 root
 tags

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
-Debug
-Release
-MinSizeRel
 build
+root
 tags
 TAGS
 *.o

--- a/lib/evaluate/descender.h
+++ b/lib/evaluate/descender.h
@@ -18,6 +18,7 @@
 // Helper friend class templates for Visitor::Visit() and Rewriter::Traverse().
 
 #include "expression.h"
+#include "../semantics/type.h"
 
 namespace Fortran::evaluate {
 

--- a/lib/evaluate/tools.cc
+++ b/lib/evaluate/tools.cc
@@ -676,6 +676,8 @@ void GetLastTargetVisitor::Pre(const Component &x) {
   if (symbol.attrs().HasAny(
           {semantics::Attr::POINTER, semantics::Attr::TARGET})) {
     Return(&symbol);
+  } else if (symbol.attrs().test(semantics::Attr::ALLOCATABLE)) {
+    Return(nullptr);
   }
 }
 

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -57,27 +57,27 @@ std::optional<Variable<A>> AsVariable(const std::optional<Expr<A>> &expr) {
 }
 
 // Predicate: true when an expression is a variable reference
-template<typename A> bool IsVariable(const A &) { return false; }
-template<typename A> bool IsVariable(const Designator<A> &designator) {
-  if constexpr (common::HasMember<Substring, decltype(Designator<A>::u)>) {
-    if (const auto *substring{std::get_if<Substring>(&designator.u)}) {
-      return substring->GetLastSymbol() != nullptr;
-    }
-  }
-  return true;
-}
-template<typename A> bool IsVariable(const FunctionRef<A> &funcRef) {
-  if (const semantics::Symbol * symbol{funcRef.proc().GetSymbol()}) {
-    return symbol->attrs().test(semantics::Attr::POINTER);
+struct IsVariableVisitor : public virtual VisitorBase<std::optional<bool>> {
+  // std::optional<> is used because it is default-constructible.
+  using Result = std::optional<bool>;
+  explicit IsVariableVisitor(std::nullptr_t);
+  void Handle(const StaticDataObject &);  // constant Substring base -> false
+  void Post(const Substring &);
+  void Pre(const Component &);
+  void Pre(const ArrayRef &);
+  void Pre(const CoarrayRef &);
+  void Pre(const ComplexPart &);
+  void Handle(const ProcedureDesignator &);
+  template<typename A> void Post(const A &) { Return(false); }
+};
+
+template<typename A> bool IsVariable(const A &x) {
+  Visitor<IsVariableVisitor> visitor{nullptr};
+  if (auto optional{visitor.Traverse(x)}) {
+    return *optional;
   } else {
     return false;
   }
-}
-template<typename T> bool IsVariable(const Expr<T> &expr) {
-  return std::visit([](const auto &x) { return IsVariable(x); }, expr.u);
-}
-template<typename A> bool IsVariable(const std::optional<A> &x) {
-  return x.has_value() && IsVariable(*x);
 }
 
 // Predicate: true when an expression is assumed-rank
@@ -614,11 +614,11 @@ struct GetLastSymbolVisitor
   : public virtual VisitorBase<std::optional<const semantics::Symbol *>> {
   // std::optional<> is used because it is default-constructible.
   using Result = std::optional<const semantics::Symbol *>;
-  explicit GetLastSymbolVisitor(std::nullptr_t) {}
-  void Handle(const semantics::Symbol &symbol) { Return(&symbol); }
-  void Handle(const Component &x) { Return(&x.GetLastSymbol()); }
-  void Handle(const NamedEntity &x) { Return(&x.GetLastSymbol()); }
-  void Handle(const ProcedureDesignator &x) { Return(x.GetSymbol()); }
+  explicit GetLastSymbolVisitor(std::nullptr_t);
+  void Handle(const semantics::Symbol &);
+  void Handle(const Component &);
+  void Handle(const NamedEntity &);
+  void Handle(const ProcedureDesignator &);
 };
 
 template<typename A> const semantics::Symbol *GetLastSymbol(const A &x) {
@@ -677,5 +677,27 @@ inline bool IsProcedurePointer(const Expr<SomeType> &expr) {
 template<typename A> bool IsProcedurePointer(const std::optional<A> &x) {
   return x.has_value() && IsProcedurePointer(*x);
 }
+
+// GetLastTarget() returns the rightmost symbol in an object
+// designator (which has perhaps been wrapped in an Expr<>) that has the
+// POINTER or TARGET attribute, or a null pointer when none is found.
+struct GetLastTargetVisitor
+  : public virtual VisitorBase<std::optional<const semantics::Symbol *>> {
+  // std::optional<> is used because it is default-constructible.
+  using Result = std::optional<const semantics::Symbol *>;
+  explicit GetLastTargetVisitor(std::nullptr_t);
+  void Handle(const semantics::Symbol &);
+  void Pre(const Component &);
+};
+
+template<typename A> const semantics::Symbol *GetLastTarget(const A &x) {
+  Visitor<GetLastTargetVisitor> visitor{nullptr};
+  if (auto optional{visitor.Traverse(x)}) {
+    return *optional;
+  } else {
+    return nullptr;
+  }
+}
+
 }
 #endif  // FORTRAN_EVALUATE_TOOLS_H_

--- a/lib/evaluate/traversal.h
+++ b/lib/evaluate/traversal.h
@@ -19,12 +19,17 @@
 #include <type_traits>
 
 // Implements an expression traversal utility framework.
-// See fold.cc to see how this framework is used to implement detection
-// of constant expressions.
+// See fold.cc to see an example of how this framework was used to
+// implement then detection of constant expressions.
+//
+// The bases of references (component, array, coarray, substring, &
+// procedures) are visited before any subscript, cosubscript, or actual
+// arguments.  Visitors may rely on this ordering of descent.
 //
 // To use for non-mutating visitation, define one or more client visitation
 // classes of the form:
 //   class MyVisitor : public virtual VisitorBase<RESULT> {
+//   public:
 //     using Result = RESULT;
 //     explicit MyVisitor(ARGTYPE);  // single-argument constructor
 //     void Handle(const T1 &);  // callback for type T1 objects

--- a/lib/semantics/assignment.cc
+++ b/lib/semantics/assignment.cc
@@ -113,7 +113,8 @@ template<typename T>
 void CheckPointerAssignment(parser::ContextualMessages &messages,
     const IntrinsicProcTable &intrinsics, const Symbol &lhs,
     const Designator<T> &d) {
-  const Symbol *last{d.GetLastSymbol()}, *base{d.GetBaseObject().symbol()};
+  const Symbol *last{d.GetLastSymbol()};
+  const Symbol *base{d.GetBaseObject().symbol()};
   if (last != nullptr && base != nullptr) {
     std::optional<parser::MessageFixedText> error;
     if (IsProcedurePointer(lhs)) {

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -319,9 +319,10 @@ const Symbol *FindSubprogram(const Symbol &symbol) {
 
 const Symbol *FindFunctionResult(const Symbol &symbol) {
   if (const Symbol * subp{FindSubprogram(symbol)}) {
-    const auto &details{subp->get<SubprogramDetails>()};
-    if (details.isFunction()) {
-      return &details.result();
+    if (const auto &subpDetails{subp->detailsIf<SubprogramDetails>()}) {
+      if (subpDetails->isFunction()) {
+        return &subpDetails->result();
+      }
     }
   }
   return nullptr;

--- a/test/semantics/symbol11.f90
+++ b/test/semantics/symbol11.f90
@@ -42,7 +42,7 @@ subroutine s2
  !DEF: /s2/x ObjectEntity CHARACTER(4_4,1)
  !DEF: /s2/y ObjectEntity CHARACTER(4_4,1)
  character(len=4) x, y
- !DEF: /s2/Block1/z AssocEntity CHARACTER(4_4,1)
+ !DEF: /s2/Block1/z AssocEntity CHARACTER(4_8,1)
  !REF: /s2/x
  associate (z => x)
   !REF: /s2/Block1/z


### PR DESCRIPTION
When an object is assigned as the target of a pointer, perhaps as a component of a structure constructor, the object must be either a pointer or have the target attribute.  The test is a little tricky, and I had botched it in the case of something like `p => a(1)%b(2)%c(3)` when (say) `b` was a pointer or target but neither `a` nor `c` were.  The old code just found the base object `a` and tested it for pointer/target attributes.  It turns out that as long as `c` is not allocatable, it effectively inherits the right to be a pointer target from `b`, and so the assignment is legal.  So the code really needs to traverse the target's designator upwards until it hits a symbol that determines whether it can be use as a target or not.

Solving this is just a few actual lines of code to implement and call a `GetLastTarget()` function in `tools.h` to find `b` (in the example above) in a designator; but I implemented it with the expression traversal framework, and while I was doing so, I re-implemented `IsVariable()` and `GetLastSymbol()` with the traversal framework as well, and beefed up that framework so that visitors and mutators could be written with member function templates as callbacks, not just member functions.  I think that tools implemented with the expression traversal framework might be less immediately readable than using mutually recursive functions, but may be less buggy in the long run (debatable).  This patch is thus mostly infrastructure work in the traversal framework, plus the new call that motivated that work.