### PR TITLE
[OpenMP] structural related checks update

### DIFF
--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -37,7 +37,7 @@ void OmpStructureChecker::SayNotMatching(
   context_
       .Say(endSource, "Unmatched %s directive"_err_en_US,
           parser::ToUpperCaseLetters(endSource.ToString()))
-      .Attach(beginSource, "Potential matching directive"_en_US);
+      .Attach(beginSource, "Does not match directive"_en_US);
 }
 
 bool OmpStructureChecker::HasInvalidWorksharingNesting(
@@ -84,8 +84,7 @@ void OmpStructureChecker::Enter(const parser::OpenMPLoopConstruct &x) {
   // check matching, End directive is optional
   if (const auto &endLoopDir{
           std::get<std::optional<parser::OmpEndLoopDirective>>(x.t)}) {
-    const auto &endDir{std::get<parser::OmpLoopDirective>(endLoopDir->t)};
-    CheckMatching(beginDir, endDir);
+    CheckMatching<parser::OmpLoopDirective>(beginLoopDir, *endLoopDir);
   }
 
   switch (beginDir.v) {
@@ -206,12 +205,9 @@ void OmpStructureChecker::Enter(const parser::OmpEndLoopDirective &x) {
 
 void OmpStructureChecker::Enter(const parser::OpenMPBlockConstruct &x) {
   const auto &beginBlockDir{std::get<parser::OmpBeginBlockDirective>(x.t)};
-  const auto &beginDir{std::get<parser::OmpBlockDirective>(beginBlockDir.t)};
-
-  // check matching
   const auto &endBlockDir{std::get<parser::OmpEndBlockDirective>(x.t)};
-  const auto &endDir{std::get<parser::OmpBlockDirective>(endBlockDir.t)};
-  CheckMatching(beginDir, endDir);
+  const auto &beginDir{
+      CheckMatching<parser::OmpBlockDirective>(beginBlockDir, endBlockDir)};
 
   switch (beginDir.v) {
   // 2.5 parallel-clause -> if-clause |
@@ -257,13 +253,9 @@ void OmpStructureChecker::Leave(const parser::OpenMPBlockConstruct &) {
 void OmpStructureChecker::Enter(const parser::OpenMPSectionsConstruct &x) {
   const auto &beginSectionsDir{
       std::get<parser::OmpBeginSectionsDirective>(x.t)};
-  const auto &beginDir{
-      std::get<parser::OmpSectionsDirective>(beginSectionsDir.t)};
-
-  // check matching
   const auto &endSectionsDir{std::get<parser::OmpEndSectionsDirective>(x.t)};
-  const auto &endDir{std::get<parser::OmpSectionsDirective>(endSectionsDir.t)};
-  CheckMatching(beginDir, endDir);
+  const auto &beginDir{CheckMatching<parser::OmpSectionsDirective>(
+      beginSectionsDir, endSectionsDir)};
 
   switch (beginDir.v) {
   // 2.7.2 sections-clause -> private-clause |

--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -499,13 +499,7 @@ void OmpStructureChecker::Enter(const parser::OmpClause &x) {
 }
 
 void OmpStructureChecker::Enter(const parser::OmpNowait &) {
-  switch (GetContext().directive) {
-  case OmpDirective::SECTIONS:
-  case OmpDirective::WORKSHARE:
-  case OmpDirective::DO_SIMD:
-  case OmpDirective::DO: break;  // NOWAIT is handled by parser
-  default: CheckAllowed(OmpClause::NOWAIT); break;
-  }
+  CheckAllowed(OmpClause::NOWAIT);
 }
 void OmpStructureChecker::Enter(const parser::OmpClause::Defaultmap &) {
   CheckAllowed(OmpClause::DEFAULTMAP);

--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -277,7 +277,14 @@ void OmpStructureChecker::Enter(const parser::OpenMPSectionsConstruct &x) {
     SetContextAllowed(allowed);
   } break;
   case parser::OmpSectionsDirective::Directive::ParallelSections: {
-    // TODO
+    PushContext(beginDir.source, OmpDirective::PARALLEL_SECTIONS);
+    OmpClauseSet allowed{OmpClause::DEFAULT, OmpClause::PRIVATE,
+        OmpClause::FIRSTPRIVATE, OmpClause::LASTPRIVATE, OmpClause::SHARED,
+        OmpClause::COPYIN, OmpClause::REDUCTION};
+    SetContextAllowed(allowed);
+    OmpClauseSet allowedOnce{
+        OmpClause::IF, OmpClause::NUM_THREADS, OmpClause::PROC_BIND};
+    SetContextAllowedOnce(allowedOnce);
   } break;
   }
 }

--- a/lib/semantics/check-omp-structure.h
+++ b/lib/semantics/check-omp-structure.h
@@ -190,6 +190,15 @@ private:
       const parser::CharBlock &, const OmpDirectiveSet &);
   void CheckAllowed(OmpClause);
   std::string ContextDirectiveAsFortran();
+  void SayNotMatching(const parser::CharBlock &, const parser::CharBlock &);
+  template<typename A, typename B>
+  void CheckMatching(const A &begin, const B &end) {
+    static_assert(
+        std::is_same_v<A, B>, "unmatched Begin and End directive types");
+    if (begin.v != end.v) {
+      SayNotMatching(begin.source, end.source);
+    }
+  }
 
   // specific clause related
   bool ScheduleModifierHasType(const parser::OmpScheduleClause &,

--- a/lib/semantics/check-omp-structure.h
+++ b/lib/semantics/check-omp-structure.h
@@ -191,13 +191,14 @@ private:
   void CheckAllowed(OmpClause);
   std::string ContextDirectiveAsFortran();
   void SayNotMatching(const parser::CharBlock &, const parser::CharBlock &);
-  template<typename A, typename B>
-  void CheckMatching(const A &begin, const B &end) {
-    static_assert(
-        std::is_same_v<A, B>, "unmatched Begin and End directive types");
+  template<typename A, typename B, typename C>
+  const A &CheckMatching(const B &beginDir, const C &endDir) {
+    const A &begin{std::get<A>(beginDir.t)};
+    const A &end{std::get<A>(endDir.t)};
     if (begin.v != end.v) {
       SayNotMatching(begin.source, end.source);
     }
+    return begin;
   }
 
   // specific clause related

--- a/test/semantics/omp-clause-validity01.f90
+++ b/test/semantics/omp-clause-validity01.f90
@@ -90,7 +90,8 @@
   do i = 1, N
      a = 3.14
   enddo
-  !$omp end parallel
+  !ERROR: NOWAIT clause is not allowed on the END PARALLEL directive
+  !$omp end parallel nowait
 
   !$omp parallel num_threads(num-10)
   do i = 1, N

--- a/test/semantics/omp-clause-validity01.f90
+++ b/test/semantics/omp-clause-validity01.f90
@@ -210,6 +210,28 @@
   !$omp end sections num_threads(4)
   !$omp end parallel
 
+! 2.11.2 parallel-sections-clause -> parallel-clause |
+!                                    sections-clause
+
+  !$omp parallel sections num_threads(4) private(b) lastprivate(d)
+  a = 0.0
+  !$omp section
+  b = 1
+  c = 2
+  !$omp section
+  d = 3
+  !$omp end parallel sections
+
+  !ERROR: At most one NUM_THREADS clause can appear on the PARALLEL SECTIONS directive
+  !$omp parallel sections num_threads(1) num_threads(4)
+  a = 0.0
+  !ERROR: Unmatched END SECTIONS directive
+  !$omp end sections
+
+  !$omp parallel sections
+  !ERROR: NOWAIT clause is not allowed on the END PARALLEL SECTIONS directive
+  !$omp end parallel sections nowait
+
 ! 2.7.3 single-clause -> private-clause |
 !                        firstprivate-clause
 !   end-single-clause -> copyprivate-clause |

--- a/test/semantics/omp-clause-validity01.f90
+++ b/test/semantics/omp-clause-validity01.f90
@@ -105,6 +105,12 @@
   enddo
   !$omp end parallel
 
+  !$omp parallel
+  do i = 1, N
+  enddo
+  !ERROR: Unmatched END TARGET directive
+  !$omp end target
+
 ! 2.7.1  do-clause -> private-clause |
 !                     firstprivate-clause |
 !                     lastprivate-clause |
@@ -160,6 +166,17 @@
      enddo
   enddo
 
+  !$omp parallel do simd
+  do i = 1, N
+  enddo
+  !$omp end parallel do simd
+
+  !$omp parallel do
+  do i = 1, N
+  enddo
+  !ERROR: Unmatched END SIMD directive
+  !$omp end simd
+
 ! 2.7.2 sections-clause -> private-clause |
 !                         firstprivate-clause |
 !                         lastprivate-clause |
@@ -172,6 +189,14 @@
   !$omp section
   b = 1
   !$omp end sections nowait
+  !$omp end parallel
+
+  !$omp parallel
+  !$omp sections
+  !$omp section
+  a = 0.0
+  !ERROR: Unmatched END PARALLEL SECTIONS directive
+  !$omp end parallel sections
   !$omp end parallel
 
   !$omp parallel


### PR DESCRIPTION
1. [OpenMP] update validity check for `OmpNowait`
Because now we set the flag for `End` directives that accept clauses,
no need to check the specific directives anymore.

2. [OpenMP] add `Begin` and `End` Directive matching check 
Straightforward checks for `Begin` and `End` directive of:
   - Block related constructs
   - Loop related constructs (`End` directive is optional)
   - Sections related constructs

3. [OpenMP] structural checks for `PARALLEL SECTIONS`
Since I was touching the `SectionsConstruct`, I thought it's better to just finish it.