### PR TITLE
Changes to add an executable construct stack

### DIFF
--- a/lib/semantics/check-do.cc
+++ b/lib/semantics/check-do.cc
@@ -647,21 +647,20 @@ void DoChecker::Leave(const parser::DoConstruct &x) {
   doContext.Check(x);
 }
 
-void DoChecker::CheckLoneStmt(const char *stmtString) const {
-  for (auto &executable : context_.executables()) {
-    if (std::holds_alternative<common::Indirection<parser::DoConstruct>>(
-            executable->u)) {
-      return;
-    }
+// C1134
+void DoChecker::Enter(const parser::CycleStmt &) {
+  if (!context_.InsideDoConstruct()) {
+    context_.Say(
+        *context_.location(), "CYCLE must be within a DO construct"_err_en_US);
   }
-  context_.Say(*context_.location(),
-      "%s must be within a DO construct"_err_en_US, stmtString);
 }
 
-// C1134
-void DoChecker::Enter(const parser::CycleStmt &) { CheckLoneStmt("CYCLE"); }
-
 // C1166
-void DoChecker::Enter(const parser::ExitStmt &) { CheckLoneStmt("EXIT"); }
+void DoChecker::Enter(const parser::ExitStmt &) {
+  if (!context_.InsideDoConstruct()) {
+    context_.Say(
+        *context_.location(), "EXIT must be within a DO construct"_err_en_US);
+  }
+}
 
 }  // namespace Fortran::semantics

--- a/lib/semantics/check-do.cc
+++ b/lib/semantics/check-do.cc
@@ -647,4 +647,21 @@ void DoChecker::Leave(const parser::DoConstruct &x) {
   doContext.Check(x);
 }
 
+void DoChecker::CheckLoneStmt(const char *stmtString) const {
+  for (auto &executable : context_.executables()) {
+    if (std::holds_alternative<common::Indirection<parser::DoConstruct>>(
+            executable->u)) {
+      return;
+    }
+  }
+  context_.Say(*context_.location(),
+      "%s must be within a DO construct"_err_en_US, stmtString);
+}
+
+// C1134
+void DoChecker::Enter(const parser::CycleStmt &) { CheckLoneStmt("CYCLE"); }
+
+// C1166
+void DoChecker::Enter(const parser::ExitStmt &) { CheckLoneStmt("EXIT"); }
+
 }  // namespace Fortran::semantics

--- a/lib/semantics/check-do.h
+++ b/lib/semantics/check-do.h
@@ -27,8 +27,12 @@ class DoChecker : public virtual BaseChecker {
 public:
   explicit DoChecker(SemanticsContext &context) : context_{context} {}
   void Leave(const parser::DoConstruct &);
+  void Enter(const parser::CycleStmt &);
+  void Enter(const parser::ExitStmt &);
 
 private:
+  void CheckLoneStmt(const char *const) const;
+
   SemanticsContext &context_;
 };
 }

--- a/lib/semantics/check-do.h
+++ b/lib/semantics/check-do.h
@@ -19,6 +19,8 @@
 
 namespace Fortran::parser {
 struct DoConstruct;
+struct CycleStmt;
+struct ExitStmt;
 }
 
 namespace Fortran::semantics {
@@ -31,8 +33,6 @@ public:
   void Enter(const parser::ExitStmt &);
 
 private:
-  void CheckLoneStmt(const char *const) const;
-
   SemanticsContext &context_;
 };
 }

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -57,10 +57,18 @@ public:
     : C{context}..., context_{context} {}
 
   template<typename N> bool Pre(const N &node) {
+    if constexpr (common::HasMember<const N *, ConstructNode>) {
+      context_.PushConstruct(node);
+    }
     Enter(node);
     return true;
   }
