### PR TITLE
Fix bug with use-associated base of component reference

### DIFF
--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -4675,7 +4675,7 @@ const parser::Name *DeclarationVisitor::FindComponent(
   if (!base || !base->symbol) {
     return nullptr;
   }
-  auto &symbol{*base->symbol};
+  auto &symbol{base->symbol->GetUltimate()};
   if (!symbol.has<AssocEntityDetails>() && !ConvertToObjectEntity(symbol)) {
     SayWithDecl(*base, symbol,
         "'%s' is an invalid base for a component reference"_err_en_US);


### PR DESCRIPTION
When the base of a component reference (`a` in `a%b`) was use
associated, we were failing to follow it to the real symbol.

Fixes #616.