### PR TITLE
Fix for builds with libc++9 and libstdc++10

### DIFF
--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -632,7 +632,7 @@ WRAPPER_CLASS(IntegerTypeSpec, std::optional<KindSelector>);
 // R723 char-length -> ( type-param-value ) | digit-string
 struct CharLength {
   UNION_CLASS_BOILERPLATE(CharLength);
-  std::variant<TypeParamValue, std::int64_t> u;
+  std::variant<TypeParamValue, std::uint64_t> u;
 };
 
 // R722 length-selector -> ( [LEN =] type-param-value ) | * char-length [,]
@@ -2931,6 +2931,9 @@ struct GenericStmt {
 // R1503 interface-stmt -> INTERFACE [generic-spec] | ABSTRACT INTERFACE
 struct InterfaceStmt {
   UNION_CLASS_BOILERPLATE(InterfaceStmt);
+  // Workaround for clang with libstc++10 bug
+  InterfaceStmt(Abstract x) : u(x) {}
+
   std::variant<std::optional<GenericSpec>, Abstract> u;
 };
 

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -2998,8 +2998,9 @@ void DeclarationVisitor::Post(const parser::CharSelector::LengthAndKind &x) {
   }
 }
 void DeclarationVisitor::Post(const parser::CharLength &x) {
-  if (const auto *length{std::get_if<std::int64_t>(&x.u)}) {
-    charInfo_.length = ParamValue{*length, common::TypeParamAttr::Len};
+  if (const auto *length{std::get_if<std::uint64_t>(&x.u)}) {
+    charInfo_.length = ParamValue{static_cast<ConstantSubscript>(*length),
+                                  common::TypeParamAttr::Len};
   } else {
     charInfo_.length = GetParamValue(
         std::get<parser::TypeParamValue>(x.u), common::TypeParamAttr::Len);


### PR DESCRIPTION
The behaviour of std::variant has been changed in the standard to forbid narrowing conversions. This behaviour is applied to variant in every standard version in both libc++9 and libstdc++10. This patch simply adds casts so that the narrowing converions don't occur anymore.

Clang (or libstdc++) also has a bug whereby the compiler greedily instantiates too far down a template stack and fails to find a valid constructor even though one exists. This patch also adds a workaround in the one place where this manifests in the f18 code, forcing clang to find the correct constructor.

Fixes issue #664 