### PR TITLE
Fix issue 594 and add a derived type component visitor framework

### DIFF
--- a/lib/semantics/check-allocate.cc
+++ b/lib/semantics/check-allocate.cc
@@ -119,14 +119,13 @@ static std::optional<AllocateCheckerInfo> CheckAllocateOptions(
     info.typeSpecLoc = parser::FindSourceLocation(*typeSpec);
     if (const DerivedTypeSpec * derived{info.typeSpec->AsDerived()}) {
       // C937
-      if (auto coarraySearch{ComponentVisitor::HasCoarrayUltimate(*derived)}) {
+      if (auto it{FindCoarrayUltimateComponent(*derived)}) {
         context
             .Say("Type-spec in ALLOCATE must not specify a type with a coarray"
                  " ultimate component"_err_en_US)
-            .Attach(coarraySearch.Result()->name(),
+            .Attach((*it)->name(),
                 "Type '%s' has coarray ultimate component '%s' declared here"_en_US,
-                info.typeSpec->AsFortran(),
-                coarraySearch.BuildResultDesignatorName());
+                info.typeSpec->AsFortran(), it.BuildResultDesignatorName());
       }
     }
   }
@@ -207,31 +206,30 @@ static std::optional<AllocateCheckerInfo> CheckAllocateOptions(
         const DerivedTypeSpec &derived{
             info.sourceExprType.value().GetDerivedTypeSpec()};
         // C949
-        if (auto coarraySearch{ComponentVisitor::HasCoarrayUltimate(derived)}) {
+        if (auto it{FindCoarrayUltimateComponent(derived)}) {
           context
               .Say(parserSourceExpr->source,
                   "SOURCE or MOLD expression must not have a type with a coarray ultimate component"_err_en_US)
-              .Attach(coarraySearch.Result()->name(),
+              .Attach((*it)->name(),
                   "Type '%s' has coarray ultimate component '%s' declared here"_en_US,
                   info.sourceExprType.value().AsFortran(),
-                  coarraySearch.BuildResultDesignatorName());
+                  it.BuildResultDesignatorName());
         }
         if (info.gotSrc) {
           // C948
           if (IsEventTypeOrLockType(&derived)) {
             context.Say(parserSourceExpr->source,
                 "SOURCE expression type must not be EVENT_TYPE or LOCK_TYPE from ISO_FORTRAN_ENV"_err_en_US);
-          } else if (auto componentSearch{
-                         ComponentVisitor::HasEventOrLockPotential(derived)}) {
+          } else if (auto it{FindEventOrLockPotentialComponent(derived)}) {
             context
                 .Say(parserSourceExpr->source,
                     "SOURCE expression type must not have potential subobject "
                     "component"
                     " of type EVENT_TYPE or LOCK_TYPE from ISO_FORTRAN_ENV"_err_en_US)
-                .Attach(componentSearch.Result()->name(),
+                .Attach((*it)->name(),
                     "Type '%s' has potential ultimate component '%s' declared here"_en_US,
                     info.sourceExprType.value().AsFortran(),
-                    componentSearch.BuildResultDesignatorName());
+                    it.BuildResultDesignatorName());
           }
         }
       }

--- a/lib/semantics/check-allocate.cc
+++ b/lib/semantics/check-allocate.cc
@@ -119,13 +119,14 @@ static std::optional<AllocateCheckerInfo> CheckAllocateOptions(
     info.typeSpecLoc = parser::FindSourceLocation(*typeSpec);
     if (const DerivedTypeSpec * derived{info.typeSpec->AsDerived()}) {
       // C937
-      if (const Symbol *
-          coarrayComponent{HasCoarrayUltimateComponent(*derived)}) {
+      if (auto coarraySearch{ComponentVisitor::HasCoarrayUltimate(*derived)}) {
         context
-            .Say(
-                "Type-spec in ALLOCATE must not specify a type with a coarray ultimate component"_err_en_US)
-            .Attach(coarrayComponent->name(),
-                "Coarray ultimate component declared here"_en_US);
+            .Say("Type-spec in ALLOCATE must not specify a type with a coarray"
+                 " ultimate component"_err_en_US)
+            .Attach(coarraySearch.Result()->name(),
+                "Type '%s' has coarray ultimate component '%s' declared here"_en_US,
+                info.typeSpec->AsFortran(),
+                coarraySearch.BuildResultDesignatorName());
       }
     }
   }
@@ -206,26 +207,31 @@ static std::optional<AllocateCheckerInfo> CheckAllocateOptions(
         const DerivedTypeSpec &derived{
             info.sourceExprType.value().GetDerivedTypeSpec()};
         // C949
-        if (const Symbol *
-            coarrayComponent{HasCoarrayUltimateComponent(derived)}) {
+        if (auto coarraySearch{ComponentVisitor::HasCoarrayUltimate(derived)}) {
           context
               .Say(parserSourceExpr->source,
                   "SOURCE or MOLD expression must not have a type with a coarray ultimate component"_err_en_US)
-              .Attach(coarrayComponent->name(),
-                  "Coarray ultimate component declared here"_en_US);
+              .Attach(coarraySearch.Result()->name(),
+                  "Type '%s' has coarray ultimate component '%s' declared here"_en_US,
+                  info.sourceExprType.value().AsFortran(),
+                  coarraySearch.BuildResultDesignatorName());
         }
         if (info.gotSrc) {
           // C948
           if (IsEventTypeOrLockType(&derived)) {
             context.Say(parserSourceExpr->source,
                 "SOURCE expression type must not be EVENT_TYPE or LOCK_TYPE from ISO_FORTRAN_ENV"_err_en_US);
-          } else if (const Symbol *
-              component{HasEventOrLockPotentialComponent(derived)}) {
+          } else if (auto componentSearch{
+                         ComponentVisitor::HasEventOrLockPotential(derived)}) {
             context
                 .Say(parserSourceExpr->source,
-                    "SOURCE expression type must not have potential subobject component of type EVENT_TYPE or LOCK_TYPE from ISO_FORTRAN_ENV"_err_en_US)
-                .Attach(component->name(),
-                    "Potential subobject component of forbidden type declared here"_en_US);
+                    "SOURCE expression type must not have potential subobject "
+                    "component"
+                    " of type EVENT_TYPE or LOCK_TYPE from ISO_FORTRAN_ENV"_err_en_US)
+                .Attach(componentSearch.Result()->name(),
+                    "Type '%s' has potential ultimate component '%s' declared here"_en_US,
+                    info.sourceExprType.value().AsFortran(),
+                    componentSearch.BuildResultDesignatorName());
           }
         }
       }

--- a/lib/semantics/check-allocate.cc
+++ b/lib/semantics/check-allocate.cc
@@ -195,7 +195,8 @@ static std::optional<AllocateCheckerInfo> CheckAllocateOptions(
     if (const auto *expr{GetExpr(DEREF(parserSourceExpr))}) {
       info.sourceExprType = expr->GetType();
       if (!info.sourceExprType.has_value()) {
-        CHECK(context.AnyFatalError());
+        context.Say(parserSourceExpr->source,
+            "Typeless item not allowed as SOURCE or MOLD in ALLOCATE"_err_en_US);
         return std::nullopt;
       }
       info.sourceExprRank = expr->Rank();

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1222,8 +1222,7 @@ MaybeExpr ExpressionAnalyzer::Analyze(
   // produces the component list X, A, Y.
   // The order is important below because a structure constructor can
   // initialize X or A by name, but not both.
-  const auto &details{typeSymbol.get<semantics::DerivedTypeDetails>()};
-  semantics::SymbolVector components{details.OrderComponents(*spec.scope())};
+  auto components{semantics::OrderedComponentIterator{spec}};
   auto nextAnonymous{components.begin()};
 
   std::set<parser::CharBlock> unavailable;

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -556,25 +556,6 @@ void DerivedTypeDetails::add_component(const Symbol &symbol) {
   componentNames_.push_back(symbol.name());
 }
 
-SymbolVector DerivedTypeDetails::OrderComponents(const Scope &scope) const {
-  SymbolVector result;
-  for (SourceName name : componentNames_) {
-    auto iter{scope.find(name)};
-    if (iter != scope.cend()) {
-      const Symbol &symbol{*iter->second};
-      if (symbol.test(Symbol::Flag::ParentComp)) {
-        CHECK(result.empty());  // parent component must appear first
-        const DerivedTypeSpec &spec{
-            symbol.get<ObjectEntityDetails>().type()->derivedTypeSpec()};
-        result = spec.typeSymbol().get<DerivedTypeDetails>().OrderComponents(
-            *spec.scope());
-      }
-      result.push_back(&symbol);
-    }
-  }
-  return result;
-}
-
 const Symbol *DerivedTypeDetails::GetParentComponent(const Scope &scope) const {
   if (auto extends{GetParentComponentName()}) {
     if (auto iter{scope.find(*extends)}; iter != scope.cend()) {

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -233,12 +233,9 @@ public:
   void add_paramDecl(const Symbol &symbol) { paramDecls_.push_back(&symbol); }
   void add_component(const Symbol &);
   void set_sequence(bool x = true) { sequence_ = x; }
-
-  // Returns the complete list of derived type components in the order
-  // in which their declarations appear in the derived type definitions
-  // (parents first).  Parent components appear in the list immediately
-  // after the components that belong to them.
-  SymbolVector OrderComponents(const Scope &) const;
+  const std::list<SourceName> &componentNames() const {
+    return componentNames_;
+  }
 
   // If this derived type extends another, locate the parent component's symbol.
   const Symbol *GetParentComponent(const Scope &) const;

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -525,8 +525,10 @@ public:
                 return x.interface().type();
               }
             },
+            [&](const ProcBindingDetails &x) { return x.symbol().GetType(); },
             [](const TypeParamDetails &x) { return x.type(); },
             [](const UseDetails &x) { return x.symbol().GetType(); },
+            [](const HostAssocDetails &x) { return x.symbol().GetType(); },
             [](const auto &) -> const DeclTypeSpec * { return nullptr; },
         },
         details_);

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -380,18 +380,6 @@ bool IsTeamType(const DerivedTypeSpec *derived) {
   return IsDerivedTypeFromModule(derived, "iso_fortran_env", "team_type");
 }
 
-const Symbol *FindUltimateComponent(const DerivedTypeSpec &derivedTypeSpec,
-    std::function<bool(const Symbol &)> predicate) {
-  return ComponentVisitor{std::move(predicate)}
-      .VisitUltimateComponents(derivedTypeSpec)
-      .Result();
-}
-
-const Symbol *HasCoarrayUltimateComponent(
-    const DerivedTypeSpec &derivedTypeSpec) {
-  return FindUltimateComponent(derivedTypeSpec, IsCoarray);
-}
-
 const bool IsEventTypeOrLockType(const DerivedTypeSpec *derivedTypeSpec) {
   return IsDerivedTypeFromModule(
              derivedTypeSpec, "iso_fortran_env", "event_type") ||
@@ -412,19 +400,12 @@ bool IsOrContainsEventOrLockComponent(const Symbol &symbol) {
       if (const DeclTypeSpec * type{details->type()}) {
         if (const DerivedTypeSpec * derived{type->AsDerived()}) {
           return IsEventTypeOrLockType(derived) ||
-              HasEventOrLockPotentialComponent(*derived);
+              ComponentVisitor::HasEventOrLockPotential(*derived);
         }
       }
     }
   }
   return false;
-}
-
-const Symbol *HasEventOrLockPotentialComponent(
-    const DerivedTypeSpec &derivedTypeSpec) {
-  return ComponentVisitor{IsEventTypeOrLockTypeObjectEntity}
-      .VisitPotentialComponents(derivedTypeSpec)
-      .Result();
 }
 
 bool IsFinalizable(const Symbol &symbol) {
@@ -888,12 +869,25 @@ ComponentVisitor &ComponentVisitor::VisitDirectComponents(
   return *this;
 }
 
+ComponentVisitor ComponentVisitor::HasEventOrLockPotential(
+    const DerivedTypeSpec &derived) {
+  return ComponentVisitor{IsEventTypeOrLockTypeObjectEntity}
+      .VisitPotentialComponents(derived);
+}
+
 std::string ComponentVisitor::BuildResultDesignatorName() const {
   std::string designator{""};
   for (const Symbol *component : componentStack_) {
     designator += "%" + component->name().ToString();
   }
   return designator;
+}
+
+const Symbol *FindUltimateComponent(const DerivedTypeSpec &derived,
+    std::function<bool(const Symbol &)> predicate) {
+  return ComponentVisitor{std::move(predicate)}
+      .VisitUltimateComponents(derived)
+      .Result();
 }
 
 }

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -380,6 +380,13 @@ bool IsTeamType(const DerivedTypeSpec *derived) {
   return IsDerivedTypeFromModule(derived, "iso_fortran_env", "team_type");
 }
 
+const Symbol *FindUltimateComponent(const DerivedTypeSpec &derivedTypeSpec,
+    std::function<bool(const Symbol &)> predicate) {
+  return ComponentVisitor{std::move(predicate)}
+      .VisitUltimateComponents(derivedTypeSpec)
+      .Result();
+}
+
 const Symbol *HasCoarrayUltimateComponent(
     const DerivedTypeSpec &derivedTypeSpec) {
   return FindUltimateComponent(derivedTypeSpec, IsCoarray);
@@ -391,38 +398,12 @@ const bool IsEventTypeOrLockType(const DerivedTypeSpec *derivedTypeSpec) {
       IsDerivedTypeFromModule(derivedTypeSpec, "iso_fortran_env", "lock_type");
 }
 
-const Symbol *HasEventOrLockPotentialComponent(
-    const DerivedTypeSpec &derivedTypeSpec) {
-
-  const Symbol &symbol{derivedTypeSpec.typeSymbol()};
-  // TODO is it guaranteed that derived type symbol have a scope and is it the
-  // right scope to look into?
-  CHECK(symbol.scope());
-  for (const Symbol *componentSymbol :
-      symbol.get<DerivedTypeDetails>().OrderComponents(*symbol.scope())) {
-    CHECK(componentSymbol);
-    if (!IsPointer(*componentSymbol)) {
-      if (const DeclTypeSpec * declTypeSpec{componentSymbol->GetType()}) {
-        if (const DerivedTypeSpec *
-            componentDerivedTypeSpec{declTypeSpec->AsDerived()}) {
-          // Avoid infinite loop, that may happen if the component
-          // is an allocatable of the same type as the derived type.
-          // TODO: Is it legal to have longer type loops: i.e type B has a
-          // component of type A that has an allocatable component of type B?
-          if (&symbol != &componentDerivedTypeSpec->typeSymbol()) {
-            if (IsEventTypeOrLockType(componentDerivedTypeSpec)) {
-              return componentSymbol;
-            } else if (const Symbol *
-                subcomponent{HasEventOrLockPotentialComponent(
-                    *componentDerivedTypeSpec)}) {
-              return subcomponent;
-            }
-          }
-        }
-      }
-    }
+static const bool IsEventTypeOrLockTypeObjectEntity(const Symbol &symbol) {
+  if (symbol.has<ObjectEntityDetails>()) {
+    const DeclTypeSpec *type{symbol.GetType()};
+    return type && IsEventTypeOrLockType(type->AsDerived());
   }
-  return nullptr;
+  return false;
 }
 
 bool IsOrContainsEventOrLockComponent(const Symbol &symbol) {
@@ -439,25 +420,11 @@ bool IsOrContainsEventOrLockComponent(const Symbol &symbol) {
   return false;
 }
 
-const Symbol *FindUltimateComponent(const DerivedTypeSpec &derivedTypeSpec,
-    std::function<bool(const Symbol &)> predicate) {
-  const auto *scope{derivedTypeSpec.typeSymbol().scope()};
-  CHECK(scope);
-  for (const auto &pair : *scope) {
-    const Symbol &component{*pair.second};
-    const DeclTypeSpec *type{component.GetType()};
-    if (!type) {
-      continue;
-    }
-    const DerivedTypeSpec *derived{type->AsDerived()};
-    bool isUltimate{IsAllocatableOrPointer(component) || !derived};
-    if (const Symbol *
-        result{!isUltimate ? FindUltimateComponent(*derived, predicate)
-                           : predicate(component) ? &component : nullptr}) {
-      return result;
-    }
-  }
-  return nullptr;
+const Symbol *HasEventOrLockPotentialComponent(
+    const DerivedTypeSpec &derivedTypeSpec) {
+  return ComponentVisitor{IsEventTypeOrLockTypeObjectEntity}
+      .VisitPotentialComponents(derivedTypeSpec)
+      .Result();
 }
 
 bool IsFinalizable(const Symbol &symbol) {
@@ -792,6 +759,141 @@ static Symbol &InstantiateSymbol(
     }
   }
   return result;
+}
+
+enum class ComponentKind { Direct, Ultimate, Potential };
+
+template<ComponentKind componentKind> class ComponentVisitorImplementation {
+public:
+  ComponentVisitorImplementation(std::function<bool(const Symbol &)> &predicate)
+    : predicate_{predicate} {}
+  SymbolVector Visit(const DerivedTypeSpec &derived) {
+    TraverseDerivedType(derived);
+    return std::move(componentStack_);
+  }
+
+private:
+  const Symbol *TraverseDerivedType(const DerivedTypeSpec &derived) {
+    const Symbol &derivedTypeSymbol{derived.typeSymbol()};
+    // Avoid infinite loop if the type is already part of the types
+    // being visited. It is possible to have "loops in type" because
+    // C744 does not forbid to use not yet declared type for
+    // ALLOCATABLE or POINTER components.
+    // When looking for potential components, the search could fall
+    // in an infinite loop. Avoid these in other search for safety.
+    for (const Symbol *typeUnderVisit : typeStack_) {
+      if (typeUnderVisit == &derivedTypeSymbol) {
+        return nullptr;
+      }
+    }
+    typeStack_.push_back(&derivedTypeSymbol);
+    const Scope *scope{derivedTypeSymbol.scope()};
+    CHECK(scope);  // derived type symbol must have a scope
+    const Symbol *result{nullptr};
+    // Note: parent subcomponents are visited first, then the parent component
+    // (if any), then other components by order of declaration
+    SymbolVector orederedComponents{
+        derivedTypeSymbol.get<DerivedTypeDetails>().OrderComponents(*scope)};
+    for (const Symbol *component : orederedComponents) {
+      if (component->has<ProcEntityDetails>()) {
+        result = VisitProcedureComponent(*component);
+      } else if (component->has<ObjectEntityDetails>()) {
+        result = VisitDataComponent(*component);
+      }
+      if (result) {
+        return result;
+      }
+    }
+    typeStack_.pop_back();
+    return nullptr;
+  }
+
+  const Symbol *VisitProcedureComponent(const Symbol &component) {
+    // Procedure components are pointers (C756)
+    if constexpr (componentKind == ComponentKind::Ultimate ||
+        componentKind == ComponentKind::Direct) {
+      if (predicate_(component)) {
+        componentStack_.push_back(&component);
+        return &component;
+      }
+    }
+    return nullptr;
+  }
+
+  const Symbol *VisitDataComponent(const Symbol &component) {
+    const DeclTypeSpec *type{component.GetType()};
+    if (!type) {
+      return nullptr;  // error recovery ?
+    }
+    bool test{false}, descend{false};
+    if constexpr (componentKind == ComponentKind::Direct) {
+      test = true;
+      descend = !IsAllocatableOrPointer(component);
+    } else if constexpr (componentKind == ComponentKind::Ultimate) {
+      descend = !IsAllocatableOrPointer(component);
+      test = !descend || type->AsIntrinsic();
+    } else {  // Potential
+      test = descend = !IsPointer(component);
+    }
+
+    // Do not descend into parent components, their components were already
+    // included by DerivedTypeDetails::OrderComponents. However, parent
+    // components should still be checked against the predicate if relevant.
+    descend &= !component.test(Symbol::Flag::ParentComp);
+
+    if (test && predicate_(component)) {
+      componentStack_.push_back(&component);
+      return &component;
+    } else if (descend) {
+      if (const auto *derived{type->AsDerived()}) {
+        componentStack_.push_back(&component);
+        if (const Symbol * result{TraverseDerivedType(*derived)}) {
+          return result;
+        }
+        componentStack_.pop_back();
+      }
+    }
+    return nullptr;
+  }
+
+  std::vector<const Symbol *> componentStack_;  // to build message info
+  std::vector<const Symbol *> typeStack_;  // to avoid infinite loops
+  std::function<bool(const Symbol &)> &predicate_;
+};
+
+ComponentVisitor &ComponentVisitor::VisitPotentialComponents(
+    const DerivedTypeSpec &derived) {
+  componentStack_.clear();
+  componentStack_ =
+      ComponentVisitorImplementation<ComponentKind::Potential>{predicate_}
+          .Visit(derived);
+  return *this;
+}
+
+ComponentVisitor &ComponentVisitor::VisitUltimateComponents(
+    const DerivedTypeSpec &derived) {
+  componentStack_.clear();
+  componentStack_ =
+      ComponentVisitorImplementation<ComponentKind::Ultimate>{predicate_}.Visit(
+          derived);
+  return *this;
+}
+
+ComponentVisitor &ComponentVisitor::VisitDirectComponents(
+    const DerivedTypeSpec &derived) {
+  componentStack_.clear();
+  componentStack_ =
+      ComponentVisitorImplementation<ComponentKind::Direct>{predicate_}.Visit(
+          derived);
+  return *this;
+}
+
+std::string ComponentVisitor::BuildResultDesignatorName() const {
+  std::string designator{""};
+  for (const Symbol *component : componentStack_) {
+    designator += "%" + component->name().ToString();
+  }
+  return designator;
 }
 
 }

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -386,21 +386,13 @@ const bool IsEventTypeOrLockType(const DerivedTypeSpec *derivedTypeSpec) {
       IsDerivedTypeFromModule(derivedTypeSpec, "iso_fortran_env", "lock_type");
 }
 
-static const bool IsEventTypeOrLockTypeObjectEntity(const Symbol &symbol) {
-  if (symbol.has<ObjectEntityDetails>()) {
-    const DeclTypeSpec *type{symbol.GetType()};
-    return type && IsEventTypeOrLockType(type->AsDerived());
-  }
-  return false;
-}
-
 bool IsOrContainsEventOrLockComponent(const Symbol &symbol) {
   if (const Symbol * root{GetAssociationRoot(symbol)}) {
     if (const auto *details{root->detailsIf<ObjectEntityDetails>()}) {
       if (const DeclTypeSpec * type{details->type()}) {
         if (const DerivedTypeSpec * derived{type->AsDerived()}) {
           return IsEventTypeOrLockType(derived) ||
-              ComponentVisitor::HasEventOrLockPotential(*derived);
+              FindEventOrLockPotentialComponent(*derived);
         }
       }
     }
@@ -742,152 +734,218 @@ static Symbol &InstantiateSymbol(
   return result;
 }
 
-enum class ComponentKind { Direct, Ultimate, Potential };
+// ComponentIterator implementation
 
-template<ComponentKind componentKind> class ComponentVisitorImplementation {
-public:
-  ComponentVisitorImplementation(std::function<bool(const Symbol &)> &predicate)
-    : predicate_{predicate} {}
-  SymbolVector Visit(const DerivedTypeSpec &derived) {
-    TraverseDerivedType(derived);
-    return std::move(componentStack_);
+template<ComponentKind componentKind>
+typename ComponentIterator<componentKind>::const_iterator
+ComponentIterator<componentKind>::const_iterator::Create(
+    const DerivedTypeSpec &derived) {
+  const_iterator it{};
+  const std::list<SourceName> &names{
+      derived.typeSymbol().get<DerivedTypeDetails>().componentNames()};
+  if (names.empty()) {
+    return it;  // end iterator
+  } else {
+    it.componentPath_.emplace_back(
+        ComponentPathNode{nullptr, &derived, names.cbegin()});
+    it.Increment();  // search first relevant component (may be the end)
+    return it;
   }
+}
 
-private:
-  const Symbol *TraverseDerivedType(const DerivedTypeSpec &derived) {
-    const Symbol &derivedTypeSymbol{derived.typeSymbol()};
-    // Avoid infinite loop if the type is already part of the types
-    // being visited. It is possible to have "loops in type" because
-    // C744 does not forbid to use not yet declared type for
-    // ALLOCATABLE or POINTER components.
-    // When looking for potential components, the search could fall
-    // in an infinite loop. Avoid these in other search for safety.
-    for (const Symbol *typeUnderVisit : typeStack_) {
-      if (typeUnderVisit == &derivedTypeSymbol) {
-        return nullptr;
-      }
-    }
-    typeStack_.push_back(&derivedTypeSymbol);
-    const Scope *scope{derivedTypeSymbol.scope()};
-    CHECK(scope);  // derived type symbol must have a scope
-    const Symbol *result{nullptr};
-    // Note: parent subcomponents are visited first, then the parent component
-    // (if any), then other components by order of declaration
-    SymbolVector orederedComponents{
-        derivedTypeSymbol.get<DerivedTypeDetails>().OrderComponents(*scope)};
-    for (const Symbol *component : orederedComponents) {
-      if (component->has<ProcEntityDetails>()) {
-        result = VisitProcedureComponent(*component);
-      } else if (component->has<ObjectEntityDetails>()) {
-        result = VisitDataComponent(*component);
-      }
-      if (result) {
-        return result;
-      }
-    }
-    typeStack_.pop_back();
-    return nullptr;
-  }
-
-  const Symbol *VisitProcedureComponent(const Symbol &component) {
-    // Procedure components are pointers (C756)
-    if constexpr (componentKind == ComponentKind::Ultimate ||
-        componentKind == ComponentKind::Direct) {
-      if (predicate_(component)) {
-        componentStack_.push_back(&component);
-        return &component;
-      }
-    }
-    return nullptr;
-  }
-
-  const Symbol *VisitDataComponent(const Symbol &component) {
-    const DeclTypeSpec *type{component.GetType()};
+template<ComponentKind componentKind>
+bool ComponentIterator<componentKind>::const_iterator::PlanComponentTraversal(
+    const Symbol &component) {
+  // only data component can be traversed
+  if (const auto *details{component.detailsIf<ObjectEntityDetails>()}) {
+    const DeclTypeSpec *type{details->type()};
     if (!type) {
-      return nullptr;  // error recovery ?
-    }
-    bool test{false}, descend{false};
-    if constexpr (componentKind == ComponentKind::Direct) {
-      test = true;
-      descend = !IsAllocatableOrPointer(component);
-    } else if constexpr (componentKind == ComponentKind::Ultimate) {
-      descend = !IsAllocatableOrPointer(component);
-      test = !descend || type->AsIntrinsic();
-    } else {  // Potential
-      test = descend = !IsPointer(component);
-    }
-
-    // Do not descend into parent components, their components were already
-    // included by DerivedTypeDetails::OrderComponents. However, parent
-    // components should still be checked against the predicate if relevant.
-    descend &= !component.test(Symbol::Flag::ParentComp);
-
-    if (test && predicate_(component)) {
-      componentStack_.push_back(&component);
-      return &component;
-    } else if (descend) {
-      if (const auto *derived{type->AsDerived()}) {
-        componentStack_.push_back(&component);
-        if (const Symbol * result{TraverseDerivedType(*derived)}) {
-          return result;
-        }
-        componentStack_.pop_back();
+      return false;  // error recovery
+    } else if (const auto *derived{type->AsDerived()}) {
+      bool traverse{false};
+      if constexpr (componentKind == ComponentKind::Ordered) {
+        // Order Component (only visit parents)
+        traverse = component.test(Symbol::Flag::ParentComp);
+      } else if constexpr (componentKind == ComponentKind::Direct) {
+        traverse = !IsAllocatableOrPointer(component);
+      } else if constexpr (componentKind == ComponentKind::Ultimate) {
+        traverse = !IsAllocatableOrPointer(component);
+      } else if constexpr (componentKind == ComponentKind::Potential) {
+        traverse = !IsPointer(component);
       }
-    }
-    return nullptr;
+      if (traverse) {
+        const Symbol *newTypeSymbol{&derived->typeSymbol()};
+        // Avoid infinite loop if the type is already part of the types
+        // being visited. It is possible to have "loops in type" because
+        // C744 does not forbid to use not yet declared type for
+        // ALLOCATABLE or POINTER components.
+        for (const auto &node : componentPath_) {
+          if (newTypeSymbol == &GetTypeSymbol(node)) {
+            return false;
+          }
+        }
+        componentPath_.emplace_back(ComponentPathNode{nullptr, derived,
+            newTypeSymbol->get<DerivedTypeDetails>()
+                .componentNames()
+                .cbegin()});
+        return true;
+      }
+    }  // intrinsic & unlimited polymorphic not traversable
   }
-
-  std::vector<const Symbol *> componentStack_;  // to build message info
-  std::vector<const Symbol *> typeStack_;  // to avoid infinite loops
-  std::function<bool(const Symbol &)> &predicate_;
-};
-
-ComponentVisitor &ComponentVisitor::VisitPotentialComponents(
-    const DerivedTypeSpec &derived) {
-  componentStack_.clear();
-  componentStack_ =
-      ComponentVisitorImplementation<ComponentKind::Potential>{predicate_}
-          .Visit(derived);
-  return *this;
+  return false;
 }
 
-ComponentVisitor &ComponentVisitor::VisitUltimateComponents(
-    const DerivedTypeSpec &derived) {
-  componentStack_.clear();
-  componentStack_ =
-      ComponentVisitorImplementation<ComponentKind::Ultimate>{predicate_}.Visit(
-          derived);
-  return *this;
+template<ComponentKind componentKind>
+static bool StopAtComponentPre(const Symbol &component) {
+  if constexpr (componentKind == ComponentKind::Ordered) {
+    // Parent components need to be iterated upon after their
+    // sub-components in structure constructor analysis.
+    return !component.test(Symbol::Flag::ParentComp);
+  } else if constexpr (componentKind == ComponentKind::Direct) {
+    return true;
+  } else if constexpr (componentKind == ComponentKind::Ultimate) {
+    return component.has<ProcEntityDetails>() ||
+        IsAllocatableOrPointer(component) ||
+        (component.get<ObjectEntityDetails>().type() &&
+            component.get<ObjectEntityDetails>().type()->AsIntrinsic());
+  } else if constexpr (componentKind == ComponentKind::Potential) {
+    return !IsPointer(component);
+  }
 }
 
-ComponentVisitor &ComponentVisitor::VisitDirectComponents(
-    const DerivedTypeSpec &derived) {
-  componentStack_.clear();
-  componentStack_ =
-      ComponentVisitorImplementation<ComponentKind::Direct>{predicate_}.Visit(
-          derived);
-  return *this;
+template<ComponentKind componentKind>
+static bool StopAtComponentPost(const Symbol &component) {
+  if constexpr (componentKind == ComponentKind::Ordered) {
+    return component.test(Symbol::Flag::ParentComp);
+  } else {
+    return false;
+  }
 }
 
-ComponentVisitor ComponentVisitor::HasEventOrLockPotential(
-    const DerivedTypeSpec &derived) {
-  return ComponentVisitor{IsEventTypeOrLockTypeObjectEntity}
-      .VisitPotentialComponents(derived);
+enum class ComponentVisitState { Resume, Pre, Post };
+
+template<ComponentKind componentKind>
+void ComponentIterator<componentKind>::const_iterator::Increment() {
+  std::int64_t level{static_cast<std::int64_t>(componentPath_.size()) - 1};
+  // Need to know if this is the first incrementation or if the visit is resumed
+  // after a user increment.
+  ComponentVisitState state{
+      level >= 0 && GetComponentSymbol(componentPath_[level])
+          ? ComponentVisitState::Resume
+          : ComponentVisitState::Pre};
+  while (level >= 0) {
+    bool descend{false};
+    const Scope *scope{GetScope(componentPath_[level])};
+    CHECK(scope);
+    auto &levelIterator{GetIterator(componentPath_[level])};
+    const auto &levelEndIterator{GetTypeSymbol(componentPath_[level])
+                                     .template get<DerivedTypeDetails>()
+                                     .componentNames()
+                                     .cend()};
+
+    while (!descend && levelIterator != levelEndIterator) {
+      const Symbol *component{GetComponentSymbol(componentPath_[level])};
+
+      switch (state) {
+      case ComponentVisitState::Resume:
+        CHECK(component);
+        if (StopAtComponentPre<componentKind>(*component)) {
+          // The symbol was not yet considered for
+          // traversal.
+          descend = PlanComponentTraversal(*component);
+        }
+        break;
+      case ComponentVisitState::Pre:
+        // Search iterator
+        if (auto iter{scope->find(*levelIterator)}; iter != scope->cend()) {
+          const Symbol *newComponent{iter->second};
+          SetComponentSymbol(componentPath_[level], newComponent);
+          if (StopAtComponentPre<componentKind>(*newComponent)) {
+            return;
+          }
+          descend = PlanComponentTraversal(*newComponent);
+          if (!descend && StopAtComponentPost<componentKind>(*newComponent)) {
+            return;
+          }
+        }
+        break;
+      case ComponentVisitState::Post:
+        CHECK(component);
+        if (StopAtComponentPost<componentKind>(*component)) {
+          return;
+        }
+        break;
+      }
+
+      if (descend) {
+        level++;
+      } else {
+        SetComponentSymbol(componentPath_[level], nullptr);  // safety
+        levelIterator++;
+      }
+      state = ComponentVisitState::Pre;
+    }
+
+    if (!descend) {  // Finished level traversal
+      componentPath_.pop_back();
+      --level;
+      state = ComponentVisitState::Post;
+    }
+  }
+  // iterator reached end of components
 }
 
-std::string ComponentVisitor::BuildResultDesignatorName() const {
+template<ComponentKind componentKind>
+std::string
+ComponentIterator<componentKind>::const_iterator::BuildResultDesignatorName()
+    const {
   std::string designator{""};
-  for (const Symbol *component : componentStack_) {
-    designator += "%" + component->name().ToString();
+  for (const auto &node : componentPath_) {
+    designator += "%" + GetComponentSymbol(node)->name().ToString();
   }
   return designator;
 }
 
+template class ComponentIterator<ComponentKind::Ordered>;
+template class ComponentIterator<ComponentKind::Direct>;
+template class ComponentIterator<ComponentKind::Ultimate>;
+template class ComponentIterator<ComponentKind::Potential>;
+
+UltimateComponentIterator::const_iterator FindCoarrayUltimateComponent(
+    const DerivedTypeSpec &derived) {
+  UltimateComponentIterator ultimates{derived};
+  return std::find_if(
+      ultimates.begin(), ultimates.end(), [](const Symbol *component) {
+        CHECK(component);
+        return component->Corank() > 0;
+      });
+}
+
+PotentialComponentIterator::const_iterator FindEventOrLockPotentialComponent(
+    const DerivedTypeSpec &derived) {
+  PotentialComponentIterator potentials{derived};
+  return std::find_if(
+      potentials.begin(), potentials.end(), [](const Symbol *component) {
+        CHECK(component);
+        if (const auto *details{component->detailsIf<ObjectEntityDetails>()}) {
+          const DeclTypeSpec *type{details->type()};
+          return type && IsEventTypeOrLockType(type->AsDerived());
+        }
+        return false;
+      });
+}
+
 const Symbol *FindUltimateComponent(const DerivedTypeSpec &derived,
     std::function<bool(const Symbol &)> predicate) {
-  return ComponentVisitor{std::move(predicate)}
-      .VisitUltimateComponents(derived)
-      .Result();
+  UltimateComponentIterator ultimates{derived};
+  if (auto it{std::find_if(ultimates.begin(), ultimates.end(),
+          [&predicate](const Symbol *component) -> bool {
+            CHECK(component);
+            return predicate(*component);
+          })}) {
+    return *it;
+  }
+  return nullptr;
 }
 
 }

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -78,8 +78,6 @@ const bool IsEventTypeOrLockType(const DerivedTypeSpec *);
 // does not really matter for the checks where it is needed.
 const Symbol *HasCoarrayUltimateComponent(const DerivedTypeSpec &);
 // Same logic as HasCoarrayUltimateComponent, but looking for
-// potential component of EVENT_TYPE or LOCK_TYPE from
-// ISO_FORTRAN_ENV module.
 const Symbol *HasEventOrLockPotentialComponent(const DerivedTypeSpec &);
 bool IsOrContainsEventOrLockComponent(const Symbol &);
 
@@ -233,10 +231,14 @@ public:
   ComponentVisitor &VisitUltimateComponents(const DerivedTypeSpec &);
   ComponentVisitor &VisitDirectComponents(const DerivedTypeSpec &);
 
-  // predefined common tests
+  // Predefined common tests
+  // Look for an ultimate component that is a coarray.
   static ComponentVisitor HasCoarrayUltimate(const DerivedTypeSpec &derived) {
     return ComponentVisitor{IsCoarray}.VisitUltimateComponents(derived);
   }
+  // Look for a potential component of EVENT_TYPE or LOCK_TYPE from
+  // ISO_FORTRAN_ENV module.
+  static ComponentVisitor HasEventOrLockPotential(const DerivedTypeSpec &);
 
   const Symbol *Result() const {
     return componentStack_.empty() ? nullptr : componentStack_.back();

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -206,5 +206,51 @@ template<typename T> std::optional<std::int64_t> GetIntValue(const T &x) {
   }
 }
 
+// Derived type component visitor that applies a predicate on all the direct,
+// ultimate or Potential components. It stops at the first component that
+// verifies the given predicate and keep the component path to the result
+// (included at the end of the path). If no component verifies the predicate
+// the path is empty.
+// The component tree is visited in component declaration order,
+// visiting the subcomponent of a component before visiting the next component.
+// Parent components and procedure pointer components are visited.
+// Note that it is made in such a way that one can easily test and build info
+// message in the following way:
+//    if (auto
+//      visitor{ComponentVisitor{predicate}.VisitDirectComponents(derived)}) {
+//       msg = visitor.BuildResultDesignatorName() + " verifies predicates";
+//       ....
+//    }
+// It is safe to re-use the same object several times, previous results are
+// cleared before each visit.
+class ComponentVisitor {
+public:
+  ComponentVisitor(std::function<bool(const Symbol &)> &&predicate)
+    : predicate_{std::move(predicate)} {}
+
+  // Object is updated with the result during visit and returned by ref
+  ComponentVisitor &VisitPotentialComponents(const DerivedTypeSpec &);
+  ComponentVisitor &VisitUltimateComponents(const DerivedTypeSpec &);
+  ComponentVisitor &VisitDirectComponents(const DerivedTypeSpec &);
+
+  // predefined common tests
+  static ComponentVisitor HasCoarrayUltimate(const DerivedTypeSpec &derived) {
+    return ComponentVisitor{IsCoarray}.VisitUltimateComponents(derived);
+  }
+
+  const Symbol *Result() const {
+    return componentStack_.empty() ? nullptr : componentStack_.back();
+  }
+
+  bool HasResult() const { return Result() != nullptr; }
+  explicit operator bool() const { return HasResult(); }
+  // build designator name for messages if there is a result
+  std::string BuildResultDesignatorName() const;
+
+private:
+  SymbolVector componentStack_;  // component path to result
+  std::function<bool(const Symbol &)> predicate_;
+};
+
 }
 #endif  // FORTRAN_SEMANTICS_TOOLS_H_

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -204,55 +204,160 @@ template<typename T> std::optional<std::int64_t> GetIntValue(const T &x) {
   }
 }
 
-// Derived type component visitor that applies a predicate on all the direct,
-// ultimate or Potential components. It stops at the first component that
-// verifies the given predicate and keep the component path to the result
-// (included at the end of the path). If no component verifies the predicate
-// the path is empty.
-// The component tree is visited in component declaration order,
-// visiting the subcomponent of a component before visiting the next component.
-// Parent components and procedure pointer components are visited.
-// Note that it is made in such a way that one can easily test and build info
-// message in the following way:
-//    if (auto
-//      visitor{ComponentVisitor{predicate}.VisitDirectComponents(derived)}) {
-//       msg = visitor.BuildResultDesignatorName() + " verifies predicates";
+// Derived type component iterator that provides a C++ LegacyForwadIterator
+// iterator over the Ordered, Direct, Ultimate or Potential components of a
+// DerivedTypeSpec. These iterators can be used with STL algorithms
+// accepting LegacyForwadIterator.
+// The kind of component is a template argument of the iterator factory
+// ComponentIterator.
+//
+//
+// - Ordered components are the components from the component order defined
+// in 7.5.4.7, except that the parent components IS added between the parent
+// component order and the components in order of declaration.
+// This "deviation" is important for structure-constructor analysis.
+// For this kind of iterator, the component tree is recursively visited in the
+// following order:
+//  - first, the Ordered components of the parent type (if relevant)
+//  - then, the parent component (if relevant, different from 7.5.4.7!)
+//  - then, the components in declaration order (without visiting subcomponents)
+//
+// - Ultimate, Direct and Potential components are as defined in 7.5.1.
+// Parent and procedure components are considered against these definitions.
+// For this kind of iterator, the component tree is recursively visited in the
+// following order:
+//  - the parent component first (if relevant)
+//  - then, the components of the parent type (if relevant)
+//      + visiting the component and then, if it is derived type data component,
+//        visiting the subcomponents before visiting the next
+//        component in declaration order.
+//  - then, components in declaration order, similarly to components of parent
+//    type.
+//  Here, the parent component is visited first so that search for a component
+//  verifying a property will never descend into a component that already
+//  verifies the property (this helps giving clearer feedback).
+//
+// ComponentIterator::const_iterator remain valid during the whole lifetime of
+// the DerivedTypeSpec passed by reference to the ComponentIterator factory.
+// Their validity is independent of the ComponentIterator factory lifetime.
+//
+// For safety and simplicity, the iterators are read only and can only be
+// incremented. This could be changed if desired.
+//
+// Note that iterators are made in such a way that one can easily test and build
+// info message in the following way:
+//    ComponentIterator<ComponentIterator> comp{derived}
+//    if (auto it{std::find_if(comp.begin(), comp.end(), predicate)}) {
+//       msg = it.BuildResultDesignatorName() + " verifies predicates";
+//       const Symbol* component{*it};
 //       ....
 //    }
-// It is safe to re-use the same object several times, previous results are
-// cleared before each visit.
-class ComponentVisitor {
+
+ENUM_CLASS(ComponentKind, Ordered, Direct, Ultimate, Potential)
+
+template<ComponentKind componentKind> class ComponentIterator {
 public:
-  ComponentVisitor(std::function<bool(const Symbol &)> &&predicate)
-    : predicate_{std::move(predicate)} {}
+  ComponentIterator(const DerivedTypeSpec &derived) : derived_{derived} {}
+  class const_iterator {
+  public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = const Symbol *;
+    using difference_type = void;
+    using pointer = const value_type *;
+    using reference = const value_type &;
 
-  // Object is updated with the result during visit and returned by ref
-  ComponentVisitor &VisitPotentialComponents(const DerivedTypeSpec &);
-  ComponentVisitor &VisitUltimateComponents(const DerivedTypeSpec &);
-  ComponentVisitor &VisitDirectComponents(const DerivedTypeSpec &);
+    static const_iterator Create(const DerivedTypeSpec &);
 
-  // Predefined common tests
-  // Look for an ultimate component that is a coarray.
-  static ComponentVisitor HasCoarrayUltimate(const DerivedTypeSpec &derived) {
-    return ComponentVisitor{IsCoarray}.VisitUltimateComponents(derived);
-  }
-  // Look for a potential component of EVENT_TYPE or LOCK_TYPE from
-  // ISO_FORTRAN_ENV module.
-  static ComponentVisitor HasEventOrLockPotential(const DerivedTypeSpec &);
+    const_iterator &operator++() {
+      Increment();
+      return *this;
+    }
+    const_iterator operator++(int) {
+      const_iterator tmp(*this);
+      Increment();
+      return tmp;
+    }
+    reference operator*() const {
+      CHECK(!componentPath_.empty());
+      return std::get<0>(componentPath_.back());
+    }
 
-  const Symbol *Result() const {
-    return componentStack_.empty() ? nullptr : componentStack_.back();
-  }
+    bool operator==(const const_iterator &other) const {
+      return componentPath_ == other.componentPath_;
+    }
+    bool operator!=(const const_iterator &other) const {
+      return !(*this == other);
+    }
 
-  bool HasResult() const { return Result() != nullptr; }
-  explicit operator bool() const { return HasResult(); }
-  // build designator name for messages if there is a result
-  std::string BuildResultDesignatorName() const;
+    // bool() operator indicates if the iterator can be dereferenced without
+    // having to check against an end() iterator.
+    explicit operator bool() const {
+      return !componentPath_.empty() &&
+          GetComponentSymbol(componentPath_.back());
+    }
+
+    // Build a designator name of the referenced component for messages.
+    // The designator helps when the component referred to by the iterator
+    // may be "buried" into other components. This gives the full
+    // path inside the iterated derived type: e.g "%a%b%c%ultimate"
+    // when (*it)->names() only gives "ultimate". Parent component are
+    // part of the path for clarity, even though they could be
+    // skipped.
+    std::string BuildResultDesignatorName() const;
+
+  private:
+    using name_iterator = typename std::list<SourceName>::const_iterator;
+    using ComponentPathNode =
+        std::tuple<const Symbol *, const DerivedTypeSpec *, name_iterator>;
+    using ComponentPath = std::vector<ComponentPathNode>;
+
+    static const Symbol *GetComponentSymbol(const ComponentPathNode &node) {
+      return std::get<0>(node);
+    }
+    static void SetComponentSymbol(ComponentPathNode &node, const Symbol *sym) {
+      std::get<0>(node) = sym;
+    }
+    static const Symbol &GetTypeSymbol(const ComponentPathNode &node) {
+      return std::get<1>(node)->typeSymbol();
+    }
+    static const Scope *GetScope(const ComponentPathNode &node) {
+      return std::get<1>(node)->scope();
+    }
+    static name_iterator &GetIterator(ComponentPathNode &node) {
+      return std::get<2>(node);
+    }
+    bool PlanComponentTraversal(const Symbol &component);
+    void Increment();
+    ComponentPath componentPath_;
+  };
+
+  const_iterator begin() { return cbegin(); }
+  const_iterator end() { return cend(); }
+  const_iterator cbegin() { return const_iterator::Create(derived_); }
+  const_iterator cend() { return const_iterator{}; }
 
 private:
-  SymbolVector componentStack_;  // component path to result
-  std::function<bool(const Symbol &)> predicate_;
+  const DerivedTypeSpec &derived_;
 };
 
+extern template class ComponentIterator<ComponentKind::Ordered>;
+extern template class ComponentIterator<ComponentKind::Direct>;
+extern template class ComponentIterator<ComponentKind::Ultimate>;
+extern template class ComponentIterator<ComponentKind::Potential>;
+using OrderedComponentIterator = ComponentIterator<ComponentKind::Ordered>;
+using DirectComponentIterator = ComponentIterator<ComponentKind::Direct>;
+using UltimateComponentIterator = ComponentIterator<ComponentKind::Ultimate>;
+using PotentialComponentIterator = ComponentIterator<ComponentKind::Potential>;
+
+// Common component searches, the iterator returned is referring to the first
+// component, according to the order defined for the related ComponentIterator,
+// that verifies the property from the name.
+// If no components verifies the property, an end iterator (casting to false)
+// is returned. Otherwise, the returned iterator cast to true and can be
+// dereferenced.
+PotentialComponentIterator::const_iterator FindEventOrLockPotentialComponent(
+    const DerivedTypeSpec &);
+UltimateComponentIterator::const_iterator FindCoarrayUltimateComponent(
+    const DerivedTypeSpec &);
 }
 #endif  // FORTRAN_SEMANTICS_TOOLS_H_

--- a/test/semantics/resolve05.f90
+++ b/test/semantics/resolve05.f90
@@ -23,6 +23,7 @@ end
 function f() result(res)
   integer :: res
   !ERROR: 'f' is already declared in this scoping unit
+  !ERROR: The type of 'f' has already been declared
   real :: f
   res = 1
 end

--- a/test/semantics/resolve05.f90
+++ b/test/semantics/resolve05.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.

--- a/test/semantics/symbol09.f90
+++ b/test/semantics/symbol09.f90
@@ -120,7 +120,7 @@ subroutine s6
  !DEF: /s6/Block1/i ObjectEntity INTEGER(4)
  !DEF: /s6/Block1/j (local) ObjectEntity INTEGER(8)
  !DEF: /s6/Block1/k (implicit) (local_init) ObjectEntity INTEGER(4)
-  !DEF: /s6/Block1/a (shared) HostAssoc
+  !DEF: /s6/Block1/a (shared) HostAssoc INTEGER(4)
  do concurrent(integer::i=1:5)local(j)local_init(k)shared(a)
  !REF: /s6/a
   !REF: /s6/Block1/i


### PR DESCRIPTION
**EDIT 07/31:** Derived type components visitor replaced  by iterators (description in comments above `ComponentIterator` declaration in `lib/semantics/tools.h`). Iterator framework now also replaces `DerivedTypeDetails::OrderComponents`.

- Fix issue #594 
- Also do not crash on typeless expressions in source-allocation that could come from the user. 
- Add an derived type component ~~visitor~~ iterator framework to verify component properties
- Uses the framework to replace `HasCoarrayUltimateComponent` and `HasEventOrLockPotentialComponent` and give more useful feedback in allocate checks errors.

**Fix 594:**
This PR fixes issue 594 by adding and handler for 'ProcBindingDetails' in `Symbol::GetType`.
`HostAssocDetails` handling was added at the same time because it did not seem right to handle
`UseDetails` but not this.
  
**Do not crash on typeless source expressions:**
If the `CHECK` failure related to #594 was indeed an internal failure, it lead me to think that a user could very well put a Boz here and an error message should be given rather than crashing.

**~~New derived type component visiting framework:~~ (Replaced by iterators, see tools.h)**
The fix unveiled an issue in `FindUltimateComponent` (type bound procedure were also searched).
Rather than just fixing this, this PR implements a new derived type component visitor framework that allows testing a predicate on ultimate/potential or direct component and also allows extracting the full component path to the matching component for better error messages.

The visitor is not using the template and virtual inheritance pattern of semantic and expression visitors because only `Symbol&` are visited and I did not want to expose the implementation in header file for a feature that is much less than. It is using a more classic callback pattern.

**Better feedback in allocate checks:**
Given the program:

```
  type t1
    real, allocatable :: my_coarray[*]
  end type
  type t2
    type(t1) :: a
  end type
  type t3
    type(t2) :: b
  end type
  type(t3) :: var, test
  allocatable :: test
  allocate(test, source=var)
end
```
The error message is now:
```
error: SOURCE or MOLD expression must not have a type with a coarray ultimate component
    allocate(test, source=var)
                          ^^^
Type 't3' has coarray ultimate component '%b%a%my_coarray' declared here
      real, allocatable :: my_coarray[*]
```

The attached part was previously only: `Coarray ultimate component  declared here` which I found was not helpful enough in case of nested derived types like this.




 