### PR TITLE
 Improve handling of generics with same name as type or procedure

### DIFF
--- a/lib/semantics/rewrite-parse-tree.cc
+++ b/lib/semantics/rewrite-parse-tree.cc
@@ -57,6 +57,7 @@ public:
   // Don't bother resolving names in end statements.
   bool Pre(parser::EndBlockDataStmt &) { return false; }
   bool Pre(parser::EndFunctionStmt &) { return false; }
+  bool Pre(parser::EndInterfaceStmt &) { return false; }
   bool Pre(parser::EndModuleStmt &) { return false; }
   bool Pre(parser::EndMpSubprogramStmt &) { return false; }
   bool Pre(parser::EndProgramStmt &) { return false; }

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -157,9 +157,11 @@ GenericDetails::GenericDetails(const SymbolVector &specificProcs)
 
 void GenericDetails::set_specific(Symbol &specific) {
   CHECK(!specific_);
+  CHECK(!derivedType_);
   specific_ = &specific;
 }
 void GenericDetails::set_derivedType(Symbol &derivedType) {
+  CHECK(!specific_);
   CHECK(!derivedType_);
   derivedType_ = &derivedType;
 }
@@ -417,6 +419,9 @@ std::ostream &operator<<(std::ostream &os, const Details &details) {
           [](const HostAssocDetails &) {},
           [&](const GenericDetails &x) {
             os << ' ' << EnumToString(x.kind());
+            DumpBool(os, "(specific)", x.specific() != nullptr);
+            DumpBool(os, "(derivedType)", x.derivedType() != nullptr);
+            os << " procs:";
             DumpSymbolVector(os, x.specificProcs());
           },
           [&](const ProcBindingDetails &x) {

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -182,8 +182,16 @@ Symbol *GenericDetails::CheckSpecific() {
   }
 }
 
-void GenericDetails::AddSpecificProcsFrom(const Symbol &generic) {
-  const auto &procs{generic.get<GenericDetails>().specificProcs()};
+void GenericDetails::CopyFrom(const GenericDetails &from) {
+  if (from.specific_) {
+    CHECK(!specific_);
+    specific_ = from.specific_;
+  }
+  if (from.derivedType_) {
+    CHECK(!derivedType_);
+    derivedType_ = from.derivedType_;
+  }
+  auto &procs{from.specificProcs_};
   specificProcs_.insert(specificProcs_.end(), procs.begin(), procs.end());
 }
 

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -402,11 +402,11 @@ public:
   void add_specificProc(const Symbol &proc) { specificProcs_.push_back(&proc); }
   void AddSpecificProcsFrom(const Symbol &generic);
 
+  // specific and derivedType indicate a specific procedure or derived type
+  // with the same name as this generic. Only one of them may be set.
   Symbol *specific() { return specific_; }
   const Symbol *specific() const { return specific_; }
   void set_specific(Symbol &specific);
-
-  // Derived type with same name as generic, if any.
   Symbol *derivedType() { return derivedType_; }
   const Symbol *derivedType() const { return derivedType_; }
   void set_derivedType(Symbol &derivedType);

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -393,14 +393,12 @@ class GenericDetails {
 public:
   GenericDetails() {}
   GenericDetails(const SymbolVector &specificProcs);
-  GenericDetails(Symbol *specific) : specific_{specific} {}
 
   GenericKind kind() const { return kind_; }
   void set_kind(GenericKind kind) { kind_ = kind; }
 
   const SymbolVector &specificProcs() const { return specificProcs_; }
   void add_specificProc(const Symbol &proc) { specificProcs_.push_back(&proc); }
-  void AddSpecificProcsFrom(const Symbol &generic);
 
   // specific and derivedType indicate a specific procedure or derived type
   // with the same name as this generic. Only one of them may be set.
@@ -410,6 +408,9 @@ public:
   Symbol *derivedType() { return derivedType_; }
   const Symbol *derivedType() const { return derivedType_; }
   void set_derivedType(Symbol &derivedType);
+
+  // Copy in specificProcs, specific, and derivedType from another generic
+  void CopyFrom(const GenericDetails &);
 
   // Check that specific is one of the specificProcs. If not, return the
   // specific as a raw pointer.

--- a/test/semantics/modfile07.f90
+++ b/test/semantics/modfile07.f90
@@ -80,9 +80,6 @@ module m2
   interface foo
     procedure foo
   end interface
-  type :: foo
-    real :: x
-  end type
 contains
   complex function foo()
     foo = 1.0
@@ -91,9 +88,6 @@ end
 !Expect: m2.mod
 !module m2
 ! generic::foo=>foo
-! type::foo
-!  real(4)::x
-! end type
 !contains
 ! function foo()
 !  complex(4)::foo

--- a/test/semantics/modfile07.f90
+++ b/test/semantics/modfile07.f90
@@ -45,7 +45,10 @@ contains
 end
 !Expect: m.mod
 !module m
-! generic::foo=>s1,s2
+! interface foo
+!  procedure::s1
+!  procedure::s2
+! end interface
 ! interface
 !  function s1(x,y)
 !   real(4)::s1
@@ -60,9 +63,22 @@ end
 !   complex(4)::y
 !  end
 ! end interface
-! generic::operator(+)=>s1,s2
-! generic::bar=>s1,s2,s3,s4
-! generic::operator(.bar.)=>s1,s2,s3,s4
+! interface operator(+)
+!  procedure::s1
+!  procedure::s2
+! end interface
+! interface bar
+!  procedure::s1
+!  procedure::s2
+!  procedure::s3
+!  procedure::s4
+! end interface
+! interface operator(.bar.)
+!  procedure::s1
+!  procedure::s2
+!  procedure::s3
+!  procedure::s4
+! end interface
 !contains
 ! function s3(x,y)
 !  logical(4)::s3
@@ -87,11 +103,35 @@ contains
 end
 !Expect: m2.mod
 !module m2
-! generic::foo=>foo
+! interface foo
+!  procedure::foo
+! end interface
 !contains
 ! function foo()
 !  complex(4)::foo
 ! end
+!end
+
+module m2b
+  type :: foo
+    real :: x
+  end type
+  interface foo
+  end interface
+  private :: bar
+  interface bar
+  end interface
+end
+!Expect: m2b.mod
+!module m2b
+! interface foo
+! end interface
+! type::foo
+!  real(4)::x
+! end type
+! interface bar
+! end interface
+! private::bar
 !end
 
 ! Test interface nested inside another interface
@@ -111,7 +151,9 @@ module m3
 end
 !Expect: m3.mod
 !module m3
-! generic::g=>s1
+! interface g
+!  procedure::s1
+! end interface
 ! interface
 !  subroutine s1(f)
 !   interface

--- a/test/semantics/resolve17.f90
+++ b/test/semantics/resolve17.f90
@@ -21,17 +21,16 @@ module m
 end module
 
 module m2
-  !Note: PGI and GNU allow this; Intel, NAG, and Sun do not
-  !ERROR: 's' is already declared in this scoping unit
   interface s
   end interface
 contains
+  !ERROR: 's' may not be the name of both a generic interface and a procedure unless it is a specific procedure of the generic
   subroutine s
   end subroutine
 end module
 
 module m3
-  ! This is okay: so is generic and specific
+  ! This is okay: s is generic and specific
   interface s
     procedure s2
   end interface

--- a/test/semantics/resolve18.f90
+++ b/test/semantics/resolve18.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ end module
 module m2
   use m1
   implicit none
-  !ERROR: 'foo' is already declared in this scoping unit
+  !ERROR: 'foo' may not be the name of both a generic interface and a procedure unless it is a specific procedure of the generic
   interface foo
     module procedure s
   end interface
@@ -42,4 +42,37 @@ end
 subroutine bar
   !ERROR: Cannot use-associate 'bar'; it is already declared in this scope
   use m1, bar => foo
+end
+
+!OK to use-associate a type with the same name as a generic
+module m3a
+  type :: foo
+  end type
+end
+module m3b
+  use m3a
+  interface foo
+  end interface
+end
+
+! Can't have derived type and function with same name
+module m4a
+  type :: foo
+  end type
+contains
+  !ERROR: 'foo' is already declared in this scoping unit
+  function foo(x)
+  end
+end
+! Even if there is also a generic interface of that name
+module m4b
+  type :: foo
+  end type
+  !ERROR: 'foo' is already declared in this scoping unit
+  interface foo
+    procedure :: foo
+  end interface foo
+contains
+  function foo(x)
+  end
 end

--- a/test/semantics/resolve18.f90
+++ b/test/semantics/resolve18.f90
@@ -76,3 +76,25 @@ contains
   function foo(x)
   end
 end
+
+! Use associating a name that is a generic and a derived type
+module m5a
+  interface g
+  end interface
+  type g
+  end type
+end module
+module m5b
+  use m5a
+  interface g
+    procedure f
+  end interface
+  type(g) :: x
+contains
+  function f(i)
+  end function
+end module
+subroutine s5
+  use m5b
+  type(g) :: y
+end

--- a/test/semantics/resolve36.f90
+++ b/test/semantics/resolve36.f90
@@ -49,7 +49,6 @@ module m2
     module integer function fun1()
     end function
   end interface
-  !ERROR: 't' is already declared in this scoping unit
   type t
   end type
   !ERROR: Declaration of 'i' conflicts with its use as module procedure
@@ -61,6 +60,7 @@ contains
   !ERROR: 'missing2' was not declared a separate module procedure
   module subroutine missing2
   end
+  !ERROR: 't' is already declared in this scoping unit
   !ERROR: 't' was not declared a separate module procedure
   module procedure t
   end

--- a/test/semantics/test_errors.sh
+++ b/test/semantics/test_errors.sh
@@ -54,6 +54,6 @@ else
   echo "$cmd"
   < $diffs \
     sed -n -e 's/^-\([0-9]\)/actual at \1/p' -e 's/^+\([0-9]\)/expect at \1/p' \
-    | sort -n -k 2
+    | sort -n -k 3
   die FAIL
 fi


### PR DESCRIPTION
Create symbols for generics in a pre-pass over the specification part so
it is easier to handle cases when they have the same name as a derived
type or subprogram. This is done by calling `PreSpecificationConstruct`
on each `SpecificationConstruct` of a specification part before we
continue walking it. The generics symbols are created there and the same
mechanism will be used to handle forward references to derived types.

Report an error when the same name is used for a generic interface,
derived type, and subprogram.

Improve the error message issued when a procedure and generic interface
have the same name but the procedure is not a specific of the generic.

Change `SayAlreadyDeclared` to report the error on the second occurence
of the name when possible. This can arise for declarations the are
processed out of order, e.g. contained subprograms and generic interfaces.

Avoid multiple "already declared" errors for the case when a contained
subprogram has the same name as a declared entity. We first create the
symbol with SubprogramNameDetails, then replace it with the entity (and
report the error), then replace it with the real subprogram (and get the
error again). By setting and checking the error flag we avoid the second
error.