### PR TITLE
Tests for call semantics

### DIFF
--- a/lib/semantics/check-do.cc
+++ b/lib/semantics/check-do.cc
@@ -163,7 +163,7 @@ public:
       // C1139: call to impure procedure
       if (name->symbol && !IsPureProcedure(*name->symbol)) {
         context_.Say(currentStatementSourcePosition_,
-            "call to impure subroutine in DO CONCURRENT not allowed"_err_en_US);
+            "call to impure procedure in DO CONCURRENT not allowed"_err_en_US);
       }
       if (name->symbol && fromScope(*name->symbol, "ieee_exceptions"s)) {
         if (name->source == "ieee_get_flag") {
@@ -183,7 +183,7 @@ public:
                           .v.thing.component};
       if (component.symbol && !IsPureProcedure(*component.symbol)) {
         context_.Say(currentStatementSourcePosition_,
-            "call to impure subroutine in DO CONCURRENT not allowed"_err_en_US);
+            "call to impure procedure in DO CONCURRENT not allowed"_err_en_US);
       }
     }
   }

--- a/test/semantics/call01.f90
+++ b/test/semantics/call01.f90
@@ -1,0 +1,130 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Confirm enforcement of constraints and restrictions in 15.6.2.1
+
+non_recursive function f01(n) result(res)
+  integer, value :: n
+  integer :: res
+  if (n <= 0) then
+    res = n
+  else
+    !ERROR: non recursive function can't recurse
+    res = n * f01(n-1) ! 15.6.2.1(3)
+  end if
+end function
+
+non_recursive function f02(n) result(res)
+  integer, value :: n
+  integer :: res
+  if (n <= 0) then
+    res = n
+  else
+    res = nested()
+  end if
+ contains
+  integer function nested
+    !ERROR: non recursive function can't recurse
+    nested = n * f02(n-1) ! 15.6.2.1(3)
+  end function nested
+end function
+
+! ERROR: assumed-length character function cannot be RECURSIVE
+recursive character(*) function f03(n) ! C723
+  integer, value :: n
+  f03 = ''
+end function
+
+recursive function f04(n) result(res) ! C723
+  integer, value :: n
+  ! ERROR: assumed-length character function cannot be RECURSIVE
+  character(*) :: res
+  res = ''
+end function
+
+character(*) function f05()
+  ! ERROR: assumed-length character function cannot return an array
+  dimension :: f05(1) ! C723
+  f05(1) = ''
+end function
+
+function f06()
+  ! ERROR: assumed-length character function cannot return an array
+  character(*) :: f06(1) ! C723
+  f06(1) = ''
+end function
+
+character(*) function f07()
+  ! ERROR: assumed-length character function cannot return a POINTER
+  pointer :: f07 ! C723
+  character, target :: a = ' '
+  f07 => a
+end function
+
+function f08()
+  ! ERROR: assumed-length character function cannot return a POINTER
+  character(*), pointer :: f08 ! C723
+  character, target :: a = ' '
+  f08 => a
+end function
+
+! ERROR: assumed-length character function cannot be declared PURE
+pure character(*) function f09() ! C723
+  f09 = ''
+end function
+
+pure function f10()
+  ! ERROR: assumed-length character function cannot be declared PURE
+  character(*) :: f10 ! C723
+  f10 = ''
+end function
+
+! ERROR: assumed-length character function cannot be declared ELEMENTAL
+elemental character(*) function f11(n) ! C723
+  integer, value :: n
+  f11 = ''
+end function
+
+elemental function f12(n)
+  ! ERROR: assumed-length character function cannot be declared ELEMENTAL
+  character(*) :: f12 ! C723
+  integer, value :: n
+  f12 = ''
+end function
+
+function f13(n) result(res)
+  integer, value :: n
+  character(*) :: res
+  if (n <= 0) then
+    res = ''
+  else
+    !ERROR: assumed-length CHARACTER(*) function can't recurse
+    res = f13(n-1) ! 15.6.2.1(3)
+  end if
+end function
+
+function f14(n) result(res)
+  integer, value :: n
+  character(*) :: res
+  if (n <= 0) then
+    res = ''
+  else
+    res = nested()
+  end if
+ contains
+  character(1) function nested
+    !ERROR: assumed-length CHARACTER(*) function can't recurse
+    nested = f14(n-1) ! 15.6.2.1(3)
+  end function nested
+end function

--- a/test/semantics/call02.f90
+++ b/test/semantics/call02.f90
@@ -1,0 +1,94 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! 15.5.1 procedure reference constraints and restrictions
+
+subroutine s01(elem, subr)
+  interface
+    ! Merely declaring an elemental dummy procedure is not an error;
+    ! if the actual argument were an elemental unrestricted specific
+    ! intrinsic function, that's okay.
+    elemental real function elem(x)
+      real, value :: x
+    end function
+    subroutine subr(elem)
+      procedure(sin) :: elem
+    end subroutine
+  end interface
+  call subr(cos) ! not an error
+  ! ERROR: cannot pass non-intrinsic ELEMENTAL procedure as argument
+  call subr(elem)
+end subroutine
+
+module m01
+  procedure(sin) :: elem01
+  interface
+    elemental real function elem02(x)
+      real, value :: x
+    end function
+    subroutine callme(f)
+      external f
+    end subroutine
+  end interface
+ contains
+  elemental real function elem03(x)
+    real, value :: x
+  end function
+  subroutine test
+    call callme(cos) ! not an error
+    ! ERROR: cannot pass non-intrinsic ELEMENTAL procedure as argument
+    call callme(elem01)
+    ! ERROR: cannot pass non-intrinsic ELEMENTAL procedure as argument
+    call callme(elem02)
+    ! ERROR: cannot pass non-intrinsic ELEMENTAL procedure as argument
+    call callme(elem03)
+    ! ERROR: cannot pass non-intrinsic ELEMENTAL procedure as argument
+    call callme(elem04)
+   contains
+    elemental real function elem04(x)
+      real, value :: x
+    end function
+  end subroutine
+end module
+
+module m02
+  interface
+    subroutine altreturn(*)
+    end subroutine
+  end interface
+ contains
+  subroutine test
+1   continue
+   contains
+    subroutine internal
+      ! ERROR: alternate return label must be in the inclusive scope
+      call altreturn(*1)
+    end subroutine
+  end subroutine
+end module
+
+module m03
+  type :: t
+    integer, pointer :: ptr
+  end type
+  type(t) :: coarray[*]
+ contains
+  subroutine callee(x)
+    type(t), intent(in) :: x
+  end subroutine
+  subroutine test
+    ! ERROR: coindexed argument cannot have a POINTER ultimate component
+    call callee(coarray[1])
+  end subroutine
+end module

