### PR TITLE
Create symbols for generics at the start of the scope

### DIFF
--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -430,8 +430,9 @@ public:
 
   // Special messages: already declared; referencing symbol's declaration;
   // about a type; two names & locations
-  void SayAlreadyDeclared(const SourceName &, Symbol &);
   void SayAlreadyDeclared(const parser::Name &, Symbol &);
+  void SayAlreadyDeclared(const SourceName &, Symbol &);
+  void SayAlreadyDeclared(const SourceName &, const SourceName &);
   void SayWithReason(
       const parser::Name &, Symbol &, MessageFixedText &&, MessageFixedText &&);
   void SayWithDecl(const parser::Name &, Symbol &, MessageFixedText &&);
@@ -513,7 +514,9 @@ public:
       SayAlreadyDeclared(name, *symbol);
       // replace the old symbol with a new one with correct details
       EraseSymbol(*symbol);
-      return MakeSymbol(name, attrs, std::move(details));
+      auto &result{MakeSymbol(name, attrs, std::move(details))};
+      context().SetError(result);
+      return result;
     }
   }
 
@@ -1029,7 +1032,7 @@ public:
   template<typename T> bool Pre(const T &) { return true; }
   template<typename T> void Post(const T &) {}
 
-  void Post(const parser::SpecificationPart &);
+  bool Pre(const parser::SpecificationPart &);
   void Post(const parser::Program &);
   bool Pre(const parser::ImplicitStmt &);
   void Post(const parser::PointerObject &);
@@ -1065,6 +1068,9 @@ private:
   std::optional<Symbol::Flag> expectedProcFlag_;
   const SourceName *prevImportStmt_{nullptr};
 
+  void PreSpecificationConstruct(const parser::SpecificationConstruct &);
+  void CreateGeneric(const parser::GenericSpec &);
+  void FinishSpecificationPart();
   void CheckImports();
   void CheckImport(const SourceName &, const SourceName &);
   void HandleCall(Symbol::Flag, const parser::Call &);
