### PR TITLE
 Fix issue: Enforce specific intrinsic characteristics

### DIFF
--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -1206,10 +1206,9 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
           DynamicType{*category, defaults.GetDefaultKind(TypeCategory::Real)};
       break;
     case KindCode::doublePrecision:
-      CHECK(result.categorySet == RealType);
-      CHECK(*category == TypeCategory::Real);
-      resultType =
-          DynamicType{TypeCategory::Real, defaults.doublePrecisionKind()};
+      CHECK(result.categorySet == CategorySet{*category});
+      CHECK(FloatingType.test(*category));
+      resultType = DynamicType{*category, defaults.doublePrecisionKind()};
       break;
     case KindCode::defaultCharKind:
       CHECK(result.categorySet == CharType);

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -1618,40 +1618,34 @@ std::optional<SpecificCall> IntrinsicProcTable::Implementation::Probe(
        ++specIter) {
     // We only need to check the cases with distinct generic names.
     if (const char *genericName{specIter->second->generic}) {
-      auto genericRange{genericFuncs_.equal_range(genericName)};
-      for (auto genIter{genericRange.first}; genIter != genericRange.second;
-           ++genIter) {
-        if (auto specificCall{genIter->second->Match(
-                call, defaults_, arguments, localContext)}) {
-          specificCall->specificIntrinsic.name = genericName;
-          specificCall->specificIntrinsic.isRestrictedSpecific =
-              specIter->second->isRestrictedSpecific;
-          if (finalBuffer != nullptr) {
-            finalBuffer->Annex(std::move(localBuffer));
-          }
-          if (specIter->second->forceResultType) {
-            // Force the result type on AMAX0/1, MIN0/1, &c.
-            TypeCategory category{TypeCategory::Integer};
-            switch (specIter->second->result.kindCode) {
-            case KindCode::defaultIntegerKind: break;
-            case KindCode::defaultRealKind:
-              category = TypeCategory::Real;
-              break;
-            default: CRASH_NO_CASE;
-            }
-            DynamicType newType{category, defaults_.GetDefaultKind(category)};
-            specificCall->specificIntrinsic.characteristics.value()
-                .functionResult.value()
-                .SetType(newType);
-          }
-          // TODO test feature AdditionalIntrinsics, warn on nonstandard
-          // specifics with DoublePrecisionComplex arguments.
-          return specificCall;
-        } else if (specificBuffer.empty()) {
-          specificBuffer.Annex(std::move(localBuffer));
-        } else {
-          specificBuffer.clear();
+      if (auto specificCall{specIter->second->Match(
+              call, defaults_, arguments, localContext)}) {
+        specificCall->specificIntrinsic.name = genericName;
+        specificCall->specificIntrinsic.isRestrictedSpecific =
+            specIter->second->isRestrictedSpecific;
+        if (finalBuffer != nullptr) {
+          finalBuffer->Annex(std::move(localBuffer));
         }
+        if (specIter->second->forceResultType) {
+          // Force the result type on AMAX0/1, MIN0/1, &c.
+          TypeCategory category{TypeCategory::Integer};
+          switch (specIter->second->result.kindCode) {
+          case KindCode::defaultIntegerKind: break;
+          case KindCode::defaultRealKind: category = TypeCategory::Real; break;
+          default: CRASH_NO_CASE;
+          }
+          DynamicType newType{category, defaults_.GetDefaultKind(category)};
+          specificCall->specificIntrinsic.characteristics.value()
+              .functionResult.value()
+              .SetType(newType);
+        }
+        // TODO test feature AdditionalIntrinsics, warn on nonstandard
+        // specifics with DoublePrecisionComplex arguments.
+        return specificCall;
+      } else if (specificBuffer.empty()) {
+        specificBuffer.Annex(std::move(localBuffer));
+      } else {
+        specificBuffer.clear();
       }
     }
   }

--- a/test/evaluate/intrinsics.cc
+++ b/test/evaluate/intrinsics.cc
@@ -226,6 +226,16 @@ void TestIntrinsics() {
   amin1Call.DoCall(Real4::GetType());
   amin1WrongCall.DoCall();
 
+  TestCall{table, "conjg"}
+      .Push(Const(Scalar<Complex4>{}))
+      .DoCall(Complex4::GetType());
+  TestCall{table, "conjg"}
+      .Push(Const(Scalar<Complex8>{}))
+      .DoCall(Complex8::GetType());
+  TestCall{table, "dconjg"}.Push(Const(Scalar<Complex4>{})).DoCall();
+  TestCall{table, "dconjg"}
+      .Push(Const(Scalar<Complex8>{}))
+      .DoCall(Complex8::GetType());
   // TODO: test other intrinsics
 }
 }


### PR DESCRIPTION

Fix issue #661.
The issue was that when probing a specific intrinsic, the constraints of the related generic intrinsic were tested instead of the more restrictive constraints of the specific intrinsic.

For issue #661 program, f18 now raises error: 
```
error: Actual argument for 'a=' has bad type or kind 'Complex(4)'
    c = dconjg(a)
        ^^^^^^
```

During the fix, found and fix an issue with `DOUBLE COMPLEX` in intrinsic matching. The intrinsic matching was only expecting REAL for kind code `KindCode::doublePrecision` that is also used for `DoublePrecisionComplex` (This caused an internal error when using `dconjg` with an complex(8) arg).