--- a/test/semantics/call03.f90
+++ b/test/semantics/call03.f90
@@ -182,6 +182,7 @@ module m01
 
   subroutine test11(in) ! C15.5.2.4(20)
     real, intent(in) :: in
+    real :: x
     ! ERROR: effective argument associated with INTENT(OUT) dummy must be definable
     call intentout(in)
     ! ERROR: effective argument associated with INTENT(OUT) dummy must be definable
@@ -194,6 +195,10 @@ module m01
     call intentinout(3.14159)
     ! ERROR: effective argument associated with INTENT(IN OUT) dummy must be definable
     call intentinout(in + 1.)
+    x = 0.
+    call intentinout(x) ! ok
+    ! ERROR: effective argument associated with INTENT(IN OUT) dummy must be definable
+    call intentinout((x))
   end subroutine
 
   subroutine test12 ! 15.5.2.4(21)

--- a/test/semantics/call03.f90
+++ b/test/semantics/call03.f90
@@ -254,7 +254,7 @@ module m01
   end subroutine
 
   subroutine test15() ! C1539
-    real, pointer :: a(10)
+    real, pointer :: a(:)
     real, asynchronous :: b(10)
     real, volatile :: c(10)
     real, asynchronous, volatile :: d(10)

--- a/test/semantics/call03.f90
+++ b/test/semantics/call03.f90
@@ -1,0 +1,305 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test 15.5.2.4 constraints and restrictions for non-POINTER non-ALLOCATABLE
+! dummy arguments.
+
+module m01
+  type :: t
+  end type
+  type :: pdt(n)
+    integer, len :: n
+  end type
+  type :: tbp
+   contains
+    procedure :: binding => subr01
+  end type
+  type :: final
+   contains
+    final :: subr02
+  end type
+  type :: alloc
+    real, allocatable :: a(:)
+  end type
+  type :: ultimateCoarray
+    real, allocatable :: a[*]
+  end type
+
+ contains
+
+  subroutine subr01(this)
+    class(tbp), intent(in) :: this
+  end subroutine
+  subroutine subr02(this)
+    class(final), intent(in) :: this
+  end subroutine
+
+  subroutine poly(x)
+    class(t), intent(in) :: x
+  end subroutine
+  subroutine assumedsize(x)
+    real :: x(*)
+  end subroutine
+  subroutine assumedrank(x)
+    real :: x(..)
+  end subroutine
+  subroutine assumedtypeandsize(x)
+    type(*) :: x(*)
+  end subroutine
+  subroutine assumedshape(x)
+    real :: x(:)
+  end subroutine
+  subroutine contiguous(x)
+    real, contiguous :: x(:)
+  end subroutine
+  subroutine intentout(x)
+    real, intent(out) :: x
+  end subroutine
+  subroutine intentinout(x)
+    real, intent(in out) :: x
+  end subroutine
+  subroutine asynchronous(x)
+    real, asynchronous :: x
+  end subroutine
+  subroutine asynchronousValue(x)
+    real, asynchronous, value :: x
+  end subroutine
+  subroutine volatile(x)
+    real, volatile :: x
+  end subroutine
+  subroutine pointer(x)
+    real, pointer :: x(:)
+  end subroutine
+  subroutine valueassumedsize(x)
+    real, value :: x(*)
+  end subroutine
+
+  subroutine test01(x) ! 15.5.2.4(2)
+    class(t), intent(in) :: x[*]
+    ! ERROR: coindexed polymorphic effective argument cannot be associated with a polymorphic dummy argument
+    call poly(x[1])
+  end subroutine
+
+  subroutine mono(x)
+    type(t), intent(in) :: x
+  end subroutine
+  subroutine test02(x) ! 15.5.2.4(2)
+    class(t), intent(in) :: x(*)
+    ! ERROR: assumed-size polymorphic array cannot be associated with a monomorphic dummy argument
+    call mono(x)
+  end subroutine
+
+  subroutine typestar(x)
+    type(*), intent(in) :: x
+  end subroutine
+  subroutine test03 ! 15.5.2.4(2)
+    type(pdt(0)) :: x
+    ! ERROR: effective argument associated with TYPE(*) dummy argument cannot have a parameterized derived type
+    call typestar(x)
+  end subroutine
+
+  subroutine test04 ! 15.5.2.4(2)
+    type(tbp) :: x
+    ! ERROR: effective argument associated with TYPE(*) dummy argument cannot have type-bound procedures
+    call typestar(x)
+  end subroutine
+
+  subroutine test05 ! 15.5.2.4(2)
+    type(final) :: x
+    ! ERROR: effective argument associated with TYPE(*) dummy argument cannot have FINAL procedures
+    call typestar(x)
+  end subroutine
+
+  subroutine ch2(x)
+    character(2), intent(in) :: x
+  end subroutine
+  subroutine test06 ! 15.5.2.4(4)
+    character :: ch1
+    ! ERROR: Length of effective character argument is less than required by dummy argument
+    call ch2(ch1)
+    ! ERROR: Length of effective character argument is less than required by dummy argument
+    call ch2(' ')
+  end subroutine
+
+  subroutine out01(x)
+    type(alloc) :: x
+  end subroutine
+  subroutine test07(x) ! 15.5.2.4(6)
+    type(alloc) :: x[*]
+    ! ERROR: coindexed effective argument with ALLOCATABLE ultimate component must be associated with a dummy argument with VALUE or INTENT(IN) attributes
+    call out01(x[1])
+  end subroutine
+
+  subroutine test08(x) ! 15.5.2.4(13)
+    real :: x[*]
+    ! ERROR: a coindexed scalar argument must be associated with a scalar dummy argument
+    call assumedsize(x[1])
+  end subroutine
+
+  subroutine charray(x)
+    character :: x(10)
+  end subroutine
+  subroutine test09(ashape, polyarray, c) ! 15.5.2.4(14), 15.5.2.11
+    real :: x, arr(10)
+    real, pointer :: p(:)
+    real :: ashape(:)
+    class(t) :: polyarray(*)
+    character(10) :: c(:)
+    ! ERROR: whole scalar argument cannot be associated with a dummy argument array
+    call assumedsize(x)
+    ! ERROR: element of pointer array cannot be associated with a dummy argument array
+    call assumedsize(p(1))
+    ! ERROR: element of assumed-shape array cannot be associated with a  dummy argument array
+    call assumedsize(ashape(1))
+    ! ERROR: element of polymorphic array cannot be associated with a dummy argument array
+    call poly(polyarray(1))
+    call charray(c(1:1))  ! not an error if character
+    call assumedsize(arr(1))  ! not an error if element in sequence
+    call assumedrank(x)  ! not an error
+    call assumedtypeandsize(x)  ! not an error
+  end subroutine
+
+  subroutine test10(a) ! 15.5.2.4(16)
+    real :: scalar, matrix
+    real :: a(*)
+    ! ERROR: rank of effective argument (0) differs from assumed-shape dummy argument (1)
+    call assumedshape(scalar)
+    ! ERROR: rank of effective argument (2) differs from assumed-shape dummy argument (1)
+    call assumedshape(matrix)
+    ! ERROR: assumed-size array cannot be associated with assumed-shape dummy argument
+  end subroutine
+
+  subroutine test11(in) ! C15.5.2.4(20)
+    real, intent(in) :: in
+    ! ERROR: effective argument associated with INTENT(OUT) dummy must be definable
+    call intentout(in)
+    ! ERROR: effective argument associated with INTENT(OUT) dummy must be definable
+    call intentout(3.14159)
+    ! ERROR: effective argument associated with INTENT(OUT) dummy must be definable
+    call intentout(in + 1.)
+    ! ERROR: effective argument associated with INTENT(IN OUT) dummy must be definable
+    call intentinout(in)
+    ! ERROR: effective argument associated with INTENT(IN OUT) dummy must be definable
+    call intentinout(3.14159)
+    ! ERROR: effective argument associated with INTENT(IN OUT) dummy must be definable
+    call intentinout(in + 1.)
+  end subroutine
+
+  subroutine test12 ! 15.5.2.4(21)
+    real :: a(1)
+    integer :: j(1)
+    j(1) = 1
+    ! ERROR: array section with vector subscript cannot be associated with a dummy argument that must be definable
+    call intentout(a(j))
+    ! ERROR: array section with vector subscript cannot be associated with a dummy argument that must be definable
+    call intentinout(a(j))
+    ! ERROR: array section with vector subscript cannot be associated with a dummy argument that must be definable
+    call asynchronous(a(j))
+    ! ERROR: array section with vector subscript cannot be associated with a dummy argument that must be definable
+    call volatile(a(j))
+  end subroutine
+
+  subroutine coarr(x)
+    type(ultimateCoarray):: x
+  end subroutine
+  subroutine volcoarr(x)
+    type(ultimateCoarray), volatile :: x
+  end subroutine
+  subroutine test13(a, b) ! 15.5.2.4(22)
+    type(ultimateCoarray) :: a
+    type(ultimateCoarray), volatile :: b
+    call coarr(a)  ! ok
+    call volcoarr(b)  ! ok
+    ! ERROR: VOLATILE attributes must match when argument has a coarray ultimate component
+    call coarr(b)
+    ! ERROR: VOLATILE attributes must match when argument has a coarray ultimate component
+    call volcoarr(a)
+  end subroutine
+
+  subroutine test14(a,b,c,d) ! C1538
+    real :: a[*]
+    real, asynchronous :: b[*]
+    real, volatile :: c[*]
+    real, asynchronous, volatile :: d[*]
+    call asynchronous(a[1])  ! ok
+    call volatile(a[1])  ! ok
+    call asynchronousValue(b[1])  ! ok
+    call asynchronousValue(c[1])  ! ok
+    call asynchronousValue(d[1])  ! ok
+    ! ERROR: coindexed ASYNCHRONOUS or VOLATILE effective argument must not be associated with dummy argument with ASYNCHRONOUS or VOLATILE attributes unless VALUE
+    call asynchronous(b[1])
+    call volatile(b[1])
+    ! ERROR: coindexed ASYNCHRONOUS or VOLATILE effective argument must not be associated with dummy argument with ASYNCHRONOUS or VOLATILE attributes unless VALUE
+    call asynchronous(c[1])
+    call volatile(c[1])
+    ! ERROR: coindexed ASYNCHRONOUS or VOLATILE effective argument must not be associated with dummy argument with ASYNCHRONOUS or VOLATILE attributes unless VALUE
+    call asynchronous(d[1])
+    call volatile(d[1])
+  end subroutine
+
+  subroutine test15() ! C1539
+    real, pointer :: a(10)
+    real, asynchronous :: b(10)
+    real, volatile :: c(10)
+    real, asynchronous, volatile :: d(10)
+    call assumedsize(a(::2)) ! ok
+    call contiguous(a(::2)) ! ok
+    call valueassumedsize(a(::2)) ! ok
+    call valueassumedsize(b(::2)) ! ok
+    call valueassumedsize(c(::2)) ! ok
+    call valueassumedsize(d(::2)) ! ok
+    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    call assumedsize(b(::2))
+    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    call contiguous(b(::2))
+    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    call assumedsize(c(::2))
+    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    call contiguous(c(::2))
+    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    call assumedsize(d(::2))
+    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    call contiguous(d(::2))
+  end subroutine
+
+  subroutine test16() ! C1540
+    real, pointer :: a(:)
+    real, asynchronous, pointer :: b(:)
+    real, volatile, pointer :: c(:)
+    real, asynchronous, volatile, pointer :: d(:)
+    call assumedsize(a) ! ok
+    call contiguous(a) ! ok
+    call pointer(a) ! ok
+    call pointer(b) ! ok
+    call pointer(c) ! ok
+    call pointer(d) ! ok
+    call valueassumedsize(a) ! ok
+    call valueassumedsize(b) ! ok
+    call valueassumedsize(c) ! ok
+    call valueassumedsize(d) ! ok
+    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    call assumedsize(b)
+    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    call contiguous(b)
+    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    call assumedsize(c)
+    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    call contiguous(c)
+    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    call assumedsize(d)
+    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    call contiguous(d)
+  end subroutine
+
+end module

