### PR TITLE
Fix bug with generic and specific having same name

### DIFF
--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -102,7 +102,7 @@ std::ostream &operator<<(std::ostream &os, const SubprogramDetails &x) {
       os << sep << arg->name();
       sep = ',';
     }
-    os << ')';
+    os << (sep == '(' ? "()" : ")");
   }
   return os;
 }

--- a/test/semantics/modfile07.f90
+++ b/test/semantics/modfile07.f90
@@ -168,3 +168,71 @@ end
 !  end
 ! end interface
 !end
+
+module m4
+  interface foo
+    integer function foo()
+    end function
+    integer function f(x)
+    end function
+  end interface
+end
+subroutine s4
+  use m4
+  i = foo()
+end
+!Expect: m4.mod
+!module m4
+! interface foo
+!  procedure::foo
+!  procedure::f
+! end interface
+! interface
+!  function foo()
+!   integer(4)::foo
+!  end
+! end interface
+! interface
+!  function f(x)
+!   integer(4)::f
+!   real(4)::x
+!  end
+! end interface
+!end
+
+! Compile contents of m4.mod and verify it gets the same thing again.
+module m5
+ interface foo
+  procedure::foo
+  procedure::f
+ end interface
+ interface
+  function foo()
+   integer(4)::foo
+  end
+ end interface
+ interface
+  function f(x)
+   integer(4)::f
+   real(4)::x
+  end
+ end interface
+end
+!Expect: m5.mod
+!module m5
+! interface foo
+!  procedure::foo
+!  procedure::f
+! end interface
+! interface
+!  function foo()
+!   integer(4)::foo
+!  end
+! end interface
+! interface
+!  function f(x)
+!   integer(4)::f
+!   real(4)::x
+!  end
+! end interface
+!end


### PR DESCRIPTION
If a generic interface had a specific procedure with the same name that
is specified by an interface body, it was not handled correctly.

We were replacing the generic symbol with the symbol for the specific
procedure. Instead, leave the generic symbol in the scope and just
insert the new symbol for the specific into the generic.

Also, don't do distinguishability checks when one of the specific
procedures already has an error.

Fixes #587.