### PR TITLE
[OpenMP] miscellaneous parse tree fix

### DIFF
--- a/lib/parser/openmp-grammar.h
+++ b/lib/parser/openmp-grammar.h
@@ -156,7 +156,7 @@ TYPE_CONTEXT_PARSER("Omp LINEAR clause"_en_US,
 
 // ALIGNED(list: alignment)
 TYPE_PARSER(construct<OmpAlignedClause>(
-    nonemptyList(name), maybe(":"_tok) >> scalarIntConstantExpr))
+    nonemptyList(name), maybe(":" >> scalarIntConstantExpr)))
 
 TYPE_PARSER(construct<OmpObject>(pure(OmpObject::Kind::Object), designator) ||
     construct<OmpObject>(

--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -276,6 +276,16 @@ void OmpStructureChecker::Enter(const parser::OmpEndSectionsDirective &x) {
 void OmpStructureChecker::Enter(const parser::OpenMPDeclareSimdConstruct &x) {
   const auto &dir{std::get<parser::Verbatim>(x.t)};
   PushContext(dir.source, OmpDirective::DECLARE_SIMD);
+  // 2.8.2 declare-simd-clause -> simdlen-clause |
+  //                              linear-clause |
+  //                              aligned-clause |
+  //                              uniform-clause |
+  //                              inbranch-clause |
+  //                              notinbranch-clause
+  OmpClauseSet allowed{OmpClause::LINEAR, OmpClause::ALIGNED,
+      OmpClause::UNIFORM, OmpClause::INBRANCH, OmpClause::NOTINBRANCH};
+  SetContextAllowed(allowed);
+  SetContextAllowedOnce(OmpClauseSet{OmpClause::SIMDLEN});
 }
 
 void OmpStructureChecker::Leave(const parser::OpenMPDeclareSimdConstruct &) {

--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -285,7 +285,7 @@ void OmpStructureChecker::Enter(const parser::OpenMPDeclareSimdConstruct &x) {
   OmpClauseSet allowed{OmpClause::LINEAR, OmpClause::ALIGNED,
       OmpClause::UNIFORM, OmpClause::INBRANCH, OmpClause::NOTINBRANCH};
   SetContextAllowed(allowed);
-  SetContextAllowedOnce(OmpClauseSet{OmpClause::SIMDLEN});
+  SetContextAllowedOnce({OmpClause::SIMDLEN});
 }
 
 void OmpStructureChecker::Leave(const parser::OpenMPDeclareSimdConstruct &) {

--- a/test/semantics/omp-declarative-directive.f90
+++ b/test/semantics/omp-declarative-directive.f90
@@ -24,7 +24,8 @@
 subroutine declare_simd_1(a, b)
   real(8), intent(inout) :: a, b
   !ERROR: Internal: no symbol found for 'declare_simd_1'
-  !$omp declare simd(declare_simd_1)
+  !ERROR: Internal: no symbol found for 'a'
+  !$omp declare simd(declare_simd_1) aligned(a)
   a = 3.14 + b
 end subroutine declare_simd_1
 


### PR DESCRIPTION
Happen to see the bug for `aligned` clause.

Fix `aligned(argument-list[ : alignment])` for `declare simd`.