--- a/test/semantics/call04.f90
+++ b/test/semantics/call04.f90
@@ -1,0 +1,74 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test 8.5.10 & 8.5.18 constraints on dummy argument declarations
+
+module m
+
+  type :: hasCoarray
+    real, allocatable :: a(:)[*]
+  end type
+  type, extends(hasCoarray) :: extendsHasCoarray
+  end type
+  type :: hasCoarray2
+    type(hasCoarray) :: x
+  end type
+  type, extends(hasCoarray2) :: extendsHasCoarray2
+  end type
+
+  real, allocatable :: coarray(:)[:]
+
+ contains
+
+  subroutine s01a(x)
+    real, allocatable, intent(out) :: x(:)
+  end subroutine
+  subroutine s01b ! C846 - can only be caught at a call via explicit interface
+    ! ERROR: An allocatable coarray cannot be associated with an INTENT(OUT) dummy argument.
+    call s01a(coarray)
+  end subroutine
+
+  subroutine s02(x) ! C846
+    ! ERROR: An INTENT(OUT) argument must not contain an allocatable coarray.
+    type(hasCoarray), intent(out) :: x
+  end subroutine
+
+  subroutine s03(x) ! C846
+    ! ERROR: An INTENT(OUT) argument must not contain an allocatable coarray.
+    type(extendsHasCoarray), intent(out) :: x
+  end subroutine
+
+  subroutine s04(x) ! C846
+    ! ERROR: An INTENT(OUT) argument must not contain an allocatable coarray.
+    type(hasCoarray2), intent(out) :: x
+  end subroutine
+
+  subroutine s05(x) ! C846
+    ! ERROR: An INTENT(OUT) argument must not contain an allocatable coarray.
+    type(extendsHasCoarray2), intent(out) :: x
+  end subroutine
+
+end module
+
+subroutine s06(x) ! C847
+  use ISO_FORTRAN_ENV, only: lock_type
+  ! ERROR: A dummy argument of TYPE(LOCK_TYPE) cannot be INTENT(OUT).
+  type(lock_type), intent(out) :: x
+end subroutine
+
+subroutine s07(x) ! C847
+  use ISO_FORTRAN_ENV, only: event_type
+  ! ERROR: A dummy argument of TYPE(EVENT_TYPE) cannot be INTENT(OUT).
+  type(event_type), intent(out) :: x
+end subroutine

