### PR TITLE
Fix a crash with IMPORT in BLOCK (issue 604)

### DIFF
--- a/lib/evaluate/characteristics.cc
+++ b/lib/evaluate/characteristics.cc
@@ -424,7 +424,7 @@ std::optional<Procedure> Procedure::Characterize(
               if (const auto passIndex{binding.passIndex()}) {
                 auto &passArg{result->dummyArguments.at(*passIndex)};
                 passArg.pass = true;
-                if (const auto *passName{binding.passName()}) {
+                if (const auto passName{binding.passName()}) {
                   CHECK(passArg.name == passName->ToString());
                 }
               }

--- a/lib/semantics/assignment.cc
+++ b/lib/semantics/assignment.cc
@@ -301,8 +301,8 @@ public:
   void Analyze(const parser::ConcurrentHeader &);
 
   template<typename A> void Analyze(const parser::Statement<A> &stmt) {
-    const auto *saveLocation{context_.location()};
-    context_.set_location(&stmt.source);
+    std::optional<parser::CharBlock> saveLocation{context_.location()};
+    context_.set_location(stmt.source);
     Analyze(stmt.statement);
     context_.set_location(saveLocation);
   }
@@ -408,7 +408,7 @@ void AssignmentContext::Analyze(const parser::ForallConstruct &construct) {
   AssignmentContext nested{*this, forall};
   const auto &forallStmt{
       std::get<parser::Statement<parser::ForallConstructStmt>>(construct.t)};
-  context_.set_location(&forallStmt.source);
+  context_.set_location(forallStmt.source);
   nested.Analyze(std::get<common::Indirection<parser::ConcurrentHeader>>(
       forallStmt.statement.t));
   for (const auto &body :
@@ -422,7 +422,7 @@ void AssignmentContext::Analyze(
   CHECK(where_ != nullptr);
   const auto &elsewhereStmt{
       std::get<parser::Statement<parser::MaskedElsewhereStmt>>(elsewhere.t)};
-  context_.set_location(&elsewhereStmt.source);
+  context_.set_location(elsewhereStmt.source);
   MaskExpr mask{
       GetMask(std::get<parser::LogicalExpr>(elsewhereStmt.statement.t))};
   MaskExpr copyCumulative{where_->cumulativeMaskExpr};

--- a/lib/semantics/check-do.cc
+++ b/lib/semantics/check-do.cc
@@ -206,7 +206,8 @@ private:
   bool EndTDeallocatesCoarray() { return false; }  // FIXME placeholder
   bool fromScope(const Symbol &symbol, const std::string &moduleName) {
     if (symbol.GetUltimate().owner().IsModule() &&
-        symbol.GetUltimate().owner().name().ToString() == moduleName) {
+        symbol.GetUltimate().owner().GetName().value().ToString() ==
+            moduleName) {
       return true;
     }
     return false;

--- a/lib/semantics/check-return.cc
+++ b/lib/semantics/check-return.cc
@@ -38,7 +38,7 @@ void ReturnStmtChecker::Leave(const parser::ReturnStmt &returnStmt) {
   // subroutine subprogram.
   // C1575 The scalar-int-expr is allowed only in the inclusive scope of a
   // subroutine subprogram.
-  const auto &scope{context_.FindScope(*context_.location())};
+  const auto &scope{context_.FindScope(context_.location().value())};
   const auto *subprogramScope{FindContainingSubprogram(scope)};
   if (subprogramScope == nullptr) {
     context_.Say(

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -2144,7 +2144,8 @@ evaluate::Expr<evaluate::SubscriptInteger> AnalyzeKindSelector(
     SemanticsContext &context, common::TypeCategory category,
     const std::optional<parser::KindSelector> &selector) {
   evaluate::ExpressionAnalyzer analyzer{context};
-  auto save{analyzer.GetContextualMessages().SetLocation(*context.location())};
+  auto save{
+      analyzer.GetContextualMessages().SetLocation(context.location().value())};
   return analyzer.AnalyzeKindSelector(category, selector);
 }
 

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -36,14 +36,15 @@ using namespace parser::literals;
 // are using another encoding.
 static constexpr auto magic{"\xef\xbb\xbf!mod$ v1 sum:"};
 
-static const SourceName *GetSubmoduleParent(const parser::Program &);
+static const std::optional<SourceName> GetSubmoduleParent(
+    const parser::Program &);
 static std::string ModFilePath(const std::string &dir, const SourceName &,
     const std::string &ancestor, const std::string &suffix);
 static std::vector<const Symbol *> CollectSymbols(const Scope &);
 static void PutEntity(std::ostream &, const Symbol &);
 static void PutObjectEntity(std::ostream &, const Symbol &);
 static void PutProcEntity(std::ostream &, const Symbol &);
-static void PutPassName(std::ostream &, const SourceName *);
+static void PutPassName(std::ostream &, const std::optional<SourceName> &);
 static void PutTypeParam(std::ostream &, const Symbol &);
 static void PutEntity(std::ostream &, const Symbol &, std::function<void()>);
 static void PutInit(std::ostream &, const Symbol &, const MaybeExpr &);
@@ -488,7 +489,7 @@ void PutProcEntity(std::ostream &os, const Symbol &symbol) {
   os << '\n';
 }
 
-void PutPassName(std::ostream &os, const SourceName *passName) {
+void PutPassName(std::ostream &os, const std::optional<SourceName> &passName) {
   if (passName) {
     PutLower(os << ",pass(", passName->ToString()) << ')';
   }
@@ -713,7 +714,7 @@ Scope *ModFileReader::Read(const SourceName &name, Scope *ancestor) {
   Scope *parentScope;  // the scope this module/submodule goes into
   if (!ancestor) {
     parentScope = &context_.globalScope();
-  } else if (auto *parent{GetSubmoduleParent(*parseTree)}) {
+  } else if (std::optional<SourceName> parent{GetSubmoduleParent(*parseTree)}) {
     parentScope = Read(*parent, ancestor);
   } else {
     parentScope = ancestor;
@@ -760,7 +761,8 @@ std::optional<std::string> ModFileReader::FindModFile(
 
 // program was read from a .mod file for a submodule; return the name of the
 // submodule's parent submodule, nullptr if none.
-static const SourceName *GetSubmoduleParent(const parser::Program &program) {
+static const std::optional<SourceName> GetSubmoduleParent(
+    const parser::Program &program) {
   CHECK(program.v.size() == 1);
   auto &unit{program.v.front()};
   auto &submod{std::get<common::Indirection<parser::Submodule>>(unit.u)};
@@ -768,9 +770,9 @@ static const SourceName *GetSubmoduleParent(const parser::Program &program) {
       std::get<parser::Statement<parser::SubmoduleStmt>>(submod.value().t)};
   auto &parentId{std::get<parser::ParentIdentifier>(stmt.statement.t)};
   if (auto &parent{std::get<std::optional<parser::Name>>(parentId.t)}) {
-    return &parent->source;
+    return parent->source;
   } else {
-    return nullptr;
+    return std::nullopt;
   }
 }
 

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -36,8 +36,7 @@ using namespace parser::literals;
 // are using another encoding.
 static constexpr auto magic{"\xef\xbb\xbf!mod$ v1 sum:"};
 
-static const std::optional<SourceName> GetSubmoduleParent(
-    const parser::Program &);
+static std::optional<SourceName> GetSubmoduleParent(const parser::Program &);
 static std::string ModFilePath(const std::string &dir, const SourceName &,
     const std::string &ancestor, const std::string &suffix);
 static std::vector<const Symbol *> CollectSymbols(const Scope &);
@@ -761,7 +760,7 @@ std::optional<std::string> ModFileReader::FindModFile(
 
 // program was read from a .mod file for a submodule; return the name of the
 // submodule's parent submodule, nullptr if none.
-static const std::optional<SourceName> GetSubmoduleParent(
+static std::optional<SourceName> GetSubmoduleParent(
     const parser::Program &program) {
   CHECK(program.v.size() == 1);
   auto &unit{program.v.front()};

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -126,7 +126,7 @@ void ModFileWriter::WriteOne(const Scope &scope) {
 // Write the module file for symbol, which must be a module or submodule.
 void ModFileWriter::Write(const Symbol &symbol) {
   auto *ancestor{symbol.get<ModuleDetails>().ancestor()};
-  auto ancestorName{ancestor ? ancestor->name().ToString() : ""s};
+  auto ancestorName{ancestor ? ancestor->GetName().value().ToString() : ""s};
   auto path{ModFilePath(context_.moduleDirectory(), symbol.name(), ancestorName,
       context_.moduleFileSuffix())};
   PutSymbols(*symbol.scope());
@@ -680,7 +680,7 @@ Scope *ModFileReader::Read(const SourceName &name, Scope *ancestor) {
     if (auto *scope{ancestor->FindSubmodule(name)}) {
       return scope;
     }
-    ancestorName = ancestor->name().ToString();
+    ancestorName = ancestor->GetName().value().ToString();
   } else {
     auto it{context_.globalScope().find(name)};
     if (it != context_.globalScope().end()) {

--- a/lib/semantics/resolve-names-utils.cc
+++ b/lib/semantics/resolve-names-utils.cc
@@ -98,16 +98,16 @@ void GenericSpecInfo::Resolve(Symbol *symbol) {
 void GenericSpecInfo::Analyze(const parser::DefinedOpName &name) {
   kind_ = GenericKind::DefinedOp;
   parseName_ = &name.v;
-  symbolName_ = &name.v.source;
+  symbolName_ = name.v.source;
 }
 
 void GenericSpecInfo::Analyze(const parser::GenericSpec &x) {
-  symbolName_ = &x.source;
+  symbolName_ = x.source;
   kind_ = std::visit(
       common::visitors{
           [&](const parser::Name &y) {
             parseName_ = &y;
-            symbolName_ = &y.source;
+            symbolName_ = y.source;
             return GenericKind::Name;
           },
           [&](const parser::DefinedOperator &y) {

--- a/lib/semantics/resolve-names-utils.h
+++ b/lib/semantics/resolve-names-utils.h
@@ -59,7 +59,7 @@ public:
   GenericSpecInfo(const parser::DefinedOpName &x) { Analyze(x); }
   GenericSpecInfo(const parser::GenericSpec &x) { Analyze(x); }
 
-  const SourceName &symbolName() const { return *symbolName_; }
+  const SourceName &symbolName() const { return symbolName_.value(); }
   // Set the GenericKind in this symbol and resolve the corresponding
   // name if there is one
   void Resolve(Symbol *);
@@ -67,7 +67,7 @@ public:
 private:
   GenericKind kind_;
   const parser::Name *parseName_{nullptr};
-  const SourceName *symbolName_{nullptr};
+  std::optional<SourceName> symbolName_;
 
   void Analyze(const parser::DefinedOpName &);
   void Analyze(const parser::GenericSpec &);

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -5292,7 +5292,7 @@ void ResolveNamesVisitor::CheckImports() {
     // C8102: all entities in host must not be hidden
     for (const auto &pair : scope.parent()) {
       auto &name{pair.first};
-      if (name != scope.name()) {
+      if (!scope.GetSymbol() || name != scope.name()) {
         CheckImport(*prevImportStmt_, name);
       }
     }

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -100,8 +100,10 @@ class MessageHandler {
 public:
   Messages &messages() { return context_->messages(); };
   void set_context(SemanticsContext &context) { context_ = &context; }
-  const SourceName *currStmtSource() { return context_->location(); }
-  void set_currStmtSource(const SourceName *source) {
+  const std::optional<SourceName> &currStmtSource() {
+    return context_->location();
+  }
+  void set_currStmtSource(const std::optional<SourceName> &source) {
     context_->set_location(source);
   }
 
@@ -140,7 +142,9 @@ public:
   void set_this(ResolveNamesVisitor *x) { this_ = x; }
 
   MessageHandler &messageHandler() { return messageHandler_; }
-  const SourceName *currStmtSource() { return context_->location(); }
+  const std::optional<SourceName> &currStmtSource() {
+    return context_->location();
+  }
   SemanticsContext &context() const { return *context_; }
   void set_context(SemanticsContext &);
   evaluate::FoldingContext &GetFoldingContext() const {
@@ -279,7 +283,7 @@ protected:
 
 private:
   MaybeExpr bindName_;  // from BIND(C, NAME="...")
-  const SourceName *passName_{nullptr};  // from PASS(...)
+  std::optional<SourceName> passName_;  // from PASS(...)
 };
 
 // Find and create types from declaration-type-spec nodes.
@@ -364,10 +368,10 @@ private:
   std::map<const Scope *, ImplicitRules> implicitRulesMap_;
   // implicit rules in effect for current scope
   ImplicitRules *implicitRules_{nullptr};
-  const SourceName *prevImplicit_{nullptr};
-  const SourceName *prevImplicitNone_{nullptr};
-  const SourceName *prevImplicitNoneType_{nullptr};
-  const SourceName *prevParameterStmt_{nullptr};
+  std::optional<SourceName> prevImplicit_;
+  std::optional<SourceName> prevImplicitNone_;
+  std::optional<SourceName> prevImplicitNoneType_;
+  std::optional<SourceName> prevParameterStmt_;
 
   bool HandleImplicitNone(const std::list<ImplicitNoneNameSpec> &nameSpecs);
 };
@@ -427,7 +431,7 @@ public:
   void SetScope(Scope &);
 
   template<typename T> bool Pre(const parser::Statement<T> &x) {
-    messageHandler().set_currStmtSource(&x.source);
+    messageHandler().set_currStmtSource(x.source);
     for (auto *scope = currScope_; scope; scope = &scope->parent()) {
       scope->AddSourceRange(x.source);
       if (scope->IsGlobal()) {
@@ -437,7 +441,7 @@ public:
     return true;
   }
   template<typename T> void Post(const parser::Statement<T> &) {
-    messageHandler().set_currStmtSource(nullptr);
+    messageHandler().set_currStmtSource(std::nullopt);
   }
 
   // Special messages: already declared; referencing symbol's declaration;
@@ -570,7 +574,7 @@ private:
   // The default access spec for this module.
   Attr defaultAccess_{Attr::PUBLIC};
   // The location of the last AccessStmt without access-ids, if any.
-  const SourceName *prevAccessStmt_{nullptr};
+  std::optional<SourceName> prevAccessStmt_;
   // The scope of the module during a UseStmt
   const Scope *useModuleScope_{nullptr};
 
@@ -662,7 +666,7 @@ private:
     const parser::DeclarationTypeSpec *parsedType{nullptr};
     const parser::Name *resultName{nullptr};
     Symbol *resultSymbol{nullptr};
-    const SourceName *source{nullptr};
+    std::optional<SourceName> source;
   } funcInfo_;
 
   // Create a subprogram symbol in the current scope and push a new scope.
@@ -831,7 +835,7 @@ private:
   } commonBlockInfo_;
   // Info about about SAVE statements and attributes in current scope
   struct {
-    const SourceName *saveAll{nullptr};  // "SAVE" without entity list
+    std::optional<SourceName> saveAll;  // "SAVE" without entity list
     std::set<SourceName> entities;  // names of entities with save attr
     std::set<SourceName> commons;  // names of common blocks with save attr
   } saveInfo_;
@@ -1089,7 +1093,7 @@ public:
 private:
   // Kind of procedure we are expecting to see in a ProcedureDesignator
   std::optional<Symbol::Flag> expectedProcFlag_;
-  const SourceName *prevImportStmt_{nullptr};
+  std::optional<SourceName> prevImportStmt_;
 
   void PreSpecificationConstruct(const parser::SpecificationConstruct &);
   void CreateGeneric(const parser::GenericSpec &);
@@ -1221,7 +1225,7 @@ Attrs AttrsVisitor::GetAttrs() {
 Attrs AttrsVisitor::EndAttrs() {
   Attrs result{GetAttrs()};
   attrs_.reset();
-  passName_ = nullptr;
+  passName_ = std::nullopt;
   bindName_.reset();
   return result;
 }
@@ -1275,7 +1279,7 @@ bool AttrsVisitor::Pre(const parser::IntentSpec &x) {
 }
 bool AttrsVisitor::Pre(const parser::Pass &x) {
   if (x.v) {
-    passName_ = &x.v->source;
+    passName_ = x.v->source;
     MakePlaceholder(*x.v, MiscDetails::Kind::PassName);
   } else {
     attrs_->set(Attr::PASS);
@@ -1371,10 +1375,10 @@ KindExpr DeclTypeSpecVisitor::GetKindParamExpr(
 // MessageHandler implementation
 
 Message &MessageHandler::Say(MessageFixedText &&msg) {
-  return context_->Say(*currStmtSource(), std::move(msg));
+  return context_->Say(currStmtSource().value(), std::move(msg));
 }
 Message &MessageHandler::Say(MessageFormattedText &&msg) {
-  return context_->Say(*currStmtSource(), std::move(msg));
+  return context_->Say(currStmtSource().value(), std::move(msg));
 }
 Message &MessageHandler::Say(const SourceName &name, MessageFixedText &&msg) {
   return Say(name, std::move(msg), name);
@@ -1434,10 +1438,10 @@ void ImplicitRulesVisitor::Post(const parser::ImplicitSpec &) {
 
 void ImplicitRulesVisitor::SetScope(const Scope &scope) {
   implicitRules_ = &implicitRulesMap_.at(&scope);
-  prevImplicit_ = nullptr;
-  prevImplicitNone_ = nullptr;
-  prevImplicitNoneType_ = nullptr;
-  prevParameterStmt_ = nullptr;
+  prevImplicit_ = std::nullopt;
+  prevImplicitNone_ = std::nullopt;
+  prevImplicitNoneType_ = std::nullopt;
+  prevParameterStmt_ = std::nullopt;
 }
 void ImplicitRulesVisitor::BeginScope(const Scope &scope) {
   // find or create implicit rules for this scope
@@ -1448,12 +1452,12 @@ void ImplicitRulesVisitor::BeginScope(const Scope &scope) {
 // TODO: for all of these errors, reference previous statement too
 bool ImplicitRulesVisitor::HandleImplicitNone(
     const std::list<ImplicitNoneNameSpec> &nameSpecs) {
-  if (prevImplicitNone_ != nullptr) {
+  if (prevImplicitNone_.has_value()) {
     Say("More than one IMPLICIT NONE statement"_err_en_US);
     Say(*prevImplicitNone_, "Previous IMPLICIT NONE statement"_en_US);
     return false;
   }
-  if (prevParameterStmt_ != nullptr) {
+  if (prevParameterStmt_.has_value()) {
     Say("IMPLICIT NONE statement after PARAMETER statement"_err_en_US);
     return false;
   }
@@ -2065,7 +2069,7 @@ void ModuleVisitor::BeginModule(const parser::Name &name, bool isSubmodule) {
   PushScope(Scope::Kind::Module, &symbol);
   details.set_scope(&currScope());
   defaultAccess_ = Attr::PUBLIC;
-  prevAccessStmt_ = nullptr;
+  prevAccessStmt_ = std::nullopt;
 }
 
 // Find a module or submodule by name and return its scope.
@@ -2777,7 +2781,7 @@ Symbol &DeclarationVisitor::HandleAttributeStmt(
       }
     }
   } else if (symbol && symbol->has<UseDetails>()) {
-    Say(*currStmtSource(),
+    Say(currStmtSource().value(),
         "Cannot change %s attribute on use-associated '%s'"_err_en_US,
         EnumToString(attr), name.source);
     return *symbol;
@@ -3144,7 +3148,8 @@ void DeclarationVisitor::Post(const parser::DerivedTypeSpec &x) {
       // context of a parameterized derived type definition, so we need to
       // clone its contents, specialize them with the actual type parameter
       // values, and check constraints.
-      auto save{GetFoldingContext().messages().SetLocation(*currStmtSource())};
+      auto save{
+          GetFoldingContext().messages().SetLocation(currStmtSource().value())};
       InstantiateDerivedType(type.derivedTypeSpec(), currScope(), context());
     }
     SetDeclTypeSpec(type);
@@ -3609,7 +3614,8 @@ bool DeclarationVisitor::Pre(const parser::CommonStmt::Block &x) {
   CheckNotInBlock("COMMON");  // C1107
   const auto &optName{std::get<std::optional<parser::Name>>(x.t)};
   parser::Name blankCommon;
-  blankCommon.source = SourceName{currStmtSource()->begin(), std::size_t{0}};
+  blankCommon.source =
+      SourceName{currStmtSource().value().begin(), std::size_t{0}};
   CHECK(!commonBlockInfo_.curr);
   commonBlockInfo_.curr =
       &MakeCommonBlockSymbol(optName ? *optName : blankCommon);
@@ -5128,7 +5134,7 @@ bool ResolveNamesVisitor::SetProcFlag(
 bool ModuleVisitor::Pre(const parser::AccessStmt &x) {
   Attr accessAttr{AccessSpecToAttr(std::get<parser::AccessSpec>(x.t))};
   if (currScope().kind() != Scope::Kind::Module) {
-    Say(*currStmtSource(),
+    Say(currStmtSource().value(),
         "%s statement may only appear in the specification part of a module"_err_en_US,
         EnumToString(accessAttr));
     return false;
@@ -5293,7 +5299,7 @@ void ResolveNamesVisitor::CheckImports() {
     for (const auto &pair : scope.parent()) {
       auto &name{pair.first};
       if (!scope.GetSymbol() || name != scope.name()) {
-        CheckImport(*prevImportStmt_, name);
+        CheckImport(prevImportStmt_.value(), name);
       }
     }
     break;
@@ -5714,7 +5720,7 @@ void ResolveNamesVisitor::SetPassArg(
         interface->name());
     return;
   }
-  const SourceName *passName{details.passName()};
+  std::optional<SourceName> passName{details.passName()};
   const auto &dummyArgs{subprogram->dummyArgs()};
   if (!passName && dummyArgs.empty()) {
     Say(name,
@@ -5728,7 +5734,7 @@ void ResolveNamesVisitor::SetPassArg(
   }
   int passArgIndex{0};
   if (!passName) {
-    passName = &dummyArgs[0]->name();
+    passName = dummyArgs[0]->name();
   } else {
     passArgIndex = FindIndexOfName(*passName, dummyArgs);
     if (passArgIndex < 0) {
@@ -5757,7 +5763,7 @@ void ResolveNamesVisitor::SetPassArg(
           " must be scalar"_err_en_US;
   }
   if (msg) {
-    Say(name, std::move(*msg), *passName, name);
+    Say(name, std::move(*msg), passName.value(), name);
     return;
   }
   const DeclTypeSpec *type{passArg.GetType()};
@@ -5770,7 +5776,7 @@ void ResolveNamesVisitor::SetPassArg(
     Say(name,
         "Passed-object dummy argument '%s' of procedure '%s'"
         " must be of type '%s' but is '%s'"_err_en_US,
-        *passName, name, typeSymbol.name(), type->AsFortran());
+        passName.value(), name, typeSymbol.name(), type->AsFortran());
     return;
   }
   if (IsExtensibleType(derived) != type->IsPolymorphic()) {
@@ -5780,7 +5786,7 @@ void ResolveNamesVisitor::SetPassArg(
               " must not be polymorphic because '%s' is not extensible"_err_en_US
             : "Passed-object dummy argument '%s' of procedure '%s'"
               " must polymorphic because '%s' is extensible"_err_en_US,
-        *passName, name, typeSymbol.name());
+        passName.value(), name, typeSymbol.name());
     return;
   }
   for (const auto &[paramName, paramValue] : derived->parameters()) {
@@ -5788,7 +5794,7 @@ void ResolveNamesVisitor::SetPassArg(
       Say(name,
           "Passed-object dummy argument '%s' of procedure '%s'"
           " has non-assumed length parameter '%s'"_err_en_US,
-          *passName, name, paramName);
+          passName.value(), name, paramName);
     }
   }
   details.set_passIndex(passArgIndex);

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -1968,7 +1968,7 @@ ModuleVisitor::SymbolRename ModuleVisitor::AddUse(
         IsDefinedOperator(useName)
             ? "Operator '%s' not found in module '%s'"_err_en_US
             : "'%s' not found in module '%s'"_err_en_US,
-        useName, useModuleScope_->name());
+        useName, useModuleScope_->GetName().value());
     return {};
   }
   if (useSymbol->attrs().test(Attr::PRIVATE)) {
@@ -1976,7 +1976,7 @@ ModuleVisitor::SymbolRename ModuleVisitor::AddUse(
         IsDefinedOperator(useName)
             ? "Operator '%s' is PRIVATE in '%s'"_err_en_US
             : "'%s' is PRIVATE in '%s'"_err_en_US,
-        useName, useModuleScope_->name());
+        useName, useModuleScope_->GetName().value());
     return {};
   }
   auto &localSymbol{MakeSymbol(localName)};
@@ -2583,7 +2583,7 @@ bool DeclarationVisitor::CheckUseError(const parser::Name &name) {
   Message &msg{Say(name, "Reference to '%s' is ambiguous"_err_en_US)};
   for (const auto &[location, module] : details->occurrences()) {
     msg.Attach(location, "'%s' was use-associated from module '%s'"_en_US,
-        name.source, module->name());
+        name.source, module->GetName().value());
   }
   return true;
 }
@@ -2620,7 +2620,7 @@ bool DeclarationVisitor::CheckAccessibleComponent(
     }
     Say(name,
         "PRIVATE component '%s' is only accessible within module '%s'"_err_en_US,
-        name.ToString(), moduleScope->name());
+        name.ToString(), moduleScope->GetName().value());
   } else {
     Say(name,
         "PRIVATE component '%s' is only accessible within its module"_err_en_US,
@@ -5298,7 +5298,8 @@ void ResolveNamesVisitor::CheckImports() {
     // C8102: all entities in host must not be hidden
     for (const auto &pair : scope.parent()) {
       auto &name{pair.first};
-      if (!scope.GetSymbol() || name != scope.name()) {
+      std::optional<SourceName> scopeName{scope.GetName()};
+      if (!scopeName.has_value() || name != *scopeName) {
         CheckImport(prevImportStmt_.value(), name);
       }
     }

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -89,9 +89,13 @@ public:
   const Symbol *GetSymbol() const;
   const Scope *GetDerivedTypeParent() const;
 
-  // It is only safe to call name() for kind of scopes for which GetSymbol
-  // will return a symbol (e.g, it will die if the scope is a Block).
-  const SourceName &name() const { return DEREF(GetSymbol()).name(); }
+  std::optional<SourceName> GetName() const {
+    if (const auto *sym{GetSymbol()}) {
+      return sym->name();
+    } else {
+      return std::nullopt;
+    }
+  }
 
   /// Make a scope nested in this one
   Scope &MakeScope(Kind kind, Symbol *symbol = nullptr);

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -89,6 +89,8 @@ public:
   const Symbol *GetSymbol() const;
   const Scope *GetDerivedTypeParent() const;
 
+  // It is only safe to call name() for kind of scopes for which GetSymbol
+  // will return a symbol (e.g, it will die if the scope is a Block).
   const SourceName &name() const { return DEREF(GetSymbol()).name(); }
 
   /// Make a scope nested in this one

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -62,13 +62,13 @@ public:
   template<typename N> void Post(const N &node) { Leave(node); }
 
   template<typename T> bool Pre(const parser::Statement<T> &node) {
-    context_.set_location(&node.source);
+    context_.set_location(node.source);
     Enter(node);
     return true;
   }
   template<typename T> void Post(const parser::Statement<T> &node) {
     Leave(node);
-    context_.set_location(nullptr);
+    context_.set_location(std::nullopt);
   }
 
   bool Walk(const parser::Program &program) {

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -54,7 +54,7 @@ public:
   int quadPrecisionKind() const { return defaultKinds_.quadPrecisionKind(); }
   bool IsEnabled(parser::LanguageFeature) const;
   bool ShouldWarn(parser::LanguageFeature) const;
-  const parser::CharBlock *location() const { return location_; }
+  const std::optional<parser::CharBlock> &location() const { return location_; }
   const std::vector<std::string> &searchDirectories() const {
     return searchDirectories_;
   }
@@ -68,7 +68,8 @@ public:
   evaluate::FoldingContext &foldingContext() { return foldingContext_; }
   parser::AllSources &allSources() { return allSources_; }
 
-  SemanticsContext &set_location(const parser::CharBlock *location) {
+  SemanticsContext &set_location(
+      const std::optional<parser::CharBlock> &location) {
     location_ = location;
     return *this;
   }
@@ -105,7 +106,7 @@ public:
   void SetError(Symbol &, bool = true);
 
   template<typename... A> parser::Message &Say(A &&... args) {
-    CHECK(location_);
+    CHECK(location_.has_value());
     return messages_.Say(*location_, std::forward<A>(args)...);
   }
   template<typename... A>
@@ -123,7 +124,7 @@ private:
   const common::IntrinsicTypeDefaultKinds &defaultKinds_;
   const parser::LanguageFeatureControl languageFeatures_;
   parser::AllSources &allSources_;
-  const parser::CharBlock *location_{nullptr};
+  std::optional<parser::CharBlock> location_;
   std::vector<std::string> searchDirectories_;
   std::string moduleDirectory_{"."s};
   std::string moduleFileSuffix_{".mod"};

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -392,10 +392,10 @@ std::ostream &operator<<(std::ostream &os, const Details &details) {
             if (x.isSubmodule()) {
               os << " (";
               if (x.ancestor()) {
-                auto &ancestor{x.ancestor()->name()};
+                auto ancestor{x.ancestor()->GetName().value()};
                 os << ancestor;
                 if (x.parent()) {
-                  auto &parent{x.parent()->name()};
+                  auto parent{x.parent()->GetName().value()};
                   if (ancestor != parent) {
                     os << ':' << parent;
                   }
@@ -430,7 +430,7 @@ std::ostream &operator<<(std::ostream &os, const Details &details) {
           [&](const UseErrorDetails &x) {
             os << " uses:";
             for (const auto &[location, module] : x.occurrences()) {
-              os << " from " << module->name() << " at " << location;
+              os << " from " << module->GetName().value() << " at " << location;
             }
           },
           [](const HostAssocDetails &) {},

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -183,13 +183,13 @@ private:
 // passIndex is set based on passName or the PASS attr.
 class WithPassArg {
 public:
-  const SourceName *passName() const { return passName_; }
-  void set_passName(const SourceName &passName) { passName_ = &passName; }
+  const std::optional<SourceName> &passName() const { return passName_; }
+  void set_passName(const SourceName &passName) { passName_ = passName; }
   std::optional<int> passIndex() const { return passIndex_; }
   void set_passIndex(int index) { passIndex_ = index; }
 
 private:
-  const SourceName *passName_{nullptr};
+  std::optional<SourceName> passName_;
   std::optional<int> passIndex_;
 };
 

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -367,7 +367,7 @@ bool IsDerivedTypeFromModule(
   } else {
     const auto &symbol{derived->typeSymbol()};
     return symbol.name() == name && symbol.owner().IsModule() &&
-        symbol.owner().name() == module;
+        symbol.owner().GetName().value() == module;
   }
 }
 

--- a/lib/semantics/unparse-with-symbols.cc
+++ b/lib/semantics/unparse-with-symbols.cc
@@ -35,16 +35,16 @@ public:
   template<typename T> bool Pre(const T &) { return true; }
   template<typename T> void Post(const T &) {}
   template<typename T> bool Pre(const parser::Statement<T> &stmt) {
-    currStmt_ = &stmt.source;
+    currStmt_ = stmt.source;
     return true;
   }
   template<typename T> void Post(const parser::Statement<T> &) {
-    currStmt_ = nullptr;
+    currStmt_ = std::nullopt;
   }
   void Post(const parser::Name &name);
 
 private:
-  const SourceName *currStmt_{nullptr};  // current statement we are processing
+  std::optional<SourceName> currStmt_;  // current statement we are processing
   std::multimap<const char *, const Symbol *> symbols_;  // location to symbol
   std::set<const Symbol *> symbolsDefined_;  // symbols that have been processed
   void Indent(std::ostream &, int) const;
@@ -75,7 +75,7 @@ void SymbolDumpVisitor::Indent(std::ostream &out, int indent) const {
 void SymbolDumpVisitor::Post(const parser::Name &name) {
   if (const auto *symbol{name.symbol}) {
     if (!symbol->has<MiscDetails>()) {
-      symbols_.emplace(DEREF(currStmt_).begin(), symbol);
+      symbols_.emplace(currStmt_.value().begin(), symbol);
     }
   }
 }

--- a/test/semantics/resolve28.f90
+++ b/test/semantics/resolve28.f90
@@ -58,6 +58,12 @@ function f
   import, all
 end
 
+subroutine sub2()
+  block
+    import, all !OK
+  end block
+end
+
 !ERROR: IMPORT is not allowed in a main program scoping unit
 import
 end

--- a/test/semantics/resolve28.f90
+++ b/test/semantics/resolve28.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+! Copyright (c) 2018-2019 NVIDIA CORPORATION.  All rights reserved.
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes issue #604.
In `CheckImports`, do not call `scope.name()` without checking that  the scope is associated to a symbol (and therefore has a name). It is legal to put imports in scopes that are not linked to symbols, such as BLOCK.

Add a comment in `scope.h` to not call `name()` without knowing it is OK.