### PR TITLE
Define iso_fortran_env error_unit.

### DIFF
--- a/module/iso_fortran_env.f90
+++ b/module/iso_fortran_env.f90
@@ -34,7 +34,7 @@ module iso_fortran_env
 
   integer, parameter :: current_team = -1, initial_team = -2, parent_team = -3
 
-  integer, parameter :: input_unit = 5, output_unit = 6
+  integer, parameter :: input_unit = 5, output_unit = 6, error_unit = 0
   integer, parameter :: iostat_end = -1, iostat_eor = -2
   integer, parameter :: iostat_inquire_internal_unit = -1
 


### PR DESCRIPTION
Provisionally use a value of 0 to match PGI.