--- a/test/semantics/call05.f90
+++ b/test/semantics/call05.f90
@@ -1,0 +1,117 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test 15.5.2.5 constraints and restrictions for POINTER & ALLOCATABLE
+! arguments when both sides of the call have the same attributes.
+
+module m
+
+  type :: t
+  end type
+  type, extends(t) :: t2
+  end type
+  type :: pdt(n)
+    integer, len :: n
+  end type
+
+  type(t), pointer :: mp(:), mpmat(:,:)
+  type(t), allocatable :: ma(:), mamat(:,:)
+  class(t), pointer :: pp(:)
+  class(t), allocatable :: pa(:)
+  class(t2), pointer :: pp2(:)
+  class(t2), allocatable :: pa2(:)
+  class(*), pointer :: up(:)
+  class(*), allocatable :: ua(:)
+  type(pdt(*)), pointer :: dmp(:)
+  type(pdt(*)), allocatable :: dma(:)
+  type(pdt(1)), pointer :: nmp(:)
+  type(pdt(1)), allocatable :: nma(:)
+
+ contains
+
+  subroutine smp(x)
+    type(t), pointer :: x(:)
+  end subroutine
+  subroutine sma(x)
+    type(t), allocatable :: x(:)
+  end subroutine
+  subroutine spp(x)
+    class(t), pointer :: x(:)
+  end subroutine
+  subroutine spa(x)
+    class(t), allocatable :: x(:)
+  end subroutine
+  subroutine sup(x)
+    class(*), pointer :: x(:)
+  end subroutine
+  subroutine sua(x)
+    class(*), allocatable :: x(:)
+  end subroutine
+  subroutine sdmp(x)
+    type(pdt(*)), pointer :: x(:)
+  end subroutine
+  subroutine sdma(x)
+    type(pdt(*)), pointer :: x(:)
+  end subroutine
+  subroutine snmp(x)
+    type(pdt(1)), pointer :: x(:)
+  end subroutine
+  subroutine snma(x)
+    type(pdt(1)), pointer :: x(:)
+  end subroutine
+
+  subroutine test
+    call smp(mp) ! ok
+    call sma(ma) ! ok
+    call spp(pp) ! ok
+    call spa(pa) ! ok
+    ! ERROR: If a dummy or effective argument is polymorphic, both must be so.
+    call smp(pp)
+    ! ERROR: If a dummy or effective argument is polymorphic, both must be so.
+    call sma(pp)
+    ! ERROR: If a dummy or effective argument is polymorphic, both must be so.
+    call spp(mp)
+    ! ERROR: If a dummy or effective argument is polymorphic, both must be so.
+    call spa(mp)
+    ! ERROR: If a dummy or effective argument is unlimited polymorphic, both must be so.
+    call sup(pp)
+    ! ERROR: If a dummy or effective argument is unlimited polymorphic, both must be so.
+    call sua(pa)
+    ! ERROR: If a dummy or effective argument is unlimited polymorphic, both must be so.
+    call spp(up)
+    ! ERROR: If a dummy or effective argument is unlimited polymorphic, both must be so.
+    call spa(ua)
+    ! ERROR: Dummy and effective arguments must have the same declared type.
+    call spp(pp2)
+    ! ERROR: Dummy and effective arguments must have the same declared type.
+    call spa(pa2)
+    ! ERROR: Dummy argument has rank 1, but effective argument has rank 2.
+    call smp(mpmat)
+    ! ERROR: Dummy argument has rank 1, but effective argument has rank 2.
+    call sma(mamat)
+    call sdmp(dmp) ! ok
+    call sdma(dma) ! ok
+    call snmp(nmp) ! ok
+    call snma(nma) ! ok
+    ! ERROR: Dummy and effective arguments must defer the same type parameters.
+    call sdmp(nmp)
+    ! ERROR: Dummy and effective arguments must defer the same type parameters.
+    call sdma(nma)
+    ! ERROR: Dummy and effective arguments must defer the same type parameters.
+    call snmp(dmp)
+    ! ERROR: Dummy and effective arguments must defer the same type parameters.
+    call snma(dma)
+  end subroutine
+
+end module

