### PR TITLE
[OpenMP] remaining Task related structural checks

### DIFF
--- a/lib/parser/openmp-grammar.h
+++ b/lib/parser/openmp-grammar.h
@@ -181,8 +181,8 @@ TYPE_PARSER("ALIGNED" >>
                     parenthesized(scalarIntExpr))) ||
     "DIST_SCHEDULE" >> construct<OmpClause>(construct<OmpClause::DistSchedule>(
                            parenthesized("STATIC ," >> scalarIntExpr))) ||
-    "FINAL" >> construct<OmpClause>(
-                   construct<OmpClause::Final>(parenthesized(scalarIntExpr))) ||
+    "FINAL" >> construct<OmpClause>(construct<OmpClause::Final>(
+                   parenthesized(scalarLogicalExpr))) ||
     "FIRSTPRIVATE" >> construct<OmpClause>(construct<OmpClause::Firstprivate>(
                           parenthesized(Parser<OmpObjectList>{}))) ||
     "FROM" >> construct<OmpClause>(construct<OmpClause::From>(

--- a/lib/parser/openmp-grammar.h
+++ b/lib/parser/openmp-grammar.h
@@ -107,8 +107,8 @@ TYPE_PARSER(construct<OmpIfClause>(
               "TARGET UPDATE" >>
                   pure(OmpIfClause::DirectiveNameModifier::TargetUpdate) ||
               "TARGET" >> pure(OmpIfClause::DirectiveNameModifier::Target) ||
-              "TASK"_id >> pure(OmpIfClause::DirectiveNameModifier::Taskloop) ||
-              "TASKLOOP" >> pure(OmpIfClause::DirectiveNameModifier::Task)) /
+              "TASK"_id >> pure(OmpIfClause::DirectiveNameModifier::Task) ||
+              "TASKLOOP" >> pure(OmpIfClause::DirectiveNameModifier::Taskloop)) /
         ":"),
     scalarLogicalExpr))
 

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -3442,7 +3442,7 @@ struct OmpClause {
   WRAPPER_CLASS(Copyprivate, OmpObjectList);
   WRAPPER_CLASS(Device, ScalarIntExpr);
   WRAPPER_CLASS(DistSchedule, ScalarIntExpr);
-  WRAPPER_CLASS(Final, ScalarIntExpr);
+  WRAPPER_CLASS(Final, ScalarLogicalExpr);
   WRAPPER_CLASS(Firstprivate, OmpObjectList);
   WRAPPER_CLASS(From, OmpObjectList);
   WRAPPER_CLASS(Grainsize, ScalarIntExpr);

--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -18,13 +18,28 @@
 
 namespace Fortran::semantics {
 
-static constexpr OmpDirectiveSet doSet{OmpDirective::DO,
-    OmpDirective::PARALLEL_DO, OmpDirective::DO_SIMD,
-    OmpDirective::PARALLEL_DO_SIMD};
+static constexpr OmpDirectiveSet doSet{OmpDirective::DISTRIBUTE_PARALLEL_DO,
+    OmpDirective::DISTRIBUTE_PARALLEL_DO_SIMD, OmpDirective::PARALLEL_DO,
+    OmpDirective::PARALLEL_DO_SIMD, OmpDirective::DO, OmpDirective::DO_SIMD,
+    OmpDirective::TARGET_PARALLEL_DO, OmpDirective::TARGET_PARALLEL_DO_SIMD,
+    OmpDirective::TARGET_TEAMS_DISTRIBUTE_PARALLEL_DO,
+    OmpDirective::TARGET_TEAMS_DISTRIBUTE_PARALLEL_DO_SIMD,
+    OmpDirective::TEAMS_DISTRIBUTE_PARALLEL_DO,
+    OmpDirective::TEAMS_DISTRIBUTE_PARALLEL_DO_SIMD};
 static constexpr OmpDirectiveSet simdSet{
-    OmpDirective::SIMD, OmpDirective::DO_SIMD, OmpDirective::PARALLEL_DO_SIMD};
+    OmpDirective::DISTRIBUTE_PARALLEL_DO_SIMD, OmpDirective::DISTRIBUTE_SIMD,
+    OmpDirective::PARALLEL_DO_SIMD, OmpDirective::DO_SIMD, OmpDirective::SIMD,
+    OmpDirective::TARGET_PARALLEL_DO_SIMD,
+    OmpDirective::TARGET_TEAMS_DISTRIBUTE_PARALLEL_DO_SIMD,
+    OmpDirective::TARGET_TEAMS_DISTRIBUTE_SIMD, OmpDirective::TARGET_SIMD,
+    OmpDirective::TASKLOOP_SIMD,
+    OmpDirective::TEAMS_DISTRIBUTE_PARALLEL_DO_SIMD,
+    OmpDirective::TEAMS_DISTRIBUTE_SIMD};
 static constexpr OmpDirectiveSet doSimdSet{
-    OmpDirective::DO_SIMD, OmpDirective::PARALLEL_DO_SIMD};
+    OmpDirective::DISTRIBUTE_PARALLEL_DO_SIMD, OmpDirective::PARALLEL_DO_SIMD,
+    OmpDirective::DO_SIMD, OmpDirective::TARGET_PARALLEL_DO_SIMD,
+    OmpDirective::TARGET_TEAMS_DISTRIBUTE_PARALLEL_DO_SIMD,
+    OmpDirective::TEAMS_DISTRIBUTE_PARALLEL_DO_SIMD};
 
 std::string OmpStructureChecker::ContextDirectiveAsFortran() {
   auto dir{EnumToString(GetContext().directive)};

--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -416,10 +416,11 @@ void OmpStructureChecker::Enter(const parser::OpenMPDeclareSimdConstruct &x) {
   //                              uniform-clause |
   //                              inbranch-clause |
   //                              notinbranch-clause
-  OmpClauseSet allowed{OmpClause::LINEAR, OmpClause::ALIGNED,
-      OmpClause::UNIFORM, OmpClause::INBRANCH, OmpClause::NOTINBRANCH};
+  OmpClauseSet allowed{
+      OmpClause::LINEAR, OmpClause::ALIGNED, OmpClause::UNIFORM};
   SetContextAllowed(allowed);
   SetContextAllowedOnce({OmpClause::SIMDLEN});
+  SetContextAllowedExclusive({OmpClause::INBRANCH, OmpClause::NOTINBRANCH});
 }
 
 void OmpStructureChecker::Leave(const parser::OpenMPDeclareSimdConstruct &) {

--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -260,6 +260,23 @@ void OmpStructureChecker::Enter(const parser::OpenMPLoopConstruct &x) {
     SetContextAllowedExclusive(allowedExclusive);
   } break;
 
+  // 2.9.3 taskloop-simd-clause -> taskloop-clause |
+  //                               simd-clause
+  case parser::OmpLoopDirective::Directive::TaskloopSimd: {
+    PushContext(beginDir.source, OmpDirective::TASKLOOP_SIMD);
+    OmpClauseSet allowed{OmpClause::LINEAR, OmpClause::ALIGNED,
+        OmpClause::SHARED, OmpClause::PRIVATE, OmpClause::FIRSTPRIVATE,
+        OmpClause::LASTPRIVATE, OmpClause::DEFAULT, OmpClause::UNTIED,
+        OmpClause::MERGEABLE, OmpClause::NOGROUP};
+    SetContextAllowed(allowed);
+    OmpClauseSet allowedOnce{OmpClause::COLLAPSE, OmpClause::SAFELEN,
+        OmpClause::SIMDLEN, OmpClause::IF, OmpClause::FINAL,
+        OmpClause::PRIORITY};
+    SetContextAllowedOnce(allowedOnce);
+    OmpClauseSet allowedExclusive{OmpClause::GRAINSIZE, OmpClause::NUM_TASKS};
+    SetContextAllowedExclusive(allowedExclusive);
+  } break;
+
   default:
     // TODO others
     break;
@@ -775,6 +792,7 @@ void OmpStructureChecker::Enter(const parser::OmpDefaultClause &) {
 void OmpStructureChecker::Enter(const parser::OmpDependClause &) {
   CheckAllowed(OmpClause::DEPEND);
 }
+
 void OmpStructureChecker::Enter(const parser::OmpIfClause &x) {
   CheckAllowed(OmpClause::IF);
 
@@ -803,6 +821,7 @@ void OmpStructureChecker::Enter(const parser::OmpIfClause &x) {
     }
   }
 }
+
 void OmpStructureChecker::Enter(const parser::OmpLinearClause &x) {
   CheckAllowed(OmpClause::LINEAR);
 

--- a/test/semantics/omp-clause-validity01.f90
+++ b/test/semantics/omp-clause-validity01.f90
@@ -414,6 +414,11 @@
   a = 1.
   !$omp end task
 
+  !ERROR: Unmatched directive name modifier TASKLOOP on the IF clause
+  !$omp task private(a) if(taskloop:a.eq.1)
+  a = 1.
+  !$omp end task
+
   !ERROR: LASTPRIVATE clause is not allowed on the TASK directive
   !ERROR: At most one FINAL clause can appear on the TASK directive
   !$omp task lastprivate(b) final(a.GE.1) final(.false.)

--- a/test/semantics/omp-clause-validity01.f90
+++ b/test/semantics/omp-clause-validity01.f90
@@ -376,7 +376,6 @@
     a = 3.14
   enddo
 
-
 ! Standalone Directives (basic)
 
   !$omp taskyield
@@ -399,4 +398,30 @@
   a = 3.14
   !ERROR: Internal: no symbol found for 'first'
   !$omp end critical (first)
+
+! 2.9.1 task-clause -> if-clause |
+!                      final-clause |
+!                      untied-clause |
+!                      default-clause |
+!                      mergeable-clause |
+!                      private-clause |
+!                      firstprivate-clause |
+!                      shared-clause |
+!                      depend-clause |
+!                      priority-clause
+
+  !$omp task shared(a) default(none) if(task:a > 1.)
+  a = 1.
+  !$omp end task
+
+  !ERROR: LASTPRIVATE clause is not allowed on the TASK directive
+  !ERROR: At most one FINAL clause can appear on the TASK directive
+  !$omp task lastprivate(b) final(a.GE.1) final(.false.)
+  b = 1
+  !$omp end task
+
+  !ERROR: The parameter of the PRIORITY clause must be a positive integer expression
+  !$omp task priority(-1) firstprivate(a) mergeable
+  a = 3.14
+  !$omp end task
 end program

--- a/test/semantics/omp-clause-validity01.f90
+++ b/test/semantics/omp-clause-validity01.f90
@@ -429,4 +429,35 @@
   !$omp task priority(-1) firstprivate(a) mergeable
   a = 3.14
   !$omp end task
+
+! 2.9.3 taskloop-simd-clause -> taskloop-clause |
+!                               simd-clause
+
+  !$omp taskloop simd
+  do i = 1, N
+     a = 3.14
+  enddo
+  !$omp end taskloop simd
+
+  !ERROR: REDUCTION clause is not allowed on the TASKLOOP SIMD directive
+  !$omp taskloop simd reduction(+:a)
+  do i = 1, N
+     a = a + 3.14
+  enddo
+  !ERROR: Unmatched END TASKLOOP directive
+  !$omp end taskloop
+
+  !ERROR: GRAINSIZE and NUM_TASKS are mutually exclusive and may not appear on the same TASKLOOP SIMD directive
+  !$omp taskloop simd num_tasks(3) grainsize(2)
+  do i = 1,N
+     a = 3.14
+  enddo
+
+  !ERROR: The parameter of the SIMDLEN clause must be a constant positive integer expression
+  !ERROR: The ALIGNMENT parameter of the ALIGNED clause must be a constant positive integer expression
+  !ERROR: Internal: no symbol found for 'a'
+  !$omp taskloop simd simdlen(-1) aligned(a:-2)
+  do i = 1, N
+     a = 3.14
+  enddo
 end program

--- a/test/semantics/omp-clause-validity01.f90
+++ b/test/semantics/omp-clause-validity01.f90
@@ -166,12 +166,13 @@
      enddo
   enddo
 
-  !$omp parallel do simd
+  !$omp parallel do simd if(parallel:a>1.)
   do i = 1, N
   enddo
   !$omp end parallel do simd
 
-  !$omp parallel do
+  !ERROR: Unmatched directive name modifier TARGET on the IF clause
+  !$omp parallel do if(target:a>1.)
   do i = 1, N
   enddo
   !ERROR: Unmatched END SIMD directive

--- a/test/semantics/omp-declarative-directive.f90
+++ b/test/semantics/omp-declarative-directive.f90
@@ -42,7 +42,8 @@ subroutine declare_simd_2
   use m1
   procedure (sub) sub1
   !ERROR: Internal: no symbol found for 'sub1'
-  !$omp declare simd(sub1)
+  !ERROR: NOTINBRANCH and INBRANCH are mutually exclusive and may not appear on the same DECLARE SIMD directive
+  !$omp declare simd(sub1) inbranch notinbranch
   procedure (sub), pointer::p
   p=>sub1
   call p(5,10)


### PR DESCRIPTION
Please see each commit for description. Basically it's adding checks for directive `Task` [2.9.1] and `Taskloop Simd` [2.9.3] along with the fixes for issues I found.