### PR TITLE
Fold LBOUND and UBOUND intrinsic functions

### DIFF
--- a/documentation/C++style.md
+++ b/documentation/C++style.md
@@ -6,9 +6,9 @@ Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 * Use *clang-format* on all C++ source and header files before
   every merge to master.  All code layout should be determined
   by means of clang-format.
-* Where [LLVM's C++ style guide](https://llvm.org/docs/CodingStandards.html#style-issues)
+* Where a clear precedent exists in the project, follow it.
+* Otherwise, where [LLVM's C++ style guide](https://llvm.org/docs/CodingStandards.html#style-issues)
 is clear on usage, follow it.
-* Otherwise, where a clear precedent exists in the project, follow it.
 * Otherwise, where a good public C++ style guide is relevant and clear,
   follow it.  [Google's](https://google.github.io/styleguide/cppguide.html)
   is pretty good and comes with lots of justifications for its rules.
@@ -39,10 +39,12 @@ headers, also alphabetically; then C and system headers.
 1. Don't use `#include <iostream>`.  If you need it for temporary debugging,
 remove the inclusion before committing.
 ### Naming
-1. C++ names that correspond to well-known interfaces from the STL and LLVM
+1. C++ names that correspond to well-known interfaces from the STL, LLVM,
+and Fortran standard
 can and should look like their models when the reader can safely assume that
 they mean the same thing -- e.g., `clear()` and `size()` member functions
 in a class that implements an STL-ish container.
+Fortran intrinsic function names are conventionally in ALL CAPS.
 1. Non-public data members should be named with leading miniscule (lower-case)
 letters, internal camelCase capitalization, and a trailing underscore,
 e.g. `DoubleEntryBookkeepingSystem myLedger_;`.  POD structures with

--- a/lib/evaluate/characteristics.cc
+++ b/lib/evaluate/characteristics.cc
@@ -63,9 +63,15 @@ std::optional<TypeAndShape> TypeAndShape::Characterize(
           [&](const semantics::HostAssocDetails &assoc) {
             return Characterize(assoc.symbol());
           },
-          [](const auto &) -> std::optional<TypeAndShape> {
-            return std::nullopt;
+          [](const semantics::AssocEntityDetails &assoc) {
+            if (const semantics::Symbol *
+                nested{UnwrapWholeSymbolDataRef(assoc.expr())}) {
+              return Characterize(*nested);
+            } else {
+              return std::optional<TypeAndShape>{};
+            }
           },
+          [](const auto &) { return std::optional<TypeAndShape>{}; },
       },
       symbol.details());
 }

--- a/lib/evaluate/characteristics.cc
+++ b/lib/evaluate/characteristics.cc
@@ -438,7 +438,7 @@ std::optional<Procedure> Procedure::Characterize(
           [&](const semantics::HostAssocDetails &assoc) {
             return Characterize(assoc.symbol(), intrinsics);
           },
-          [](const auto &) -> std::optional<Procedure> { return std::nullopt; },
+          [](const auto &) { return std::optional<Procedure>{}; },
       },
       symbol.details());
 }

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -85,11 +85,11 @@ std::optional<DynamicType> ExpressionBase<A>::GetType() const {
     return Result::GetType();
   } else {
     return std::visit(
-        [&](const auto &x) {
+        [&](const auto &x) -> std::optional<DynamicType> {
           if constexpr (!common::HasMember<decltype(x), TypelessExpression>) {
             return x.GetType();
           } else {
-            return std::optional<DynamicType>{};
+            return std::nullopt;
           }
         },
         derived().u);

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -85,11 +85,12 @@ std::optional<DynamicType> ExpressionBase<A>::GetType() const {
     return Result::GetType();
   } else {
     return std::visit(
-        [&](const auto &x) -> std::optional<DynamicType> {
+        [&](const auto &x) {
           if constexpr (!common::HasMember<decltype(x), TypelessExpression>) {
             return x.GetType();
+          } else {
+            return std::optional<DynamicType>{};
           }
-          return std::nullopt;
         },
         derived().u);
   }

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -433,10 +433,10 @@ Expr<Type<TypeCategory::Integer, KIND>> LBOUND(FoldingContext &context,
             return Fold(context,
                 ConvertToType<T>(
                     GetLowerBound(context, *named, static_cast<int>(*dim))));
-          } else if (auto lbounds{
-                         AsConstantShape(GetLowerBounds(context, *named))}) {
+          } else if (auto extents{
+                         AsExtentArrayExpr(GetLowerBounds(context, *named))}) {
             return Fold(context,
-                ConvertToType<T>(Expr<ExtentType>{std::move(*lbounds)}));
+                ConvertToType<T>(Expr<ExtentType>{std::move(*extents)}));
           }
         } else {
           lowerBoundsAreOne = symbol.Rank() == 0;  // LBOUND(array%component)
@@ -496,9 +496,9 @@ Expr<Type<TypeCategory::Integer, KIND>> UBOUND(FoldingContext &context,
               CHECK(!ubounds.back().has_value());
               ubounds.back() = ExtentExpr{-1};
             }
-            if (auto constant{AsConstantShape(ubounds)}) {
+            if (auto extents{AsExtentArrayExpr(ubounds)}) {
               return Fold(context,
-                  ConvertToType<T>(Expr<ExtentType>{std::move(*constant)}));
+                  ConvertToType<T>(Expr<ExtentType>{std::move(*extents)}));
             }
           }
         } else {

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -348,9 +348,9 @@ std::optional<std::vector<A>> GetIntegerVector(const B &x) {
 // gets re-folded.
 template<typename T> Expr<T> MakeInvalidIntrinsic(FunctionRef<T> &&funcRef) {
   SpecificIntrinsic invalid{std::get<SpecificIntrinsic>(funcRef.proc().u)};
-  invalid.name = "invalid";
-  return Expr<T>{FunctionRef<T>{
-      ProcedureDesignator{std::move(invalid)}, std::move(funcRef.arguments())}};
+  invalid.name = "(invalid intrinsic function call)";
+  return Expr<T>{FunctionRef<T>{ProcedureDesignator{std::move(invalid)},
+      ActualArguments{ActualArgument{AsGenericExpr(std::move(funcRef))}}}};
 }
 
 template<typename T>
@@ -563,7 +563,7 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldIntrinsicFunction(
             context.messages().Say(
                 "LBOUND(array,dim=%jd) dimension is out of range for rank-%d array"_en_US,
                 static_cast<std::intmax_t>(*dim), rank);
-            return Expr<T>(std::move(funcRef));
+            return MakeInvalidIntrinsic<T>(std::move(funcRef));
           }
         }
         bool lowerBoundsAreOne{true};
@@ -775,7 +775,7 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldIntrinsicFunction(
             context.messages().Say(
                 "UBOUND(array,dim=%jd) dimension is out of range for rank-%d array"_en_US,
                 static_cast<std::intmax_t>(*dim), rank);
-            return Expr<T>(std::move(funcRef));
+            return MakeInvalidIntrinsic<T>(std::move(funcRef));
           }
         }
         bool takeBoundsFromShape{true};

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -430,10 +430,9 @@ Expr<Type<TypeCategory::Integer, KIND>> LBOUND(FoldingContext &context,
         if (symbol.Rank() == rank) {
           lowerBoundsAreOne = false;
           if (dim.has_value()) {
-            if (auto lb{
-                    GetLowerBound(context, *named, static_cast<int>(*dim))}) {
-              return Fold(context, ConvertToType<T>(std::move(*lb)));
-            }
+            return Fold(context,
+                ConvertToType<T>(
+                    GetLowerBound(context, *named, static_cast<int>(*dim))));
           } else if (auto lbounds{
                          AsConstantShape(GetLowerBounds(context, *named))}) {
             return Fold(context,
@@ -1448,8 +1447,8 @@ std::optional<Constant<T>> GetConstantComponent(FoldingContext &context,
               [&](Component &base) {
                 return GetConstantComponent<SomeDerived>(context, base);
               },
-              [&](CoarrayRef &) -> std::optional<Constant<SomeDerived>> {
-                return std::nullopt;
+              [&](CoarrayRef &) {
+                return std::optional<Constant<SomeDerived>>{};
               },
           },
           component.base().u)}) {

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -1125,7 +1125,8 @@ Expr<Type<TypeCategory::Character, KIND>> FoldIntrinsicFunction(
 // Get the value of a PARAMETER
 template<typename T>
 std::optional<Expr<T>> GetParameterValue(
-    FoldingContext &context, const Symbol &symbol) {
+    FoldingContext &context, const Symbol &symbol0) {
+  const Symbol &symbol{ResolveAssociations(symbol0)};
   if (symbol.attrs().test(semantics::Attr::PARAMETER)) {
     if (const auto *object{
             symbol.detailsIf<semantics::ObjectEntityDetails>()}) {

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -1497,9 +1497,7 @@ static bool ApplySpecificChecks(
     if (const auto &arg{call.arguments[0]}) {
       if (const auto *expr{arg->UnwrapExpr()}) {
         if (const Symbol * symbol{GetLastSymbol(*expr)}) {
-          const Symbol &resolved{ResolveAssociations(*symbol)};
-          ok = resolved.has<semantics::ObjectEntityDetails>() &&
-              resolved.attrs().test(semantics::Attr::ALLOCATABLE);
+          ok = symbol->attrs().test(semantics::Attr::ALLOCATABLE);
         }
       }
     }

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -1497,8 +1497,9 @@ static bool ApplySpecificChecks(
     if (const auto &arg{call.arguments[0]}) {
       if (const auto *expr{arg->UnwrapExpr()}) {
         if (const Symbol * symbol{GetLastSymbol(*expr)}) {
-          ok = symbol->has<semantics::ObjectEntityDetails>() &&
-              symbol->attrs().test(semantics::Attr::ALLOCATABLE);
+          const Symbol &resolved{ResolveAssociations(*symbol)};
+          ok = resolved.has<semantics::ObjectEntityDetails>() &&
+              resolved.attrs().test(semantics::Attr::ALLOCATABLE);
         }
       }
     }

--- a/lib/evaluate/shape.cc
+++ b/lib/evaluate/shape.cc
@@ -302,7 +302,7 @@ MaybeExtentExpr GetExtent(FoldingContext &context, const Subscript &subscript,
       subscript.u);
 }
 
-MaybeExtentExpr GetUpperBound(
+MaybeExtentExpr ComputeUpperBound(
     FoldingContext &context, ExtentExpr &&lower, MaybeExtentExpr &&extent) {
   if (extent.has_value()) {
     return Fold(context, std::move(*extent) - std::move(lower) + ExtentExpr{1});
@@ -323,7 +323,8 @@ MaybeExtentExpr GetUpperBound(
         } else if (details->IsAssumedSize() && dimension + 1 == symbol.Rank()) {
           break;
         } else {
-          return GetUpperBound(context, GetLowerBound(context, base, dimension),
+          return ComputeUpperBound(context,
+              GetLowerBound(context, base, dimension),
               GetExtent(context, base, dimension));
         }
       }
@@ -344,7 +345,7 @@ Shape GetUpperBounds(FoldingContext &context, const NamedEntity &base) {
         CHECK(dim + 1 == base.Rank());
         result.emplace_back(std::nullopt);  // UBOUND folding replaces with -1
       } else {
-        result.emplace_back(GetUpperBound(context,
+        result.emplace_back(ComputeUpperBound(context,
             GetLowerBound(context, base, dim), GetExtent(context, base, dim)));
       }
       ++dim;

--- a/lib/evaluate/shape.cc
+++ b/lib/evaluate/shape.cc
@@ -406,7 +406,7 @@ void GetShapeVisitor::Handle(const NamedEntity &base) {
       Return(std::move(result));
     }
   } else {
-    Return();  // error recovery
+    Handle(symbol);
   }
 }
 

--- a/lib/evaluate/shape.h
+++ b/lib/evaluate/shape.h
@@ -69,6 +69,9 @@ MaybeExtentExpr GetExtent(
     FoldingContext &, const Subscript &, const NamedEntity &, int dimension);
 MaybeExtentExpr GetUpperBound(
     FoldingContext &, MaybeExtentExpr &&lower, MaybeExtentExpr &&extent);
+MaybeExtentExpr GetUpperBound(
+    FoldingContext &, const NamedEntity &, int dimension);
+Shape GetUpperBounds(FoldingContext &, const NamedEntity &);
 
 // Compute an element count for a triplet or trip count for a DO.
 ExtentExpr CountTrips(
@@ -104,6 +107,7 @@ public:
   void Handle(const StaticDataObject::Pointer &) { Scalar(); }
   void Handle(const ArrayRef &);
   void Handle(const CoarrayRef &);
+  void Handle(const Substring &);
   void Handle(const ProcedureRef &);
   void Handle(const StructureConstructor &) { Scalar(); }
   template<typename T> void Handle(const ArrayConstructor<T> &aconst) {

--- a/lib/evaluate/shape.h
+++ b/lib/evaluate/shape.h
@@ -61,14 +61,13 @@ inline int GetRank(const Shape &s) { return static_cast<int>(s.size()); }
 
 // The dimension argument to these inquiries is zero-based,
 // unlike the DIM= arguments to many intrinsics.
-MaybeExtentExpr GetLowerBound(
-    FoldingContext &, const NamedEntity &, int dimension);
+ExtentExpr GetLowerBound(FoldingContext &, const NamedEntity &, int dimension);
 Shape GetLowerBounds(FoldingContext &, const NamedEntity &);
 MaybeExtentExpr GetExtent(FoldingContext &, const NamedEntity &, int dimension);
 MaybeExtentExpr GetExtent(
     FoldingContext &, const Subscript &, const NamedEntity &, int dimension);
 MaybeExtentExpr GetUpperBound(
-    FoldingContext &, MaybeExtentExpr &&lower, MaybeExtentExpr &&extent);
+    FoldingContext &, ExtentExpr &&lower, MaybeExtentExpr &&extent);
 MaybeExtentExpr GetUpperBound(
     FoldingContext &, const NamedEntity &, int dimension);
 Shape GetUpperBounds(FoldingContext &, const NamedEntity &);

--- a/lib/evaluate/shape.h
+++ b/lib/evaluate/shape.h
@@ -62,15 +62,15 @@ inline int GetRank(const Shape &s) { return static_cast<int>(s.size()); }
 // The dimension argument to these inquiries is zero-based,
 // unlike the DIM= arguments to many intrinsics.
 ExtentExpr GetLowerBound(FoldingContext &, const NamedEntity &, int dimension);
+MaybeExtentExpr GetUpperBound(
+    FoldingContext &, const NamedEntity &, int dimension);
+MaybeExtentExpr ComputeUpperBound(
+    FoldingContext &, ExtentExpr &&lower, MaybeExtentExpr &&extent);
 Shape GetLowerBounds(FoldingContext &, const NamedEntity &);
+Shape GetUpperBounds(FoldingContext &, const NamedEntity &);
 MaybeExtentExpr GetExtent(FoldingContext &, const NamedEntity &, int dimension);
 MaybeExtentExpr GetExtent(
     FoldingContext &, const Subscript &, const NamedEntity &, int dimension);
-MaybeExtentExpr GetUpperBound(
-    FoldingContext &, ExtentExpr &&lower, MaybeExtentExpr &&extent);
-MaybeExtentExpr GetUpperBound(
-    FoldingContext &, const NamedEntity &, int dimension);
-Shape GetUpperBounds(FoldingContext &, const NamedEntity &);
 
 // Compute an element count for a triplet or trip count for a DO.
 ExtentExpr CountTrips(

--- a/lib/evaluate/tools.cc
+++ b/lib/evaluate/tools.cc
@@ -489,17 +489,17 @@ std::optional<Expr<LogicalResult>> Relate(parser::ContextualMessages &messages,
                   } else {
                     messages.Say(
                         "CHARACTER operands do not have same KIND"_err_en_US);
-                    return std::optional<Expr<LogicalResult>>{};
+                    return std::nullopt;
                   }
                 },
                 std::move(cx.u), std::move(cy.u));
           },
           // Default case
-          [&](auto &&, auto &&) -> std::optional<Expr<LogicalResult>> {
+          [&](auto &&, auto &&) {
             // TODO: defined operator
             messages.Say(
                 "relational operands do not have comparable types"_err_en_US);
-            return std::nullopt;
+            return std::optional<Expr<LogicalResult>>{};
           },
       },
       std::move(x.u), std::move(y.u));

--- a/lib/evaluate/tools.cc
+++ b/lib/evaluate/tools.cc
@@ -622,7 +622,8 @@ std::optional<Expr<SomeType>> ConvertToType(
   }
 }
 
-bool IsAssumedRank(const semantics::Symbol &symbol) {
+bool IsAssumedRank(const semantics::Symbol &symbol0) {
+  const semantics::Symbol &symbol{ResolveAssociations(symbol0)};
   if (const auto *details{symbol.detailsIf<semantics::ObjectEntityDetails>()}) {
     return details->IsAssumedRank();
   } else {
@@ -657,6 +658,15 @@ void GetLastTargetVisitor::Pre(const Component &x) {
   } else if (symbol.attrs().test(semantics::Attr::ALLOCATABLE)) {
     Return(nullptr);
   }
+}
+
+const semantics::Symbol &ResolveAssociations(const semantics::Symbol &symbol) {
+  if (const auto *details{symbol.detailsIf<semantics::AssocEntityDetails>()}) {
+    if (const Symbol * nested{UnwrapWholeSymbolDataRef(details->expr())}) {
+      return ResolveAssociations(*nested);
+    }
+  }
+  return symbol;
 }
 
 }

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -40,7 +40,7 @@ std::optional<Variable<A>> AsVariable(const Expr<A> &expr) {
   return std::visit(
       [](const auto &x) -> std::optional<Variable<A>> {
         if constexpr (common::HasMember<std::decay_t<decltype(x)>, Variant>) {
-          return std::make_optional<Variable<A>>(x);
+          return Variable<A>{x};
         }
         return std::nullopt;
       },
@@ -217,8 +217,9 @@ std::optional<DataRef> ExtractDataRef(const Designator<T> &d) {
       [](const auto &x) -> std::optional<DataRef> {
         if constexpr (common::HasMember<decltype(x), decltype(DataRef::u)>) {
           return DataRef{x};
+        } else {
+          return std::nullopt;
         }
-        return std::nullopt;
       },
       d.u);
 }
@@ -245,7 +246,7 @@ template<typename A> std::optional<NamedEntity> ExtractNamedEntity(const A &x) {
             [](Component &&component) -> std::optional<NamedEntity> {
               return NamedEntity{std::move(component)};
             },
-            [](auto &&) -> std::optional<NamedEntity> { return std::nullopt; },
+            [](auto &&) { return std::optional<NamedEntity>{}; },
         },
         std::move(dataRef->u));
   } else {

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -744,5 +744,8 @@ template<typename A> const semantics::Symbol *GetLastTarget(const A &x) {
   }
 }
 
+// Resolve any whole ASSOCIATE(B=>A) associations
+const semantics::Symbol &ResolveAssociations(const semantics::Symbol &);
+
 }
 #endif  // FORTRAN_EVALUATE_TOOLS_H_

--- a/lib/evaluate/traversal.h
+++ b/lib/evaluate/traversal.h
@@ -49,7 +49,7 @@
 // and call:
 //   RESULT result{v.Traverse(topLevelExpr)};
 // Within the callback routines (Handle, Pre, Post), one may call
-//   void Return(RESULT &&);  // to define the result and end traversal
+//   void Return(A &&);  // to assign to the result and end traversal
 //   void Return();  // to end traversal with current result
 //   RESULT &result();  // to reference the result to define or update it
 // For any given expression object type T for which a callback is defined
@@ -90,7 +90,8 @@ public:
   std::nullptr_t Post(std::nullptr_t);
 
   void Return() { done_ = true; }
-  void Return(RESULT &&x) {
+
+  template<typename A> void Return(A &&x) {
     result_ = std::move(x);
     done_ = true;
   }
@@ -150,7 +151,6 @@ public:
     return std::move(result_);
   }
 
-private:
   template<typename B> void Visit(const B &x) {
     if (!done_) {
       if constexpr ((... || HasVisitorHandle<A, B, void>::value)) {
@@ -174,6 +174,7 @@ private:
     }
   }
 
+private:
   friend class Descender<Visitor>;
   Descender<Visitor> descender_{*this};
 };

--- a/lib/evaluate/traversal.h
+++ b/lib/evaluate/traversal.h
@@ -54,8 +54,6 @@
 //   RESULT &result();  // to reference the result to define or update it
 // For any given expression object type T for which a callback is defined
 // in any visitor class, the callback must be distinct from all others.
-// Further, if there is a Handle(const T &) callback, there cannot be a
-// Pre(const T &) or a Post(const T &).
 //
 // For rewriting traversals, the paradigm is similar; however, the
 // argument types are rvalues and the non-void result types match
@@ -91,7 +89,7 @@ public:
 
   void Return() { done_ = true; }
 
-  template<typename A> void Return(A &&x) {
+  template<typename A> common::IfNoLvalue<void, A> Return(A &&x) {
     result_ = std::move(x);
     done_ = true;
   }

--- a/lib/evaluate/type.cc
+++ b/lib/evaluate/type.cc
@@ -78,7 +78,8 @@ static bool IsDescriptor(const ProcEntityDetails &details) {
   return details.HasExplicitInterface();
 }
 
-bool IsDescriptor(const Symbol &symbol) {
+bool IsDescriptor(const Symbol &symbol0) {
+  const Symbol &symbol{evaluate::ResolveAssociations(symbol0)};
   if (const auto *objectDetails{symbol.detailsIf<ObjectEntityDetails>()}) {
     return IsAllocatableOrPointer(symbol) || IsDescriptor(*objectDetails);
   } else if (const auto *procDetails{symbol.detailsIf<ProcEntityDetails>()}) {

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -340,7 +340,7 @@ public:
 private:
   void SetBounds(std::optional<Expr<SubscriptInteger>> &,
       std::optional<Expr<SubscriptInteger>> &);
-  std::variant<DataRef, StaticDataObject::Pointer> parent_;
+  Parent parent_;
   std::optional<IndirectSubscriptIntegerExpr> lower_, upper_;
 };
 

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -754,7 +754,7 @@ std::optional<Subscript> ExpressionAnalyzer::AnalyzeSectionSubscript(
           },
           [&](const auto &s) -> std::optional<Subscript> {
             if (auto subscriptExpr{AsSubscript(Analyze(s))}) {
-              return {Subscript{std::move(*subscriptExpr)}};
+              return Subscript{std::move(*subscriptExpr)};
             } else {
               return std::nullopt;
             }

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -478,11 +478,6 @@ bool IsFinalizable(const Symbol &symbol) {
 
 bool IsCoarray(const Symbol &symbol) { return symbol.Corank() > 0; }
 
-bool IsAssumedSizeArray(const Symbol &symbol) {
-  const auto *details{symbol.detailsIf<ObjectEntityDetails>()};
-  return details && details->IsAssumedSize();
-}
-
 bool IsExternalInPureContext(const Symbol &symbol, const Scope &scope) {
   if (const auto *pureProc{semantics::FindPureProcedureContaining(&scope)}) {
     if (const Symbol * root{GetAssociationRoot(symbol)}) {

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -110,7 +110,10 @@ inline bool IsProtected(const Symbol &symbol) {
 }
 bool IsFinalizable(const Symbol &symbol);
 bool IsCoarray(const Symbol &symbol);
-bool IsAssumedSizeArray(const Symbol &symbol);
+inline bool IsAssumedSizeArray(const Symbol &symbol) {
+  const auto *details{symbol.detailsIf<ObjectEntityDetails>()};
+  return details && details->IsAssumedSize();
+}
 std::optional<parser::MessageFixedText> WhyNotModifiable(
     const Symbol &symbol, const Scope &scope);
 // Is the symbol modifiable in this scope

--- a/test/evaluate/CMakeLists.txt
+++ b/test/evaluate/CMakeLists.txt
@@ -129,6 +129,7 @@ set(FOLDING_TESTS
   folding05.f90
   folding06.f90
   folding07.f90
+  folding08.f90
 )
 
 

--- a/test/evaluate/folding08.f90
+++ b/test/evaluate/folding08.f90
@@ -1,0 +1,52 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+! implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test folding of LBOUND and UBOUND
+
+subroutine testlbound(n1,a1,a2)
+  integer, intent(in) :: n1
+  real, intent(in) :: a1(0:n1), a2(0:*)
+  type :: t
+    real :: a
+  end type
+  type(t) :: ta(0:2)
+  character(len=2) :: ca(-1:1)
+  integer, parameter :: lba1(:) = lbound(a1)
+  logical, parameter :: test_lba1 = all(lba1 == [0])
+  integer, parameter :: lba2(:) = lbound(a2)
+  logical, parameter :: test_lba2 = all(lba2 == [0])
+  integer, parameter :: uba2(:) = ubound(a2)
+  logical, parameter :: test_uba2 = all(uba2 == [-1])
+  integer, parameter :: lbta1(:) = lbound(ta)
+  logical, parameter :: test_lbta1 = all(lbta1 == [0])
+  integer, parameter :: ubta1(:) = ubound(ta)
+  logical, parameter :: test_ubta1 = all(ubta1 == [2])
+  integer, parameter :: lbta2(:) = lbound(ta(:))
+  logical, parameter :: test_lbta2 = all(lbta2 == [1])
+  integer, parameter :: ubta2(:) = ubound(ta(:))
+  logical, parameter :: test_ubta2 = all(ubta2 == [3])
+  integer, parameter :: lbta3(:) = lbound(ta%a)
+  logical, parameter :: test_lbta3 = all(lbta3 == [1])
+  integer, parameter :: ubta3(:) = ubound(ta%a)
+  logical, parameter :: test_ubta3 = all(ubta3 == [3])
+  integer, parameter :: lbca1(:) = lbound(ca)
+  logical, parameter :: test_lbca1 = all(lbca1 == [-1])
+  integer, parameter :: ubca1(:) = ubound(ca)
+  logical, parameter :: test_ubca1 = all(ubca1 == [1])
+  integer, parameter :: lbca2(:) = lbound(ca(:)(1:1))
+  logical, parameter :: test_lbca2 = all(lbca2 == [1])
+  integer, parameter :: ubca2(:) = ubound(ca(:)(1:1))
+  logical, parameter :: test_ubca2 = all(ubca2 == [3])
+end

--- a/test/evaluate/folding08.f90
+++ b/test/evaluate/folding08.f90
@@ -15,7 +15,7 @@
 
 ! Test folding of LBOUND and UBOUND
 
-subroutine testlbound(n1,a1,a2)
+subroutine test(n1,a1,a2)
   integer, intent(in) :: n1
   real, intent(in) :: a1(0:n1), a2(0:*)
   type :: t

--- a/test/evaluate/folding08.f90
+++ b/test/evaluate/folding08.f90
@@ -34,6 +34,10 @@ module m
     logical, parameter :: test_lba2 = all(lba2 == [0])
     integer, parameter :: uba2(:) = ubound(a2)
     logical, parameter :: test_uba2 = all(uba2 == [-1])
+    integer, parameter :: lbtadim(:) = lbound(ta,1)
+    logical, parameter :: test_lbtadim = lbtadim == 0
+    integer, parameter :: ubtadim(:) = ubound(ta,1)
+    logical, parameter :: test_ubtadim = ubtadim == 2
     integer, parameter :: lbta1(:) = lbound(ta)
     logical, parameter :: test_lbta1 = all(lbta1 == [0])
     integer, parameter :: ubta1(:) = ubound(ta)

--- a/test/evaluate/folding08.f90
+++ b/test/evaluate/folding08.f90
@@ -59,4 +59,23 @@ module m
     integer, parameter :: ubfoo(:) = ubound(foo())
     logical, parameter :: test_ubfoo = all(ubfoo == [2,3])
   end subroutine
+  subroutine test2
+    real :: a(2:3,4:6)
+    associate (b => a)
+      block
+        integer, parameter :: lbb(:) = lbound(b)
+        logical, parameter :: test_lbb = all(lbb == [2,4])
+        integer, parameter :: ubb(:) = ubound(b)
+        logical, parameter :: test_ubb = all(ubb == [3,6])
+      end block
+    end associate
+    associate (b => a + 0)
+      block
+        integer, parameter :: lbb(:) = lbound(b)
+        logical, parameter :: test_lbb = all(lbb == [1,1])
+        integer, parameter :: ubb(:) = ubound(b)
+        logical, parameter :: test_ubb = all(ubb == [2,3])
+      end block
+    end associate
+  end subroutine
 end

--- a/test/evaluate/folding08.f90
+++ b/test/evaluate/folding08.f90
@@ -15,38 +15,48 @@
 
 ! Test folding of LBOUND and UBOUND
 
-subroutine test(n1,a1,a2)
-  integer, intent(in) :: n1
-  real, intent(in) :: a1(0:n1), a2(0:*)
-  type :: t
-    real :: a
-  end type
-  type(t) :: ta(0:2)
-  character(len=2) :: ca(-1:1)
-  integer, parameter :: lba1(:) = lbound(a1)
-  logical, parameter :: test_lba1 = all(lba1 == [0])
-  integer, parameter :: lba2(:) = lbound(a2)
-  logical, parameter :: test_lba2 = all(lba2 == [0])
-  integer, parameter :: uba2(:) = ubound(a2)
-  logical, parameter :: test_uba2 = all(uba2 == [-1])
-  integer, parameter :: lbta1(:) = lbound(ta)
-  logical, parameter :: test_lbta1 = all(lbta1 == [0])
-  integer, parameter :: ubta1(:) = ubound(ta)
-  logical, parameter :: test_ubta1 = all(ubta1 == [2])
-  integer, parameter :: lbta2(:) = lbound(ta(:))
-  logical, parameter :: test_lbta2 = all(lbta2 == [1])
-  integer, parameter :: ubta2(:) = ubound(ta(:))
-  logical, parameter :: test_ubta2 = all(ubta2 == [3])
-  integer, parameter :: lbta3(:) = lbound(ta%a)
-  logical, parameter :: test_lbta3 = all(lbta3 == [1])
-  integer, parameter :: ubta3(:) = ubound(ta%a)
-  logical, parameter :: test_ubta3 = all(ubta3 == [3])
-  integer, parameter :: lbca1(:) = lbound(ca)
-  logical, parameter :: test_lbca1 = all(lbca1 == [-1])
-  integer, parameter :: ubca1(:) = ubound(ca)
-  logical, parameter :: test_ubca1 = all(ubca1 == [1])
-  integer, parameter :: lbca2(:) = lbound(ca(:)(1:1))
-  logical, parameter :: test_lbca2 = all(lbca2 == [1])
-  integer, parameter :: ubca2(:) = ubound(ca(:)(1:1))
-  logical, parameter :: test_ubca2 = all(ubca2 == [3])
+module m
+ contains
+  function foo()
+    real :: foo(2:3,4:6)
+  end function
+  subroutine test(n1,a1,a2)
+    integer, intent(in) :: n1
+    real, intent(in) :: a1(0:n1), a2(0:*)
+    type :: t
+      real :: a
+    end type
+    type(t) :: ta(0:2)
+    character(len=2) :: ca(-1:1)
+    integer, parameter :: lba1(:) = lbound(a1)
+    logical, parameter :: test_lba1 = all(lba1 == [0])
+    integer, parameter :: lba2(:) = lbound(a2)
+    logical, parameter :: test_lba2 = all(lba2 == [0])
+    integer, parameter :: uba2(:) = ubound(a2)
+    logical, parameter :: test_uba2 = all(uba2 == [-1])
+    integer, parameter :: lbta1(:) = lbound(ta)
+    logical, parameter :: test_lbta1 = all(lbta1 == [0])
+    integer, parameter :: ubta1(:) = ubound(ta)
+    logical, parameter :: test_ubta1 = all(ubta1 == [2])
+    integer, parameter :: lbta2(:) = lbound(ta(:))
+    logical, parameter :: test_lbta2 = all(lbta2 == [1])
+    integer, parameter :: ubta2(:) = ubound(ta(:))
+    logical, parameter :: test_ubta2 = all(ubta2 == [3])
+    integer, parameter :: lbta3(:) = lbound(ta%a)
+    logical, parameter :: test_lbta3 = all(lbta3 == [1])
+    integer, parameter :: ubta3(:) = ubound(ta%a)
+    logical, parameter :: test_ubta3 = all(ubta3 == [3])
+    integer, parameter :: lbca1(:) = lbound(ca)
+    logical, parameter :: test_lbca1 = all(lbca1 == [-1])
+    integer, parameter :: ubca1(:) = ubound(ca)
+    logical, parameter :: test_ubca1 = all(ubca1 == [1])
+    integer, parameter :: lbca2(:) = lbound(ca(:)(1:1))
+    logical, parameter :: test_lbca2 = all(lbca2 == [1])
+    integer, parameter :: ubca2(:) = ubound(ca(:)(1:1))
+    logical, parameter :: test_ubca2 = all(ubca2 == [3])
+    integer, parameter :: lbfoo(:) = lbound(foo())
+    logical, parameter :: test_lbfoo = all(lbfoo == [1,1])
+    integer, parameter :: ubfoo(:) = ubound(foo())
+    logical, parameter :: test_ubfoo = all(ubfoo == [2,3])
+  end subroutine
 end


### PR DESCRIPTION
Also tweak expression semantics so that it no longer inserts empty subscript triplets into whole array references (that breaks these bounds intrinsics), and restructure `GetShape` so that it uses the expression visitation framework rather than a class of mutually recursive functions.