### PR TITLE
Dodge two bogus warnings from g++ 8.1

### DIFF
--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -88,9 +88,8 @@ std::optional<DynamicType> ExpressionBase<A>::GetType() const {
         [&](const auto &x) -> std::optional<DynamicType> {
           if constexpr (!common::HasMember<decltype(x), TypelessExpression>) {
             return x.GetType();
-          } else {
-            return std::nullopt;
           }
+          return std::nullopt;  // w/o "else" to dodge bogus g++ 8.1 warning
         },
         derived().u);
   }

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -217,9 +217,8 @@ std::optional<DataRef> ExtractDataRef(const Designator<T> &d) {
       [](const auto &x) -> std::optional<DataRef> {
         if constexpr (common::HasMember<decltype(x), decltype(DataRef::u)>) {
           return DataRef{x};
-        } else {
-          return std::nullopt;
         }
+        return std::nullopt;  // w/o "else" to dodge bogus g++ 8.1 warning
       },
       d.u);
 }


### PR DESCRIPTION
Thanks, Jean, for noticing them.  I've extended my script that performs builds with all supported compiler versions to catch warnings better, too.