### PR TITLE
Fix bugs writing .mod files

### DIFF
--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -91,7 +91,8 @@ std::ostream &Constant<Type<TypeCategory::Character, KIND>>::AsFortran(
     Scalar<Result> value{values_.substr(j * length_, length_)};
     if (j > 0) {
       o << ',';
-    } else if (Rank() == 0 && (Result::kind != 1 || !formatForPGF90)) {
+    }
+    if (Result::kind != 1 || !formatForPGF90) {
       o << Result::kind << '_';
     }
     o << parser::QuoteCharacterLiteral(value);

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -786,11 +786,11 @@ static std::string ModFilePath(const std::string &dir, const SourceName &name,
 void SubprogramSymbolCollector::Collect() {
   const auto &details{symbol_.get<SubprogramDetails>()};
   isInterface_ = details.isInterface();
-  if (details.isFunction()) {
-    DoSymbol(details.result());
-  }
   for (const Symbol *dummyArg : details.dummyArgs()) {
     DoSymbol(DEREF(dummyArg));
+  }
+  if (details.isFunction()) {
+    DoSymbol(details.result());
   }
   for (const auto &pair : scope_) {
     const Symbol *symbol{pair.second};

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -2647,6 +2647,7 @@ void DeclarationVisitor::Post(const parser::EntityDecl &x) {
   const auto &name{std::get<parser::ObjectName>(x.t)};
   Attrs attrs{attrs_ ? HandleSaveName(name.source, *attrs_) : Attrs{}};
   Symbol &symbol{DeclareUnknownEntity(name, attrs)};
+  symbol.ReplaceName(name.source);
   if (auto &init{std::get<std::optional<parser::Initialization>>(x.t)}) {
     if (ConvertToObjectEntity(symbol)) {
       Initialization(name, *init, false);
@@ -2658,7 +2659,8 @@ void DeclarationVisitor::Post(const parser::EntityDecl &x) {
 
 void DeclarationVisitor::Post(const parser::PointerDecl &x) {
   const auto &name{std::get<parser::Name>(x.t)};
-  DeclareUnknownEntity(name, Attrs{Attr::POINTER});
+  Symbol &symbol{DeclareUnknownEntity(name, Attrs{Attr::POINTER})};
+  symbol.ReplaceName(name.source);
 }
 
 bool DeclarationVisitor::Pre(const parser::BindEntity &x) {
@@ -3219,6 +3221,7 @@ void DeclarationVisitor::Post(const parser::DerivedTypeStmt &x) {
     }
   }
   auto &symbol{MakeSymbol(name, GetAttrs(), DerivedTypeDetails{})};
+  symbol.ReplaceName(name.source);
   derivedTypeInfo_.type = &symbol;
   PushScope(Scope::Kind::DerivedType, &symbol);
   if (extendsType != nullptr) {

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -247,6 +247,13 @@ bool Symbol::CanReplaceDetails(const Details &details) const {
   }
 }
 
+// Usually a symbol's name is the first occurrence in the source, but sometimes
+// we want to replace it with one at a different location (but same characters).
+void Symbol::ReplaceName(const SourceName &name) {
+  CHECK(name == name_);
+  name_ = name;
+}
+
 Symbol &Symbol::GetUltimate() {
   return const_cast<Symbol &>(const_cast<const Symbol *>(this)->GetUltimate());
 }

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -465,6 +465,8 @@ public:
   Scope *scope() { return scope_; }
   const Scope *scope() const { return scope_; }
   void set_scope(Scope *scope) { scope_ = scope; }
+  // Give the symbol a name with a different source location but same chars.
+  void ReplaceName(const SourceName &);
 
   // Does symbol have this type of details?
   template<typename D> bool has() const {

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -211,6 +211,7 @@ set(MODFILE_TESTS
   modfile27.f90
   modfile28.f90
   modfile29.f90
+  modfile30.f90
 )
 
 set(LABEL_TESTS

--- a/test/semantics/modfile04.f90
+++ b/test/semantics/modfile04.f90
@@ -65,8 +65,8 @@ end
 !real(4)::x
 !end
 !function f2(y)
-!real(4)::f2
 !complex(4)::y
+!real(4)::f2
 !end
 !end
 
@@ -75,12 +75,12 @@ end
 !contains
 !function f3(x)
 ! use m1,only:t
-! type(t)::f3
 ! type::t2(b)
 !  integer(4),kind::b=2_4
 !  integer(4)::y
 ! end type
 ! type(t2(b=2_4))::x
+! type(t)::f3
 !end
 !function f4() result(x)
 !complex(4)::x

--- a/test/semantics/modfile07.f90
+++ b/test/semantics/modfile07.f90
@@ -51,16 +51,16 @@ end
 ! end interface
 ! interface
 !  function s1(x,y)
-!   real(4)::s1
 !   real(4)::x
 !   real(4)::y
+!   real(4)::s1
 !  end
 ! end interface
 ! interface
 !  function s2(x,y)
-!   complex(4)::s2
 !   complex(4)::x
 !   complex(4)::y
+!   complex(4)::s2
 !  end
 ! end interface
 ! interface operator(+)
@@ -81,14 +81,14 @@ end
 ! end interface
 !contains
 ! function s3(x,y)
-!  logical(4)::s3
 !  logical(4)::x
 !  logical(4)::y
+!  logical(4)::s3
 ! end
 ! function s4(x,y)
-!  integer(4)::s4
 !  integer(4)::x
 !  integer(4)::y
+!  integer(4)::s4
 ! end
 !end
 
@@ -158,11 +158,11 @@ end
 !  subroutine s1(f)
 !   interface
 !    function f(x)
-!     real(4)::f
 !     interface
 !      subroutine x()
 !      end
 !     end interface
+!     real(4)::f
 !    end
 !   end interface
 !  end
@@ -194,8 +194,8 @@ end
 ! end interface
 ! interface
 !  function f(x)
-!   integer(4)::f
 !   real(4)::x
+!   integer(4)::f
 !  end
 ! end interface
 !end
@@ -231,8 +231,8 @@ end
 ! end interface
 ! interface
 !  function f(x)
-!   integer(4)::f
 !   real(4)::x
+!   integer(4)::f
 !  end
 ! end interface
 !end

--- a/test/semantics/modfile19.f90
+++ b/test/semantics/modfile19.f90
@@ -25,9 +25,9 @@ end
 !Expect: m.mod
 !module m
 !  real(4)::x
-!  real(4)::y
 !  integer(4)::i
 !  complex(8)::z
+!  real(4)::y
 !  namelist/nl1/x,y,i,z
 !  namelist/nl2/y,x
 !end

--- a/test/semantics/modfile20.f90
+++ b/test/semantics/modfile20.f90
@@ -12,7 +12,7 @@
 ! See the License for the specific language governing permissions and
 ! limitations under the License.
 
-! Check modfile generation for generic interfaces
+! Test modfiles for entities with initialization
 module m
   integer, parameter :: k8 = 8
   integer(8), parameter :: k4 = k8/2
@@ -20,7 +20,14 @@ module m
   integer(k8), parameter :: i = 2_k8
   real :: r = 2.0_k4
   character(10, kind=k1) :: c = k1_"asdf"
-  complex*16 :: z = (1.0_k8, 2.0_k8)
+  character(10), parameter :: c2 = k1_"qwer"
+  complex*16, parameter :: z = (1.0_k8, 2.0_k8)
+  type t
+    integer :: a = 123
+    type(t), pointer :: b => null()
+  end type
+  type(t), parameter :: x = t(456)
+  type(t), parameter :: y = t(789, null())
 end
 
 !Expect: m.mod
@@ -29,7 +36,14 @@ end
 !  integer(8),parameter::k4=4_8
 !  integer(4),parameter::k1=1_4
 !  integer(8),parameter::i=2_8
-!  real(4)::r=2._4
-!  character(10_4,1)::c=1_"asdf      "
-!  complex(8)::z=(1._8,2._8)
+!  real(4)::r
+!  character(10_4,1)::c
+!  character(10_4,1),parameter::c2=1_"qwer      "
+!  complex(8),parameter::z=(1._8,2._8)
+!  type::t
+!    integer(4)::a=123_4
+!    type(t),pointer::b=>NULL()
+!  end type
+!  type(t),parameter::x=t(a=456_4,b=NULL())
+!  type(t),parameter::y=t(a=789_4,b=NULL())
 !end

--- a/test/semantics/modfile21.f90
+++ b/test/semantics/modfile21.f90
@@ -35,9 +35,9 @@ end
 !  real(4)::c
 !  real(4)::y
 !  real(4)::z
-!  complex(4)::w
 !  real(4)::u
 !  real(4)::v
+!  complex(4)::w
 !  real(4)::cb
 !  common/cb2/a,b,c
 !  bind(c)::/cb2/

--- a/test/semantics/modfile22.f90
+++ b/test/semantics/modfile22.f90
@@ -32,5 +32,5 @@ end module m
 !character(3_4,int(k,kind=8))::b
 !end type
 !type(t(k=1_4)),parameter::p=t(k=1_4)(a=1_"x",b=1_"xx ")
-!character(2_4,1),parameter::c2(1_8:3_8)=[CHARACTER(KIND=1,LEN=2)::"x ","xx","xx"]
+!character(2_4,1),parameter::c2(1_8:3_8)=[CHARACTER(KIND=1,LEN=2)::1_"x ",1_"xx",1_"xx"]
 !end

--- a/test/semantics/modfile28.f90
+++ b/test/semantics/modfile28.f90
@@ -30,7 +30,7 @@ end module m
 !module m
 !character(:,4),parameter::c4=4_"Hi! \344\275\240\345\245\275!"
 !character(:,1),parameter::c1=1_"Hi! \344\275\240\345\245\275!"
-!character(:,4),parameter::c4a(1_8:*)=[CHARACTER(KIND=4,LEN=1)::"\344\270\200","\344\272\214","\344\270\211","\345\233\233","\344\272\224"]
+!character(:,4),parameter::c4a(1_8:*)=[CHARACTER(KIND=4,LEN=1)::4_"\344\270\200",4_"\344\272\214",4_"\344\270\211",4_"\345\233\233",4_"\344\272\224"]
 !integer(4),parameter::lc4=7_4
 !integer(4),parameter::lc1=11_4
 !end

--- a/test/semantics/modfile30.f90
+++ b/test/semantics/modfile30.f90
@@ -39,3 +39,18 @@ end
 !  integer(4)::f2(1_8:1_8*size(x,dim=1))
 ! end
 !end
+
+! Order of names in PUBLIC statement shouldn't affect .mod file.
+module m2
+  public :: a
+  type t
+  end type
+  type(t), parameter :: a = t()
+end
+
+!Expect: m2.mod
+!module m2
+! type::t
+! end type
+! type(t),parameter::a=t()
+!end

--- a/test/semantics/modfile30.f90
+++ b/test/semantics/modfile30.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -12,30 +12,30 @@
 ! See the License for the specific language governing permissions and
 ! limitations under the License.
 
-! Check modfile generation for external interface
-module m
-  interface
-    integer function f(x)
-    end function
-    subroutine s(y, z)
-      logical y
-      complex z
-    end subroutine
-  end interface
+! Verify miscellaneous bugs
+
+! The function result must be declared after the dummy arguments
+module m1
+contains
+  function f1(x) result(y)
+    integer :: x(:)
+    integer :: y(size(x))
+  end
+  function f2(x)
+    integer :: x(:)
+    integer :: f2(size(x))
+  end
 end
 
-!Expect: m.mod
-!module m
-! interface
-!  function f(x)
-!   real(4)::x
-!   integer(4)::f
-!  end
-! end interface
-! interface
-!  subroutine s(y,z)
-!   logical(4)::y
-!   complex(4)::z
-!  end
-! end interface
+!Expect: m1.mod
+!module m1
+!contains
+! function f1(x) result(y)
+!  integer(4)::x(:)
+!  integer(4)::y(1_8:1_8*size(x,dim=1))
+! end
+! function f2(x)
+!  integer(4)::x(:)
+!  integer(4)::f2(1_8:1_8*size(x,dim=1))
+! end
 !end

--- a/test/semantics/modfile30.f90
+++ b/test/semantics/modfile30.f90
@@ -54,3 +54,44 @@ end
 ! end type
 ! type(t),parameter::a=t()
 !end
+
+! Don't write out intrinsics
+module m3a
+  integer, parameter :: i4 = selected_int_kind(9)
+end
+module m3b
+  use m3a
+  integer(i4) :: j
+end
+
+!Expect: m3a.mod
+!module m3a
+! integer(4),parameter::i4=4_4
+!end
+
+!Expect: m3b.mod
+!module m3b
+! use m3a,only:i4
+! integer(4)::j
+!end
+
+! Test that character literals written with backslash escapes are read correctly.
+module m4a
+  character(1), parameter :: a = achar(1)
+end
+module m4b
+  use m4a
+  character(1), parameter :: b = a
+end
+
+!Expect: m4a.mod
+!module m4a
+! character(1_4,1),parameter::a=1_"\001"
+!end
+
+!Expect: m4b.mod
+!module m4b
+! use m4a,only:a
+! character(1_4,1),parameter::b=1_"\001"
+!end
+


### PR DESCRIPTION
See individual commits.

When a `.mod` file is compiled as Fortran (with `-fbackslash`) it should produce exactly the same `.mod` file again. There are no more known cases where that does not happen.