-  template<typename N> void Post(const N &node) { Leave(node); }
+  template<typename N> void Post(const N &node) {
+    Leave(node);
+    if constexpr (common::HasMember<const N *, ConstructNode>) {
+      context_.PopConstruct();
+    }
+  }
 
   template<typename T> bool Pre(const parser::Statement<T> &node) {
     context_.set_location(node.source);
@@ -79,127 +87,6 @@ public:
   template<typename T> void Post(const parser::UnlabeledStatement<T> &node) {
     Leave(node);
     context_.set_location(std::nullopt);
-  }
-
-  bool Pre(const parser::AssociateConstruct &associateConstruct) {
-    context_.PushConstruct(associateConstruct);
-    Enter(associateConstruct);
-    return true;
-  }
-
-  bool Pre(const parser::BlockConstruct &blockConstruct) {
-    context_.PushConstruct(blockConstruct);
-    Enter(blockConstruct);
-    return true;
-  }
-
-  bool Pre(const parser::CaseConstruct &caseConstruct) {
-    context_.PushConstruct(caseConstruct);
-    Enter(caseConstruct);
-    return true;
-  }
-
-  bool Pre(const parser::CriticalConstruct &criticalConstruct) {
-    context_.PushConstruct(criticalConstruct);
-    Enter(criticalConstruct);
-    return true;
-  }
-
-  bool Pre(const parser::ChangeTeamConstruct &changeTeamConstruct) {
-    context_.PushConstruct(changeTeamConstruct);
-    Enter(changeTeamConstruct);
-    return true;
-  }
-
-  bool Pre(const parser::DoConstruct &doConstruct) {
-    context_.PushConstruct(doConstruct);
-    Enter(doConstruct);
-    return true;
-  }
-
-  bool Pre(const parser::ForAllConstruct &forAllConstruct) {
-    context_.PushConstruct(&forAllConstruct);
-    Enter(forAllConstruct);
-    return true;
-  }
-
-  bool Pre(const parser::IfConstruct &ifConstruct) {
-    context_.PushConstruct(ifConstruct);
-    Enter(ifConstruct);
-    return true;
-  }
-
-  bool Pre(const parser::SelectRankConstruct &selectRankConstruct) {
-    context_.PushConstruct(selectRankConstruct);
-    Enter(selectRankConstruct);
-    return true;
-  }
-
-  bool Pre(const parser::SelectTypeConstruct &selectTypeConstruct) {
-    context_.PushConstruct(selectTypeConstruct);
-    Enter(selectTypeConstruct);
-    return true;
-  }
-
-  bool Pre(const parser::WhereConstruct &whereConstruct) {
-    context_.PushConstruct(whereConstruct);
-    Enter(whereConstruct);
-    return true;
-  }
-
-  void Post(const parser::AssociateConstruct &associateConstruct) {
-    Leave(associateConstruct);
-    context_.PopConstruct();
-  }
-
-  void Post(const parser::BlockConstruct &blockConstruct) {
-    Leave(blockConstruct);
-    context_.PopConstruct();
-  }
-
-  void Post(const parser::CaseConstruct &caseConstruct) {
-    Leave(caseConstruct);
-    context_.PopConstruct();
-  }
-
-  void Post(const parser::DoConstruct &doConstruct) {
-    Leave(doConstruct);
-    context_.PopConstruct();
-  }
-
-  void Post(const parser::CriticalConstruct &criticalConstruct) {
-    Leave(criticalConstruct);
-    context_.PopConstruct();
-  }
-
-  void Post(const parser::ChangeTeamConstruct &changeTeamConstruct) {
-    Leave(changeTeamConstruct);
-    context_.PopConstruct();
-  }
-
-  void Post(const parser::ForAllConstruct &forAllConstruct) {
-    Leave(forAllConstruct);
-    context_.PopConstruct();
-  }
-
-  void Post(const parser::IfConstruct &ifConstruct) {
-    Leave(ifConstruct);
-    context_.PopConstruct();
-  }
-
-  void Post(const parser::SelectRankConstruct &selectRankConstruct) {
-    Leave(selectRankConstruct);
-    context_.PopConstruct();
-  }
-
-  void Post(const parser::SelectTypeConstruct &selectTypeConstruct) {
-    Leave(selectTypeConstruct);
-    context_.PopConstruct();
-  }
-
-  void Post(const parser::WhereConstruct &whereConstruct) {
-    Leave(whereConstruct);
-    context_.PopConstruct();
   }
 
   bool Walk(const parser::Program &program) {

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -82,67 +82,67 @@ public:
   }
 
   bool Pre(const parser::AssociateConstruct &associateConstruct) {
-    context_.PushConstruct(ConstructNode{&associateConstruct});
+    context_.PushConstruct(associateConstruct);
     Enter(associateConstruct);
     return true;
   }
 
   bool Pre(const parser::BlockConstruct &blockConstruct) {
-    context_.PushConstruct(ConstructNode{&blockConstruct});
+    context_.PushConstruct(blockConstruct);
     Enter(blockConstruct);
     return true;
   }
 
   bool Pre(const parser::CaseConstruct &caseConstruct) {
-    context_.PushConstruct(ConstructNode{&caseConstruct});
+    context_.PushConstruct(caseConstruct);
     Enter(caseConstruct);
     return true;
   }
 
   bool Pre(const parser::CriticalConstruct &criticalConstruct) {
-    context_.PushConstruct(ConstructNode{&criticalConstruct});
+    context_.PushConstruct(criticalConstruct);
     Enter(criticalConstruct);
     return true;
   }
 
   bool Pre(const parser::ChangeTeamConstruct &changeTeamConstruct) {
-    context_.PushConstruct(ConstructNode{&changeTeamConstruct});
+    context_.PushConstruct(changeTeamConstruct);
     Enter(changeTeamConstruct);
     return true;
   }
 
   bool Pre(const parser::DoConstruct &doConstruct) {
-    context_.PushConstruct(ConstructNode{&doConstruct});
+    context_.PushConstruct(doConstruct);
     Enter(doConstruct);
     return true;
   }
 
   bool Pre(const parser::ForAllConstruct &forAllConstruct) {
-    context_.PushConstruct(ConstructNode{&forAllConstruct});
+    context_.PushConstruct(&forAllConstruct);
     Enter(forAllConstruct);
     return true;
   }
 
   bool Pre(const parser::IfConstruct &ifConstruct) {
-    context_.PushConstruct(ConstructNode{&ifConstruct});
+    context_.PushConstruct(ifConstruct);
     Enter(ifConstruct);
     return true;
   }
 
   bool Pre(const parser::SelectRankConstruct &selectRankConstruct) {
-    context_.PushConstruct(ConstructNode{&selectRankConstruct});
+    context_.PushConstruct(selectRankConstruct);
     Enter(selectRankConstruct);
     return true;
   }
 
   bool Pre(const parser::SelectTypeConstruct &selectTypeConstruct) {
-    context_.PushConstruct(ConstructNode{&selectTypeConstruct});
+    context_.PushConstruct(selectTypeConstruct);
     Enter(selectTypeConstruct);
     return true;
   }
 
   bool Pre(const parser::WhereConstruct &whereConstruct) {
-    context_.PushConstruct(ConstructNode{&whereConstruct});
+    context_.PushConstruct(whereConstruct);
     Enter(whereConstruct);
     return true;
   }
@@ -296,10 +296,6 @@ Scope &SemanticsContext::FindScope(parser::CharBlock source) {
   } else {
     common::die("invalid source location");
   }
-}
-
-void SemanticsContext::PushConstruct(ConstructNode &&construct) {
-  constructStack_.emplace_back(construct);
 }
 
 void SemanticsContext::PopConstruct() {

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -81,15 +81,125 @@ public:
     context_.set_location(std::nullopt);
   }
 
