### PR TITLE
Added -fget-definition and -fget-symbols-sources.

### DIFF
--- a/lib/parser/provenance.h
+++ b/lib/parser/provenance.h
@@ -138,17 +138,6 @@ private:
   std::vector<ContiguousProvenanceMapping> provenanceMap_;
 };
 
-struct SourcePosition {
-  SourcePosition(const SourceFile &file, int line, int column)
-    : file{file}, line{line}, column{column} {}
-  SourcePosition(const SourceFile &file, std::pair<int, int> pos)
-    : file{file}, line{pos.first}, column{pos.second} {}
-  SourcePosition(const SourceFile &, std::size_t);
-
-  const SourceFile &file;
-  int line, column;
-};
-
 // A singleton AllSources instance for the whole compilation
 // is shared by reference.
 class AllSources {

--- a/lib/parser/provenance.h
+++ b/lib/parser/provenance.h
@@ -52,6 +52,8 @@ namespace Fortran::parser {
 // by the upper bits of an offset, but that does not appear to be
 // necessary.)
 
+class AllSources;
+
 class Provenance {
 public:
   Provenance() {}
@@ -122,7 +124,6 @@ public:
   void Put(ProvenanceRange);
   void Put(const OffsetToProvenanceMappings &);
   ProvenanceRange Map(std::size_t at) const;
-  std::optional<std::size_t> ReverseMap(Provenance) const;
   void RemoveLastBytes(std::size_t);
   ProvenanceRangeToOffsetMappings Invert(const AllSources &) const;
   std::ostream &Dump(std::ostream &) const;
@@ -173,7 +174,7 @@ public:
   const SourceFile *GetSourceFile(
       Provenance, std::size_t *offset = nullptr) const;
   std::optional<SourcePosition> GetSourcePosition(Provenance) const;
-  std::optional<ProvenanceRange> GetFirstFileProvenance();
+  std::optional<ProvenanceRange> GetFirstFileProvenance() const;
   std::string GetPath(Provenance) const;  // __FILE__
   int GetLineNumber(Provenance) const;  // __LINE__
   Provenance CompilerInsertionProvenance(char ch);
@@ -237,11 +238,11 @@ public:
   bool IsValid(ProvenanceRange r) const { return allSources_.IsValid(r); }
 
   std::optional<ProvenanceRange> GetProvenanceRange(CharBlock) const;
-  std::optional<CharBlock> GetCharBlock(ProvenanceRange) const;
   std::optional<CharBlock> GetCharBlockFromLineAndColumns(
       int line, int startColumn, int endColumn) const;
   std::optional<std::pair<SourcePosition, SourcePosition>>
       GetSourcePositionRange(CharBlock) const;
+  std::optional<CharBlock> GetCharBlock(ProvenanceRange) const;
 
   // The result of a Put() is the offset that the new data
   // will have in the eventually marshaled contiguous buffer.

--- a/lib/parser/source.cc
+++ b/lib/parser/source.cc
@@ -256,10 +256,10 @@ void SourceFile::Close() {
   path_.clear();
 }
 
-std::pair<int, int> SourceFile::FindOffsetLineAndColumn(std::size_t at) const {
+SourcePosition SourceFile::FindOffsetLineAndColumn(std::size_t at) const {
   CHECK(at < bytes_);
   if (lineStart_.empty()) {
-    return {1, static_cast<int>(at + 1)};
+    return {*this, 1, static_cast<int>(at + 1)};
   }
   std::size_t low{0}, count{lineStart_.size()};
   while (count > 1) {
@@ -271,7 +271,7 @@ std::pair<int, int> SourceFile::FindOffsetLineAndColumn(std::size_t at) const {
       low = mid;
     }
   }
-  return {
-      static_cast<int>(low + 1), static_cast<int>(at - lineStart_[low] + 1)};
+  return {*this, static_cast<int>(low + 1),
+      static_cast<int>(at - lineStart_[low] + 1)};
 }
 }

--- a/lib/parser/source.h
+++ b/lib/parser/source.h
@@ -33,6 +33,18 @@ std::string DirectoryName(std::string path);
 std::string LocateSourceFile(
     std::string name, const std::vector<std::string> &searchPath);
 
+class SourceFile;
+
+struct SourcePosition {
+  SourcePosition(const SourceFile &file, int line, int column)
+    : file{file}, line{line}, column{column} {}
+  SourcePosition(const SourceFile &file, std::pair<int, int> pos)
+    : file{file}, line{pos.first}, column{pos.second} {}
+
+  const SourceFile &file;
+  int line, column;
+};
+
 class SourceFile {
 public:
   explicit SourceFile(Encoding e) : encoding_{e} {}
@@ -46,7 +58,7 @@ public:
   bool Open(std::string path, std::stringstream *error);
   bool ReadStandardInput(std::stringstream *error);
   void Close();
-  std::pair<int, int> FindOffsetLineAndColumn(std::size_t) const;
+  SourcePosition FindOffsetLineAndColumn(std::size_t) const;
   std::size_t GetLineStartOffset(int lineNumber) const {
     return lineStart_.at(lineNumber - 1);
   }

--- a/lib/parser/source.h
+++ b/lib/parser/source.h
@@ -36,11 +36,6 @@ std::string LocateSourceFile(
 class SourceFile;
 
 struct SourcePosition {
-  SourcePosition(const SourceFile &file, int line, int column)
-    : file{file}, line{line}, column{column} {}
-  SourcePosition(const SourceFile &file, std::pair<int, int> pos)
-    : file{file}, line{pos.first}, column{pos.second} {}
-
   const SourceFile &file;
   int line, column;
 };

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -42,8 +42,20 @@ namespace Fortran::semantics {
 
 using NameToSymbolMap = std::map<const char *, const Symbol *>;
 static void DoDumpSymbols(std::ostream &, const Scope &, int indent = 0);
-static void GetSymbolNames(const Scope &, NameToSymbolMap &);
 static void PutIndent(std::ostream &, int indent);
+
+static void GetSymbolNames(const Scope &scope, NameToSymbolMap &symbols) {
+  // Finds all symbol names in the scope without collecting duplicates.
+  for (const auto &pair : scope) {
+    symbols.emplace(pair.second->name().begin(), pair.second);
+  }
+  for (const auto &pair : scope.commonBlocks()) {
+    symbols.emplace(pair.second->name().begin(), pair.second);
+  }
+  for (const auto &child : scope.children()) {
+    GetSymbolNames(child, symbols);
+  }
+}
 
 // A parse tree visitor that calls Enter/Leave functions from each checker
 // class C supplied as template parameters. Enter is called before the node's
@@ -219,6 +231,23 @@ void Semantics::DumpSymbols(std::ostream &os) {
   DoDumpSymbols(os, context_.globalScope());
 }
 
+void Semantics::DumpSymbolsSources(std::ostream &os) const {
+  NameToSymbolMap symbols;
+  GetSymbolNames(context_.globalScope(), symbols);
+  for (const auto pair : symbols) {
+    const Symbol &symbol{*pair.second};
+    auto sourceInfo{cooked_.GetSourcePositionRange(symbol.name())};
+    if (sourceInfo) {
+      os << symbol.name().ToString() << ": " << sourceInfo->first.file.path()
+         << ", " << sourceInfo->first.line << ", " << sourceInfo->first.column
+         << "-" << sourceInfo->second.column << "\n";
+    } else if (symbol.has<semantics::UseDetails>()) {
+      os << symbol.name().ToString() << ": "
+         << symbol.GetUltimate().owner().symbol()->name().ToString() << "\n";
+    }
+  }
+}
+
 void DoDumpSymbols(std::ostream &os, const Scope &scope, int indent) {
   PutIndent(os, indent);
   os << Scope::EnumToString(scope.kind()) << " scope:";
@@ -268,36 +297,6 @@ void DoDumpSymbols(std::ostream &os, const Scope &scope, int indent) {
     DoDumpSymbols(os, child, indent);
   }
   --indent;
-}
-
-void Semantics::DumpSymbolsSources(std::ostream &os) const {
-  NameToSymbolMap symbols;
-  GetSymbolNames(context_.globalScope(), symbols);
-  for (const auto pair : symbols) {
-    const Symbol &symbol{*pair.second};
-    auto sourceInfo{cooked_.GetSourcePositionRange(symbol.name())};
-    if (sourceInfo) {
-      os << symbol.name().ToString() << ": " << sourceInfo->first.file.path()
-         << ", " << sourceInfo->first.line << ", " << sourceInfo->first.column
-         << "-" << sourceInfo->second.column << "\n";
-    } else if (symbol.has<semantics::UseDetails>()) {
-      os << symbol.name().ToString() << ": "
-         << symbol.GetUltimate().owner().symbol()->name().ToString() << "\n";
-    }
-  }
-}
-
-void GetSymbolNames(const Scope &scope, NameToSymbolMap &symbols) {
-  // Finds all symbol names in the scope without collecting duplicates.
-  for (const auto &pair : scope) {
-    symbols.emplace(pair.second->name().begin(), pair.second);
-  }
-  for (const auto &pair : scope.commonBlocks()) {
-    symbols.emplace(pair.second->name().begin(), pair.second);
-  }
-  for (const auto &child : scope.children()) {
-    GetSymbolNames(child, symbols);
-  }
 }
 
 static void PutIndent(std::ostream &os, int indent) {

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -236,8 +236,7 @@ void Semantics::DumpSymbolsSources(std::ostream &os) const {
   GetSymbolNames(context_.globalScope(), symbols);
   for (const auto pair : symbols) {
     const Symbol &symbol{*pair.second};
-    auto sourceInfo{cooked_.GetSourcePositionRange(symbol.name())};
-    if (sourceInfo) {
+    if (auto sourceInfo{cooked_.GetSourcePositionRange(symbol.name())}) {
       os << symbol.name().ToString() << ": " << sourceInfo->first.file.path()
          << ", " << sourceInfo->first.line << ", " << sourceInfo->first.column
          << "-" << sourceInfo->second.column << "\n";

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -181,6 +181,7 @@ public:
   bool AnyFatalError() const { return context_.AnyFatalError(); }
   void EmitMessages(std::ostream &) const;
   void DumpSymbols(std::ostream &);
+  void DumpSymbolsSources(std::ostream &) const;
 
 private:
   SemanticsContext &context_;

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -244,6 +244,18 @@ set(FORALL_TESTS
   forall*.[Ff]90
 )
 
+set(GETSYMBOLS_TESTS
+  getsymbols01.f90
+  getsymbols02-*.f90
+  getsymbols03-a.f90
+)
+
+set(GETDEFINITION_TESTS
+  getdefinition01.f90
+  getdefinition02.f
+  getdefinition03-a.f90
+)
+
 set(F18 $<TARGET_FILE:f18>)
 
 foreach(test ${ERROR_TESTS})
@@ -261,7 +273,8 @@ foreach(test ${MODFILE_TESTS})
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_modfile.sh ${test} ${F18})
 endforeach()
 
-foreach(test ${LABEL_TESTS} ${CANONDO_TESTS} ${DOCONCURRENT_TESTS} ${FORALL_TESTS})
+foreach(test ${LABEL_TESTS} ${CANONDO_TESTS} ${DOCONCURRENT_TESTS} 
+             ${FORALL_TESTS} ${GETSYMBOLS_TESTS} ${GETDEFINITION_TESTS})
   add_test(NAME ${test}
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_any.sh ${test} ${F18})
 endforeach()

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -248,12 +248,16 @@ set(GETSYMBOLS_TESTS
   getsymbols01.f90
   getsymbols02-*.f90
   getsymbols03-a.f90
+  getsymbols04.f90
+  getsymbols05.f90
 )
 
 set(GETDEFINITION_TESTS
   getdefinition01.f90
   getdefinition02.f
   getdefinition03-a.f90
+  getdefinition04.f90
+  getdefinition05.f90
 )
 
 set(F18 $<TARGET_FILE:f18>)

--- a/test/semantics/getdefinition01.f90
+++ b/test/semantics/getdefinition01.f90
@@ -1,0 +1,54 @@
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Tests -fget-definition returning source position of symbol definition.
+
+!DEF: /m Module
+module m
+ !DEF: /m/f PRIVATE, PURE, RECURSIVE Subprogram REAL(4)
+ private :: f
+contains
+ !DEF: /m/s BIND(C), PUBLIC, PURE Subprogram
+ !DEF: /m/s/x INTENT(IN) (implicit) ObjectEntity REAL(4)
+ !DEF: /m/s/y INTENT(INOUT) (implicit) ObjectEntity REAL(4)
+ pure subroutine s (x, yyy) bind(c)
+  !REF: /m/s/x
+  intent(in) :: x
+  !REF: /m/s/y
+  intent(inout) :: yyy
+ contains
+  !DEF: /m/s/ss PURE Subprogram
+  pure subroutine ss
+  end subroutine
+ end subroutine
+ !REF: /m/f
+ !DEF: /m/f/x ALLOCATABLE ObjectEntity REAL(4)
+ recursive pure function f() result(x)
+  !REF: /m/f/x
+  real, allocatable :: x
+  !REF: /m/f/x
+  x = 1.0
+ end function
+end module
+
+! RUN: echo %t 1>&2;
+! RUN: ${F18} -fget-definition 27 17 18 -fparse-only -fdebug-semantics %s > %t;
+! RUN: ${F18} -fget-definition 29 20 23 -fparse-only -fdebug-semantics %s >> %t;
+! RUN: ${F18} -fget-definition 41 3 4 -fparse-only -fdebug-semantics %s >> %t;
+! RUN: ${F18} -fget-definition -fparse-only -fdebug-semantics %s >> %t 2>&1;
+! RUN: cat %t | ${FileCheck} %s
+! CHECK:x:.*getdefinition01.f90, 25, 21-22
+! CHECK:yyy:.*getdefinition01.f90, 25, 24-27
+! CHECK:x:.*getdefinition01.f90, 39, 24-25
+! CHECK:Invalid argument to -fget-definitions

--- a/test/semantics/getdefinition02.f
+++ b/test/semantics/getdefinition02.f
@@ -1,0 +1,52 @@
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Tests -fget-definition with fixed form.
+
+      !DEF: /m Module
+      module m
+       !DEF: /m/f PRIVATE, PURE, RECURSIVE Subprogram REAL(4)
+       private :: f
+      contains
+       !DEF: /m/s BIND(C), PUBLIC, PURE Subprogram
+       !DEF: /m/s/x INTENT(IN) (implicit) ObjectEntity REAL(4)
+       !DEF: /m/s/y INTENT(INOUT) (implicit) ObjectEntity REAL(4)
+       pure subroutine s (x, yyy) bind(c)
+        !REF: /m/s/x
+        intent(in) :: 
+     *  x
+        !REF: /m/s/y
+        intent(inout) :: yyy
+       contains
+        !DEF: /m/s/ss PURE Subprogram
+        pure subroutine ss
+        end subroutine
+       end subroutine
+       !REF: /m/f
+       !DEF: /m/f/x ALLOCATABLE ObjectEntity REAL(4)
+       recursive pure function f() result(x)
+        !REF: /m/f/x
+        real, allocatable :: x
+        !REF: /m/f/x
+        x = 1.0
+       end function
+      end module
+
+! RUN: ${F18} -fget-definition 28 9 10 -fparse-only -fdebug-semantics %s > %t;
+! RUN: ${F18} -fget-definition 30 26 29 -fparse-only -fdebug-semantics %s >> %t;
+! RUN: ${F18} -fget-definition 42 9 10 -fparse-only -fdebug-semantics %s >> %t;
+! RUN: cat %t | ${FileCheck} %s
+! CHECK:x:.*getdefinition02.f, 25, 27-28
+! CHECK:yyy:.*getdefinition02.f, 25, 30-33
+! CHECK:x:.*getdefinition02.f, 40, 30-31

--- a/test/semantics/getdefinition03-a.f90
+++ b/test/semantics/getdefinition03-a.f90
@@ -1,0 +1,29 @@
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Tests -fget-definition with INCLUDE
+
+INCLUDE "getdefinition03-b.f90"
+
+program main
+ use m
+ integer :: x
+ x = f
+end program
+
+! RUN: ${F18} -fget-definition 22 6 7 -fparse-only -fdebug-semantics %s > %t;
+! RUN: ${F18} -fget-definition 22 2 3 -fparse-only -fdebug-semantics %s >> %t;
+! RUN: cat %t | ${FileCheck} %s;
+! CHECK:f:.*getdefinition03-b.f90, 16, 12-13
+! CHECK:x:.*getdefinition03-a.f90, 21, 13-14

--- a/test/semantics/getdefinition03-b.f90
+++ b/test/semantics/getdefinition03-b.f90
@@ -1,0 +1,17 @@
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+module m
+ public :: f
+end module

--- a/test/semantics/getdefinition04.f90
+++ b/test/semantics/getdefinition04.f90
@@ -1,0 +1,25 @@
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Tests -fget-definition with COMMON block with same name as variable.
+
+program main
+  integer :: x
+  integer :: y
+  common /x/ y
+  x = y
+end program
+
+! RUN: ${F18} -fget-definition 21 3 4 -fparse-only -fdebug-semantics %s | ${FileCheck} %s
+! CHECK:x:.*getdefinition04.f90, 18, 14-15

--- a/test/semantics/getdefinition05.f90
+++ b/test/semantics/getdefinition05.f90
@@ -1,0 +1,35 @@
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Tests -fget-symbols-sources with BLOCK that contains same variable name as 
+! another in an outer scope.
+
+program main
+  integer :: x
+  integer :: y
+  block
+    integer :: x
+    integer :: y
+    x = y
+  end block
+  x = y
+end program
+
+!! Inner x
+! RUN: ${F18} -fget-definition 24 5 6 -fparse-only -fdebug-semantics %s > %t;
+! CHECK:x:.*getdefinition05.f90, 22, 16-17
+!! Outer y
+! RUN: ${F18} -fget-definition 26 7 8 -fparse-only -fdebug-semantics %s >> %t;
+! CHECK:y:.*getdefinition05.f90, 20, 14-15
+! RUN: cat %t | ${FileCheck} %s;

--- a/test/semantics/getsymbols01.f90
+++ b/test/semantics/getsymbols01.f90
@@ -43,10 +43,10 @@ contains
 end module
 
 ! RUN: ${F18} -fget-symbols-sources -fparse-only -fdebug-semantics %s 2>&1 | ${FileCheck} %s
-! CHECK:m:.*getsymbols01.f90, 18, 8-9
-! CHECK:f:.*getsymbols01.f90, 37, 26-27
-! CHECK:s:.*getsymbols01.f90, 25, 18-19
-! CHECK:ss:.*getsymbols01.f90, 32, 19-21
-! CHECK:x:.*getsymbols01.f90, 25, 21-22
-! CHECK:y:.*getsymbols01.f90, 25, 24-25
-! CHECK:x:.*getsymbols01.f90, 39, 24-25
+! CHECK-ONCE:m:.*getsymbols01.f90, 18, 8-9
+! CHECK-ONCE:f:.*getsymbols01.f90, 37, 26-27
+! CHECK-ONCE:s:.*getsymbols01.f90, 25, 18-19
+! CHECK-ONCE:ss:.*getsymbols01.f90, 32, 19-21
+! CHECK-ONCE:x:.*getsymbols01.f90, 25, 21-22
+! CHECK-ONCE:y:.*getsymbols01.f90, 25, 24-25
+! CHECK-ONCE:x:.*getsymbols01.f90, 39, 24-25

--- a/test/semantics/getsymbols01.f90
+++ b/test/semantics/getsymbols01.f90
@@ -1,0 +1,52 @@
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Tests -fget-symbols-sources finding all symbols in file.
+
+!DEF: /m Module
+module m
+ !DEF: /m/f PRIVATE, PURE, RECURSIVE Subprogram REAL(4)
+ private :: f
+contains
+ !DEF: /m/s BIND(C), PUBLIC, PURE Subprogram
+ !DEF: /m/s/x INTENT(IN) (implicit) ObjectEntity REAL(4)
+ !DEF: /m/s/y INTENT(INOUT) (implicit) ObjectEntity REAL(4)
+ pure subroutine s (x, y) bind(c)
+  !REF: /m/s/x
+  intent(in) :: x
+  !REF: /m/s/y
+  intent(inout) :: y
+ contains
+  !DEF: /m/s/ss PURE Subprogram
+  pure subroutine ss
+  end subroutine
+ end subroutine
+ !REF: /m/f
+ !DEF: /m/f/x ALLOCATABLE ObjectEntity REAL(4)
+ recursive pure function f() result(x)
+  !REF: /m/f/x
+  real, allocatable :: x
+  !REF: /m/f/x
+  x = 1.0
+ end function
+end module
+
+! RUN: ${F18} -fget-symbols-sources -fparse-only -fdebug-semantics %s 2>&1 | ${FileCheck} %s
+! CHECK:m:.*getsymbols01.f90, 18, 8-9
+! CHECK:f:.*getsymbols01.f90, 37, 26-27
+! CHECK:s:.*getsymbols01.f90, 25, 18-19
+! CHECK:ss:.*getsymbols01.f90, 32, 19-21
+! CHECK:x:.*getsymbols01.f90, 25, 21-22
+! CHECK:y:.*getsymbols01.f90, 25, 24-25
+! CHECK:x:.*getsymbols01.f90, 39, 24-25

--- a/test/semantics/getsymbols02-a.f90
+++ b/test/semantics/getsymbols02-a.f90
@@ -1,0 +1,26 @@
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! RUN: ${F18} -fparse-only -fdebug-semantics %s
+
+module m2
+implicit none
+private
+  public :: get5
+contains
+  function get5() result(ret)
+    integer :: ret
+    ret = 5
+    end function get5
+end module m2

--- a/test/semantics/getsymbols02-b.f90
+++ b/test/semantics/getsymbols02-b.f90
@@ -1,0 +1,28 @@
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! RUN: ${F18} -fparse-only -fdebug-semantics %s
+
+module m1
+use m2
+implicit none
+private
+  public :: callget5
+contains
+  function callget5() result(ret)
+    implicit none
+    INTEGER :: ret
+    ret = get5()
+  end function callget5
+end module m1

--- a/test/semantics/getsymbols02-c.f90
+++ b/test/semantics/getsymbols02-c.f90
@@ -1,0 +1,26 @@
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Tests -fget-symbols-sources with modules.
+
+PROGRAM helloworld
+    use m1
+    implicit none
+    integer::i
+    i = callget5()
+ENDPROGRAM
+
+! RUN: ${F18} -fget-symbols-sources -fparse-only -fdebug-semantics %s 2>&1 | ${FileCheck} %s
+! CHECK:callget5: m1
+! CHECK:get5: m2

--- a/test/semantics/getsymbols03-a.f90
+++ b/test/semantics/getsymbols03-a.f90
@@ -1,0 +1,29 @@
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Tests -fget-symbols with INCLUDE
+
+INCLUDE "getsymbols03-b.f90"
+
+program main
+ use m
+ integer :: x
+ x = f
+end program
+
+! RUN: ${F18} -fget-symbols-sources -fparse-only -fdebug-semantics %s 2>&1 | ${FileCheck} %s
+! CHECK:m:.*getsymbols03-b.f90, 15, 8-9
+! CHECK:f:.*getsymbols03-b.f90, 16, 12-13
+! CHECK:main:.*getsymbols03-a.f90, 19, 9-13
+! CHECK:x:.*getsymbols03-a.f90, 21, 13-14

--- a/test/semantics/getsymbols03-b.f90
+++ b/test/semantics/getsymbols03-b.f90
@@ -1,0 +1,17 @@
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+module m
+ public :: f
+end module

--- a/test/semantics/getsymbols04.f90
+++ b/test/semantics/getsymbols04.f90
@@ -1,0 +1,27 @@
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Tests -fget-symbols-sources with COMMON.
+
+program main
+  integer :: x
+  integer :: y
+  common /x/ y
+  x = y
+end program
+
+! RUN: ${F18} -fget-symbols-sources -fparse-only -fdebug-semantics %s 2>&1 | ${FileCheck} %s
+! CHECK:x:.*getsymbols04.f90, 18, 14-15
+! CHECK:y:.*getsymbols04.f90, 19, 14-15
+! CHECK:x:.*getsymbols04.f90, 20, 11-12

--- a/test/semantics/getsymbols05.f90
+++ b/test/semantics/getsymbols05.f90
@@ -1,0 +1,30 @@
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Tests -fget-symbols-sources with COMMON.
+
+program main
+  integer :: x
+  integer :: y
+  block
+    integer :: x
+    x = y
+  end block
+  x = y
+end program
+
+! RUN: ${F18} -fget-symbols-sources -fparse-only -fdebug-semantics %s 2>&1 | ${FileCheck} %s
+! CHECK:x:.*getsymbols05.f90, 18, 14-15
+! CHECK:y:.*getsymbols05.f90, 19, 14-15
+! CHECK:x:.*getsymbols05.f90, 21, 16-17

--- a/test/semantics/test_any.sh
+++ b/test/semantics/test_any.sh
@@ -53,6 +53,10 @@ gr=0
 for input in ${srcdir}/$*; do
   CMD=$(cat ${input} | egrep '^[[:space:]]*![[:space:]]*RUN:[[:space:]]*' | sed -e 's/^[[:space:]]*![[:space:]]*RUN:[[:space:]]*//')
   CMD=$(echo ${CMD} | sed -e "s:%s:${input}:g")
+  if egrep -q -e '%t' <<< ${CMD} ; then
+    temp=`mktemp`
+    CMD=$(echo ${CMD} | sed -e "s:%t:${temp}:g")
+  fi
   if $(eval $CMD); then
     echo "PASS  ${input}"
   else


### PR DESCRIPTION
-fget-definition with specified line and two column numbers will return the line and column numbers of the symbol definition.
-fget-symbols-sources will output all symbol names inside of the file along with their line and column numbers. For symbols that exists in another module, it will print the name of the source module instead.

A few notes:
I added ReverseMap as a way to go from Provenance to CookedSource. I was only able to implement it as a sequential search because a binary search would not work when there are macros or when the source is fixed-form, as the provenance within provenance map is no longer sorted. Please let me know if my approach is wrong.
I'm unsure about some of these method names, so feedback would be appreciated.
I added a way to use a temporary file (%t) to test_any.sh.
I will squash these commits before these changes get merged.

Thanks!