@@ -1517,16 +1523,26 @@ void ScopeHandler::SayAlreadyDeclared(const parser::Name &name, Symbol &prev) {
   SayAlreadyDeclared(name.source, prev);
 }
 void ScopeHandler::SayAlreadyDeclared(const SourceName &name, Symbol &prev) {
-  auto &msg{
-      Say(name, "'%s' is already declared in this scoping unit"_err_en_US)};
-  if (const auto *details{prev.detailsIf<UseDetails>()}) {
-    msg.Attach(details->location(),
-        "It is use-associated with '%s' in module '%s'"_err_en_US,
-        details->symbol().name(), details->module().name());
+  if (context().HasError(prev)) {
+    // don't report another error about prev
+  } else if (const auto *details{prev.detailsIf<UseDetails>()}) {
+    Say(name, "'%s' is already declared in this scoping unit"_err_en_US)
+        .Attach(details->location(),
+            "It is use-associated with '%s' in module '%s'"_err_en_US,
+            details->symbol().name(), details->module().name());
   } else {
-    msg.Attach(prev.name(), "Previous declaration of '%s'"_en_US, prev.name());
+    SayAlreadyDeclared(name, prev.name());
   }
   context().SetError(prev);
+}
+void ScopeHandler::SayAlreadyDeclared(
+    const SourceName &name1, const SourceName &name2) {
+  if (name1.begin() < name2.begin()) {
+    SayAlreadyDeclared(name2, name1);
+  } else {
+    Say(name1, "'%s' is already declared in this scoping unit"_err_en_US)
+        .Attach(name2, "Previous declaration of '%s'"_en_US, name2);
+  }
 }
 
 void ScopeHandler::SayWithReason(const parser::Name &name, Symbol &symbol,
@@ -2067,65 +2083,9 @@ void InterfaceVisitor::Post(const parser::EndInterfaceStmt &) {
 
 // Create a symbol in genericSymbol_ for this GenericSpec.
 bool InterfaceVisitor::Pre(const parser::GenericSpec &x) {
-  auto info{GenericSpecInfo{x}};
-  const SourceName &symbolName{info.symbolName()};
-  if (IsLogicalConstant(context(), symbolName)) {
-    Say(symbolName,
-        "Logical constant '%s' may not be used as a defined operator"_err_en_US);
-    return false;
+  if (auto *symbol{currScope().FindSymbol(GenericSpecInfo{x}.symbolName())}) {
+    SetGenericSymbol(*symbol);
   }
-  Symbol *symbol{currScope().FindSymbol(symbolName)};
-  if (symbol) {
-    if (symbol->has<DerivedTypeDetails>()) {
-      // A generic and derived type with same name: create a generic symbol
-      // and save derived type in it.
-      CHECK(symbol->scope()->symbol() == symbol);
-      GenericDetails details;
-      details.set_derivedType(*symbol);
-      EraseSymbol(*symbol);
-      symbol = &MakeSymbol(symbolName);
-      symbol->set_details(details);
-      // preserve access attributes
-      symbol->attrs() |=
-          details.derivedType()->attrs() & Attrs{Attr::PUBLIC, Attr::PRIVATE};
-    } else if (symbol->has<UnknownDetails>()) {
-      // okay
-    } else if (!symbol->IsSubprogram()) {
-      SayAlreadyDeclared(symbolName, *symbol);
-      EraseSymbol(*symbol);
-      symbol = nullptr;
-    } else if (symbol->has<UseDetails>()) {
-      // copy the USEd symbol into this scope so we can modify it
-      const Symbol &ultimate{symbol->GetUltimate()};
-      EraseSymbol(*symbol);
-      symbol = &CopySymbol(symbolName, ultimate);
-      if (const auto *details{ultimate.detailsIf<GenericDetails>()}) {
-        symbol->set_details(GenericDetails{details->specificProcs()});
-      } else if (const auto *details{ultimate.detailsIf<SubprogramDetails>()}) {
-        symbol->set_details(SubprogramDetails{*details});
-      } else {
-        DIE("unexpected kind of symbol");
-      }
-    }
-  }
-  if (!symbol || symbol->has<UnknownDetails>()) {
-    symbol = &MakeSymbol(symbolName);
-    symbol->set_details(GenericDetails{});
-  }
-  if (symbol->has<GenericDetails>()) {
-    // okay
-  } else if (symbol->has<SubprogramDetails>() ||
-      symbol->has<SubprogramNameDetails>()) {
-    GenericDetails genericDetails;
-    genericDetails.set_specific(*symbol);
-    EraseSymbol(*symbol);
-    symbol = &MakeSymbol(symbolName);
-    symbol->set_details(genericDetails);
-  } else {
-    common::die("unexpected kind of symbol");
-  }
-  info.Resolve(symbol);
-  SetGenericSymbol(*symbol);
   return false;
 }
 
@@ -2237,7 +2197,14 @@ void InterfaceVisitor::CheckGenericProcedures(Symbol &generic) {
   ResolveSpecificsInGeneric(generic);
   auto &details{generic.get<GenericDetails>()};
   if (auto *proc{details.CheckSpecific()}) {
-    SayAlreadyDeclared(generic.name(), *proc);
+    auto msg{
+        "'%s' may not be the name of both a generic interface and a"
+        " procedure unless it is a specific procedure of the generic"_err_en_US};
+    if (proc->name().begin() > generic.name().begin()) {
+      Say(proc->name(), std::move(msg));
+    } else {
+      Say(generic.name(), std::move(msg));
+    }
   }
   auto &specifics{details.specificProcs()};
   if (specifics.empty()) {
@@ -5027,7 +4994,77 @@ static bool NeedsExplicitType(const Symbol &symbol) {
   }
 }
 
-void ResolveNamesVisitor::Post(const parser::SpecificationPart &) {
+bool ResolveNamesVisitor::Pre(const parser::SpecificationPart &x) {
+  Walk(std::get<0>(x.t));
+  Walk(std::get<1>(x.t));
+  Walk(std::get<2>(x.t));
+  Walk(std::get<3>(x.t));
+  const std::list<parser::DeclarationConstruct> &decls{std::get<4>(x.t)};
+  for (const auto &decl : decls) {
+    if (const auto *spec{
+            std::get_if<parser::SpecificationConstruct>(&decl.u)}) {
+      PreSpecificationConstruct(*spec);
+    }
+  }
+  Walk(decls);
+  FinishSpecificationPart();
+  return false;
+}
+
+// Initial processing on specification constructs, before visiting them.
+void ResolveNamesVisitor::PreSpecificationConstruct(
+    const parser::SpecificationConstruct &spec) {
+  std::visit(
+      common::visitors{
+          [&](const Indirection<parser::DerivedTypeDef> &y) {},
+          [&](const parser::Statement<Indirection<parser::GenericStmt>> &y) {
+            CreateGeneric(std::get<parser::GenericSpec>(y.statement.value().t));
+          },
+          [&](const Indirection<parser::InterfaceBlock> &y) {
+            const auto &stmt{std::get<parser::Statement<parser::InterfaceStmt>>(
+                y.value().t)};
+            const auto *spec{std::get_if<std::optional<parser::GenericSpec>>(
+                &stmt.statement.u)};
+            if (spec && spec->has_value()) {
+              CreateGeneric(**spec);
+            }
+          },
+          [&](const auto &) {},
+      },
+      spec.u);
+}
+
+void ResolveNamesVisitor::CreateGeneric(const parser::GenericSpec &x) {
+  auto info{GenericSpecInfo{x}};
+  const SourceName &symbolName{info.symbolName()};
+  if (IsLogicalConstant(context(), symbolName)) {
+    Say(symbolName,
+        "Logical constant '%s' may not be used as a defined operator"_err_en_US);
+    return;
+  }
+  GenericDetails genericDetails;
+  if (Symbol * existing{currScope().FindSymbol(symbolName)}) {
+    if (existing->has<GenericDetails>()) {
+      info.Resolve(existing);
+      return;  // already have generic, add to it
+    }
+    Symbol &ultimate{existing->GetUltimate()};
+    if (ultimate.has<GenericDetails>()) {
+      genericDetails.AddSpecificProcsFrom(ultimate);
+    } else if (ultimate.has<SubprogramDetails>() ||
+        ultimate.has<SubprogramNameDetails>()) {
+      genericDetails.set_specific(ultimate);
+    } else if (ultimate.has<DerivedTypeDetails>()) {
+      genericDetails.set_derivedType(ultimate);
+    } else {
+      SayAlreadyDeclared(symbolName, *existing);
+    }
+    EraseSymbol(*existing);
+  }
+  info.Resolve(&MakeSymbol(symbolName, Attrs{}, std::move(genericDetails)));
+}
+
+void ResolveNamesVisitor::FinishSpecificationPart() {
   badStmtFuncFound_ = false;
   CheckImports();
   bool inModule{currScope().kind() == Scope::Kind::Module};

--- a/lib/semantics/rewrite-parse-tree.cc
+++ b/lib/semantics/rewrite-parse-tree.cc
@@ -57,6 +57,7 @@ public:
   // Don't bother resolving names in end statements.
   bool Pre(parser::EndBlockDataStmt &) { return false; }
   bool Pre(parser::EndFunctionStmt &) { return false; }
+  bool Pre(parser::EndInterfaceStmt &) { return false; }
   bool Pre(parser::EndModuleStmt &) { return false; }
   bool Pre(parser::EndMpSubprogramStmt &) { return false; }
   bool Pre(parser::EndProgramStmt &) { return false; }

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -417,6 +417,9 @@ std::ostream &operator<<(std::ostream &os, const Details &details) {
           [](const HostAssocDetails &) {},
           [&](const GenericDetails &x) {
             os << ' ' << EnumToString(x.kind());
+            DumpBool(os, "(specific)", x.specific() != nullptr);
+            DumpBool(os, "(derivedType)", x.derivedType() != nullptr);
+            os << " procs:";
             DumpSymbolVector(os, x.specificProcs());
           },
           [&](const ProcBindingDetails &x) {

--- a/test/semantics/resolve17.f90
+++ b/test/semantics/resolve17.f90
@@ -21,17 +21,16 @@ module m
 end module
 
 module m2
-  !Note: PGI and GNU allow this; Intel, NAG, and Sun do not
-  !ERROR: 's' is already declared in this scoping unit
   interface s
   end interface
 contains
+  !ERROR: 's' may not be the name of both a generic interface and a procedure unless it is a specific procedure of the generic
   subroutine s
   end subroutine
 end module
 
 module m3
-  ! This is okay: so is generic and specific
+  ! This is okay: s is generic and specific
   interface s
     procedure s2
   end interface

--- a/test/semantics/resolve18.f90
+++ b/test/semantics/resolve18.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ end module
 module m2
   use m1
   implicit none
-  !ERROR: 'foo' is already declared in this scoping unit
+  !ERROR: 'foo' may not be the name of both a generic interface and a procedure unless it is a specific procedure of the generic
   interface foo
     module procedure s
   end interface
@@ -42,4 +42,47 @@ end
 subroutine bar
   !ERROR: Cannot use-associate 'bar'; it is already declared in this scope
   use m1, bar => foo
+end
+
+!OK to use-associate a type with the same name as a generic
+module m3a
+  type :: foo
+  end type
+end
+module m3b
+  use m3a
+  interface foo
+  end interface
+end
+
+! Can't have derived type and function with same name...
+module m4a
+  type :: foo
+  end type
+contains
+  !ERROR: 'foo' is already declared in this scoping unit
+  function foo(x)
+  end
+end
+! ...unless there is also a generic interface of that name
+module m4b
+  type :: foo
+  end type
+  interface foo
+    procedure :: foo
+  end interface foo
+contains
+  function foo(x)
+  end
+end
+! ...but foo has to be a specific proc of the generic or it's still an error
+module m4c
+  type :: foo
+  end type
+  interface foo
+  end interface foo
+contains
+  !ERROR: 'foo' may not be the name of both a generic interface and a procedure unless it is a specific procedure of the generic
+  function foo(x)
+  end
 end

--- a/test/semantics/resolve36.f90
+++ b/test/semantics/resolve36.f90
@@ -49,7 +49,6 @@ module m2
     module integer function fun1()
     end function
   end interface
-  !ERROR: 't' is already declared in this scoping unit
   type t
   end type
   !ERROR: Declaration of 'i' conflicts with its use as module procedure
@@ -61,6 +60,7 @@ contains
   !ERROR: 'missing2' was not declared a separate module procedure
   module subroutine missing2
   end
+  !ERROR: 't' is already declared in this scoping unit
   !ERROR: 't' was not declared a separate module procedure
   module procedure t
   end


### PR DESCRIPTION
Generic interfaces can have the same name as contained subprograms
or derived types. This means a subprogram and derived type can have
the same name **if** there is a generic interface with that name.
Change the order of processing declarations to do generics first
so that we don't report a conflict between the subprogram and type.
(See `module m4b` in `test/semantics/resolve18.f90` for an example.)

`PreSpecificationConstruct` is called on each `SpecificationConstruct`
of a specification part before we continue walking it. We use that
to call `CreateGeneric` for each generic interface so that they already
exist when we do the normal walk of the declarations.

Improve the error message issued when a procedure and generic interface
have the same name but the procedure is not a specific of the generic.

Change `SayAlreadyDeclared` to report the error on the second occurence
of the name when possible. This can arise for declarations the are
processed out of order, e.g. contained subprograms and generic
interfaces.

Avoid multiple "already declared" errors for the case when a contained
subprogram has the same name as a declared entity. We first create the
symbol with SubprogramNameDetails, then replace it with the entity
(and report the error), then replace it with the real subprogram
(and get the error again). By setting and checking the error flag
we avoid the second error.