### PR TITLE
Checks for constraint C1129

### DIFF
--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -143,6 +143,7 @@ set(ERROR_TESTS
   dosemantics06.f90
   dosemantics07.f90
   dosemantics08.f90
+  dosemantics09.f90
   expr-errors01.f90
   null01.f90
   omp-clause-validity01.f90

--- a/test/semantics/dosemantics04.f90
+++ b/test/semantics/dosemantics04.f90
@@ -18,12 +18,12 @@ PROGRAM dosemantics04
   IMPLICIT NONE
   INTEGER :: a, i, j, k, n
 
-!ERROR: concurrent-header mask-expr references variable 'n' in locality-spec
+!ERROR: concurrent-header mask-expr references variable 'n' in LOCAL locality-spec
   DO CONCURRENT (INTEGER *2 :: i = 1:10, i < j + n) LOCAL(n)
     PRINT *, "hello"
   END DO
 
-!ERROR: concurrent-header mask-expr references variable 'a' in locality-spec
+!ERROR: concurrent-header mask-expr references variable 'a' in LOCAL locality-spec
   DO 30 CONCURRENT (i = 1:n:1, j=1:n:2, k=1:n:3, a<3) LOCAL (a)
     PRINT *, "hello"
 30 END DO

--- a/test/semantics/dosemantics04.f90
+++ b/test/semantics/dosemantics04.f90
@@ -18,11 +18,12 @@ PROGRAM dosemantics04
   IMPLICIT NONE
   INTEGER :: a, i, j, k, n
 
-! No problems here
+!ERROR: concurrent-header mask-expr references variable 'n' in locality-spec
   DO CONCURRENT (INTEGER *2 :: i = 1:10, i < j + n) LOCAL(n)
     PRINT *, "hello"
   END DO
 
+!ERROR: concurrent-header mask-expr references variable 'a' in locality-spec
   DO 30 CONCURRENT (i = 1:n:1, j=1:n:2, k=1:n:3, a<3) LOCAL (a)
     PRINT *, "hello"
 30 END DO

--- a/test/semantics/dosemantics09.f90
+++ b/test/semantics/dosemantics09.f90
@@ -1,0 +1,125 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+!C1129 
+!A variable that is referenced by the scalar-mask-expr of a
+!concurrent-header or by any concurrent-limit or concurrent-step in that
+!concurrent-header shall not appear in a LOCAL locality-spec in the same DO
+!CONCURRENT statement.
+
+subroutine s1()
+
+!ERROR: 'i' is already declared in this scoping unit
+  do concurrent (i=1:10) local(i)
+  end do
+end subroutine s1
+
+subroutine s2()
+!ERROR: 'i' is already declared in this scoping unit
+  do concurrent (i=1:10) local_init(i)
+  end do
+end subroutine s2
+
+subroutine s3()
+!ERROR: 'i' is already declared in this scoping unit
+  do concurrent (i=i:10) shared(i)
+  end do
+end subroutine s3
+
+subroutine s4()
+!ERROR: concurrent-header expression references variable 'i' in locality-spec
+  do concurrent (j=i:10) local(i)
+  end do
+end subroutine s4
+
+subroutine s5()
+  !OK because the locality-spec is local_init
+  do concurrent (j=i:10) local_init(i)
+  end do
+end subroutine s5
+
+subroutine s6()
+  !OK because the locality-spec is shared
+  do concurrent (j=i:10) shared(i)
+  end do
+end subroutine s6
+
+subroutine s7()
+!ERROR: concurrent-header expression references variable 'i' in locality-spec
+  do concurrent (j=1:i) local(i)
+  end do
+end subroutine s7
+
+subroutine s8()
+  !OK because the locality-spec is local_init
+  do concurrent (j=1:i) local_init(i)
+  end do
+end subroutine s8
+
+subroutine s9()
+  !OK because the locality-spec is shared
+  do concurrent (j=1:i) shared(i)
+  end do
+end subroutine s9
+
+subroutine s10()
+!ERROR: concurrent-header expression references variable 'i' in locality-spec
+  do concurrent (j=1:10:i) local(i)
+  end do
+end subroutine s10
+
+subroutine s11()
+  !OK because the locality-spec is local_init
+  do concurrent (j=1:10:i) local_init(i)
+  end do
+end subroutine s11
+
+subroutine s12()
+  !OK because the locality-spec is shared
+  do concurrent (j=1:10:i) shared(i)
+  end do
+end subroutine s12
+
+subroutine s13()
+  ! Test construct-association, in this case, established by the "shared"
+  integer :: ivar
+  associate (avar => ivar)
+!ERROR: concurrent-header expression references variable 'ivar' in locality-spec
+    do concurrent (j=1:10:avar) local(avar)
+    end do
+  end associate
+end subroutine s13
+
+module m1
+  integer :: mvar
+end module m1
+subroutine s14()
+  ! Test use-association, in this case, established by the "shared"
+  use m1
+
+!ERROR: concurrent-header expression references variable 'mvar' in locality-spec
+  do concurrent (k=mvar:10) local(mvar)
+  end do
+end subroutine s14
+
+subroutine s15()
+  ! Test host-association, in this case, established by the "shared"
+  ! locality-spec
+  ivar = 3
+  do concurrent (j=ivar:10) shared(ivar)
+!ERROR: concurrent-header expression references variable 'ivar' in locality-spec
+    do concurrent (k=ivar:10) local(ivar)
+    end do
+  end do
+end subroutine s15

--- a/test/semantics/dosemantics09.f90
+++ b/test/semantics/dosemantics09.f90
@@ -31,14 +31,8 @@ subroutine s2()
   end do
 end subroutine s2
 
-subroutine s3()
-!ERROR: 'i' is already declared in this scoping unit
-  do concurrent (i=i:10) shared(i)
-  end do
-end subroutine s3
-
 subroutine s4()
-!ERROR: concurrent-header expression references variable 'i' in locality-spec
+!ERROR: concurrent-header expression references variable 'i' in LOCAL locality-spec
   do concurrent (j=i:10) local(i)
   end do
 end subroutine s4
@@ -56,7 +50,7 @@ subroutine s6()
 end subroutine s6
 
 subroutine s7()
-!ERROR: concurrent-header expression references variable 'i' in locality-spec
+!ERROR: concurrent-header expression references variable 'i' in LOCAL locality-spec
   do concurrent (j=1:i) local(i)
   end do
 end subroutine s7
@@ -74,7 +68,7 @@ subroutine s9()
 end subroutine s9
 
 subroutine s10()
-!ERROR: concurrent-header expression references variable 'i' in locality-spec
+!ERROR: concurrent-header expression references variable 'i' in LOCAL locality-spec
   do concurrent (j=1:10:i) local(i)
   end do
 end subroutine s10
@@ -95,7 +89,7 @@ subroutine s13()
   ! Test construct-association, in this case, established by the "shared"
   integer :: ivar
   associate (avar => ivar)
-!ERROR: concurrent-header expression references variable 'ivar' in locality-spec
+!ERROR: concurrent-header expression references variable 'ivar' in LOCAL locality-spec
     do concurrent (j=1:10:avar) local(avar)
     end do
   end associate
@@ -108,7 +102,7 @@ subroutine s14()
   ! Test use-association, in this case, established by the "shared"
   use m1
 
-!ERROR: concurrent-header expression references variable 'mvar' in locality-spec
+!ERROR: concurrent-header expression references variable 'mvar' in LOCAL locality-spec
   do concurrent (k=mvar:10) local(mvar)
   end do
 end subroutine s14
@@ -118,7 +112,7 @@ subroutine s15()
   ! locality-spec
   ivar = 3
   do concurrent (j=ivar:10) shared(ivar)
-!ERROR: concurrent-header expression references variable 'ivar' in locality-spec
+!ERROR: concurrent-header expression references variable 'ivar' in LOCAL locality-spec
     do concurrent (k=ivar:10) local(ivar)
     end do
   end do


### PR DESCRIPTION
"A variable that is referenced by the scalar-mask-expr of a concurrent-header or by any concurrent-limit or concurrent-step in that concurrent-header shall not appear in a LOCAL locality-spec in the same DO CONCURRENT statement."

In the process of implementing these checks, I found and fixed some other problems.  I also cleaned up some of the code in check-do.cc.  I ran into two notable difficulties in implementing these checks.  First, the symbols associated with the names in a locality spec get created when the locality specs are process during name resolution.  Thus, they're different from the symbols associated with names that appear in the control expressions.  At Tim's suggestion, I dealt with this by looking up the symbols from the names in the locality spec starting with the closest enclosing scope containing the DO construct.  Second, the symbols can be hidden behind host- use- and construct-associations.