### PR TITLE
Fix issue 581: extended derived type kind parameter comparison 

### DIFF
--- a/lib/evaluate/type.cc
+++ b/lib/evaluate/type.cc
@@ -151,14 +151,11 @@ bool DynamicType::IsTypeCompatibleWith(const DynamicType &that) const {
 // corresponding kind type parameters of the type2?
 static bool IsKindCompatible(const semantics::DerivedTypeSpec &type1,
     const semantics::DerivedTypeSpec &type2) {
-  for (const auto &[name, symbol] : *type1.scope()) {
-    if (const auto *details{symbol->detailsIf<semantics::TypeParamDetails>()}) {
-      if (details->attr() == common::TypeParamAttr::Kind) {
-        const semantics::ParamValue *param1{type1.FindParameter(name)};
-        const semantics::ParamValue *param2{type2.FindParameter(name)};
-        if (!PointeeComparison(param1, param2)) {
-          return false;
-        }
+  for (const auto &[name, param1] : type1.parameters()) {
+    if (param1.isKind()) {
+      const semantics::ParamValue *param2{type2.FindParameter(name)};
+      if (!PointeeComparison(&param1, param2)) {
+        return false;
       }
     }
   }

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -834,6 +834,8 @@ private:
   Symbol *MakeTypeSymbol(const parser::Name &, Details &&);
   bool OkToAddComponent(const parser::Name &, const Symbol * = nullptr);
   ParamValue GetParamValue(const parser::TypeParamValue &);
+  ParamValue GetLenParamValue(const parser::TypeParamValue &);
+  ParamValue GetLenParamValue(common::ConstantSubscript);
   Symbol &MakeCommonBlockSymbol(const parser::Name &);
   void CheckCommonBlockDerivedType(const SourceName &, const Symbol &);
   std::optional<MessageFixedText> CheckSaveAttr(const Symbol &);
@@ -2866,7 +2868,7 @@ void DeclarationVisitor::Post(const parser::IntrinsicTypeSpec::Logical &x) {
 }
 void DeclarationVisitor::Post(const parser::IntrinsicTypeSpec::Character &x) {
   if (!charInfo_.length) {
-    charInfo_.length = ParamValue{1};
+    charInfo_.length = GetLenParamValue(1);
   }
   if (!charInfo_.kind.has_value()) {
     charInfo_.kind =
@@ -2879,19 +2881,19 @@ void DeclarationVisitor::Post(const parser::IntrinsicTypeSpec::Character &x) {
 void DeclarationVisitor::Post(const parser::CharSelector::LengthAndKind &x) {
   charInfo_.kind = EvaluateSubscriptIntExpr(x.kind);
   if (x.length) {
-    charInfo_.length = GetParamValue(*x.length);
+    charInfo_.length = GetLenParamValue(*x.length);
   }
 }
 void DeclarationVisitor::Post(const parser::CharLength &x) {
   if (const auto *length{std::get_if<std::int64_t>(&x.u)}) {
-    charInfo_.length = ParamValue{*length};
+    charInfo_.length = GetLenParamValue(*length);
   } else {
-    charInfo_.length = GetParamValue(std::get<parser::TypeParamValue>(x.u));
+    charInfo_.length = GetLenParamValue(std::get<parser::TypeParamValue>(x.u));
   }
 }
 void DeclarationVisitor::Post(const parser::LengthSelector &x) {
   if (const auto *param{std::get_if<parser::TypeParamValue>(&x.u)}) {
-    charInfo_.length = GetParamValue(*param);
+    charInfo_.length = GetLenParamValue(*param);
   }
 }
 
@@ -4060,6 +4062,19 @@ ParamValue DeclarationVisitor::GetParamValue(const parser::TypeParamValue &x) {
           },
       },
       x.u);
+}
+
+ParamValue DeclarationVisitor::GetLenParamValue(
+    const parser::TypeParamValue &x) {
+  ParamValue param{GetParamValue(x)};
+  param.set_attr(common::TypeParamAttr::Len);
+  return param;
+}
+
+ParamValue DeclarationVisitor::GetLenParamValue(common::ConstantSubscript l) {
+  ParamValue param{l};
+  param.set_attr(common::TypeParamAttr::Len);
+  return param;
 }
 
 // ConstructVisitor implementation

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -833,9 +833,8 @@ private:
   Symbol *MakeTypeSymbol(const SourceName &, Details &&);
   Symbol *MakeTypeSymbol(const parser::Name &, Details &&);
   bool OkToAddComponent(const parser::Name &, const Symbol * = nullptr);
-  ParamValue GetParamValue(const parser::TypeParamValue &);
-  ParamValue GetLenParamValue(const parser::TypeParamValue &);
-  ParamValue GetLenParamValue(common::ConstantSubscript);
+  ParamValue GetParamValue(
+      const parser::TypeParamValue &, common::TypeParamAttr attr);
   Symbol &MakeCommonBlockSymbol(const parser::Name &);
   void CheckCommonBlockDerivedType(const SourceName &, const Symbol &);
   std::optional<MessageFixedText> CheckSaveAttr(const Symbol &);
@@ -2868,7 +2867,7 @@ void DeclarationVisitor::Post(const parser::IntrinsicTypeSpec::Logical &x) {
 }
 void DeclarationVisitor::Post(const parser::IntrinsicTypeSpec::Character &x) {
   if (!charInfo_.length) {
-    charInfo_.length = GetLenParamValue(1);
+    charInfo_.length = ParamValue{1, common::TypeParamAttr::Len};
   }
   if (!charInfo_.kind.has_value()) {
     charInfo_.kind =
@@ -2881,19 +2880,20 @@ void DeclarationVisitor::Post(const parser::IntrinsicTypeSpec::Character &x) {
 void DeclarationVisitor::Post(const parser::CharSelector::LengthAndKind &x) {
   charInfo_.kind = EvaluateSubscriptIntExpr(x.kind);
   if (x.length) {
-    charInfo_.length = GetLenParamValue(*x.length);
+    charInfo_.length = GetParamValue(*x.length, common::TypeParamAttr::Len);
   }
 }
 void DeclarationVisitor::Post(const parser::CharLength &x) {
   if (const auto *length{std::get_if<std::int64_t>(&x.u)}) {
-    charInfo_.length = GetLenParamValue(*length);
+    charInfo_.length = ParamValue{*length, common::TypeParamAttr::Len};
   } else {
-    charInfo_.length = GetLenParamValue(std::get<parser::TypeParamValue>(x.u));
+    charInfo_.length = GetParamValue(
+        std::get<parser::TypeParamValue>(x.u), common::TypeParamAttr::Len);
   }
 }
 void DeclarationVisitor::Post(const parser::LengthSelector &x) {
   if (const auto *param{std::get_if<parser::TypeParamValue>(&x.u)}) {
-    charInfo_.length = GetLenParamValue(*param);
+    charInfo_.length = GetParamValue(*param, common::TypeParamAttr::Len);
   }
 }
 
@@ -2956,6 +2956,7 @@ void DeclarationVisitor::Post(const parser::DerivedTypeSpec &x) {
     const auto &optKeyword{
         std::get<std::optional<parser::Keyword>>(typeParamSpec.t)};
     SourceName name;
+    common::TypeParamAttr attr{common::TypeParamAttr::Kind};
     if (optKeyword.has_value()) {
       seenAnyName = true;
       name = optKeyword->v.source;
@@ -2965,6 +2966,7 @@ void DeclarationVisitor::Post(const parser::DerivedTypeSpec &x) {
         Say(name,
             "'%s' is not the name of a parameter for this type"_err_en_US);
       } else {
+        attr = (*it)->get<TypeParamDetails>().attr();
         Resolve(optKeyword->v, const_cast<Symbol *>(*it));
       }
     } else if (seenAnyName) {
@@ -2972,6 +2974,11 @@ void DeclarationVisitor::Post(const parser::DerivedTypeSpec &x) {
       continue;
     } else if (nextNameIter != parameterNames.end()) {
       name = *nextNameIter++;
+      auto it{std::find_if(parameterDecls.begin(), parameterDecls.end(),
+          [&](const Symbol *symbol) { return symbol->name() == name; })};
+      if (it != parameterDecls.end()) {
+        attr = (*it)->get<TypeParamDetails>().attr();
+      }
     } else {
       Say(typeName.source,
           "Too many type parameters given for derived type '%s'"_err_en_US);
@@ -2982,7 +2989,7 @@ void DeclarationVisitor::Post(const parser::DerivedTypeSpec &x) {
           "Multiple values given for type parameter '%s'"_err_en_US, name);
     } else {
       const auto &value{std::get<parser::TypeParamValue>(typeParamSpec.t)};
-      ParamValue param{GetParamValue(value)};  // folded
+      ParamValue param{GetParamValue(value, attr)};  // folded
       if (!param.isExplicit() || param.GetExplicit().has_value()) {
         spec.AddParamValue(name, std::move(param));
       }
@@ -4050,31 +4057,19 @@ bool DeclarationVisitor::OkToAddComponent(
   return true;
 }
 
-ParamValue DeclarationVisitor::GetParamValue(const parser::TypeParamValue &x) {
+ParamValue DeclarationVisitor::GetParamValue(
+    const parser::TypeParamValue &x, common::TypeParamAttr attr) {
   return std::visit(
       common::visitors{
           [=](const parser::ScalarIntExpr &x) {
-            return ParamValue{EvaluateIntExpr(x)};
+            return ParamValue{EvaluateIntExpr(x), attr};
           },
-          [](const parser::Star &) { return ParamValue::Assumed(); },
-          [](const parser::TypeParamValue::Deferred &) {
-            return ParamValue::Deferred();
+          [=](const parser::Star &) { return ParamValue::Assumed(attr); },
+          [=](const parser::TypeParamValue::Deferred &) {
+            return ParamValue::Deferred(attr);
           },
       },
       x.u);
-}
-
-ParamValue DeclarationVisitor::GetLenParamValue(
-    const parser::TypeParamValue &x) {
-  ParamValue param{GetParamValue(x)};
-  param.set_attr(common::TypeParamAttr::Len);
-  return param;
-}
-
-ParamValue DeclarationVisitor::GetLenParamValue(common::ConstantSubscript l) {
-  ParamValue param{l};
-  param.set_attr(common::TypeParamAttr::Len);
-  return param;
 }
 
 // ConstructVisitor implementation
@@ -4516,10 +4511,12 @@ const DeclTypeSpec &ConstructVisitor::ToDeclTypeSpec(
   CHECK(type.category() == common::TypeCategory::Character);
   if (length.has_value()) {
     return currScope().MakeCharacterType(
-        ParamValue{SomeIntExpr{*std::move(length)}}, KindExpr{type.kind()});
+        ParamValue{SomeIntExpr{*std::move(length)}, common::TypeParamAttr::Len},
+        KindExpr{type.kind()});
   } else {
     return currScope().MakeCharacterType(
-        ParamValue::Deferred(), KindExpr{type.kind()});
+        ParamValue::Deferred(common::TypeParamAttr::Len),
+        KindExpr{type.kind()});
   }
 }
 

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -700,10 +700,8 @@ void ProcessParameterExpressions(
       if (paramValue != nullptr) {
         paramValue->SetExplicit(std::move(*expr));
       } else {
-        ParamValue implicitParam{std::move(*expr)};
-        implicitParam.set_attr(details.attr());
         spec.AddParamValue(
-            symbol->name(), ParamValue{std::move(implicitParam)});
+            symbol->name(), ParamValue{std::move(*expr), details.attr()});
       }
     }
   }

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -700,7 +700,10 @@ void ProcessParameterExpressions(
       if (paramValue != nullptr) {
         paramValue->SetExplicit(std::move(*expr));
       } else {
-        spec.AddParamValue(symbol->name(), ParamValue{std::move(*expr)});
+        ParamValue implicitParam{std::move(*expr)};
+        implicitParam.set_attr(details.attr());
+        spec.AddParamValue(
+            symbol->name(), ParamValue{std::move(implicitParam)});
       }
     }
   }

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -129,7 +129,7 @@ bool IsExplicit(const ArraySpec &arraySpec) {
 
 ParamValue::ParamValue(MaybeIntExpr &&expr) : expr_{std::move(expr)} {}
 ParamValue::ParamValue(SomeIntExpr &&expr) : expr_{std::move(expr)} {}
-ParamValue::ParamValue(std::int64_t value)
+ParamValue::ParamValue(common::ConstantSubscript value)
   : ParamValue(SomeIntExpr{evaluate::Expr<evaluate::SubscriptInteger>{value}}) {
 }
 

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -127,11 +127,14 @@ bool IsExplicit(const ArraySpec &arraySpec) {
   return true;
 }
 
-ParamValue::ParamValue(MaybeIntExpr &&expr) : expr_{std::move(expr)} {}
-ParamValue::ParamValue(SomeIntExpr &&expr) : expr_{std::move(expr)} {}
-ParamValue::ParamValue(common::ConstantSubscript value)
-  : ParamValue(SomeIntExpr{evaluate::Expr<evaluate::SubscriptInteger>{value}}) {
-}
+ParamValue::ParamValue(MaybeIntExpr &&expr, common::TypeParamAttr attr)
+  : attr_{attr}, expr_{std::move(expr)} {}
+ParamValue::ParamValue(SomeIntExpr &&expr, common::TypeParamAttr attr)
+  : attr_{attr}, expr_{std::move(expr)} {}
+ParamValue::ParamValue(
+    common::ConstantSubscript value, common::TypeParamAttr attr)
+  : ParamValue(
+        SomeIntExpr{evaluate::Expr<evaluate::SubscriptInteger>{value}}, attr) {}
 
 void ParamValue::SetExplicit(SomeIntExpr &&x) {
   category_ = Category::Explicit;

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -85,12 +85,16 @@ private:
 // A type parameter value: integer expression or assumed or deferred.
 class ParamValue {
 public:
-  static ParamValue Assumed() { return Category::Assumed; }
-  static ParamValue Deferred() { return Category::Deferred; }
+  static ParamValue Assumed(common::TypeParamAttr attr) {
+    return ParamValue{Category::Assumed, attr};
+  }
+  static ParamValue Deferred(common::TypeParamAttr attr) {
+    return ParamValue{Category::Deferred, attr};
+  }
   ParamValue(const ParamValue &) = default;
-  explicit ParamValue(MaybeIntExpr &&);
-  explicit ParamValue(SomeIntExpr &&);
-  explicit ParamValue(common::ConstantSubscript);
+  explicit ParamValue(MaybeIntExpr &&, common::TypeParamAttr);
+  explicit ParamValue(SomeIntExpr &&, common::TypeParamAttr attr);
+  explicit ParamValue(common::ConstantSubscript, common::TypeParamAttr attr);
   bool isExplicit() const { return category_ == Category::Explicit; }
   bool isAssumed() const { return category_ == Category::Assumed; }
   bool isDeferred() const { return category_ == Category::Deferred; }
@@ -106,7 +110,8 @@ public:
 
 private:
   enum class Category { Explicit, Deferred, Assumed };
-  ParamValue(Category category) : category_{category} {}
+  ParamValue(Category category, common::TypeParamAttr attr)
+    : category_{category}, attr_{attr} {}
   Category category_{Category::Explicit};
   common::TypeParamAttr attr_{common::TypeParamAttr::Kind};
   MaybeIntExpr expr_;

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -90,7 +90,7 @@ public:
   ParamValue(const ParamValue &) = default;
   explicit ParamValue(MaybeIntExpr &&);
   explicit ParamValue(SomeIntExpr &&);
-  explicit ParamValue(std::int64_t);
+  explicit ParamValue(common::ConstantSubscript);
   bool isExplicit() const { return category_ == Category::Explicit; }
   bool isAssumed() const { return category_ == Category::Assumed; }
   bool isDeferred() const { return category_ == Category::Deferred; }

--- a/test/semantics/resolve53.f90
+++ b/test/semantics/resolve53.f90
@@ -251,10 +251,22 @@ end module
 
 ! Types distinguished by kind (but not length) parameters
 module m15
-  type :: t(k, l)
-    integer, kind :: k = 1
-    integer, len :: l
+  type :: t1(k1, l1)
+    integer, kind :: k1 = 1
+    integer, len :: l1 = 101
   end type
+
+  type, extends(t1) :: t2(k2a, l2, k2b)
+    integer, kind :: k2a = 2
+    integer, kind :: k2b = 3
+    integer, len :: l2 = 102
+  end type
+
+  type, extends(t2) :: t3(l3, k3)
+    integer, kind :: k3 = 4
+    integer, len :: l3 = 103
+  end type
+
   interface g1
     procedure s1
     procedure s2
@@ -264,17 +276,72 @@ module m15
     procedure s1
     procedure s3
   end interface
+  !ERROR: Generic 'g3' may not have specific procedures 's4' and 's5' as their interfaces are not distinguishable
+  interface g3
+    procedure s4
+    procedure s5
+  end interface
+  interface g4
+    procedure s5
+    procedure s6
+    procedure s9
+  end interface
+  interface g5
+    procedure s4
+    procedure s7
+    procedure s9
+  end interface
+  interface g6
+    procedure s5
+    procedure s8
+    procedure s9
+  end interface
+  !ERROR: Generic 'g7' may not have specific procedures 's6' and 's7' as their interfaces are not distinguishable
+  interface g7
+    procedure s6
+    procedure s7
+  end interface
+  !ERROR: Generic 'g8' may not have specific procedures 's6' and 's8' as their interfaces are not distinguishable
+  interface g8
+    procedure s6
+    procedure s8
+  end interface
+  !ERROR: Generic 'g9' may not have specific procedures 's7' and 's8' as their interfaces are not distinguishable
+  interface g9
+    procedure s7
+    procedure s8
+  end interface
+
 contains
   subroutine s1(x)
-    type(t(1, 4)) :: x
+    type(t1(1, 4)) :: x
   end
   subroutine s2(x)
-    type(t(2, 4)) :: x
+    type(t1(2, 4)) :: x
   end
   subroutine s3(x)
-    type(t(l=5)) :: x
+    type(t1(l1=5)) :: x
   end
+  subroutine s4(x)
+    type(t3(1, 101, 2, 102, 3, 103, 4)) :: x
+  end subroutine
+  subroutine s5(x)
+    type(t3) :: x
+  end subroutine
+  subroutine s6(x)
+    type(t3(1, 99, k2b=2, k2a=3, l2=*, l3=97, k3=4)) :: x
+  end subroutine
+  subroutine s7(x)
+    type(t3(k1=1, l1=99, k2a=3, k2b=2, k3=4)) :: x
+  end subroutine
+  subroutine s8(x)
+    type(t3(1, :, 3, :, 2, :, 4)), allocatable :: x
+  end subroutine
+  subroutine s9(x)
+    type(t3(k1=2)) :: x
+  end subroutine
 end
+
 
 ! Check that specifics for type-bound generics can be distinguished
 module m16


### PR DESCRIPTION
**Fix extended derived type kind compatibility check (#581):**

`HaveCompatibleKindParameters` was not considering the kind parameters of the parent types leading to false answers. This change fixes this by directly looking into the map of `ParamValue` of the `DeclTypeSpec` instead of going through the symbols of the derived type scope. This map contains all the parent and implicit type parameters.

**Fix ParamValue attribute (kind/len) of implicit type parameters:**
While testing fix for issue 581 it appeared that 'ParamValue`
implicit len parameters had incorrect attribute kind.

- Set correct attribute when creating `ParamValue` for implicit type parameter.

- Also set the correct attribute for character length `ParamValue` though this attribute is currently not used anywhere.

-  Change some `std::int64_t` to `common::ConstantSubscript` on the way.