--- a/test/semantics/call06.f90
+++ b/test/semantics/call06.f90
@@ -1,0 +1,69 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test 15.5.2.6 constraints and restrictions for ALLOCATABLE
+! dummy arguments.
+
+module m
+
+  real, allocatable :: cov[:], com[:,:]
+
+ contains
+
+  subroutine s01(x)
+    real, allocatable :: x
+  end subroutine
+  subroutine s02(x)
+    real, allocatable :: x[:]
+  end subroutine
+  subroutine s03(x)
+    real, allocatable :: x[:,:]
+  end subroutine
+  subroutine s04(x)
+    real, allocatable, intent(in) :: x
+  end subroutine
+  subroutine s05(x)
+    real, allocatable, intent(out) :: x
+  end subroutine
+  subroutine s06(x)
+    real, allocatable, intent(in out) :: x
+  end subroutine
+  function allofunc()
+    real, allocatable :: allofunc
+  end function
+
+  subroutine test(x)
+    real :: scalar
+    real, allocatable, intent(in) :: x
+    ! ERROR: ALLOCATABLE dummy argument must be associated with an ALLOCATABLE effective argument
+    call s01(scalar)
+    ! ERROR: ALLOCATABLE dummy argument must be associated with an ALLOCATABLE effective argument
+    call s01(1.)
+    ! ERROR: ALLOCATABLE dummy argument must be associated with an ALLOCATABLE effective argument
+    call s01(allofunc()) ! subtle: ALLOCATABLE function result isn't
+    call s02(cov) ! ok
+    call s03(com) ! ok
+    ! ERROR: Dummy argument has corank 1, but effective argument has corank 2
+    call s02(com)
+    ! ERROR: Dummy argument has corank 2, but effective argument has corank 1
+    call s03(cov)
+    call s04(cov[1]) ! ok
+    ! ERROR: Coindexed ALLOCATABLE effective argument must be associated with INTENT(IN) dummy argument
+    call s01(cov[1])
+    ! ERROR: Effective argument associated with INTENT(OUT) dummy is not definable.
+    call s05(x)
+    ! ERROR: Effective argument associated with INTENT(IN OUT) dummy is not definable.
+    call s06(x)
+  end subroutine
+end module

--- a/test/semantics/call07.f90
+++ b/test/semantics/call07.f90
@@ -30,7 +30,7 @@ module m
   subroutine test
     ! ERROR: CONTIGUOUS pointer must be an array
     real, pointer, contiguous :: a01 ! C830
-    real, pointer :: a02
+    real, pointer :: a02(:)
     real, target :: a03(10)
     real :: a04(10) ! not TARGET
     call s01(a03) ! ok

--- a/test/semantics/call07.f90
+++ b/test/semantics/call07.f90
@@ -1,0 +1,54 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test 15.5.2.7 constraints and restrictions for POINTER dummy arguments.
+
+module m
+ contains
+
+  subroutine s01(p)
+    real, pointer, contiguous, intent(in) :: p(:)
+  end subroutine
+  subroutine s02(p)
+    real, pointer :: p(:)
+  end subroutine
+  subroutine s03(p)
+    real, pointer, intent(in) :: p(:)
+  end subroutine
+
+  subroutine test
+    ! ERROR: CONTIGUOUS pointer must be an array
+    real, pointer, contiguous :: a01 ! C830
+    real, pointer :: a02
+    real, target :: a03(10)
+    real :: a04(10) ! not TARGET
+    call s01(a03) ! ok
+    ! ERROR: Effective argument associated with CONTIGUOUS POINTER dummy argument must be simply contiguous
+    call s01(a02)
+    ! ERROR: Effective argument associated with CONTIGUOUS POINTER dummy argument must be simply contiguous
+    call s01(a03(::2))
+    ! ERROR: Effective argument associated with CONTIGUOUS POINTER dummy argument must be simply contiguous
+    call s01(a03([1,2,4]))
+    call s02(a02) ! ok
+    call s03(a03) ! ok
+    ! ERROR: Effective argument associated with POINTER dummy argument must be POINTER unless INTENT(IN)
+    call s02(a03)
+    ! ERROR: Effective argument associated with POINTER INTENT(IN) dummy argument must be a valid target if not a POINTER
+    call s03(a03([1,2,4]))
+    ! ERROR: Effective argument associated with POINTER INTENT(IN) dummy argument must be a valid target if not a POINTER
+    call s03([1.])
+    ! ERROR: Effective argument associated with POINTER INTENT(IN) dummy argument must be a valid target if not a POINTER
+    call s03(a04)
+  end subroutine
+end module

