### PR TITLE
Handle forward references to procedures and interfaces

### DIFF
--- a/lib/evaluate/characteristics.cc
+++ b/lib/evaluate/characteristics.cc
@@ -420,8 +420,7 @@ std::optional<Procedure> Procedure::Characterize(
             return result;
           },
           [&](const semantics::ProcBindingDetails &binding) {
-            auto result{Characterize(binding.symbol(), intrinsics)};
-            if (result) {
+            if (auto result{Characterize(binding.symbol(), intrinsics)}) {
               if (const auto passIndex{binding.passIndex()}) {
                 auto &passArg{result->dummyArguments.at(*passIndex)};
                 passArg.pass = true;
@@ -429,8 +428,9 @@ std::optional<Procedure> Procedure::Characterize(
                   CHECK(passArg.name == passName->ToString());
                 }
               }
+              return result;
             }
-            return result;
+            return std::optional<Procedure>{};
           },
           [&](const semantics::UseDetails &use) {
             return Characterize(use.symbol(), intrinsics);

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -1073,6 +1073,8 @@ struct TypeBoundProcDecl {
 // R749 type-bound-procedure-stmt ->
 //        PROCEDURE [[, bind-attr-list] ::] type-bound-proc-decl-list |
 //        PROCEDURE ( interface-name ) , bind-attr-list :: binding-name-list
+// The second form, with interface-name, requires DEFERRED in bind-attr-list,
+// and thus can appear only in an abstract type.
 struct TypeBoundProcedureStmt {
   UNION_CLASS_BOILERPLATE(TypeBoundProcedureStmt);
   struct WithoutInterface {

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -1627,7 +1627,7 @@ public:
     Word("EXTERNAL :: "), Walk(x.v, ", ");
   }
   void Unparse(const ProcedureDeclarationStmt &x) {  // R1512
-    Word("PROCEDURE ("), Walk(std::get<std::optional<ProcInterface>>(x.t));
+    Word("PROCEDURE("), Walk(std::get<std::optional<ProcInterface>>(x.t));
     Put(')'), Walk(", ", std::get<std::list<ProcAttrSpec>>(x.t), ", ");
     Put(" :: "), Walk(std::get<std::list<ProcDecl>>(x.t), ", ");
   }

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -3429,7 +3429,7 @@ void DeclarationVisitor::Post(
 
 void DeclarationVisitor::CheckBindings(
     const parser::TypeBoundProcedureStmt::WithoutInterface &tbps) {
-  CHECK(currScope().kind() == Scope::Kind::DerivedType);
+  CHECK(currScope().IsDerivedType());
   for (auto &declaration : tbps.declarations) {
     auto &bindingName{std::get<parser::Name>(declaration.t)};
     if (Symbol * binding{FindInScope(currScope(), bindingName)}) {
@@ -5511,7 +5511,7 @@ public:
     const auto &name{std::get<parser::Name>(x.t)};
     if (Symbol * symbol{name.symbol}) {
       if (Scope * scope{symbol->scope()}) {
-        if (scope->kind() == Scope::Kind::DerivedType) {
+        if (scope->IsDerivedType()) {
           resolver_.PushScope(*scope);
           pushedScope_ = true;
         }

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -216,7 +216,7 @@ void Scope::add_importName(const SourceName &name) {
 
 // true if name can be imported or host-associated from parent scope.
 bool Scope::CanImport(const SourceName &name) const {
-  if (IsGlobal()) {
+  if (IsGlobal() || parent_.IsGlobal()) {
     return false;
   }
   switch (GetImportKind()) {

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -359,6 +359,9 @@ std::ostream &operator<<(std::ostream &os, const ProcEntityDetails &x) {
   }
   DumpOptional(os, "bindName", x.bindName());
   DumpOptional(os, "passName", x.passName());
+  if (x.init_ != nullptr) {
+    os << " => " << x.init_->name();
+  }
   return os;
 }
 

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -359,8 +359,12 @@ std::ostream &operator<<(std::ostream &os, const ProcEntityDetails &x) {
   }
   DumpOptional(os, "bindName", x.bindName());
   DumpOptional(os, "passName", x.passName());
-  if (x.init_ != nullptr) {
-    os << " => " << x.init_->name();
+  if (x.init()) {
+    if (const Symbol * target{*x.init()}) {
+      os << " => " << target->name();
+    } else {
+      os << " => NULL()";
+    }
   }
   return os;
 }

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -263,7 +263,7 @@ public:
   const Symbol &symbol() const { return *symbol_; }
 
 private:
-  const Symbol *symbol_;  // procedure bound to
+  const Symbol *symbol_;  // procedure bound to; may be forward
 };
 
 ENUM_CLASS(GenericKind,  // Kinds of generic-spec

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -204,13 +204,15 @@ public:
   void set_interface(const ProcInterface &interface) { interface_ = interface; }
   inline bool HasExplicitInterface() const;
 
+  // Be advised: !init().has_value() => uninitialized pointer,
+  // while *init() == nullptr => explicit NULL() initialization.
   std::optional<const Symbol *> init() const { return init_; }
   void set_init(const Symbol &symbol) { init_ = &symbol; }
   void set_init(std::nullptr_t) { init_ = nullptr; }
 
 private:
   ProcInterface interface_;
-  std::optional<const Symbol *> init_;  // if present but null => NULL()
+  std::optional<const Symbol *> init_;
   friend std::ostream &operator<<(std::ostream &, const ProcEntityDetails &);
 };
 

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -204,13 +204,13 @@ public:
   void set_interface(const ProcInterface &interface) { interface_ = interface; }
   inline bool HasExplicitInterface() const;
 
-  const Symbol *init() const { return init_; }
-  Symbol *init() { return init_; }
-  void set_init(Symbol &symbol) { init_ = &symbol; }
+  std::optional<const Symbol *> init() const { return init_; }
+  void set_init(const Symbol &symbol) { init_ = &symbol; }
+  void set_init(std::nullptr_t) { init_ = nullptr; }
 
 private:
   ProcInterface interface_;
-  Symbol *init_{nullptr};
+  std::optional<const Symbol *> init_;  // if present but null => NULL()
   friend std::ostream &operator<<(std::ostream &, const ProcEntityDetails &);
 };
 

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -204,8 +204,13 @@ public:
   void set_interface(const ProcInterface &interface) { interface_ = interface; }
   inline bool HasExplicitInterface() const;
 
+  const Symbol *init() const { return init_; }
+  Symbol *init() { return init_; }
+  void set_init(Symbol &symbol) { init_ = &symbol; }
+
 private:
   ProcInterface interface_;
+  Symbol *init_{nullptr};
   friend std::ostream &operator<<(std::ostream &, const ProcEntityDetails &);
 };
 

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -418,27 +418,6 @@ bool IsSaved(const Symbol &symbol) {
   }
 }
 
-const Symbol *FindUltimateComponent(const DerivedTypeSpec &derivedTypeSpec,
-    std::function<bool(const Symbol &)> predicate) {
-  const auto *scope{derivedTypeSpec.typeSymbol().scope()};
-  CHECK(scope);
-  for (const auto &pair : *scope) {
-    const Symbol &component{*pair.second};
-    const DeclTypeSpec *type{component.GetType()};
-    if (!type) {
-      continue;
-    }
-    const DerivedTypeSpec *derived{type->AsDerived()};
-    bool isUltimate{IsAllocatableOrPointer(component) || !derived};
-    if (const Symbol *
-        result{!isUltimate ? FindUltimateComponent(*derived, predicate)
-                           : predicate(component) ? &component : nullptr}) {
-      return result;
-    }
-  }
-  return nullptr;
-}
-
 bool IsFinalizable(const Symbol &symbol) {
   if (const DeclTypeSpec * type{symbol.GetType()}) {
     if (const DerivedTypeSpec * derived{type->AsDerived()}) {

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -418,6 +418,23 @@ bool IsSaved(const Symbol &symbol) {
   }
 }
 
+// Check this symbol suitable as a type-bound procedure - C769
+bool CanBeTypeBoundProc(const Symbol *symbol) {
+  if (symbol == nullptr || IsDummy(*symbol) || IsProcedurePointer(*symbol)) {
+    return false;
+  } else if (symbol->has<SubprogramNameDetails>()) {
+    return symbol->owner().kind() == Scope::Kind::Module;
+  } else if (auto *details{symbol->detailsIf<SubprogramDetails>()}) {
+    return symbol->owner().kind() == Scope::Kind::Module ||
+        details->isInterface();
+  } else if (const auto *proc{symbol->detailsIf<ProcEntityDetails>()}) {
+    return !symbol->attrs().test(Attr::INTRINSIC) &&
+        proc->HasExplicitInterface();
+  } else {
+    return false;
+  }
+}
+
 bool IsFinalizable(const Symbol &symbol) {
   if (const DeclTypeSpec * type{symbol.GetType()}) {
     if (const DerivedTypeSpec * derived{type->AsDerived()}) {

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -82,6 +82,8 @@ const Symbol *HasCoarrayUltimateComponent(const DerivedTypeSpec &);
 // Same logic as HasCoarrayUltimateComponent, but looking for
 const Symbol *HasEventOrLockPotentialComponent(const DerivedTypeSpec &);
 bool IsOrContainsEventOrLockComponent(const Symbol &);
+// Has an explicit or implied SAVE attribute
+bool IsSaved(const Symbol &);
 
 // Return an ultimate component of type that matches predicate, or nullptr.
 const Symbol *FindUltimateComponent(

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -84,6 +84,7 @@ const Symbol *HasEventOrLockPotentialComponent(const DerivedTypeSpec &);
 bool IsOrContainsEventOrLockComponent(const Symbol &);
 // Has an explicit or implied SAVE attribute
 bool IsSaved(const Symbol &);
+bool CanBeTypeBoundProc(const Symbol *);
 
 // Return an ultimate component of type that matches predicate, or nullptr.
 const Symbol *FindUltimateComponent(

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -211,7 +211,7 @@ template<typename T> std::optional<std::int64_t> GetIntValue(const T &x) {
   }
 }
 
-// Derived type component iterator that provides a C++ LegacyForwadIterator
+// Derived type component iterator that provides a C++ LegacyForwardIterator
 // iterator over the Ordered, Direct, Ultimate or Potential components of a
 // DerivedTypeSpec. These iterators can be used with STL algorithms
 // accepting LegacyForwadIterator.
@@ -220,7 +220,7 @@ template<typename T> std::optional<std::int64_t> GetIntValue(const T &x) {
 //
 //
 // - Ordered components are the components from the component order defined
-// in 7.5.4.7, except that the parent components IS added between the parent
+// in 7.5.4.7, except that the parent component IS added between the parent
 // component order and the components in order of declaration.
 // This "deviation" is important for structure-constructor analysis.
 // For this kind of iterator, the component tree is recursively visited in the

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -170,6 +170,7 @@ set(SYMBOL_TESTS
   symbol12.f90
   symbol13.f90
   symbol14.f90
+  symbol15.f90
   kinds01.f90
   kinds03.f90
   procinterface01.f90

--- a/test/semantics/allocate08.f90
+++ b/test/semantics/allocate08.f90
@@ -119,6 +119,12 @@ end function
 
 program test_typeless
   class(*), allocatable :: x
+  interface
+    subroutine sub
+    end subroutine
+    real function func()
+    end function
+  end interface
   procedure (sub), pointer :: subp => sub
   procedure (func), pointer :: funcp => func
 

--- a/test/semantics/dosemantics03.f90
+++ b/test/semantics/dosemantics03.f90
@@ -25,12 +25,6 @@
 ! C1120 -- DO variable (and associated expressions) must be INTEGER.
 ! This is extended by allowing REAL and DOUBLE PRECISION
 
-SUBROUTINE sub()
-END SUBROUTINE sub
-
-FUNCTION ifunc()
-END FUNCTION ifunc
-
 MODULE share
   INTEGER :: intvarshare
   REAL :: realvarshare
@@ -56,6 +50,12 @@ PROGRAM do_issue_458
   REAL, POINTER :: prvar
   DOUBLE PRECISION, POINTER :: pdvar
   LOGICAL, POINTER :: plvar
+  INTERFACE
+    SUBROUTINE sub()
+    END SUBROUTINE sub
+    FUNCTION ifunc()
+    END FUNCTION ifunc
+  END INTERFACE
   PROCEDURE(ifunc), POINTER :: pifunc => NULL()
 
 ! DO variables

--- a/test/semantics/procinterface01.f90
+++ b/test/semantics/procinterface01.f90
@@ -51,7 +51,7 @@ module module1
  type :: derived1
   !REF: /module1/abstract1
   !DEF: /module1/derived1/p1 NOPASS, POINTER ProcEntity REAL(4)
-  !DEF: /module1/nested1 ELEMENTAL, PUBLIC Subprogram REAL(4)
+  !DEF: /module1/nested1 PUBLIC Subprogram REAL(4)
   procedure(abstract1), pointer, nopass :: p1 => nested1
   !REF: /module1/explicit1
   !DEF: /module1/derived1/p2 NOPASS, POINTER ProcEntity REAL(4)
@@ -84,7 +84,7 @@ contains
 
  !REF: /module1/nested1
  !DEF: /module1/nested1/x INTENT(IN) ObjectEntity REAL(4)
- real elemental function nested1(x)
+ real function nested1(x)
   !REF: /module1/nested1/x
   real, intent(in) :: x
   !DEF: /module1/nested1/nested1 ObjectEntity REAL(4)

--- a/test/semantics/resolve20.f90
+++ b/test/semantics/resolve20.f90
@@ -22,20 +22,20 @@ module m
   procedure(integer) :: b
   procedure(foo) :: c
   procedure(bar) :: d
-  !ERROR: The interface of 'e' ('missing') is not an abstract interface or a procedure with an explicit interface
+  !ERROR: 'missing' must be an abstract interface or a procedure with an explicit interface
   procedure(missing) :: e
-  !ERROR: The interface of 'f' ('b') is not an abstract interface or a procedure with an explicit interface
+  !ERROR: 'b' must be an abstract interface or a procedure with an explicit interface
   procedure(b) :: f
   procedure(c) :: g
   external :: h
-  !ERROR: The interface of 'i' ('h') is not an abstract interface or a procedure with an explicit interface
+  !ERROR: 'h' must be an abstract interface or a procedure with an explicit interface
   procedure(h) :: i
   procedure(forward) :: j
-  !ERROR: The interface of 'k1' ('bad1') is not an abstract interface or a procedure with an explicit interface
+  !ERROR: 'bad1' must be an abstract interface or a procedure with an explicit interface
   procedure(bad1) :: k1
-  !ERROR: The interface of 'k2' ('bad2') is not an abstract interface or a procedure with an explicit interface
+  !ERROR: 'bad2' must be an abstract interface or a procedure with an explicit interface
   procedure(bad2) :: k2
-  !ERROR: The interface of 'k3' ('bad3') is not an abstract interface or a procedure with an explicit interface
+  !ERROR: 'bad3' must be an abstract interface or a procedure with an explicit interface
   procedure(bad3) :: k3
 
   abstract interface

--- a/test/semantics/resolve20.f90
+++ b/test/semantics/resolve20.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.

--- a/test/semantics/resolve32.f90
+++ b/test/semantics/resolve32.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.

--- a/test/semantics/resolve32.f90
+++ b/test/semantics/resolve32.f90
@@ -35,21 +35,21 @@ module m
   type t1
     integer :: c
   contains
-    !ERROR: Procedure 'missing' not found
+    !ERROR: The binding of 'a' ('missing') must be either an accessible module procedure or an external procedure with an explicit interface
     procedure, nopass :: a => missing
     procedure, nopass :: b => s, s2
-    !ERROR: 'c' is not a module procedure or external procedure with explicit interface
+    !ERROR: Type parameter, component, or procedure binding 'c' already defined in this type
     procedure, nopass :: c
     !ERROR: DEFERRED is only allowed when an interface-name is provided
     procedure, nopass, deferred :: d => s
     !Note: s3 not found because it's not accessible -- should we issue a message
     !to that effect?
-    !ERROR: Procedure 's3' not found
+    !ERROR: 's3' must be either an accessible module procedure or an external procedure with an explicit interface
     procedure, nopass :: s3
     procedure, nopass :: foo
-    !ERROR: 'bar' is not a module procedure or external procedure with explicit interface
+    !ERROR: 'bar' must be either an accessible module procedure or an external procedure with an explicit interface
     procedure, nopass :: bar
-    !ERROR: 'i' is not a module procedure or external procedure with explicit interface
+    !ERROR: 'i' must be either an accessible module procedure or an external procedure with an explicit interface
     procedure, nopass :: i
     !ERROR: Type parameter, component, or procedure binding 'b' already defined in this type
     procedure, nopass :: b => s4
@@ -59,7 +59,7 @@ module m
     procedure(foo), nopass, deferred :: f
     !ERROR: DEFERRED is required when an interface-name is provided
     procedure(foo), nopass :: g
-    !ERROR: The interface of 'h' ('bar') is not an abstract interface or a procedure with an explicit interface
+    !ERROR: 'bar' must be an abstract interface or a procedure with an explicit interface
     procedure(bar), nopass, deferred :: h
   end type
   type t2

--- a/test/semantics/symbol15.f90
+++ b/test/semantics/symbol15.f90
@@ -1,0 +1,267 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Forward references in pointer initializers and TBP bindings.
+
+!DEF: /m Module
+module m
+ implicit none
+ abstract interface
+  !DEF: /m/iface PUBLIC Subprogram
+  subroutine iface
+  end subroutine
+ end interface
+ !DEF: /m/op1 POINTER, PUBLIC ObjectEntity REAL(4)
+ real, pointer :: op1
+ !DEF: /m/op2 POINTER, PUBLIC ObjectEntity REAL(4)
+ real, pointer :: op2 => null()
+ !DEF: /m/op3 POINTER, PUBLIC ObjectEntity REAL(4)
+ !DEF: /m/x PUBLIC, TARGET ObjectEntity REAL(4)
+ real, pointer :: op3 => x
+ !DEF: /m/op4 POINTER, PUBLIC ObjectEntity REAL(4)
+ !DEF: /m/y PUBLIC, TARGET ObjectEntity REAL(4)
+ real, pointer :: op4 => y(1)
+ !REF: /m/iface
+ !DEF: /m/pp1 EXTERNAL, POINTER, PUBLIC ProcEntity
+ procedure(iface), pointer :: pp1
+ !REF: /m/iface
+ !DEF: /m/pp2 EXTERNAL, POINTER, PUBLIC ProcEntity
+ procedure(iface), pointer :: pp2 => null()
+ !REF: /m/iface
+ !DEF: /m/pp3 EXTERNAL, POINTER, PUBLIC ProcEntity
+ !DEF: /m/ext1 EXTERNAL, PUBLIC ProcEntity
+ procedure(iface), pointer :: pp3 => ext1
+ !REF: /m/iface
+ !DEF: /m/pp4 EXTERNAL, POINTER, PUBLIC ProcEntity
+ !DEF: /m/ext2 EXTERNAL, PUBLIC Subprogram
+ procedure(iface), pointer :: pp4 => ext2
+ !REF: /m/iface
+ !DEF: /m/pp5 EXTERNAL, POINTER, PUBLIC ProcEntity
+ !DEF: /m/ext3 EXTERNAL, PUBLIC ProcEntity
+ procedure(iface), pointer :: pp5 => ext3
+ !REF: /m/iface
+ !DEF: /m/pp6 EXTERNAL, POINTER, PUBLIC ProcEntity
+ !DEF: /m/modproc1 PUBLIC Subprogram
+ procedure(iface), pointer :: pp6 => modproc1
+ !DEF: /m/t1 PUBLIC DerivedType
+ type :: t1
+  !DEF: /m/t1/opc1 POINTER ObjectEntity REAL(4)
+  real, pointer :: opc1
+  !DEF: /m/t1/opc2 POINTER ObjectEntity REAL(4)
+  real, pointer :: opc2 => null()
+  !DEF: /m/t1/opc3 POINTER ObjectEntity REAL(4)
+  !REF: /m/x
+  real, pointer :: opc3 => x
+  !DEF: /m/t1/opc4 POINTER ObjectEntity REAL(4)
+  !REF: /m/y
+  real, pointer :: opc4 => y(1)
+  !REF: /m/iface
+  !DEF: /m/t1/ppc1 NOPASS, POINTER ProcEntity
+  procedure(iface), nopass, pointer :: ppc1
+  !REF: /m/iface
+  !DEF: /m/t1/ppc2 NOPASS, POINTER ProcEntity
+  procedure(iface), nopass, pointer :: ppc2 => null()
+  !REF: /m/iface
+  !DEF: /m/t1/ppc3 NOPASS, POINTER ProcEntity
+  !REF: /m/ext1
+  procedure(iface), nopass, pointer :: ppc3 => ext1
+  !REF: /m/iface
+  !DEF: /m/t1/ppc4 NOPASS, POINTER ProcEntity
+  !REF: /m/ext2
+  procedure(iface), nopass, pointer :: ppc4 => ext2
+  !REF: /m/iface
+  !DEF: /m/t1/ppc5 NOPASS, POINTER ProcEntity
+  !REF: /m/ext3
+  procedure(iface), nopass, pointer :: ppc5 => ext3
+  !REF: /m/iface
+  !DEF: /m/t1/ppc6 NOPASS, POINTER ProcEntity
+  !REF: /m/modproc1
+  procedure(iface), nopass, pointer :: ppc6 => modproc1
+ contains
+  !DEF: /m/t1/b2 NOPASS ProcBinding
+  !REF: /m/ext2
+  procedure, nopass :: b2 => ext2
+  !DEF: /m/t1/b3 NOPASS ProcBinding
+  !REF: /m/ext3
+  procedure, nopass :: b3 => ext3
+  !DEF: /m/t1/b4 NOPASS ProcBinding
+  !REF: /m/modproc1
+  procedure, nopass :: b4 => modproc1
+ end type
+ !DEF: /m/pdt1 PUBLIC DerivedType
+ !DEF: /m/pdt1/k TypeParam INTEGER(4)
+ type :: pdt1(k)
+  !REF: /m/pdt1/k
+  integer, kind :: k
+  !DEF: /m/pdt1/opc1 POINTER ObjectEntity REAL(4)
+  real, pointer :: opc1
+  !DEF: /m/pdt1/opc2 POINTER ObjectEntity REAL(4)
+  real, pointer :: opc2 => null()
+  !DEF: /m/pdt1/opc3 POINTER ObjectEntity REAL(4)
+  !REF: /m/x
+  real, pointer :: opc3 => x
+  !DEF: /m/pdt1/opc4 POINTER ObjectEntity REAL(4)
+  !REF: /m/y
+  !REF: /m/pdt1/k
+  real, pointer :: opc4 => y(k)
+  !REF: /m/iface
+  !DEF: /m/pdt1/ppc1 NOPASS, POINTER ProcEntity
+  procedure(iface), nopass, pointer :: ppc1
+  !REF: /m/iface
+  !DEF: /m/pdt1/ppc2 NOPASS, POINTER ProcEntity
+  procedure(iface), nopass, pointer :: ppc2 => null()
+  !REF: /m/iface
+  !DEF: /m/pdt1/ppc3 NOPASS, POINTER ProcEntity
+  !REF: /m/ext1
+  procedure(iface), nopass, pointer :: ppc3 => ext1
+  !REF: /m/iface
+  !DEF: /m/pdt1/ppc4 NOPASS, POINTER ProcEntity
+  !REF: /m/ext2
+  procedure(iface), nopass, pointer :: ppc4 => ext2
+  !REF: /m/iface
+  !DEF: /m/pdt1/ppc5 NOPASS, POINTER ProcEntity
+  !REF: /m/ext3
+  procedure(iface), nopass, pointer :: ppc5 => ext3
+  !REF: /m/iface
+  !DEF: /m/pdt1/ppc6 NOPASS, POINTER ProcEntity
+  !REF: /m/modproc1
+  procedure(iface), nopass, pointer :: ppc6 => modproc1
+ contains
+  !DEF: /m/pdt1/b2 NOPASS ProcBinding
+  !REF: /m/ext2
+  procedure, nopass :: b2 => ext2
+  !DEF: /m/pdt1/b3 NOPASS ProcBinding
+  !REF: /m/ext3
+  procedure, nopass :: b3 => ext3
+  !DEF: /m/pdt1/b4 NOPASS ProcBinding
+  !REF: /m/modproc1
+  procedure, nopass :: b4 => modproc1
+ end type
+ !REF: /m/t1
+ !DEF: /m/t1x PUBLIC ObjectEntity TYPE(t1)
+ type(t1) :: t1x
+ !REF: /m/pdt1
+ !DEF: /m/pdt1x PUBLIC ObjectEntity TYPE(pdt1(k=1_4))
+ type(pdt1(1)) :: pdt1x
+ !REF: /m/x
+ !REF: /m/y
+ real, target :: x, y(2)
+ !REF: /m/ext1
+ external :: ext1
+ !REF: /m/iface
+ !REF: /m/ext3
+ procedure(iface) :: ext3
+ interface
+  !REF: /m/ext2
+  subroutine ext2
+  end subroutine
+ end interface
+ !DEF: /m/op10 POINTER, PUBLIC ObjectEntity REAL(4)
+ !REF: /m/x
+ real, pointer :: op10 => x
+ !DEF: /m/op11 POINTER, PUBLIC ObjectEntity REAL(4)
+ !REF: /m/y
+ real, pointer :: op11 => y(1)
+ !REF: /m/iface
+ !DEF: /m/pp10 EXTERNAL, POINTER, PUBLIC ProcEntity
+ !REF: /m/ext1
+ procedure(iface), pointer :: pp10 => ext1
+ !REF: /m/iface
+ !DEF: /m/pp11 EXTERNAL, POINTER, PUBLIC ProcEntity
+ !REF: /m/ext2
+ procedure(iface), pointer :: pp11 => ext2
+ !DEF: /m/t2 PUBLIC DerivedType
+ type :: t2
+  !DEF: /m/t2/opc10 POINTER ObjectEntity REAL(4)
+  !REF: /m/x
+  real, pointer :: opc10 => x
+  !DEF: /m/t2/opc11 POINTER ObjectEntity REAL(4)
+  !REF: /m/y
+  real, pointer :: opc11 => y(1)
+  !REF: /m/iface
+  !DEF: /m/t2/ppc10 NOPASS, POINTER ProcEntity
+  !REF: /m/ext1
+  procedure(iface), nopass, pointer :: ppc10 => ext1
+  !REF: /m/iface
+  !DEF: /m/t2/ppc11 NOPASS, POINTER ProcEntity
+  !REF: /m/ext2
+  procedure(iface), nopass, pointer :: ppc11 => ext2
+ contains
+  !DEF: /m/t2/b10 NOPASS ProcBinding
+  !REF: /m/ext2
+  procedure, nopass :: b10 => ext2
+  !DEF: /m/t2/b11 NOPASS ProcBinding
+  !REF: /m/ext3
+  procedure, nopass :: b11 => ext3
+ end type
+ !DEF: /m/pdt2 PUBLIC DerivedType
+ !DEF: /m/pdt2/k TypeParam INTEGER(4)
+ type :: pdt2(k)
+  !REF: /m/pdt2/k
+  integer, kind :: k
+  !DEF: /m/pdt2/opc10 POINTER ObjectEntity REAL(4)
+  !REF: /m/x
+  real, pointer :: opc10 => x
+  !DEF: /m/pdt2/opc11 POINTER ObjectEntity REAL(4)
+  !REF: /m/y
+  !REF: /m/pdt2/k
+  real, pointer :: opc11 => y(k)
+  !REF: /m/iface
+  !DEF: /m/pdt2/ppc10 NOPASS, POINTER ProcEntity
+  !REF: /m/ext1
+  procedure(iface), nopass, pointer :: ppc10 => ext1
+  !REF: /m/iface
+  !DEF: /m/pdt2/ppc11 NOPASS, POINTER ProcEntity
+  !REF: /m/ext2
+  procedure(iface), nopass, pointer :: ppc11 => ext2
+ contains
+  !DEF: /m/pdt2/b10 NOPASS ProcBinding
+  !REF: /m/ext2
+  procedure, nopass :: b10 => ext2
+  !DEF: /m/pdt2/b11 NOPASS ProcBinding
+  !REF: /m/ext3
+  procedure, nopass :: b11 => ext3
+ end type
+ !REF: /m/t2
+ !DEF: /m/t2x PUBLIC ObjectEntity TYPE(t2)
+ type(t2) :: t2x
+ !REF: /m/pdt2
+ !DEF: /m/pdt2x PUBLIC ObjectEntity TYPE(pdt2(k=1_4))
+ type(pdt2(1)) :: pdt2x
+contains
+ !REF: /m/modproc1
+ subroutine modproc1
+ end subroutine
+end module
+!DEF: /ext1 Subprogram
+subroutine ext1
+end subroutine
+!DEF: /ext2 Subprogram
+subroutine ext2
+end subroutine
+!DEF: /ext3 Subprogram
+subroutine ext3
+end subroutine
+!DEF: /main MainProgram
+program main
+ !REF: /m
+ use :: m
+ !DEF: /main/pdt1 Use
+ !DEF: /main/pdt1y ObjectEntity TYPE(pdt1(k=2_4))
+ type(pdt1(2)) :: pdt1y
+ !DEF: /main/pdt2 Use
+ !DEF: /main/pdt2y ObjectEntity TYPE(pdt2(k=2_4))
+ type(pdt2(2)) :: pdt2y
+ print *, "compiled"
+end program


### PR DESCRIPTION
Add a pass to name resolution to allow for forward references to procedures and interfaces to appear in pointer initializations, procedure component initializations, and type-bound procedure bindings.

(The new `test/semantics/symbol15.f90` walks through the cases and might be worth reading first.)

Also fix `Scope::FindSymbol()` (actually, `CanImport()`) to ensure that symbols from the global scope don't leak into independent compilation units.

Also add a predicate `IsSaved()` to check for the SAVE attribute, including conditions that imply the SAVE attribute.