-  bool Pre(const parser::ExecutableConstruct &executable) {
-    context_.PushExecutable(executable);
-    Enter(executable);
+  bool Pre(const parser::AssociateConstruct &associateConstruct) {
+    context_.PushConstruct(&associateConstruct);
+    Enter(associateConstruct);
     return true;
   }
 
-  void Post(const parser::ExecutableConstruct &executable) {
-    Leave(executable);
-    context_.PopExecutable();
+  bool Pre(const parser::BlockConstruct &blockConstruct) {
+    context_.PushConstruct(&blockConstruct);
+    Enter(blockConstruct);
+    return true;
+  }
+
+  bool Pre(const parser::CaseConstruct &caseConstruct) {
+    context_.PushConstruct(&caseConstruct);
+    Enter(caseConstruct);
+    return true;
+  }
+
+  bool Pre(const parser::DoConstruct &doConstruct) {
+    context_.PushConstruct(&doConstruct);
+    Enter(doConstruct);
+    return true;
+  }
+
+  bool Pre(const parser::CriticalConstruct &criticalConstruct) {
+    context_.PushConstruct(&criticalConstruct);
+    Enter(criticalConstruct);
+    return true;
+  }
+
+  bool Pre(const parser::ChangeTeamConstruct &changeTeamConstruct) {
+    context_.PushConstruct(&changeTeamConstruct);
+    Enter(changeTeamConstruct);
+    return true;
+  }
+
+  bool Pre(const parser::ForAllConstruct &forAllConstruct) {
+    context_.PushConstruct(&forAllConstruct);
+    Enter(forAllConstruct);
+    return true;
+  }
+
+  bool Pre(const parser::IfConstruct &ifConstruct) {
+    context_.PushConstruct(&ifConstruct);
+    Enter(ifConstruct);
+    return true;
+  }
+
+  bool Pre(const parser::SelectRankConstruct &selectRankConstruct) {
+    context_.PushConstruct(&selectRankConstruct);
+    Enter(selectRankConstruct);
+    return true;
+  }
+
+  bool Pre(const parser::SelectTypeConstruct &selectTypeConstruct) {
+    context_.PushConstruct(&selectTypeConstruct);
+    Enter(selectTypeConstruct);
+    return true;
+  }
+
+  bool Pre(const parser::WhereConstruct &whereConstruct) {
+    context_.PushConstruct(&whereConstruct);
+    Enter(whereConstruct);
+    return true;
+  }
+
+  void Post(const parser::AssociateConstruct &associateConstruct) {
+    Leave(associateConstruct);
+    context_.PopConstruct();
+  }
+
+  void Post(const parser::BlockConstruct &blockConstruct) {
+    Leave(blockConstruct);
+    context_.PopConstruct();
+  }
+
+  void Post(const parser::CaseConstruct &caseConstruct) {
+    Leave(caseConstruct);
+    context_.PopConstruct();
+  }
+
+  void Post(const parser::DoConstruct &doConstruct) {
+    Leave(doConstruct);
+    context_.PopConstruct();
+  }
+
+  void Post(const parser::CriticalConstruct &criticalConstruct) {
+    Leave(criticalConstruct);
+    context_.PopConstruct();
+  }
+
+  void Post(const parser::ChangeTeamConstruct &changeTeamConstruct) {
+    Leave(changeTeamConstruct);
+    context_.PopConstruct();
+  }
+
+  void Post(const parser::ForAllConstruct &forAllConstruct) {
+    Leave(forAllConstruct);
+    context_.PopConstruct();
+  }
+
+  void Post(const parser::IfConstruct &ifConstruct) {
+    Leave(ifConstruct);
+    context_.PopConstruct();
+  }
+
+  void Post(const parser::SelectRankConstruct &selectRankConstruct) {
+    Leave(selectRankConstruct);
+    context_.PopConstruct();
+  }
+
+  void Post(const parser::SelectTypeConstruct &selectTypeConstruct) {
+    Leave(selectTypeConstruct);
+    context_.PopConstruct();
+  }
+
+  void Post(const parser::WhereConstruct &whereConstruct) {
+    Leave(whereConstruct);
+    context_.PopConstruct();
   }
 
   bool Walk(const parser::Program &program) {
@@ -188,14 +298,22 @@ Scope &SemanticsContext::FindScope(parser::CharBlock source) {
   }
 }
 
-void SemanticsContext::PushExecutable(
-    const parser::ExecutableConstruct &executable) {
-  executables_.push_back(&executable);
+void SemanticsContext::PushConstruct(const ConstructNode &construct) {
+  constructStack_.emplace_back(construct);
 }
 
-void SemanticsContext::PopExecutable() {
-  CHECK(executables_.size() > 0);
-  executables_.pop_back();
+void SemanticsContext::PopConstruct() {
+  CHECK(!constructStack_.empty());
+  constructStack_.pop_back();
+}
+
+bool SemanticsContext::InsideDoConstruct() const {
+  for (const ConstructNode construct : constructStack_) {
+    if (std::holds_alternative<const parser::DoConstruct *>(construct)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 bool Semantics::Perform() {

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -82,67 +82,67 @@ public:
   }
 
   bool Pre(const parser::AssociateConstruct &associateConstruct) {
-    context_.PushConstruct(&associateConstruct);
+    context_.PushConstruct(ConstructNode{&associateConstruct});
     Enter(associateConstruct);
     return true;
   }
 
   bool Pre(const parser::BlockConstruct &blockConstruct) {
-    context_.PushConstruct(&blockConstruct);
+    context_.PushConstruct(ConstructNode{&blockConstruct});
     Enter(blockConstruct);
     return true;
   }
 
   bool Pre(const parser::CaseConstruct &caseConstruct) {
-    context_.PushConstruct(&caseConstruct);
+    context_.PushConstruct(ConstructNode{&caseConstruct});
     Enter(caseConstruct);
     return true;
   }
 
-  bool Pre(const parser::DoConstruct &doConstruct) {
-    context_.PushConstruct(&doConstruct);
-    Enter(doConstruct);
-    return true;
-  }
-
   bool Pre(const parser::CriticalConstruct &criticalConstruct) {
-    context_.PushConstruct(&criticalConstruct);
+    context_.PushConstruct(ConstructNode{&criticalConstruct});
     Enter(criticalConstruct);
     return true;
   }
 
   bool Pre(const parser::ChangeTeamConstruct &changeTeamConstruct) {
-    context_.PushConstruct(&changeTeamConstruct);
+    context_.PushConstruct(ConstructNode{&changeTeamConstruct});
     Enter(changeTeamConstruct);
     return true;
   }
 
+  bool Pre(const parser::DoConstruct &doConstruct) {
+    context_.PushConstruct(ConstructNode{&doConstruct});
+    Enter(doConstruct);
+    return true;
+  }
+
   bool Pre(const parser::ForAllConstruct &forAllConstruct) {
-    context_.PushConstruct(&forAllConstruct);
+    context_.PushConstruct(ConstructNode{&forAllConstruct});
     Enter(forAllConstruct);
     return true;
   }
 
   bool Pre(const parser::IfConstruct &ifConstruct) {
-    context_.PushConstruct(&ifConstruct);
+    context_.PushConstruct(ConstructNode{&ifConstruct});
     Enter(ifConstruct);
     return true;
   }
 
   bool Pre(const parser::SelectRankConstruct &selectRankConstruct) {
-    context_.PushConstruct(&selectRankConstruct);
+    context_.PushConstruct(ConstructNode{&selectRankConstruct});
     Enter(selectRankConstruct);
     return true;
   }
 
   bool Pre(const parser::SelectTypeConstruct &selectTypeConstruct) {
-    context_.PushConstruct(&selectTypeConstruct);
+    context_.PushConstruct(ConstructNode{&selectTypeConstruct});
     Enter(selectTypeConstruct);
     return true;
   }
 
   bool Pre(const parser::WhereConstruct &whereConstruct) {
-    context_.PushConstruct(&whereConstruct);
+    context_.PushConstruct(ConstructNode{&whereConstruct});
     Enter(whereConstruct);
     return true;
   }
@@ -298,7 +298,7 @@ Scope &SemanticsContext::FindScope(parser::CharBlock source) {
   }
 }
 
-void SemanticsContext::PushConstruct(const ConstructNode &construct) {
+void SemanticsContext::PushConstruct(ConstructNode &&construct) {
   constructStack_.emplace_back(construct);
 }
 

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -140,7 +140,9 @@ public:
   Scope &FindScope(parser::CharBlock);
 
   const ConstructStack &constructStack() const { return constructStack_; }
-  void PushConstruct(ConstructNode &&construct);
+  template<typename N> void PushConstruct(const N &node) {
+    constructStack_.emplace_back(&node);
+  }
   void PopConstruct();
   bool InsideDoConstruct() const;
 

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -140,7 +140,7 @@ public:
   Scope &FindScope(parser::CharBlock);
 
   const ConstructStack &constructStack() const { return constructStack_; }
-  void PushConstruct(const ConstructNode &construct);
+  void PushConstruct(ConstructNode &&construct);
   void PopConstruct();
   bool InsideDoConstruct() const;
 

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -20,6 +20,7 @@
 #include "../evaluate/intrinsics.h"
 #include "../parser/features.h"
 #include "../parser/message.h"
+#include "../parser/parse-tree.h"
 #include <iosfwd>
 #include <string>
 #include <vector>
@@ -120,6 +121,12 @@ public:
   const Scope &FindScope(parser::CharBlock) const;
   Scope &FindScope(parser::CharBlock);
 
+  const std::vector<const parser::ExecutableConstruct *> executables() const {
+    return executables_;
+  }
+  void PushExecutable(const parser::ExecutableConstruct &executable);
+  void PopExecutable();
+
 private:
   const common::IntrinsicTypeDefaultKinds &defaultKinds_;
   const parser::LanguageFeatureControl languageFeatures_;
@@ -136,6 +143,7 @@ private:
   evaluate::FoldingContext foldingContext_{defaultKinds_};
 
   bool CheckError(bool);
+  std::vector<const parser::ExecutableConstruct *> executables_;
 };
 
 class Semantics {

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -146,6 +146,7 @@ set(ERROR_TESTS
   dosemantics07.f90
   dosemantics08.f90
   dosemantics09.f90
+  dosemantics10.f90
   expr-errors01.f90
   null01.f90
   omp-clause-validity01.f90

--- a/test/semantics/dosemantics10.f90
+++ b/test/semantics/dosemantics10.f90
@@ -17,6 +17,25 @@
 ! C1166 An EXIT statement must be within a DO construct
 
 subroutine s1()
+! this one's OK
+  do i = 1,10
+    cycle
+  end do
+
+! this one's OK
+  do i = 1,10
+    exit
+  end do
+
+! all of these are OK
+  outer: do i = 1,10
+    cycle
+    inner: do j = 1,10
+      cycle
+    end do inner
+    cycle
+  end do outer
+
 !ERROR: CYCLE must be within a DO construct
   cycle
 

--- a/test/semantics/dosemantics10.f90
+++ b/test/semantics/dosemantics10.f90
@@ -1,0 +1,32 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+!
+! C1134 A CYCLE statement must be within a DO construct
+!
+! C1166 An EXIT statement must be within a DO construct
+
+subroutine s1()
+!ERROR: CYCLE must be within a DO construct
+  cycle
+
+!ERROR: EXIT must be within a DO construct
+  exit
+
+!ERROR: CYCLE must be within a DO construct
+  if(.true.) cycle
+
+!ERROR: EXIT must be within a DO construct
+  if(.true.) exit
+
+end subroutine s1


### PR DESCRIPTION
I added a stack of ExecutableConstruct's to SemanticsContext along with
functions to push and pop constructs.  I added code to the SemanticsVisitor
to use these new functions.  I also added functions Pre and Post functions
for UnlabeledStatement's so that we could isolate the source positions for
statements embedded in "if" statements to improve error messages.

I also added code to check-do.[h,cc] to use this new infrastructure to check
for CYCLE and EXIT statements that are not contained within DO constructs
along with a test.