### PR TITLE
Fix bug #644, always enable backslash escapes when reading module files

### DIFF
--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -695,6 +695,7 @@ Scope *ModFileReader::Read(const SourceName &name, Scope *ancestor) {
   parser::Parsing parsing{context_.allSources()};
   parser::Options options;
   options.isModuleFile = true;
+  options.features.Enable(parser::LanguageFeature::BackslashEscapes);
   parsing.Prescan(*path, options);
   parsing.Parse(nullptr);
   auto &parseTree{parsing.parseTree()};

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -121,7 +121,7 @@ public:
 
 private:
   const common::IntrinsicTypeDefaultKinds &defaultKinds_;
-  const parser::LanguageFeatureControl &languageFeatures_;
+  const parser::LanguageFeatureControl languageFeatures_;
   parser::AllSources &allSources_;
   const parser::CharBlock *location_{nullptr};
   std::vector<std::string> searchDirectories_;


### PR DESCRIPTION
The language feature set used to configure the prescanner for reading module files just needed to enable backslashes (which will always be used by the code that formats character literals back into Fortran).  While here, converted a reference to a small value into a copy of the small value.