### PR TITLE
Prevent result symbol to be converted into function when they are called

### DIFF
--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1840,9 +1840,9 @@ static void CheckFuncRefToArrayElementRefHasSubscripts(
   if (std::get<std::list<parser::ActualArgSpec>>(funcRef.v.t).empty()) {
     auto &proc{std::get<parser::ProcedureDesignator>(funcRef.v.t)};
     const auto *name{std::get_if<parser::Name>(&proc.u)};
-    name = {name
-            ? name
-            : &std::get<parser::ProcComponentRef>(proc.u).v.thing.component};
+    if (name == nullptr) {
+      name = &std::get<parser::ProcComponentRef>(proc.u).v.thing.component;
+    }
     auto &msg{context.Say(funcRef.v.source,
         "Reference to array '%s' with empty subscript list"_err_en_US,
         name->source)};

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -937,11 +937,15 @@ const Symbol *FindUltimateComponent(const DerivedTypeSpec &derived,
   return nullptr;
 }
 
-bool IsFunctionResultWithSameNameAsFunction(const Symbol &symbol) {
-  if ((symbol.has<semantics::ObjectEntityDetails>() &&
-          symbol.get<semantics::ObjectEntityDetails>().isFuncResult()) ||
+bool IsFunctionResult(const Symbol &symbol) {
+  return (symbol.has<semantics::ObjectEntityDetails>() &&
+             symbol.get<semantics::ObjectEntityDetails>().isFuncResult()) ||
       (symbol.has<semantics::ProcEntityDetails>() &&
-          symbol.get<semantics::ProcEntityDetails>().isFuncResult())) {
+          symbol.get<semantics::ProcEntityDetails>().isFuncResult());
+}
+
+bool IsFunctionResultWithSameNameAsFunction(const Symbol &symbol) {
+  if (IsFunctionResult(symbol)) {
     if (const Symbol * function{symbol.owner().symbol()}) {
       return symbol.name() == function->name();
     }

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -937,4 +937,16 @@ const Symbol *FindUltimateComponent(const DerivedTypeSpec &derived,
   return nullptr;
 }
 
+bool IsFunctionResultWithSameNameAsFunction(const Symbol &symbol) {
+  if ((symbol.has<semantics::ObjectEntityDetails>() &&
+          symbol.get<semantics::ObjectEntityDetails>().isFuncResult()) ||
+      (symbol.has<semantics::ProcEntityDetails>() &&
+          symbol.get<semantics::ProcEntityDetails>().isFuncResult())) {
+    if (const Symbol * function{symbol.owner().symbol()}) {
+      return symbol.name() == function->name();
+    }
+  }
+  return false;
+}
+
 }

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -362,5 +362,7 @@ PotentialComponentIterator::const_iterator FindEventOrLockPotentialComponent(
     const DerivedTypeSpec &);
 UltimateComponentIterator::const_iterator FindCoarrayUltimateComponent(
     const DerivedTypeSpec &);
+bool IsFunctionResultWithSameNameAsFunction(const Symbol &);
+
 }
 #endif  // FORTRAN_SEMANTICS_TOOLS_H_

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -364,7 +364,5 @@ PotentialComponentIterator::const_iterator FindEventOrLockPotentialComponent(
     const DerivedTypeSpec &);
 UltimateComponentIterator::const_iterator FindCoarrayUltimateComponent(
     const DerivedTypeSpec &);
-bool IsFunctionResultWithSameNameAsFunction(const Symbol &);
-
 }
 #endif  // FORTRAN_SEMANTICS_TOOLS_H_

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -62,6 +62,8 @@ bool IsProcedure(const Symbol &);
 bool IsProcName(const Symbol &symbol);  // proc-name
 bool IsVariableName(const Symbol &symbol);  // variable-name
 bool IsProcedurePointer(const Symbol &);
+bool IsFunctionResult(const Symbol &);
+bool IsFunctionResultWithSameNameAsFunction(const Symbol &);
 bool IsExtensibleType(const DerivedTypeSpec *);
 // Is this a derived type from module with this name?
 bool IsDerivedTypeFromModule(

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -95,6 +95,7 @@ set(ERROR_TESTS
   resolve56.f90
   resolve57.f90
   resolve58.f90
+  resolve59.f90
   stop01.f90
   structconst01.f90
   structconst02.f90

--- a/test/semantics/resolve59.f90
+++ b/test/semantics/resolve59.f90
@@ -1,0 +1,127 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Testing 15.6.2.2 point 4 (What function-name refers to depending on the
+! presence of RESULT).
+
+
+module m_no_result
+! Without RESULT, it refers to the result object (no recursive
+! calls possible)
+contains
+  ! testing with data object results
+  function f1()
+    real :: x, f1
+    !ERROR: Reference to array 'f1' with empty subscript list
+    x = acos(f1())
+    f1 = x
+    x = acos(f1) !OK
+  end function
+  function f2(i)
+    integer i
+    real :: x, f2
+    !ERROR: Reference to rank-0 object 'f2' has 1 subscripts
+    x = acos(f2(i+1))
+    f2 = x
+    x = acos(f2) !OK
+  end function
+  function f3(i)
+    integer i
+    real :: x, f3(1)
+    ! OK reference to array result f1
+    x = acos(f3(i+1))
+    f3 = x
+    x = sum(acos(f3)) !OK
+  end function
+
+  ! testing with function pointer results
+  function rf()
+    real :: rf
+  end function
+  function f4()
+    procedure(rf), pointer :: f4
+    f4 => rf
+    ! OK call to f4 pointer (rf)
+    x = acos(f4())
+    !ERROR: Typeless item not allowed for 'x=' argument
+    x = acos(f4)
+  end function
+  function f5(x)
+    real :: x
+    procedure(acos), pointer :: f5
+    f5 => acos
+    ! OK call to f5 pointer (acos)
+    x = acos(f5(x+1))
+    !ERROR: Typeless item not allowed for 'x=' argument
+    x = acos(f5)
+  end function
+end module
+
+module m_with_result
+! With RESULT, it refers to the function (recursive calls possible)
+contains
+  ! testing with data object results
+  function f1() result(r)
+    real :: r
+    r = acos(f1()) !OK, recursive call
+    !ERROR: Typeless item not allowed for 'x=' argument
+    x = acos(f1)
+  end function
+  function f2(i) result(r)
+    integer i
+    real :: r
+    r = acos(f2(i+1)) ! OK, recursive call
+    !ERROR: Typeless item not allowed for 'x=' argument
+    r = acos(f2)
+  end function
+  function f3(i) result(r)
+    integer i
+    real :: r(1)
+    r = acos(f3(i+1)) !OK recursive call
+    !ERROR: Typeless item not allowed for 'x=' argument
+    r = sum(acos(f3))
+  end function
+
+  ! testing with function pointer results
+  function rf()
+    real :: rf
+  end function
+  function f4() result(r)
+    real :: x
+    procedure(rf), pointer :: r
+    r => rf
+    !ERROR: Typeless item not allowed for 'x=' argument
+    x = acos(f4()) ! recursive call
+    !ERROR: Typeless item not allowed for 'x=' argument
+    x = acos(f4)
+    x = acos(r()) ! OK
+  end function
+  function f5(x) result(r)
+    real :: x
+    procedure(acos), pointer :: r
+    r => acos
+    !ERROR: Typeless item not allowed for 'x=' argument
+    x = acos(f5(x+1)) ! recursive call
+    !ERROR: Typeless item not allowed for 'x=' argument
+    x = acos(f5)
+    x = acos(r(x+1)) ! OK
+  end function
+
+  ! testing that calling the result is also caught
+  function f6() result(r)
+    real :: x, r
+    !ERROR: Reference to array 'r' with empty subscript list
+    x = r()
+  end function
+end module


### PR DESCRIPTION
This PR:
+ Fixes issue #589
+ Adds an error for empty subscript list in array reference

In name resolution, when skimming through the execution statement of a function, calls to the result symbol should not trigger the conversion of this symbol to a function symbol. The result is a data object and cannot be called unless it was explictly declared to be a procedure pointer.
Notably, recursive function calls cannot be made if RESULT was not used.

The symbol is prevented from being transformed into a function symbol by transforming it into an object before skimming through the executable statement. This is done after processing all the specifications so that if the result actually is a procedure pointer, the call to `ConvertToObjectEntity` introduced by this commit will not convert it to an object by mistake.

Also introduce a check when fixing mis-parsed function reference into array reference to verify the array reference has array subscripts. Currently this went uncaught. It is not possible to complain later in expressions because the subscript list of expression might be empty for unrelated error recovery reasons (e.g. if an entity of the wrong type appeared as subscripts).