--- a/test/semantics/call08.f90
+++ b/test/semantics/call08.f90
@@ -1,0 +1,61 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test 15.5.2.8 coarray dummy arguments
+
+module m
+
+  real :: c1[*]
+  real, volatile :: c2[*]
+  real, pointer :: c3(:)[*]
+  real, pointer, contiguous :: c4(:)[*]
+
+ contains
+
+  subroutine s01(x)
+    real :: x[*]
+  end subroutine
+  subroutine s02(x)
+    real, volatile :: x[*]
+  end subroutine
+  subroutine s03(x)
+    real, contiguous :: x(:)[*]
+  end subroutine
+  subroutine s04(x)
+    real :: x(*)[*]
+  end subroutine
+
+  subroutine test(x)
+    real :: scalar
+    real :: x(:)[*]
+    call s01(c1) ! ok
+    call s02(c2) ! ok
+    call s03(c4) ! ok
+    call s04(c4) ! ok
+    ! ERROR: Effective argument associated with a coarray dummy argument must be a coarray
+    call s01(scalar)
+    ! ERROR: VOLATILE coarray cannot be associated with non-VOLATILE dummy argument
+    call s01(c2)
+    ! ERROR: non-VOLATILE coarray cannot be associated with VOLATILE dummy argument
+    call s02(c1)
+    ! ERROR: Effective argument associated with a CONTIGUOUS coarray dummy argument must be simply contiguous
+    call s03(c3)
+    ! ERROR: Effective argument associated with a CONTIGUOUS coarray dummy argument must be simply contiguous
+    call s03(x)
+    ! ERROR: Effective argument associated with a CONTIGUOUS coarray dummy argument must be simply contiguous
+    call s04(c3)
+    ! ERROR: Effective argument associated with a CONTIGUOUS coarray dummy argument must be simply contiguous
+    call s04(x)
+  end subroutine
+end module

--- a/test/semantics/call09.f90
+++ b/test/semantics/call09.f90
@@ -1,0 +1,52 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test 15.5.2.9(5) dummy procedure POINTER requirements
+
+module m
+
+ contains
+
+  subroutine s01(p)
+    procedure(sin), pointer, intent(in) :: p
+  end subroutine
+  subroutine s02(p)
+    procedure(sin), pointer :: p
+  end subroutine
+
+  function procptr()
+    procedure(sin), pointer :: procptr
+    procptr => cos
+  end function
+
+  subroutine test
+    procedure(tan), pointer :: p
+    p => tan
+    call s01(p) ! ok
+    call s01(procptr()) ! ok
+    call s01(null()) ! ok
+    call s01(null(p)) ! ok
+    call s01(sin) ! ok
+    call s02(p) ! ok
+    ! ERROR: Effective argument associated with dummy procedure pointer must be a procedure pointer unless INTENT(IN)
+    call s02(procptr())
+    ! ERROR: Effective argument associated with dummy procedure pointer must be a procedure pointer unless INTENT(IN)
+    call s02(null())
+    ! ERROR: Effective argument associated with dummy procedure pointer must be a procedure pointer unless INTENT(IN)
+    call s02(null(p))
+    ! ERROR: Effective argument associated with dummy procedure pointer must be a procedure pointer unless INTENT(IN)
+    call s02(sin)
+  end subroutine
+
+end module

--- a/test/semantics/call10.f90
+++ b/test/semantics/call10.f90
@@ -1,0 +1,131 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test 15.7 (C1583-C1590, C1592-C1599) constraints and restrictions
+! for PURE procedures.
+! (C1591 is tested in call11.f90.)
+
+module m
+
+  type :: impureFinal
+   contains
+    final :: impure
+  end type
+  type :: t
+  end type
+  type :: polyAlloc
+    class(t), allocatable :: a
+  end type
+
+  abstract interface
+    subroutine impure
+    end subroutine
+  end interface
+
+ contains
+
+  subroutine impure(x)
+    type(impureFinal) :: x
+  end subroutine
+
+  pure real function f01(a)
+    real, intent(in) :: a ! ok
+  end function
+  pure real function f02(a)
+    real, value :: a ! ok
+  end function
+  pure real function f03(a) ! C1583
+    ! ERROR: non-POINTER dummy argument of PURE function must be INTENT(IN) or VALUE
+    real :: a
+  end function
+  pure real function f03a(a)
+    real, pointer :: a ! ok
+  end function
+  pure real function f04(a) ! C1583
+    ! ERROR: non-POINTER dummy argument of PURE function must be INTENT(IN) or VALUE
+    real, intent(out) :: a
+  end function
+  pure real function f04a(a)
+    real, pointer, intent(out) :: a ! ok if pointer
+  end function
+  pure real function f05(a) ! C1583
+    real, intent(out), value :: a ! weird, but ok
+  end function
+  pure function f06() ! C1584
+    ! ERROR: Result of PURE function cannot have an impure FINAL procedure
+    type(impureFinal) :: f06
+  end function
+  pure function f07() ! C1585
+    ! ERROR: Result of PURE function cannot be both polymorphic and ALLOCATABLE
+    class(t), allocatable :: f07
+  end function
+  pure function f08() ! C1585
+    ! ERROR: Result of PURE function cannot have a polymorphic ALLOCATABLE ultimate component
+    type(polyAlloc) :: f08
+  end function
+
+  pure subroutine s01(a) ! C1586
+    ! ERROR: non-POINTER dummy argument of PURE subroutine must have INTENT() or VALUE attribute
+    real :: a
+  end subroutine
+  pure subroutine s01a(a)
+    real, pointer :: a
+  end subroutine
+  pure subroutine s02(a) ! C1587
+    ! ERROR: An INTENT(OUT) dummy argument of a PURE procedure cannot have an impure FINAL procedure
+    type(impureFinal), intent(out) :: a
+  end subroutine
+  pure subroutine s03(a) ! C1588
+    ! ERROR: An INTENT(OUT) dummy argument of a PURE procedure cannot be polymorphic
+    class(t), intent(out) :: a
+  end subroutine
+  pure subroutine s04(a) ! C1588
+    ! ERROR: An INTENT(OUT) dummy argument of a PURE procedure cannot have a polymorphic ultimate component
+    class(polyAlloc), intent(out) :: a
+  end subroutine
+  pure subroutine s05 ! C1589
+    ! ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
+    real, save :: v1
+    ! ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
+    real :: v2 = 0.
+    ! ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
+    real :: v3
+    data v3/0./
+    ! ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
+    real :: v4
+    common /blk/ v4
+    block
+      ! ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
+      real, save :: v5
+      ! ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
+      real :: v6 = 0.
+      ! ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
+    end block
+  end subroutine
+  pure subroutine s06 ! C1589
+    ! ERROR: A PURE subprogram cannot have local variables with the VOLATILE attribute
+    real, volatile :: v1
+    block
+      ! ERROR: A PURE subprogram cannot have local variables with the VOLATILE attribute
+      real, volatile :: v2
+    end block
+  end subroutine
+  pure subroutine s06(p) ! C1590
+    ! ERROR: A dummy procedure of a PURE subprogram must be PURE.
+    procedure(impure) :: p
+  end subroutine
+
+  ! pmk: Continue with C1592 - C1599
+
+end module

