### PR TITLE
Fix declaration of module procedure subprograms

### DIFF
--- a/test/semantics/resolve36.f90
+++ b/test/semantics/resolve36.f90
@@ -79,3 +79,23 @@ contains
   module procedure sub
   end procedure
 end module
+
+! Separate module procedure defined in a submodule
+module m4
+  interface
+    module subroutine a
+    end subroutine
+    module subroutine b
+    end subroutine
+  end interface
+end module
+submodule(m4) s4a
+contains
+  module procedure a
+  end procedure
+end submodule
+submodule(m4:s4a) s4b
+contains
+  module procedure b
+  end procedure
+end


### PR DESCRIPTION
Names of subprograms declared with MODULE PROCEDURE in a submodule
were not found correctly. The fix is to separate the handling of
these from other subprograms. The subprogram being defined must have
been declared in the same module or an ancestor module/submodule.

Fixes #709