### PR TITLE
Implement ENUM name resolution

### DIFF
--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -1178,10 +1178,10 @@ Expr<Type<TypeCategory::Character, KIND>> FoldIntrinsicFunction(
 
 // Get the value of a PARAMETER
 template<typename T>
-std::optional<Expr<T>> GetParameterValue(
+std::optional<Expr<T>> GetNamedConstantValue(
     FoldingContext &context, const Symbol &symbol0) {
   const Symbol &symbol{ResolveAssociations(symbol0)};
-  if (symbol.attrs().test(semantics::Attr::PARAMETER)) {
+  if (IsNamedConstant(symbol)) {
     if (const auto *object{
             symbol.detailsIf<semantics::ObjectEntityDetails>()}) {
       if (object->initWasValidated()) {
@@ -1261,9 +1261,9 @@ std::optional<Expr<T>> GetParameterValue(
 }
 
 template<typename T>
-static std::optional<Constant<T>> GetFoldedParameterValue(
+static std::optional<Constant<T>> GetFoldedNamedConstantValue(
     FoldingContext &context, const Symbol &symbol) {
-  if (auto value{GetParameterValue<T>(context, symbol)}) {
+  if (auto value{GetNamedConstantValue<T>(context, symbol)}) {
     Expr<T> folded{Fold(context, std::move(*value))};
     if (const Constant<T> *value{UnwrapConstantValue<T>(folded)}) {
       return *value;
@@ -1458,7 +1458,7 @@ std::optional<Constant<T>> FoldArrayRef(
   }
   if (Component * component{aRef.base().UnwrapComponent()}) {
     return GetConstantComponent<T>(context, *component, &subscripts);
-  } else if (std::optional<Constant<T>> array{GetFoldedParameterValue<T>(
+  } else if (std::optional<Constant<T>> array{GetFoldedNamedConstantValue<T>(
                  context, aRef.base().GetLastSymbol())}) {
     return ApplySubscripts(context.messages(), *array, subscripts);
   } else {
@@ -1473,7 +1473,8 @@ std::optional<Constant<T>> GetConstantComponent(FoldingContext &context,
   if (std::optional<Constant<SomeDerived>> structures{std::visit(
           common::visitors{
               [&](const Symbol *symbol) {
-                return GetFoldedParameterValue<SomeDerived>(context, *symbol);
+                return GetFoldedNamedConstantValue<SomeDerived>(
+                    context, *symbol);
               },
               [&](ArrayRef &aRef) {
                 return FoldArrayRef<SomeDerived>(context, aRef);
@@ -1513,7 +1514,8 @@ Expr<T> FoldOperation(FoldingContext &context, Designator<T> &&designator) {
       common::visitors{
           [&](const Symbol *symbol) {
             if (symbol != nullptr) {
-              if (auto constant{GetFoldedParameterValue<T>(context, *symbol)}) {
+              if (auto constant{
+                      GetFoldedNamedConstantValue<T>(context, *symbol)}) {
                 return Expr<T>{std::move(*constant)};
               }
             }
@@ -2488,7 +2490,7 @@ public:
         common::TypeParamAttr::Kind);
   }
   void Handle(const semantics::Symbol &symbol) {
-    Check(symbol.attrs().test(semantics::Attr::PARAMETER));
+    Check(IsNamedConstant(symbol));
   }
   void Handle(const CoarrayRef &) { Return(false); }
   void Pre(const semantics::ParamValue &param) { Check(param.isExplicit()); }

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -747,5 +747,12 @@ template<typename A> const semantics::Symbol *GetLastTarget(const A &x) {
 // Resolve any whole ASSOCIATE(B=>A) associations
 const semantics::Symbol &ResolveAssociations(const semantics::Symbol &);
 
+// Increment Integer expression
+template<int KIND>
+Expr<Type<TypeCategory::Integer, KIND>> Increment(
+    Expr<Type<TypeCategory::Integer, KIND>> &&expr) {
+  using IntT = Type<TypeCategory::Integer, KIND>;
+  return Expr<IntT>{Add<IntT>{std::move(expr), Expr<IntT>{1}}};
+}
 }
 #endif  // FORTRAN_EVALUATE_TOOLS_H_

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -747,12 +747,5 @@ template<typename A> const semantics::Symbol *GetLastTarget(const A &x) {
 // Resolve any whole ASSOCIATE(B=>A) associations
 const semantics::Symbol &ResolveAssociations(const semantics::Symbol &);
 
-// Increment Integer expression
-template<int KIND>
-Expr<Type<TypeCategory::Integer, KIND>> Increment(
-    Expr<Type<TypeCategory::Integer, KIND>> &&expr) {
-  using IntT = Type<TypeCategory::Integer, KIND>;
-  return Expr<IntT>{Add<IntT>{std::move(expr), Expr<IntT>{1}}};
-}
 }
 #endif  // FORTRAN_EVALUATE_TOOLS_H_

--- a/lib/evaluate/type.h
+++ b/lib/evaluate/type.h
@@ -54,6 +54,7 @@ using common::TypeCategory;
 template<TypeCategory CATEGORY, int KIND = 0> class Type;
 
 using SubscriptInteger = Type<TypeCategory::Integer, 8>;
+using CInteger = Type<TypeCategory::Integer, 4>;
 using LogicalResult = Type<TypeCategory::Logical, 1>;
 using LargestReal = Type<TypeCategory::Real, 16>;
 

--- a/lib/semantics/resolve-names-utils.cc
+++ b/lib/semantics/resolve-names-utils.cc
@@ -536,7 +536,7 @@ bool EquivalenceSets::CheckObject(const parser::Name &name) {
   } else if (symbol.attrs().test(Attr::TARGET)) {  // C8108
     msg = "Variable '%s' with TARGET attribute"
           " is not allowed in an equivalence set"_err_en_US;
-  } else if (symbol.attrs().test(Attr::PARAMETER)) {  // C8106
+  } else if (IsNamedConstant(symbol)) {  // C8106
     msg = "Named constant '%s' is not allowed in an equivalence set"_err_en_US;
   } else if (InCommonWithBind(symbol)) {  // C8106
     msg = "Variable '%s' in common block with BIND attribute"

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -2941,11 +2941,11 @@ bool DeclarationVisitor::CheckArraySpec(const parser::Name &name,
     Say(name, "Assumed-rank array '%s' must be a dummy argument"_err_en_US);
     return false;
   } else if (isImplied) {
-    if (!symbol.attrs().test(Attr::PARAMETER)) {  // C836
+    if (!IsNamedConstant(symbol)) {  // C836
       Say(name, "Implied-shape array '%s' must be a named constant"_err_en_US);
       return false;
     }
-  } else if (symbol.attrs().test(Attr::PARAMETER)) {
+  } else if (IsNamedConstant(symbol)) {
     if (!isExplicit && !isImplied) {
       Say(name,
           "Named constant '%s' array must have explicit or implied shape"_err_en_US);

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -131,7 +131,7 @@ bool IsPointerDummy(const Symbol &symbol) {
 // variable-name
 bool IsVariableName(const Symbol &symbol) {
   if (const Symbol * root{GetAssociationRoot(symbol)}) {
-    return root->has<ObjectEntityDetails>() && !IsParameter(*root);
+    return root->has<ObjectEntityDetails>() && !IsNamedConstant(*root);
   } else {
     return false;
   }

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -99,7 +99,7 @@ inline bool IsAllocatable(const Symbol &symbol) {
 inline bool IsAllocatableOrPointer(const Symbol &symbol) {
   return IsPointer(symbol) || IsAllocatable(symbol);
 }
-inline bool IsParameter(const Symbol &symbol) {
+inline bool IsNamedConstant(const Symbol &symbol) {
   return symbol.attrs().test(Attr::PARAMETER);
 }
 inline bool IsOptional(const Symbol &symbol) {

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -96,6 +96,7 @@ set(ERROR_TESTS
   resolve57.f90
   resolve58.f90
   resolve59.f90
+  resolve60.f90
   stop01.f90
   structconst01.f90
   structconst02.f90
@@ -215,6 +216,7 @@ set(MODFILE_TESTS
   modfile28.f90
   modfile29.f90
   modfile30.f90
+  modfile31.f90
 )
 
 set(LABEL_TESTS

--- a/test/semantics/modfile31.f90
+++ b/test/semantics/modfile31.f90
@@ -1,0 +1,47 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test 7.6 enum values
+
+module m1
+  integer, parameter :: x(1) = [4]
+  enum, bind(C)
+    enumerator :: red, green
+    enumerator blue
+    enumerator yellow
+    enumerator :: purple = 2
+    enumerator :: brown
+  end enum
+
+  enum, bind(C)
+    enumerator :: oak, beech = -rank(x)*x(1), pine, poplar = brown
+  end enum
+
+end
+
+!Expect: m1.mod
+!module m1
+!integer(4),parameter::x(1_8:1_8)=[Integer(4)::4_4]
+!integer(4),parameter::red=0_4
+!integer(4),parameter::green=1_4
+!integer(4),parameter::blue=2_4
+!integer(4),parameter::yellow=3_4
+!integer(4),parameter::purple=2_4
+!integer(4),parameter::brown=3_4
+!integer(4),parameter::oak=0_4
+!integer(4),parameter::beech=-4_4
+!integer(4),parameter::pine=-3_4
+!integer(4),parameter::poplar=3_4
+!end
+

--- a/test/semantics/resolve60.f90
+++ b/test/semantics/resolve60.f90
@@ -1,0 +1,51 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Testing 7.6 enum
+
+  ! OK
+  enum, bind(C)
+    enumerator :: red, green
+    enumerator blue, pink
+    enumerator yellow
+    enumerator :: purple = 2
+  end enum
+
+  integer(yellow) anint4
+
+  enum, bind(C)
+    enumerator :: square, cicrle
+    !ERROR: 'square' is already declared in this scoping unit
+    enumerator square
+  end enum
+
+  dimension :: apple(4)
+  real :: peach
+
+  enum, bind(C)
+    !ERROR: 'apple' is already declared in this scoping unit
+    enumerator :: apple
+    enumerator :: pear
+    !ERROR: 'peach' is already declared in this scoping unit
+    enumerator :: peach
+    !ERROR: 'red' is already declared in this scoping unit
+    enumerator :: red
+  end enum
+
+  enum, bind(C)
+    !ERROR: Must be a constant value
+    enumerator :: wrong = 0/0
+  end enum
+
+end

--- a/test/semantics/resolve60.f90
+++ b/test/semantics/resolve60.f90
@@ -44,6 +44,7 @@
   end enum
 
   enum, bind(C)
+    !ERROR: Enumerator value could not be computed from the given expression
     !ERROR: Must be a constant value
     enumerator :: wrong = 0/0
   end enum


### PR DESCRIPTION
Fix #667.
Implement name resolution for Fortran `ENUM` that are always `BIND(C)` and therefore just like C enum.

Similar to the C standard, Fortran standard does not mandate what integer type should implement an enum. It just states that enum values must hold into a `C_INT`. So let's just use that.
Other compilers are also doing this by default.
`CInteger` type alias is added inside `lib/evaluate/type.h` to represent `C_INT` for `ISO_C_BINDING` type inside the compiler.

Enumerators symbols are given the `Attr::PARAMETER` to store the fact that they are named constants. This is justified by the standard 7.6 p4 `An enumerator is treated as if it were explicitly declared with the PARAMETER attribute.`. Also, no use case was found that would require to recall the fact that such name constant came from an `ENUM`. 

Finally, `IsParameter` is replaced by `IsNamedConstant` and the word `Parameter` is replaced by `NamedConstant` when  possible so that it is clearer the related symbol could also be an enumerator.