### PR TITLE
Fix IMPLICIT issue 547

### DIFF
--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -73,8 +73,10 @@ public:
   void set_inheritFromParent(bool x) { inheritFromParent_ = x; }
   // Get the implicit type for identifiers starting with ch. May be null.
   const DeclTypeSpec *GetType(char ch) const;
-  // Record the implicit type for this range of characters.
-  void SetType(const DeclTypeSpec &type, parser::Location lo, parser::Location);
+  // Record the implicit type for the range of characters [fromLetter,
+  // toLetter].
+  void SetTypeMapping(const DeclTypeSpec &type, parser::Location fromLetter,
+      parser::Location toLetter);
 
 private:
   static char Incr(char ch);
@@ -1138,15 +1140,15 @@ const DeclTypeSpec *ImplicitRules::GetType(char ch) const {
   }
 }
 
-void ImplicitRules::SetType(
-    const DeclTypeSpec &type, parser::Location lo, parser::Location hi) {
-  for (char ch = *lo; ch; ch = ImplicitRules::Incr(ch)) {
+void ImplicitRules::SetTypeMapping(const DeclTypeSpec &type,
+    parser::Location fromLetter, parser::Location toLetter) {
+  for (char ch = *fromLetter; ch; ch = ImplicitRules::Incr(ch)) {
     auto res{map_.emplace(ch, &type)};
     if (!res.second) {
-      context_.Say(parser::CharBlock{lo},
+      context_.Say(parser::CharBlock{fromLetter},
           "More than one implicit type specified for '%c'"_err_en_US, ch);
     }
-    if (ch == *hi) {
+    if (ch == *toLetter) {
       break;
     }
   }
@@ -1410,7 +1412,7 @@ bool ImplicitRulesVisitor::Pre(const parser::LetterSpec &x) {
       return false;
     }
   }
-  implicitRules().SetType(*GetDeclTypeSpec(), loLoc, hiLoc);
+  implicitRules().SetTypeMapping(*GetDeclTypeSpec(), loLoc, hiLoc);
   return false;
 }
 
@@ -1760,18 +1762,16 @@ static bool NeedsType(const Symbol &symbol) {
 }
 void ScopeHandler::ApplyImplicitRules(Symbol &symbol) {
   if (NeedsType(symbol)) {
-    if (const auto *type{GetImplicitType(symbol)}) {
+    if (const DeclTypeSpec * type{GetImplicitType(symbol)}) {
       symbol.set(Symbol::Flag::Implicit);
       symbol.SetType(*type);
+    } else if (symbol.has<ProcEntityDetails>() &&
+        !symbol.attrs().test(Attr::EXTERNAL) &&
+        context().intrinsics().IsIntrinsic(symbol.name().ToString())) {
+      // type will be determined in expression semantics
+      symbol.attrs().set(Attr::INTRINSIC);
     } else {
-      if (symbol.has<ProcEntityDetails>() &&
-          !symbol.attrs().test(Attr::EXTERNAL) &&
-          context().intrinsics().IsIntrinsic(symbol.name().ToString())) {
-        // type will be determined in expression semantics
-        symbol.attrs().set(Attr::INTRINSIC);
-      } else {
-        Say(symbol.name(), "No explicit type declared for '%s'"_err_en_US);
-      }
+      Say(symbol.name(), "No explicit type declared for '%s'"_err_en_US);
     }
   }
 }

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -74,18 +74,19 @@ public:
   // Get the implicit type for identifiers starting with ch. May be null.
   const DeclTypeSpec *GetType(char ch) const;
   // Record the implicit type for this range of characters.
-  void SetType(const DeclTypeSpec &type, parser::Location lo, parser::Location,
-      bool isDefault = false);
+  void SetType(const DeclTypeSpec &type, parser::Location lo, parser::Location);
 
 private:
   static char Incr(char ch);
 
   ImplicitRules *parent_;
   SemanticsContext &context_;
-  bool inheritFromParent_;  // look in parent if not specified here
-  std::optional<bool> isImplicitNoneType_;
-  std::optional<bool> isImplicitNoneExternal_;
-  // map initial character of identifier to nullptr or its default type
+  bool inheritFromParent_{false};  // look in parent if not specified here
+  bool isImplicitNoneType_{false};
+  bool isImplicitNoneExternal_{false};
+  // map_ contains the mapping between letters and types that were defined
+  // by the IMPLICIT statements of the related scope. It does not contain
+  // the default Fortran mappings nor the mapping defined in parents.
   std::map<char, const DeclTypeSpec *> map_;
 
   friend std::ostream &operator<<(std::ostream &, const ImplicitRules &);
@@ -1102,9 +1103,9 @@ private:
 // ImplicitRules implementation
 
 bool ImplicitRules::isImplicitNoneType() const {
-  if (isImplicitNoneType_.has_value()) {
-    return isImplicitNoneType_.value();
-  } else if (inheritFromParent_) {
+  if (isImplicitNoneType_) {
+    return true;
+  } else if (map_.empty() && inheritFromParent_) {
     return parent_->isImplicitNoneType();
   } else {
     return false;  // default if not specified
@@ -1112,8 +1113,8 @@ bool ImplicitRules::isImplicitNoneType() const {
 }
 
 bool ImplicitRules::isImplicitNoneExternal() const {
-  if (isImplicitNoneExternal_.has_value()) {
-    return isImplicitNoneExternal_.value();
+  if (isImplicitNoneExternal_) {
+    return true;
   } else if (inheritFromParent_) {
     return parent_->isImplicitNoneExternal();
   } else {
@@ -1122,7 +1123,7 @@ bool ImplicitRules::isImplicitNoneExternal() const {
 }
 
 const DeclTypeSpec *ImplicitRules::GetType(char ch) const {
-  if (isImplicitNoneType()) {
+  if (isImplicitNoneType_) {
     return nullptr;
   } else if (auto it{map_.find(ch)}; it != map_.end()) {
     return it->second;
@@ -1137,13 +1138,11 @@ const DeclTypeSpec *ImplicitRules::GetType(char ch) const {
   }
 }
 
-// isDefault is set when we are applying the default rules, so it is not
-// an error if the type is already set.
-void ImplicitRules::SetType(const DeclTypeSpec &type, parser::Location lo,
-    parser::Location hi, bool isDefault) {
+void ImplicitRules::SetType(
+    const DeclTypeSpec &type, parser::Location lo, parser::Location hi) {
   for (char ch = *lo; ch; ch = ImplicitRules::Incr(ch)) {
     auto res{map_.emplace(ch, &type)};
-    if (!res.second && !isDefault) {
+    if (!res.second) {
       context_.Say(parser::CharBlock{lo},
           "More than one implicit type specified for '%c'"_err_en_US, ch);
     }

--- a/test/semantics/resolve04.f90
+++ b/test/semantics/resolve04.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -35,3 +35,36 @@ contains
     j = 2
   end subroutine
 end subroutine
+
+module m1
+  implicit none
+contains
+  subroutine s1
+    implicit real (a-h)
+    a1 = 1.
+    h1 = 1.
+    !ERROR: No explicit type declared for 'i1'
+    i1 = 1
+    !ERROR: No explicit type declared for 'z1'
+    z1 = 2.
+  contains
+    subroutine ss1
+      implicit integer(f-j) ! overlap with host scope import is OK
+      a2 = 1.
+      h2 = 1
+      i2 = 1
+      !ERROR: No explicit type declared for 'z2'
+      z2 = 2.
+    contains
+      subroutine sss1
+        implicit none
+        !ERROR: No explicit type declared for 'a3'
+        a3 = 1.
+      end subroutine
+    end subroutine
+  end subroutine
+  subroutine s2
+    !ERROR: No explicit type declared for 'b1'
+    b1 = 1.
+  end subroutine
+end module


### PR DESCRIPTION
Fix issue #547 and refactor `ImplicitRules` a bit.
In name resolution, the `IMPLICIT NONE` (for type) is represented by `isImplicitNoneType_` in the `ImplicitRules` class.
So far, it was a ternary with (I guess) the following intention:
- unset -> nothing about implicit in this scope, look into parent scope `ImplicitRules`
- set true -> There is an IMPLICIT NONE for types in this scope.
- set to false -> There is an IMPLICIT statement mapping types in this scope.


However, it was never set to false, so the IMPORT NONE of parent scopes was "leaking" when it should not.
Rather than just setting this to false, this PR actually change `ImplicitRules` a little based on the observation that the default mappings were actually not entered in the type `map_` as the comment suggested but hard coded  in `GetType`. So the `set to false` can be deduced from `!(set to true) && !map_.empty()`. Also, I do not think a ternary for `isImplicitNoneExternal_` is necessary as it can only be set to true and always "leak" to hosted scopes.

So both ternary are transformed to `bool` and related functions modified.

Last, `GetType` is modified to check `isImplicitNoneType_` because IMPLCIT NONE of parents should be considered when recursively calling `ImplicitRules` parents `GetType`.
This make the `isImplicitNone` redundant in `ApplyImplicitRules`. Instead, `GetImplicitType` is modified to not emit an error message and `ApplyImplicitRules` emits all error messages when it gets a nullptr from  `GetImplicitType`.