### PR TITLE
 Handle AssocEntityDetails in mis-parsed function reference

### DIFF
--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1885,6 +1885,8 @@ static void FixMisparsedFunctionReference(
       Symbol &symbol{origSymbol->GetUltimate()};
       if (symbol.has<semantics::ObjectEntityDetails>() ||
           symbol.has<semantics::AssocEntityDetails>()) {
+        // Note that expression in AssocEntityDetails cannot be a procedure
+        // pointer as per C1105 so this cannot be a function reference.
         if constexpr (common::HasMember<common::Indirection<parser::Designator>,
                           uType>) {
           CheckFuncRefToArrayElementRefHasSubscripts(context, funcRef);

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1883,7 +1883,8 @@ static void FixMisparsedFunctionReference(
             },
             proc.u)}) {
       Symbol &symbol{origSymbol->GetUltimate()};
-      if (symbol.has<semantics::ObjectEntityDetails>()) {
+      if (symbol.has<semantics::ObjectEntityDetails>() ||
+          symbol.has<semantics::AssocEntityDetails>()) {
         if constexpr (common::HasMember<common::Indirection<parser::Designator>,
                           uType>) {
           CheckFuncRefToArrayElementRefHasSubscripts(context, funcRef);

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -5058,7 +5058,8 @@ void ResolveNamesVisitor::HandleProcedureName(
       return;  // reported error
     }
     if (IsProcedure(*symbol) || symbol->has<DerivedTypeDetails>() ||
-        symbol->has<ObjectEntityDetails>()) {
+        symbol->has<ObjectEntityDetails>() ||
+        symbol->has<AssocEntityDetails>()) {
       // these are all valid as procedure-designators
     } else if (symbol->test(Symbol::Flag::Implicit)) {
       Say(name,

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -5060,7 +5060,11 @@ void ResolveNamesVisitor::HandleProcedureName(
     if (IsProcedure(*symbol) || symbol->has<DerivedTypeDetails>() ||
         symbol->has<ObjectEntityDetails>() ||
         symbol->has<AssocEntityDetails>()) {
-      // these are all valid as procedure-designators
+      // Symbols with DerivedTypeDetails, ObjectEntityDetails and
+      // AssocEntityDetails are accepted here as procedure-designators because
+      // this means the related FunctionReference are mis-parsed structure
+      // constructors or array references that will be fixed later when
+      // analyzing expressions.
     } else if (symbol->test(Symbol::Flag::Implicit)) {
       Say(name,
           "Use of '%s' as a procedure conflicts with its implicit definition"_err_en_US);

--- a/test/semantics/resolve39.f90
+++ b/test/semantics/resolve39.f90
@@ -28,3 +28,18 @@ subroutine s2
   associate (a => z'1')
   end associate
 end
+
+subroutine s3
+! Test that associated entities are not preventing to fix
+! mis-parsed function references into array references
+  real :: a(10)
+  associate (b => a(2:10:2))
+    ! Check no complains about "Use of 'b' as a procedure"
+    print *, b(1) ! OK
+  end associate
+  associate (c => a(2:10:2))
+    ! Check the function reference has been fixed to an array reference
+    !ERROR: Reference to array 'c' with empty subscript list
+    print *, c()
+  end associate
+end


### PR DESCRIPTION
Fix issue #574.
Array references can be mistaken for function references during parsing. This is handled and fixed by semantics. however, if the symbol in the mis-parsed array reference was construct associated,
then semantics was not handling the case correctly because
semantics was only expecting `ObjectEntityDetails`.
It was not possible to change the related `GetUltimate` into `GetAssociationRoot` because associated symbols are not always associated to another symbol (variable) but may be associated to an expression. Hence, this change simply allows `AssocEntityDetails` to be also accepted when dealing with array references mis-parsed as function references.