### PR TITLE
Resolve index in pointer assignment to array element

### DIFF
--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -4710,7 +4710,14 @@ const parser::Name *DeclarationVisitor::ResolveDataRef(
           [=](const Indirection<parser::StructureComponent> &y) {
             return ResolveStructureComponent(y.value());
           },
-          [=](const auto &y) { return ResolveDataRef(y.value().base); },
+          [&](const common::Indirection<parser::ArrayElement> &y) {
+            Walk(y.value().subscripts);
+            return ResolveDataRef(y.value().base);
+          },
+          [&](const common::Indirection<parser::CoindexedNamedObject> &y) {
+            Walk(y.value().imageSelector);
+            return ResolveDataRef(y.value().base);
+          },
       },
       x.u);
 }

--- a/test/semantics/resolve49.f90
+++ b/test/semantics/resolve49.f90
@@ -45,3 +45,14 @@ program p3
   a(n:,n:) => b
   a(1:n,1:n) => b
 end
+
+! Test pointer assignment to array element
+program p4
+  type :: t
+    real, pointer :: a
+  end type
+  type(t) :: x(10)
+  integer :: i
+  real, target :: y
+  x(i)%a => y
+end program


### PR DESCRIPTION
When the LHS of a pointer assignment is an array element, the
index must be resolved.

Fixed #684.