### PR TITLE
Semantic checks for target construct

### DIFF
--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -385,6 +385,24 @@ void OmpStructureChecker::Enter(const parser::OpenMPBlockConstruct &x) {
         OmpClause::IF, OmpClause::FINAL, OmpClause::PRIORITY};
     SetContextAllowedOnce(allowedOnce);
   } break;
+  // 2.10.4 target-clause -> if-clause |
+  //                         device-clause |
+  //                         private-clause |
+  //                         firstprivate-clause |
+  //                         map-clause |
+  //                         is-device-ptr-clause |
+  //                         defaultmap-clause |
+  //                         nowait-clause |
+  //                         depend-clause
+  case parser::OmpBlockDirective::Directive::Target: {
+    PushContext(beginDir.source, OmpDirective::TARGET);
+    OmpClauseSet allowed{OmpClause::IF, OmpClause::PRIVATE, OmpClause::MAP,
+        OmpClause::DEPEND, OmpClause::FIRSTPRIVATE, OmpClause::IS_DEVICE_PTR};
+    SetContextAllowed(allowed);
+    OmpClauseSet allowedOnce{
+        OmpClause::DEVICE, OmpClause::DEFAULTMAP, OmpClause::NOWAIT};
+    SetContextAllowedOnce(allowedOnce);
+  } break;
   default:
     // TODO others
     break;

--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -396,8 +396,9 @@ void OmpStructureChecker::Enter(const parser::OpenMPBlockConstruct &x) {
   //                         depend-clause
   case parser::OmpBlockDirective::Directive::Target: {
     PushContext(beginDir.source, OmpDirective::TARGET);
-    OmpClauseSet allowed{OmpClause::IF, OmpClause::PRIVATE, OmpClause::MAP,
-        OmpClause::DEPEND, OmpClause::FIRSTPRIVATE, OmpClause::IS_DEVICE_PTR};
+    OmpClauseSet allowed{OmpClause::IF, OmpClause::PRIVATE,
+        OmpClause::FIRSTPRIVATE, OmpClause::MAP, OmpClause::IS_DEVICE_PTR,
+        OmpClause::DEPEND};
     SetContextAllowed(allowed);
     OmpClauseSet allowedOnce{
         OmpClause::DEVICE, OmpClause::DEFAULTMAP, OmpClause::NOWAIT};
@@ -825,8 +826,14 @@ void OmpStructureChecker::Enter(const parser::OmpAlignedClause &x) {
 void OmpStructureChecker::Enter(const parser::OmpDefaultClause &) {
   CheckAllowed(OmpClause::DEFAULT);
 }
-void OmpStructureChecker::Enter(const parser::OmpDefaultmapClause &) {
+void OmpStructureChecker::Enter(const parser::OmpDefaultmapClause &x) {
   CheckAllowed(OmpClause::DEFAULTMAP);
+  using VariableCategory = parser::OmpDefaultmapClause::VariableCategory;
+  if (!std::get<std::optional<VariableCategory>>(x.t)) {
+    context_.Say(GetContext().clauseSource,
+        "The scalar VARIABLECATEGORY must be specified on the DEFAULTMAP "
+        "clause"_err_en_US);
+  }
 }
 void OmpStructureChecker::Enter(const parser::OmpDependClause &) {
   CheckAllowed(OmpClause::DEPEND);

--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -831,7 +831,7 @@ void OmpStructureChecker::Enter(const parser::OmpDefaultmapClause &x) {
   using VariableCategory = parser::OmpDefaultmapClause::VariableCategory;
   if (!std::get<std::optional<VariableCategory>>(x.t)) {
     context_.Say(GetContext().clauseSource,
-        "The scalar VARIABLECATEGORY must be specified on the DEFAULTMAP "
+        "The argument TOFROM:SCALAR must be specified on the DEFAULTMAP "
         "clause"_err_en_US);
   }
 }

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -153,6 +153,7 @@ set(ERROR_TESTS
 #  omp-nested01.f90
   omp-declarative-directive.f90
   omp-atomic.f90
+  omp-device-constructs.f90
   equivalence01.f90
   init01.f90
   if_arith01.f90

--- a/test/semantics/omp-device-constructs.f90
+++ b/test/semantics/omp-device-constructs.f90
@@ -56,7 +56,7 @@ program main
   enddo
   !$omp end target
 
-  !ERROR: The scalar VARIABLECATEGORY must be specified on the DEFAULTMAP clause
+  !ERROR: The argument TOFROM:SCALAR must be specified on the DEFAULTMAP clause
   !$omp target defaultmap(tofrom)
   do i = 1, N
      a = 3.14

--- a/test/semantics/omp-device-constructs.f90
+++ b/test/semantics/omp-device-constructs.f90
@@ -1,0 +1,61 @@
+! Copyright (c) 2019, Arm Ltd.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! OPTIONS: -fopenmp
+! Check OpenMP clause validity for the following directives:
+!     2.10 Device constructs
+program main
+
+  real(8) :: arrayA(256), arrayB(256)
+  integer :: N
+
+  arrayA = 1.414
+  arrayB = 3.14
+  N = 256
+
+  !$omp target map(arrayA)
+  do i = 1, N
+     a = 3.14
+  enddo
+  !$omp end target
+
+  !$omp target device(0)
+  do i = 1, N
+     a = 3.14
+  enddo
+  !$omp end target
+
+
+  !ERROR: At most one DEVICE clause can appear on the TARGET directive
+  !$omp target device(0) device(1)
+  do i = 1, N
+     a = 3.14
+  enddo
+  !$omp end target
+
+  !ERROR: SCHEDULE clause is not allowed on the TARGET directive
+  !$omp target schedule(static)
+  do i = 1, N
+     a = 3.14
+  enddo
+  !$omp end target
+
+  !ERROR: At most one DEFAULTMAP clause can appear on the TARGET directive
+  !$omp target defaultmap(tofrom:scalar) defaultmap(tofrom:scalar)
+  do i = 1, N
+     a = 3.14
+  enddo
+  !$omp end target
+
+end program main

--- a/test/semantics/omp-device-constructs.f90
+++ b/test/semantics/omp-device-constructs.f90
@@ -36,7 +36,6 @@ program main
   enddo
   !$omp end target
 
-
   !ERROR: At most one DEVICE clause can appear on the TARGET directive
   !$omp target device(0) device(1)
   do i = 1, N
@@ -46,6 +45,19 @@ program main
 
   !ERROR: SCHEDULE clause is not allowed on the TARGET directive
   !$omp target schedule(static)
+  do i = 1, N
+     a = 3.14
+  enddo
+  !$omp end target
+
+  !$omp target defaultmap(tofrom:scalar)
+  do i = 1, N
+     a = 3.14
+  enddo
+  !$omp end target
+
+  !ERROR: The scalar VARIABLECATEGORY must be specified on the DEFAULTMAP clause
+  !$omp target defaultmap(tofrom)
   do i = 1, N
      a = 3.14
   enddo


### PR DESCRIPTION
This patch implements basic semantic checks for the TARGET construct.
The requirement that only a single device or nowait clause can appear is technically from OpenMP 5.0 not 4.5, however it is just an added clarification in 5.0 because there are no reasonable semantics for multiple clauses of these types. As such I've added that requirement here.