### PR TITLE
Fix for segfault in invalid proc interface message

### DIFF
--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -5723,7 +5723,7 @@ void ResolveNamesVisitor::SetPassArg(
   const auto *subprogram{interface->detailsIf<SubprogramDetails>()};
   if (!subprogram) {
     Say(name, "Procedure component '%s' has invalid interface '%s'"_err_en_US,
-        interface->name());
+        name, interface->name());
     return;
   }
   std::optional<SourceName> passName{details.passName()};

--- a/test/semantics/resolve20.f90
+++ b/test/semantics/resolve20.f90
@@ -63,6 +63,14 @@ module m
   !ERROR: PARAMETER attribute not allowed on 'bar'
   parameter(bar=2)
 
+  type, abstract :: t1
+    integer :: i
+  contains
+    !ERROR: 'proc' must be an abstract interface or a procedure with an explicit interface
+    !ERROR: Procedure component 'p1' has invalid interface 'proc'
+    procedure(proc), deferred :: p1
+  end type t1
+
 contains
   subroutine bar
   end subroutine


### PR DESCRIPTION
The segfault happened due to a missing argument.