--- a/test/semantics/call10.f90
+++ b/test/semantics/call10.f90
@@ -28,11 +28,6 @@ module m
     class(t), allocatable :: a
   end type
 
-  abstract interface
-    subroutine impure
-    end subroutine
-  end interface
-
   real, volatile, target :: volatile
 
  contains
@@ -127,12 +122,12 @@ module m
       real, volatile :: v2
     end block
   end subroutine
-  pure subroutine s06(p) ! C1590
+  pure subroutine s07(p) ! C1590
     ! ERROR: A dummy procedure of a PURE subprogram must be PURE.
     procedure(impure) :: p
   end subroutine
   ! C1591 is tested in call11.f90.
-  pure subroutine s07 ! C1592
+  pure subroutine s08 ! C1592
    contains
     pure subroutine pure ! ok
     end subroutine
@@ -147,7 +142,7 @@ module m
     real, pointer, volatile :: volptr
     volptr => volatile
   end function
-  pure subroutine s08 ! C1593
+  pure subroutine s09 ! C1593
     real :: x
     ! ERROR: A VOLATILE variable may not appear in a PURE subprogram.
     x = volatile
@@ -155,27 +150,27 @@ module m
     x = volptr
   end subroutine
   ! C1594 is tested in call12.f90.
-  pure subroutine s09 ! C1595
+  pure subroutine s10 ! C1595
     integer :: n
     ! ERROR: Any procedure referenced in a PURE subprogram must also be PURE.
     n = notpure(1)
   end subroutine
-  pure subroutine s10(to) ! C1596
+  pure subroutine s11(to) ! C1596
     type(polyAlloc) :: auto, to
     ! ERROR: Deallocation of a polymorphic object is not permitted in a PURE subprogram.
     to = auto
     ! Implicit deallocation at the end of the subroutine:
     ! ERROR: Deallocation of a polymorphic object is not permitted in a PURE subprogram.
   end subroutine
-  pure subroutine s11
-    character :: buff(20)
+  pure subroutine s12
+    character(20) :: buff
     real :: x
     write(buff, *) 1.0 ! ok
     read(buff, *) x ! ok
     ! ERROR: External I/O is not allowed in a PURE subprogram
     print *, 'hi' ! C1597
     ! ERROR: External I/O is not allowed in a PURE subprogram
-    open(1, 'launch-codes') ! C1597
+    open(1, file='launch-codes') ! C1597
     ! ERROR: External I/O is not allowed in a PURE subprogram
     close(1) ! C1597
     ! ERROR: External I/O is not allowed in a PURE subprogram
@@ -199,7 +194,7 @@ module m
     ! ERROR: External I/O is not allowed in a PURE subprogram
     write(*, *) ! C1598
   end subroutine
-  pure subroutine s12
+  pure subroutine s13
     ! ERROR: An image control statement is not allowed in a PURE subprogram.
     sync all ! C1599
     ! TODO others from 11.6.1 (many)

--- a/test/semantics/call11.f90
+++ b/test/semantics/call11.f90
@@ -18,12 +18,12 @@ module m
 
   type :: t
    contains
-    procedure :: tbp => pure
+    procedure, nopass :: tbp => pure
   end type
   type, extends(t) :: t2
    contains
     ! ERROR: An overridden PURE type-bound procedure binding must also be PURE
-    procedure :: tbp => impure ! 7.5.7.3
+    procedure, nopass :: tbp => impure ! 7.5.7.3
   end type
 
  contains
@@ -45,9 +45,9 @@ module m
       ! ERROR: A procedure referenced in a FORALL body must be PURE.
       a(j) = impure(j) ! C1037
     end forall
-    ! ERROR: A procedure referenced in a mask expression must be PURE.
+    ! ERROR: concurrent-header mask expression cannot reference an impure procedure
     do concurrent (j=1:1, impure(j) /= 0) ! C1121
-      ! ERROR: A procedure referenced in a DO CONCURRENT body must be PURE.
+      ! ERROR: call to impure subroutine in DO CONCURRENT not allowed
       a(j) = impure(j) ! C1139
     end do
   end subroutine

--- a/test/semantics/call11.f90
+++ b/test/semantics/call11.f90
@@ -1,0 +1,54 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test 15.7 C1591 & others: contexts requiring PURE subprograms
+
+module m
+
+  type :: t
+   contains
+    procedure :: tbp => pure
+  end type
+  type, extends(t) :: t2
+   contains
+    ! ERROR: An overridden PURE type-bound procedure binding must also be PURE
+    procedure :: tbp => impure ! 7.5.7.3
+  end type
+
+ contains
+
+  pure integer function pure(n)
+    integer, value :: n
+    pure = n
+  end function
+  impure integer function impure(n)
+    integer, value :: n
+    impure = n
+  end function
+
+  subroutine test
+    real :: a(pure(1)) ! ok
+    ! ERROR: A function referenced in a specification expression must be PURE.
+    real :: b(impure(1)) ! 10.1.11(4)
+    forall (j=1:1)
+      ! ERROR: A procedure referenced in a FORALL body must be PURE.
+      a(j) = impure(j) ! C1037
+    end forall
+    ! ERROR: A procedure referenced in a mask expression must be PURE.
+    do concurrent (j=1:1, impure(j) /= 0) ! C1121
+      ! ERROR: A procedure referenced in a DO CONCURRENT body must be PURE.
+      a(j) = impure(j) ! C1139
+    end do
+  end subroutine
+end module

