### PR TITLE
Create a throwaway wrapper for the throwaway driver.

### DIFF
--- a/tools/f18/CMakeLists.txt
+++ b/tools/f18/CMakeLists.txt
@@ -55,10 +55,28 @@ foreach(filename ${MODULES})
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include"
     DEPENDS f18 ${PROJECT_SOURCE_DIR}/module/${filename}.f90
   )
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.fmf
+    COMMAND f18 -fparse-only -fdebug-semantics -module-suffix .fmf ${PROJECT_SOURCE_DIR}/module/${filename}.f90
+    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include"
+    DEPENDS f18 ${PROJECT_SOURCE_DIR}/module/${filename}.f90
+  )
   list(APPEND MODULE_FILES "${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.mod")
+  list(APPEND MODULE_FILES "${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.fmf")
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.mod DESTINATION include)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.fmf DESTINATION include)
 endforeach()
 
 add_custom_target(module_files ALL DEPENDS ${MODULE_FILES})
 
 install(TARGETS f18 f18-parse-demo DESTINATION bin)
+
+file(COPY flang.sh
+  DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/bin"
+  FILE_PERMISSIONS
+    OWNER_READ OWNER_WRITE OWNER_EXECUTE
+    GROUP_READ GROUP_EXECUTE
+    WORLD_READ WORLD_EXECUTE
+)
+file(RENAME "${CMAKE_CURRENT_BINARY_DIR}/bin/flang.sh" "${CMAKE_CURRENT_BINARY_DIR}/bin/flang")
+
+install(PROGRAMS flang.sh DESTINATION bin RENAME flang)

--- a/tools/f18/CMakeLists.txt
+++ b/tools/f18/CMakeLists.txt
@@ -55,15 +55,15 @@ foreach(filename ${MODULES})
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include"
     DEPENDS f18 ${PROJECT_SOURCE_DIR}/module/${filename}.f90
   )
-  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.fmf
-    COMMAND f18 -fparse-only -fdebug-semantics -module-suffix .fmf ${PROJECT_SOURCE_DIR}/module/${filename}.f90
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.f18.mod
+    COMMAND f18 -fparse-only -fdebug-semantics -module-suffix .f18.mod ${PROJECT_SOURCE_DIR}/module/${filename}.f90
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include"
     DEPENDS f18 ${PROJECT_SOURCE_DIR}/module/${filename}.f90
   )
   list(APPEND MODULE_FILES "${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.mod")
-  list(APPEND MODULE_FILES "${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.fmf")
+  list(APPEND MODULE_FILES "${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.f18.mod")
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.mod DESTINATION include)
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.fmf DESTINATION include)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.f18.mod DESTINATION include)
 endforeach()
 
 add_custom_target(module_files ALL DEPENDS ${MODULE_FILES})

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -471,6 +471,9 @@ int main(int argc, char *const argv[]) {
     } else if (arg == "-module-suffix") {
       driver.moduleFileSuffix = args.front();
       args.pop_front();
+    } else if (arg == "-intrinsic-module-directory") {
+      driver.searchDirectories.push_back(args.front());
+      args.pop_front();
     } else if (arg == "-futf-8") {
       driver.encoding = Fortran::parser::Encoding::UTF_8;
     } else if (arg == "-flatin") {

--- a/tools/f18/flang.sh
+++ b/tools/f18/flang.sh
@@ -19,4 +19,4 @@ function abspath() {
 
 wd=`abspath $(dirname "$0")/..`
 
-$wd/bin/f18 -fdebug-semantics -module-suffix .fmf -I $wd/include $*
+${wd}/bin/f18 -fdebug-semantics -module-suffix .f18.mod -intrinsic-module-directory ${wd}/include $*

--- a/tools/f18/flang.sh
+++ b/tools/f18/flang.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+function abspath() {
+  pushd . > /dev/null;
+  if [ -d "$1" ]; then
+    cd "$1";
+    dirs -l +0;
+  else
+    cd "`dirname \"$1\"`";
+    cur_dir=`dirs -l +0`;
+    if [ "$cur_dir" == "/" ]; then
+      echo "$cur_dir`basename \"$1\"`";
+    else
+      echo "$cur_dir/`basename \"$1\"`";
+    fi;
+  fi;
+  popd > /dev/null;
+}
+
+wd=`abspath $(dirname "$0")/..`
+
+$wd/bin/f18 -fdebug-semantics -module-suffix .fmf -I $wd/include $*


### PR DESCRIPTION
Add a script called flang to the bin directory that calls f18 with the -I option pointing to the module files for the predefined modules. The wrapper also sets the module suffix to .fmf to avoid conflicts with module file names generated by other compilers. Also, now the build creates and installs both
.mod and .fmf files for the predefined module files, the latter to accommodate the flang script.