### PR TITLE
Create a throwaway wrapper for the throwaway driver.

### DIFF
--- a/test/semantics/test_errors.sh
+++ b/test/semantics/test_errors.sh
@@ -32,7 +32,7 @@ sed -n 's/^ *! *OPTIONS: *//p' $src > $options
 cat $options
 
 include=$(dirname $(dirname $F18))/include
-cmd="$F18 $F18_OPTIONS -I$include `cat $options` $src"
+cmd="$F18 $F18_OPTIONS -I$include -module-suffix .fmf `cat $options` $src"
 ( cd $temp; $cmd ) > $log 2>&1
 if [[ $? -ge 128 ]]; then
   cat $log

--- a/tools/f18/CMakeLists.txt
+++ b/tools/f18/CMakeLists.txt
@@ -50,15 +50,26 @@ set(MODULES
 
 # Create module files directly from the top-level module source directory
 foreach(filename ${MODULES})
-  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.mod
-    COMMAND f18 -fparse-only -fdebug-semantics ${PROJECT_SOURCE_DIR}/module/${filename}.f90
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.fmf
+    COMMAND f18 -fparse-only -fdebug-semantics -module-suffix .fmf ${PROJECT_SOURCE_DIR}/module/${filename}.f90
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include"
     DEPENDS f18 ${PROJECT_SOURCE_DIR}/module/${filename}.f90
   )
-  list(APPEND MODULE_FILES "${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.mod")
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.mod DESTINATION include)
+  list(APPEND MODULE_FILES "${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.fmf")
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.fmf DESTINATION include)
 endforeach()
 
 add_custom_target(module_files ALL DEPENDS ${MODULE_FILES})
 
 install(TARGETS f18 f18-parse-demo DESTINATION bin)
+
+file(COPY flang.sh
+  DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/bin"
+  FILE_PERMISSIONS
+    OWNER_READ OWNER_WRITE OWNER_EXECUTE
+    GROUP_READ GROUP_EXECUTE
+    WORLD_READ WORLD_EXECUTE
+)
+file(RENAME "${CMAKE_CURRENT_BINARY_DIR}/bin/flang.sh" "${CMAKE_CURRENT_BINARY_DIR}/bin/flang")
+
+install(PROGRAMS flang.sh DESTINATION bin RENAME flang)

--- a/tools/f18/flang.sh
+++ b/tools/f18/flang.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+function abspath() {
+  pushd . > /dev/null;
+  if [ -d "$1" ]; then
+    cd "$1";
+    dirs -l +0;
+  else
+    cd "`dirname \"$1\"`";
+    cur_dir=`dirs -l +0`;
+    if [ "$cur_dir" == "/" ]; then
+      echo "$cur_dir`basename \"$1\"`";
+    else
+      echo "$cur_dir/`basename \"$1\"`";
+    fi;
+  fi;
+  popd > /dev/null;
+}
+
+wd=`abspath $(dirname "$0")/..`
+
+$wd/bin/f18 -fdebug-semantics -module-suffix .fmf -I $wd/include $*


### PR DESCRIPTION
This change makes the throwaway driver more useful as a driver for other compilers because it changes the suffix used for module files to .fmf, including the module files that are generated as part of the build, thus avoiding potential naming collisions with .mod files.  The wrapper is called flang. It also sets the f18 -I option to point to the directory containing the fmf files for the predefined modules.