--- a/test/semantics/call12.f90
+++ b/test/semantics/call12.f90
@@ -15,5 +15,65 @@
 ! Test 15.7 C1594 - prohibited assignments in PURE subprograms
 
 module m
-  ! TODO pmk
+  type :: t
+    real :: a
+  end type
+  type(t) :: x
+  type :: hasPtr
+    real, pointer :: p
+  end type
+ contains
+  pure subroutine msubr
+    ! ERROR: A PURE subprogram must not define a host-associated object.
+    x%a = 0.
+  end subroutine
 end module
+
+pure function test(ptr, in)
+  use m
+  type(t), pointer :: ptr, ptr2
+  type(t), target, intent(in) :: in
+  type(t), save :: co[*]
+  type(t) :: y, z
+  type(hasPtr) :: hp
+  type(hasPtr) :: alloc
+  integer :: n
+  common /block/ y
+  ! ERROR: A PURE subprogram must not define an object in COMMON.
+  y%a = 0. ! C1594(1)
+  ! ERROR: A PURE subprogram must not define a USE-associated object.
+  x%a = 0.  ! C1594(1)
+  ! ERROR: A PURE function must not define a pointer dummy argument.
+  ptr%a = 0. ! C1594(1)
+  ! ERROR: A PURE subprogram must not define an INTENT(IN) dummy argument.
+  in%a = 0. ! C1594(1)
+  ! ERROR: A PURE subprogram must not define a coindexed object.
+  co[1]%a = 0. ! C1594(1)
+  ! ERROR: A PURE function must not define a pointer dummy argument.
+  ptr => y ! C1594(2)
+  ! ERROR: A PURE subprogram must not define a pointer dummy argument.
+  nullify(ptr) ! C1594(2), 19.6.8
+  ! ERROR: A PURE subprogram must not use a pointer dummy argument as the target of pointer assignment.
+  ptr2 => ptr ! C1594(3)
+  ! ERROR: A PURE subprogram must not use an INTENT(IN) dummy argument as the target of pointer assignment.
+  ptr2 => in ! C1594(3)
+  ! ERROR: A PURE subprogram must not use an object in COMMON as the target of pointer assignment.
+  n = size([hasPtr(y%a)]) ! C1594(4)
+  ! ERROR: A PURE subprogram must not use a USE-associated object as the target of pointer assignment.
+  n = size([hasPtr(x%a)]) ! C1594(4)
+  ! ERROR: A PURE function must not use a pointer dummy argument as the target of pointer assignment.
+  n = size([hasPtr(ptr%a)]) ! C1594(4)
+  ! ERROR: A PURE subprogram must not use an INTENT(IN) dummy argument as the target of pointer assignment.
+  n = size([hasPtr(in%a)]) ! C1594(4)
+  ! ERROR: A PURE subprogram must not assign to a variable with a POINTER component.
+  hp = hp ! C1594(5)
+  ! ERROR: A PURE subprogram must not use a derived type with a POINTER component as a SOURCE=.
+  allocate(alloc, source=hp)
+ contains
+  pure subroutine internal
+    ! ERROR: A PURE subprogram must not define a host-associated object.
+    z%a = 0.
+    ! ERROR: A PURE subprogram must not use a host-associated object as the target of pointer assignment.
+    hp = hasPtr(z%a)
+  end subroutine
+end function

--- a/test/semantics/call12.f90
+++ b/test/semantics/call12.f90
@@ -16,9 +16,10 @@
 
 module m
   type :: t
+    sequence
     real :: a
   end type
-  type(t) :: x
+  type(t), target :: x
   type :: hasPtr
     real, pointer :: p
   end type
@@ -34,9 +35,9 @@ pure function test(ptr, in)
   type(t), pointer :: ptr, ptr2
   type(t), target, intent(in) :: in
   type(t), save :: co[*]
-  type(t) :: y, z
+  type(t), target :: y, z
   type(hasPtr) :: hp
-  type(hasPtr) :: alloc
+  type(hasPtr), allocatable :: alloc
   integer :: n
   common /block/ y
   ! ERROR: A PURE subprogram must not define an object in COMMON.
@@ -57,11 +58,11 @@ pure function test(ptr, in)
   ptr2 => ptr ! C1594(3)
   ! ERROR: A PURE subprogram must not use an INTENT(IN) dummy argument as the target of pointer assignment.
   ptr2 => in ! C1594(3)
-  ! ERROR: A PURE subprogram must not use an object in COMMON as the target of pointer assignment.
+  ! ERROR: Externally visible object 'block' must not be associated with pointer component 'p' in a PURE procedure
   n = size([hasPtr(y%a)]) ! C1594(4)
-  ! ERROR: A PURE subprogram must not use a USE-associated object as the target of pointer assignment.
+  ! ERROR: Externally visible object 'x' must not be associated with pointer component 'p' in a PURE procedure
   n = size([hasPtr(x%a)]) ! C1594(4)
-  ! ERROR: A PURE function must not use a pointer dummy argument as the target of pointer assignment.
+  ! ERROR: Externally visible object 'ptr' must not be associated with pointer component 'p' in a PURE procedure
   n = size([hasPtr(ptr%a)]) ! C1594(4)
   ! ERROR: A PURE subprogram must not use an INTENT(IN) dummy argument as the target of pointer assignment.
   n = size([hasPtr(in%a)]) ! C1594(4)
@@ -73,7 +74,7 @@ pure function test(ptr, in)
   pure subroutine internal
     ! ERROR: A PURE subprogram must not define a host-associated object.
     z%a = 0.
-    ! ERROR: A PURE subprogram must not use a host-associated object as the target of pointer assignment.
+    ! ERROR: Externally visible object 'z' must not be associated with pointer component 'p' in a PURE procedure
     hp = hasPtr(z%a)
   end subroutine
 end function

--- a/test/semantics/call12.f90
+++ b/test/semantics/call12.f90
@@ -1,0 +1,19 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test 15.7 C1594 - prohibited assignments in PURE subprograms
+
+module m
+  ! TODO pmk
+end module


### PR DESCRIPTION
Here's some new tests for semantics to exercise the constraints and restrictions that we'll need to check on procedures and their references.  The tests are not enabled.  More to come, too.