### PR TITLE
[OpenMP] miscellaneous parse tree updates

### DIFF
--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -1901,7 +1901,7 @@ public:
   }
   void Unparse(const OmpClause::From &x) {
     Word("FROM(");
-    Walk(x.v, ",");
+    Walk(x.v);
     Put(")");
   }
   void Unparse(const OmpClause::Grainsize &x) {
@@ -1965,12 +1965,12 @@ public:
   }
   void Unparse(const OmpClause::To &x) {
     Word("TO(");
-    Walk(x.v, ",");
+    Walk(x.v);
     Put(")");
   }
   void Unparse(const OmpClause::Link &x) {
     Word("LINK(");
-    Walk(x.v, ",");
+    Walk(x.v);
     Put(")");
   }
   void Unparse(const OmpClause::Uniform &x) {


### PR DESCRIPTION
1. Big chunk: update comments in parse-tree.h and openmp-grammar.h
   with Spec chapter/section info, simple explanation, or productions.

2. Update `To`, `Link`, and `From` clauses with `OmpObjectList` to allow
   `/Common Block/`. Spec does not mention whether `Common Block name`
   should be accepted or not, so we should assume that these clauses
   accept normal `list-item`, which is `Variable`, `Array Section`, or
   `Common Block name`.