### PR TITLE
Begin semantic checks for calls

### DIFF
--- a/lib/evaluate/call.h
+++ b/lib/evaluate/call.h
@@ -37,6 +37,7 @@ class Component;
 class IntrinsicProcTable;
 }
 namespace Fortran::evaluate::characteristics {
+struct DummyArgument;
 struct Procedure;
 }
 
@@ -105,6 +106,8 @@ public:
 
   std::optional<parser::CharBlock> keyword;
   bool isAlternateReturn{false};  // when true, "value" is a label number
+
+  bool Matches(const characteristics::DummyArgument &) const;
 
   // TODO: Mark legacy %VAL and %REF arguments
 

--- a/lib/semantics/CMakeLists.txt
+++ b/lib/semantics/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(FortranSemantics
   check-arithmeticif.cc
   check-coarray.cc
   check-deallocate.cc
+  check-declarations.cc
   check-do.cc
   check-if-stmt.cc
   check-io.cc

--- a/lib/semantics/check-declarations.cc
+++ b/lib/semantics/check-declarations.cc
@@ -1,0 +1,65 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Static declaration checking
+
+#include "semantics.h"
+#include "tools.h"
+
+namespace Fortran::semantics {
+
+static void CheckSymbol(SemanticsContext &context, const Symbol &symbol) {
+  if (context.HasError(symbol)) {
+    return;
+  }
+  context.set_location(symbol.name());
+  if (IsAssumedLengthCharacterFunction(symbol)) {  // C723
+    if (symbol.attrs().test(Attr::RECURSIVE)) {
+      context.Say(
+          "An assumed-length CHARACTER(*) function cannot be RECURSIVE."_err_en_US);
+    }
+    if (symbol.Rank() > 0) {
+      context.Say(
+          "An assumed-length CHARACTER(*) function cannot return an array."_err_en_US);
+    }
+    if (symbol.attrs().test(Attr::PURE)) {
+      context.Say(
+          "An assumed-length CHARACTER(*) function cannot be PURE."_err_en_US);
+    }
+    if (symbol.attrs().test(Attr::ELEMENTAL)) {
+      context.Say(
+          "An assumed-length CHARACTER(*) function cannot be ELEMENTAL."_err_en_US);
+    }
+    if (const Symbol * result{FindFunctionResult(symbol)}) {
+      if (result->attrs().test(Attr::POINTER)) {
+        context.Say(
+            "An assumed-length CHARACTER(*) function cannot return a POINTER."_err_en_US);
+      }
+    }
+  }
+}
+
+static void CheckScope(SemanticsContext &context, const Scope &scope) {
+  for (const auto &pair : scope) {
+    CheckSymbol(context, *pair.second);
+  }
+  for (const Scope &child : scope.children()) {
+    CheckScope(context, child);
+  }
+}
+
+void CheckDeclarations(SemanticsContext &context) {
+  CheckScope(context, context.globalScope());
+}
+}

--- a/lib/semantics/check-declarations.cc
+++ b/lib/semantics/check-declarations.cc
@@ -14,7 +14,10 @@
 
 // Static declaration checking
 
+#include "check-declarations.h"
+#include "scope.h"
 #include "semantics.h"
+#include "symbol.h"
 #include "tools.h"
 
 namespace Fortran::semantics {

--- a/lib/semantics/check-declarations.h
+++ b/lib/semantics/check-declarations.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Static declaration checks
+
+#ifndef FORTRAN_SEMANTICS_CHECK_DECLARATIONS_H_
+#define FORTRAN_SEMANTICS_CHECK_DECLARATIONS_H_
+namespace Fortran::semantics {
+class SemanticsContext;
+void CheckDeclarations(SemanticsContext &);
+}
+#endif

--- a/lib/semantics/check-io.h
+++ b/lib/semantics/check-io.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef FORTRAN_SEMANTICS_IO_H_
-#define FORTRAN_SEMANTICS_IO_H_
+#ifndef FORTRAN_SEMANTICS_CHECK_IO_H_
+#define FORTRAN_SEMANTICS_CHECK_IO_H_
 
 #include "semantics.h"
 #include "tools.h"
@@ -141,4 +141,4 @@ private:
 };
 
 }
-#endif  // FORTRAN_SEMANTICS_IO_H_
+#endif  // FORTRAN_SEMANTICS_CHECK_IO_H_

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1513,17 +1513,42 @@ std::optional<ActualArgument> ExpressionAnalyzer::AnalyzeActualArgument(
 
 MaybeExpr ExpressionAnalyzer::Analyze(
     const parser::FunctionReference &funcRef) {
+  return AnalyzeCall(funcRef.v, false);
+}
+
+void ExpressionAnalyzer::Analyze(const parser::CallStmt &call) {
+  AnalyzeCall(call.v, true);
+}
+
+MaybeExpr ExpressionAnalyzer::AnalyzeCall(
+    const parser::Call &call, bool isSubroutine) {
+  auto save{GetContextualMessages().SetLocation(call.source)};
+  if (auto arguments{AnalyzeArguments(call, isSubroutine)}) {
+    // TODO: map non-intrinsic generic procedure to specific procedure
+    if (std::optional<CalleeAndArguments> callee{Procedure(
+            std::get<parser::ProcedureDesignator>(call.t), *arguments)}) {
+      if (isSubroutine) {
+        // TODO
+      } else {
+        return MakeFunctionRef(std::move(*callee));
+      }
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<ActualArguments> ExpressionAnalyzer::AnalyzeArguments(
+    const parser::Call &call, bool isSubroutine) {
+  evaluate::ActualArguments arguments;
   // TODO: C1002: Allow a whole assumed-size array to appear if the dummy
   // argument would accept it.  Handle by special-casing the context
   // ActualArg -> Variable -> Designator.
   // TODO: Actual arguments that are procedures and procedure pointers need to
   // be detected and represented (they're not expressions).
   // TODO: C1534: Don't allow a "restricted" specific intrinsic to be passed.
-  auto save{GetContextualMessages().SetLocation(funcRef.v.source)};
-  ActualArguments arguments;
-  for (const auto &arg :
-      std::get<std::list<parser::ActualArgSpec>>(funcRef.v.t)) {
-    std::optional<ActualArgument> actual;
+  // TODO: map non-intrinsic generic procedure to specific procedure
+  for (const auto &arg : std::get<std::list<parser::ActualArgSpec>>(call.t)) {
+    std::optional<evaluate::ActualArgument> actual;
     std::visit(
         common::visitors{
             [&](const common::Indirection<parser::Expr> &x) {
@@ -1532,7 +1557,9 @@ MaybeExpr ExpressionAnalyzer::Analyze(
               actual = AnalyzeActualArgument(x.value());
             },
             [&](const parser::AltReturnSpec &) {
-              Say("alternate return specification may not appear on function reference"_err_en_US);
+              if (!isSubroutine) {
+                Say("alternate return specification may not appear on function reference"_err_en_US);
+              }
             },
             [&](const parser::ActualArg::PercentRef &) {
               Say("TODO: %REF() argument"_err_en_US);
@@ -1551,15 +1578,7 @@ MaybeExpr ExpressionAnalyzer::Analyze(
       return std::nullopt;
     }
   }
-
-  // TODO: map non-intrinsic generic procedure to specific procedure
-  if (std::optional<CalleeAndArguments> callee{Procedure(
-          std::get<parser::ProcedureDesignator>(funcRef.v.t), arguments)}) {
-    if (MaybeExpr funcRef{MakeFunctionRef(std::move(*callee))}) {
-      return funcRef;
-    }
-  }
-  return std::nullopt;
+  return arguments;
 }
 
 // Unary operations
@@ -2152,8 +2171,18 @@ evaluate::Expr<evaluate::SubscriptInteger> AnalyzeKindSelector(
   return analyzer.AnalyzeKindSelector(category, selector);
 }
 
+ExprChecker::ExprChecker(SemanticsContext &context) : context_{context} {}
+
 bool ExprChecker::Walk(const parser::Program &program) {
   parser::Walk(program, *this);
   return !context_.AnyFatalError();
 }
+
+CallChecker::CallChecker(SemanticsContext &context) : analyzer_{context} {}
+
+void CallChecker::Enter(const parser::CallStmt &call) {
+  analyzer_.Analyze(call);
+}
+
+void CallChecker::Leave(const parser::CallStmt &) {}
 }

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1447,6 +1447,27 @@ auto ExpressionAnalyzer::Procedure(const parser::ProcedureDesignator &pd,
                 return std::nullopt;
               }
             }
+            if (const auto *scope{symbol.scope()}) {
+              if (scope->sourceRange().Contains(n.source)) {
+                if (symbol.attrs().test(
+                        semantics::Attr::NON_RECURSIVE)) {  // 15.6.2.1(3)
+                  if (auto *msg{Say(
+                          "NON_RECURSIVE procedure '%s' cannot call itself"_err_en_US,
+                          n.source)}) {
+                    msg->Attach(
+                        symbol.name(), "definition of '%s'"_en_US, n.source);
+                  }
+                } else if (IsAssumedLengthCharacterFunction(
+                               symbol)) {  // 15.6.2.1(3)
+                  if (auto *msg{Say(
+                          "assumed-length CHARACTER(*) function '%s' cannot call itself"_err_en_US,
+                          n.source)}) {
+                    msg->Attach(
+                        symbol.name(), "definition of '%s'"_en_US, n.source);
+                  }
+                }
+              }
+            }
             if (symbol.HasExplicitInterface()) {
               // TODO: check actual arguments vs. interface
             } else {

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1452,7 +1452,7 @@ auto ExpressionAnalyzer::Procedure(const parser::ProcedureDesignator &pd,
                 if (symbol.attrs().test(
                         semantics::Attr::NON_RECURSIVE)) {  // 15.6.2.1(3)
                   if (auto *msg{Say(
-                          "NON_RECURSIVE procedure '%s' cannot call itself"_err_en_US,
+                          "NON_RECURSIVE procedure '%s' cannot call itself."_err_en_US,
                           n.source)}) {
                     msg->Attach(
                         symbol.name(), "definition of '%s'"_en_US, n.source);
@@ -1460,7 +1460,7 @@ auto ExpressionAnalyzer::Procedure(const parser::ProcedureDesignator &pd,
                 } else if (IsAssumedLengthCharacterFunction(
                                symbol)) {  // 15.6.2.1(3)
                   if (auto *msg{Say(
-                          "assumed-length CHARACTER(*) function '%s' cannot call itself"_err_en_US,
+                          "Assumed-length CHARACTER(*) function '%s' cannot call itself."_err_en_US,
                           n.source)}) {
                     msg->Attach(
                         symbol.name(), "definition of '%s'"_en_US, n.source);

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -235,6 +235,8 @@ public:
   }
   MaybeExpr Analyze(const parser::StructureComponent &);
 
+  void Analyze(const parser::CallStmt &);
+
 protected:
   int IntegerTypeSpecKind(const parser::IntegerTypeSpec &);
 
@@ -317,6 +319,10 @@ private:
     ProcedureDesignator procedureDesignator;
     ActualArguments arguments;
   };
+
+  MaybeExpr AnalyzeCall(const parser::Call &, bool isSubroutine);
+  std::optional<ActualArguments> AnalyzeArguments(
+      const parser::Call &, bool isSubroutine);
   std::optional<CalleeAndArguments> Procedure(
       const parser::ProcedureDesignator &, ActualArguments &);
   bool EnforceTypeConstraint(parser::CharBlock, const MaybeExpr &, TypeCategory,
@@ -373,7 +379,7 @@ evaluate::Expr<evaluate::SubscriptInteger> AnalyzeKindSelector(
 // decorated with typed representations for top-level expressions.
 class ExprChecker {
 public:
-  explicit ExprChecker(SemanticsContext &context) : context_{context} {}
+  explicit ExprChecker(SemanticsContext &);
 
   template<typename A> bool Pre(const A &) { return true; }
   template<typename A> void Post(const A &) {}
@@ -412,5 +418,18 @@ public:
 private:
   SemanticsContext &context_;
 };
+
+// Semantic analysis of all CALL statements in a parse tree.
+// (Function references are processed as primary expressions.)
+class CallChecker {
+public:
+  explicit CallChecker(SemanticsContext &);
+  void Enter(const parser::CallStmt &);
+  void Leave(const parser::CallStmt &);
+
+private:
+  evaluate::ExpressionAnalyzer analyzer_;
+};
+
 }  // namespace Fortran::semantics
 #endif  // FORTRAN_SEMANTICS_EXPRESSION_H_

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -108,6 +108,7 @@ static bool PerformStatementSemantics(
     SemanticsContext &context, parser::Program &program) {
   ResolveNames(context, program);
   RewriteParseTree(context, program);
+  CheckDeclarations(context);
   StatementSemanticsPass1{context}.Walk(program);
   return StatementSemanticsPass2{context}.Walk(program);
 }

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -100,7 +100,7 @@ private:
 
 using StatementSemanticsPass1 = ExprChecker;
 using StatementSemanticsPass2 = SemanticsVisitor<AllocateChecker,
-    ArithmeticIfStmtChecker, AssignmentChecker, CoarrayChecker,
+    ArithmeticIfStmtChecker, AssignmentChecker, CallChecker, CoarrayChecker,
     DeallocateChecker, DoChecker, IfStmtChecker, IoChecker, NullifyChecker,
     OmpStructureChecker, ReturnStmtChecker, StopChecker>;
 

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -20,6 +20,7 @@
 #include "check-arithmeticif.h"
 #include "check-coarray.h"
 #include "check-deallocate.h"
+#include "check-declarations.h"
 #include "check-do.h"
 #include "check-if-stmt.h"
 #include "check-io.h"

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -193,5 +193,8 @@ struct BaseChecker {
   template<typename N> void Enter(const N &) {}
   template<typename N> void Leave(const N &) {}
 };
+
+// Static declaration checks
+void CheckDeclarations(SemanticsContext &);
 }
 #endif

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -193,8 +193,5 @@ struct BaseChecker {
   template<typename N> void Enter(const N &) {}
   template<typename N> void Leave(const N &) {}
 };
-
-// Static declaration checks
-void CheckDeclarations(SemanticsContext &);
 }
 #endif

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -453,6 +453,22 @@ bool IsFinalizable(const Symbol &symbol) {
 
 bool IsCoarray(const Symbol &symbol) { return symbol.Corank() > 0; }
 
+bool IsAssumedLengthCharacter(const Symbol &symbol) {
+  if (const DeclTypeSpec * type{symbol.GetType()}) {
+    return type->category() == DeclTypeSpec::Character &&
+        type->characterTypeSpec().length().isAssumed();
+  } else {
+    return false;
+  }
+}
+
+bool IsAssumedLengthCharacterFunction(const Symbol &symbol) {
+  // Assumed-length character functions only appear as such in their
+  // definitions; their interfaces, pointers to them, and dummy procedures
+  // cannot be assumed-length.
+  return symbol.has<SubprogramDetails>() && IsAssumedLengthCharacter(symbol);
+}
+
 bool IsExternalInPureContext(const Symbol &symbol, const Scope &scope) {
   if (const auto *pureProc{semantics::FindPureProcedureContaining(&scope)}) {
     if (const Symbol * root{GetAssociationRoot(symbol)}) {

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -111,12 +111,14 @@ inline bool IsIntentIn(const Symbol &symbol) {
 inline bool IsProtected(const Symbol &symbol) {
   return symbol.attrs().test(Attr::PROTECTED);
 }
-bool IsFinalizable(const Symbol &symbol);
-bool IsCoarray(const Symbol &symbol);
+bool IsFinalizable(const Symbol &);
+bool IsCoarray(const Symbol &);
 inline bool IsAssumedSizeArray(const Symbol &symbol) {
   const auto *details{symbol.detailsIf<ObjectEntityDetails>()};
   return details && details->IsAssumedSize();
 }
+bool IsAssumedLengthCharacter(const Symbol &);
+bool IsAssumedLengthCharacterFunction(const Symbol &);
 std::optional<parser::MessageFixedText> WhyNotModifiable(
     const Symbol &symbol, const Scope &scope);
 // Is the symbol modifiable in this scope

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -162,6 +162,7 @@ set(ERROR_TESTS
   blockconstruct01.f90
   blockconstruct02.f90
   blockconstruct03.f90
+  call01.f90
 )
 
 # These test files have expected symbols in the source

--- a/test/semantics/call01.f90
+++ b/test/semantics/call01.f90
@@ -20,7 +20,7 @@ non_recursive function f01(n) result(res)
   if (n <= 0) then
     res = n
   else
-    !ERROR: NON_RECURSIVE procedure 'f01' cannot call itself
+    !ERROR: NON_RECURSIVE procedure 'f01' cannot call itself.
     res = n * f01(n-1) ! 15.6.2.1(3)
   end if
 end function
@@ -35,69 +35,69 @@ non_recursive function f02(n) result(res)
   end if
  contains
   integer function nested
-    !ERROR: NON_RECURSIVE procedure 'f02' cannot call itself
+    !ERROR: NON_RECURSIVE procedure 'f02' cannot call itself.
     nested = n * f02(n-1) ! 15.6.2.1(3)
   end function nested
 end function
 
-!ERROR: assumed-length character function cannot be RECURSIVE
+!ERROR: An assumed-length CHARACTER(*) function cannot be RECURSIVE.
 recursive character(*) function f03(n) ! C723
   integer, value :: n
   f03 = ''
 end function
 
+!ERROR: An assumed-length CHARACTER(*) function cannot be RECURSIVE.
 recursive function f04(n) result(res) ! C723
   integer, value :: n
-  !ERROR: assumed-length character function cannot be RECURSIVE
   character(*) :: res
   res = ''
 end function
 
+!ERROR: An assumed-length CHARACTER(*) function cannot return an array.
 character(*) function f05()
-  !ERROR: assumed-length character function cannot return an array
   dimension :: f05(1) ! C723
   f05(1) = ''
 end function
 
+!ERROR: An assumed-length CHARACTER(*) function cannot return an array.
 function f06()
-  !ERROR: assumed-length character function cannot return an array
   character(*) :: f06(1) ! C723
   f06(1) = ''
 end function
 
+!ERROR: An assumed-length CHARACTER(*) function cannot return a POINTER.
 character(*) function f07()
-  !ERROR: assumed-length character function cannot return a POINTER
   pointer :: f07 ! C723
   character, target :: a = ' '
   f07 => a
 end function
 
+!ERROR: An assumed-length CHARACTER(*) function cannot return a POINTER.
 function f08()
-  !ERROR: assumed-length character function cannot return a POINTER
   character(*), pointer :: f08 ! C723
   character, target :: a = ' '
   f08 => a
 end function
 
-!ERROR: assumed-length character function cannot be declared PURE
+!ERROR: An assumed-length CHARACTER(*) function cannot be PURE.
 pure character(*) function f09() ! C723
   f09 = ''
 end function
 
+!ERROR: An assumed-length CHARACTER(*) function cannot be PURE.
 pure function f10()
-  !ERROR: assumed-length character function cannot be declared PURE
   character(*) :: f10 ! C723
   f10 = ''
 end function
 
-!ERROR: assumed-length character function cannot be declared ELEMENTAL
+!ERROR: An assumed-length CHARACTER(*) function cannot be ELEMENTAL.
 elemental character(*) function f11(n) ! C723
   integer, value :: n
   f11 = ''
 end function
 
+!ERROR: An assumed-length CHARACTER(*) function cannot be ELEMENTAL.
 elemental function f12(n)
-  !ERROR: assumed-length character function cannot be declared ELEMENTAL
   character(*) :: f12 ! C723
   integer, value :: n
   f12 = ''
@@ -109,7 +109,7 @@ function f13(n) result(res)
   if (n <= 0) then
     res = ''
   else
-    !ERROR: assumed-length CHARACTER(*) function 'f13' cannot call itself
+    !ERROR: Assumed-length CHARACTER(*) function 'f13' cannot call itself.
     res = f13(n-1) ! 15.6.2.1(3)
   end if
 end function
@@ -124,7 +124,7 @@ function f14(n) result(res)
   end if
  contains
   character(1) function nested
-    !ERROR: assumed-length CHARACTER(*) function 'f14' cannot call itself
+    !ERROR: Assumed-length CHARACTER(*) function 'f14' cannot call itself.
     nested = f14(n-1) ! 15.6.2.1(3)
   end function nested
 end function

--- a/test/semantics/call01.f90
+++ b/test/semantics/call01.f90
@@ -20,7 +20,7 @@ non_recursive function f01(n) result(res)
   if (n <= 0) then
     res = n
   else
-    !ERROR: non recursive function can't recurse
+    !ERROR: NON_RECURSIVE procedure 'f01' cannot call itself
     res = n * f01(n-1) ! 15.6.2.1(3)
   end if
 end function
@@ -35,12 +35,12 @@ non_recursive function f02(n) result(res)
   end if
  contains
   integer function nested
-    !ERROR: non recursive function can't recurse
+    !ERROR: NON_RECURSIVE procedure 'f02' cannot call itself
     nested = n * f02(n-1) ! 15.6.2.1(3)
   end function nested
 end function
 
-! ERROR: assumed-length character function cannot be RECURSIVE
+!ERROR: assumed-length character function cannot be RECURSIVE
 recursive character(*) function f03(n) ! C723
   integer, value :: n
   f03 = ''
@@ -48,56 +48,56 @@ end function
 
 recursive function f04(n) result(res) ! C723
   integer, value :: n
-  ! ERROR: assumed-length character function cannot be RECURSIVE
+  !ERROR: assumed-length character function cannot be RECURSIVE
   character(*) :: res
   res = ''
 end function
 
 character(*) function f05()
-  ! ERROR: assumed-length character function cannot return an array
+  !ERROR: assumed-length character function cannot return an array
   dimension :: f05(1) ! C723
   f05(1) = ''
 end function
 
 function f06()
-  ! ERROR: assumed-length character function cannot return an array
+  !ERROR: assumed-length character function cannot return an array
   character(*) :: f06(1) ! C723
   f06(1) = ''
 end function
 
 character(*) function f07()
-  ! ERROR: assumed-length character function cannot return a POINTER
+  !ERROR: assumed-length character function cannot return a POINTER
   pointer :: f07 ! C723
   character, target :: a = ' '
   f07 => a
 end function
 
 function f08()
-  ! ERROR: assumed-length character function cannot return a POINTER
+  !ERROR: assumed-length character function cannot return a POINTER
   character(*), pointer :: f08 ! C723
   character, target :: a = ' '
   f08 => a
 end function
 
-! ERROR: assumed-length character function cannot be declared PURE
+!ERROR: assumed-length character function cannot be declared PURE
 pure character(*) function f09() ! C723
   f09 = ''
 end function
 
 pure function f10()
-  ! ERROR: assumed-length character function cannot be declared PURE
+  !ERROR: assumed-length character function cannot be declared PURE
   character(*) :: f10 ! C723
   f10 = ''
 end function
 
-! ERROR: assumed-length character function cannot be declared ELEMENTAL
+!ERROR: assumed-length character function cannot be declared ELEMENTAL
 elemental character(*) function f11(n) ! C723
   integer, value :: n
   f11 = ''
 end function
 
 elemental function f12(n)
-  ! ERROR: assumed-length character function cannot be declared ELEMENTAL
+  !ERROR: assumed-length character function cannot be declared ELEMENTAL
   character(*) :: f12 ! C723
   integer, value :: n
   f12 = ''
@@ -109,7 +109,7 @@ function f13(n) result(res)
   if (n <= 0) then
     res = ''
   else
-    !ERROR: assumed-length CHARACTER(*) function can't recurse
+    !ERROR: assumed-length CHARACTER(*) function 'f13' cannot call itself
     res = f13(n-1) ! 15.6.2.1(3)
   end if
 end function
@@ -124,7 +124,7 @@ function f14(n) result(res)
   end if
  contains
   character(1) function nested
-    !ERROR: assumed-length CHARACTER(*) function can't recurse
+    !ERROR: assumed-length CHARACTER(*) function 'f14' cannot call itself
     nested = f14(n-1) ! 15.6.2.1(3)
   end function nested
 end function

--- a/test/semantics/call02.f90
+++ b/test/semantics/call02.f90
@@ -27,7 +27,7 @@ subroutine s01(elem, subr)
     end subroutine
   end interface
   call subr(cos) ! not an error
-  ! ERROR: cannot pass non-intrinsic ELEMENTAL procedure as argument
+  !ERROR: cannot pass non-intrinsic ELEMENTAL procedure as argument
   call subr(elem)
 end subroutine
 
@@ -47,13 +47,13 @@ module m01
   end function
   subroutine test
     call callme(cos) ! not an error
-    ! ERROR: cannot pass non-intrinsic ELEMENTAL procedure as argument
+    !ERROR: cannot pass non-intrinsic ELEMENTAL procedure as argument
     call callme(elem01)
-    ! ERROR: cannot pass non-intrinsic ELEMENTAL procedure as argument
+    !ERROR: cannot pass non-intrinsic ELEMENTAL procedure as argument
     call callme(elem02)
-    ! ERROR: cannot pass non-intrinsic ELEMENTAL procedure as argument
+    !ERROR: cannot pass non-intrinsic ELEMENTAL procedure as argument
     call callme(elem03)
-    ! ERROR: cannot pass non-intrinsic ELEMENTAL procedure as argument
+    !ERROR: cannot pass non-intrinsic ELEMENTAL procedure as argument
     call callme(elem04)
    contains
     elemental real function elem04(x)
@@ -72,7 +72,7 @@ module m02
 1   continue
    contains
     subroutine internal
-      ! ERROR: alternate return label must be in the inclusive scope
+      !ERROR: alternate return label must be in the inclusive scope
       call altreturn(*1)
     end subroutine
   end subroutine
@@ -88,7 +88,7 @@ module m03
     type(t), intent(in) :: x
   end subroutine
   subroutine test
-    ! ERROR: coindexed argument cannot have a POINTER ultimate component
+    !ERROR: coindexed argument cannot have a POINTER ultimate component
     call callee(coarray[1])
   end subroutine
 end module

--- a/test/semantics/call03.f90
+++ b/test/semantics/call03.f90
@@ -87,7 +87,7 @@ module m01
 
   subroutine test01(x) ! 15.5.2.4(2)
     class(t), intent(in) :: x[*]
-    ! ERROR: coindexed polymorphic effective argument cannot be associated with a polymorphic dummy argument
+    !ERROR: coindexed polymorphic effective argument cannot be associated with a polymorphic dummy argument
     call poly(x[1])
   end subroutine
 
@@ -96,7 +96,7 @@ module m01
   end subroutine
   subroutine test02(x) ! 15.5.2.4(2)
     class(t), intent(in) :: x(*)
-    ! ERROR: assumed-size polymorphic array cannot be associated with a monomorphic dummy argument
+    !ERROR: assumed-size polymorphic array cannot be associated with a monomorphic dummy argument
     call mono(x)
   end subroutine
 
@@ -105,19 +105,19 @@ module m01
   end subroutine
   subroutine test03 ! 15.5.2.4(2)
     type(pdt(0)) :: x
-    ! ERROR: effective argument associated with TYPE(*) dummy argument cannot have a parameterized derived type
+    !ERROR: effective argument associated with TYPE(*) dummy argument cannot have a parameterized derived type
     call typestar(x)
   end subroutine
 
   subroutine test04 ! 15.5.2.4(2)
     type(tbp) :: x
-    ! ERROR: effective argument associated with TYPE(*) dummy argument cannot have type-bound procedures
+    !ERROR: effective argument associated with TYPE(*) dummy argument cannot have type-bound procedures
     call typestar(x)
   end subroutine
 
   subroutine test05 ! 15.5.2.4(2)
     type(final) :: x
-    ! ERROR: effective argument associated with TYPE(*) dummy argument cannot have FINAL procedures
+    !ERROR: effective argument associated with TYPE(*) dummy argument cannot have FINAL procedures
     call typestar(x)
   end subroutine
 
@@ -126,9 +126,9 @@ module m01
   end subroutine
   subroutine test06 ! 15.5.2.4(4)
     character :: ch1
-    ! ERROR: Length of effective character argument is less than required by dummy argument
+    !ERROR: Length of effective character argument is less than required by dummy argument
     call ch2(ch1)
-    ! ERROR: Length of effective character argument is less than required by dummy argument
+    !ERROR: Length of effective character argument is less than required by dummy argument
     call ch2(' ')
   end subroutine
 
@@ -137,13 +137,13 @@ module m01
   end subroutine
   subroutine test07(x) ! 15.5.2.4(6)
     type(alloc) :: x[*]
-    ! ERROR: coindexed effective argument with ALLOCATABLE ultimate component must be associated with a dummy argument with VALUE or INTENT(IN) attributes
+    !ERROR: coindexed effective argument with ALLOCATABLE ultimate component must be associated with a dummy argument with VALUE or INTENT(IN) attributes
     call out01(x[1])
   end subroutine
 
   subroutine test08(x) ! 15.5.2.4(13)
     real :: x[*]
-    ! ERROR: a coindexed scalar argument must be associated with a scalar dummy argument
+    !ERROR: a coindexed scalar argument must be associated with a scalar dummy argument
     call assumedsize(x[1])
   end subroutine
 
@@ -156,13 +156,13 @@ module m01
     real :: ashape(:)
     class(t) :: polyarray(*)
     character(10) :: c(:)
-    ! ERROR: whole scalar argument cannot be associated with a dummy argument array
+    !ERROR: whole scalar argument cannot be associated with a dummy argument array
     call assumedsize(x)
-    ! ERROR: element of pointer array cannot be associated with a dummy argument array
+    !ERROR: element of pointer array cannot be associated with a dummy argument array
     call assumedsize(p(1))
-    ! ERROR: element of assumed-shape array cannot be associated with a  dummy argument array
+    !ERROR: element of assumed-shape array cannot be associated with a  dummy argument array
     call assumedsize(ashape(1))
-    ! ERROR: element of polymorphic array cannot be associated with a dummy argument array
+    !ERROR: element of polymorphic array cannot be associated with a dummy argument array
     call poly(polyarray(1))
     call charray(c(1:1))  ! not an error if character
     call assumedsize(arr(1))  ! not an error if element in sequence
@@ -173,31 +173,31 @@ module m01
   subroutine test10(a) ! 15.5.2.4(16)
     real :: scalar, matrix
     real :: a(*)
-    ! ERROR: rank of effective argument (0) differs from assumed-shape dummy argument (1)
+    !ERROR: rank of effective argument (0) differs from assumed-shape dummy argument (1)
     call assumedshape(scalar)
-    ! ERROR: rank of effective argument (2) differs from assumed-shape dummy argument (1)
+    !ERROR: rank of effective argument (2) differs from assumed-shape dummy argument (1)
     call assumedshape(matrix)
-    ! ERROR: assumed-size array cannot be associated with assumed-shape dummy argument
+    !ERROR: assumed-size array cannot be associated with assumed-shape dummy argument
   end subroutine
 
   subroutine test11(in) ! C15.5.2.4(20)
     real, intent(in) :: in
     real :: x
-    ! ERROR: effective argument associated with INTENT(OUT) dummy must be definable
+    !ERROR: effective argument associated with INTENT(OUT) dummy must be definable
     call intentout(in)
-    ! ERROR: effective argument associated with INTENT(OUT) dummy must be definable
+    !ERROR: effective argument associated with INTENT(OUT) dummy must be definable
     call intentout(3.14159)
-    ! ERROR: effective argument associated with INTENT(OUT) dummy must be definable
+    !ERROR: effective argument associated with INTENT(OUT) dummy must be definable
     call intentout(in + 1.)
-    ! ERROR: effective argument associated with INTENT(IN OUT) dummy must be definable
+    !ERROR: effective argument associated with INTENT(IN OUT) dummy must be definable
     call intentinout(in)
-    ! ERROR: effective argument associated with INTENT(IN OUT) dummy must be definable
+    !ERROR: effective argument associated with INTENT(IN OUT) dummy must be definable
     call intentinout(3.14159)
-    ! ERROR: effective argument associated with INTENT(IN OUT) dummy must be definable
+    !ERROR: effective argument associated with INTENT(IN OUT) dummy must be definable
     call intentinout(in + 1.)
     x = 0.
     call intentinout(x) ! ok
-    ! ERROR: effective argument associated with INTENT(IN OUT) dummy must be definable
+    !ERROR: effective argument associated with INTENT(IN OUT) dummy must be definable
     call intentinout((x))
   end subroutine
 
@@ -205,13 +205,13 @@ module m01
     real :: a(1)
     integer :: j(1)
     j(1) = 1
-    ! ERROR: array section with vector subscript cannot be associated with a dummy argument that must be definable
+    !ERROR: array section with vector subscript cannot be associated with a dummy argument that must be definable
     call intentout(a(j))
-    ! ERROR: array section with vector subscript cannot be associated with a dummy argument that must be definable
+    !ERROR: array section with vector subscript cannot be associated with a dummy argument that must be definable
     call intentinout(a(j))
-    ! ERROR: array section with vector subscript cannot be associated with a dummy argument that must be definable
+    !ERROR: array section with vector subscript cannot be associated with a dummy argument that must be definable
     call asynchronous(a(j))
-    ! ERROR: array section with vector subscript cannot be associated with a dummy argument that must be definable
+    !ERROR: array section with vector subscript cannot be associated with a dummy argument that must be definable
     call volatile(a(j))
   end subroutine
 
@@ -226,9 +226,9 @@ module m01
     type(ultimateCoarray), volatile :: b
     call coarr(a)  ! ok
     call volcoarr(b)  ! ok
-    ! ERROR: VOLATILE attributes must match when argument has a coarray ultimate component
+    !ERROR: VOLATILE attributes must match when argument has a coarray ultimate component
     call coarr(b)
-    ! ERROR: VOLATILE attributes must match when argument has a coarray ultimate component
+    !ERROR: VOLATILE attributes must match when argument has a coarray ultimate component
     call volcoarr(a)
   end subroutine
 
@@ -242,13 +242,13 @@ module m01
     call asynchronousValue(b[1])  ! ok
     call asynchronousValue(c[1])  ! ok
     call asynchronousValue(d[1])  ! ok
-    ! ERROR: coindexed ASYNCHRONOUS or VOLATILE effective argument must not be associated with dummy argument with ASYNCHRONOUS or VOLATILE attributes unless VALUE
+    !ERROR: coindexed ASYNCHRONOUS or VOLATILE effective argument must not be associated with dummy argument with ASYNCHRONOUS or VOLATILE attributes unless VALUE
     call asynchronous(b[1])
     call volatile(b[1])
-    ! ERROR: coindexed ASYNCHRONOUS or VOLATILE effective argument must not be associated with dummy argument with ASYNCHRONOUS or VOLATILE attributes unless VALUE
+    !ERROR: coindexed ASYNCHRONOUS or VOLATILE effective argument must not be associated with dummy argument with ASYNCHRONOUS or VOLATILE attributes unless VALUE
     call asynchronous(c[1])
     call volatile(c[1])
-    ! ERROR: coindexed ASYNCHRONOUS or VOLATILE effective argument must not be associated with dummy argument with ASYNCHRONOUS or VOLATILE attributes unless VALUE
+    !ERROR: coindexed ASYNCHRONOUS or VOLATILE effective argument must not be associated with dummy argument with ASYNCHRONOUS or VOLATILE attributes unless VALUE
     call asynchronous(d[1])
     call volatile(d[1])
   end subroutine
@@ -264,17 +264,17 @@ module m01
     call valueassumedsize(b(::2)) ! ok
     call valueassumedsize(c(::2)) ! ok
     call valueassumedsize(d(::2)) ! ok
-    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    !ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
     call assumedsize(b(::2))
-    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    !ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
     call contiguous(b(::2))
-    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    !ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
     call assumedsize(c(::2))
-    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    !ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
     call contiguous(c(::2))
-    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    !ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
     call assumedsize(d(::2))
-    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    !ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
     call contiguous(d(::2))
   end subroutine
 
@@ -293,17 +293,17 @@ module m01
     call valueassumedsize(b) ! ok
     call valueassumedsize(c) ! ok
     call valueassumedsize(d) ! ok
-    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    !ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
     call assumedsize(b)
-    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    !ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
     call contiguous(b)
-    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    !ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
     call assumedsize(c)
-    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    !ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
     call contiguous(c)
-    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    !ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
     call assumedsize(d)
-    ! ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
+    !ERROR: ASYNCHRONOUS or VOLATILE effective argument that is not simply contiguous cannot be associated with a contiguous dummy argument
     call contiguous(d)
   end subroutine
 

--- a/test/semantics/call04.f90
+++ b/test/semantics/call04.f90
@@ -35,27 +35,27 @@ module m
     real, allocatable, intent(out) :: x(:)
   end subroutine
   subroutine s01b ! C846 - can only be caught at a call via explicit interface
-    ! ERROR: An allocatable coarray cannot be associated with an INTENT(OUT) dummy argument.
+    !ERROR: An allocatable coarray cannot be associated with an INTENT(OUT) dummy argument.
     call s01a(coarray)
   end subroutine
 
   subroutine s02(x) ! C846
-    ! ERROR: An INTENT(OUT) argument must not contain an allocatable coarray.
+    !ERROR: An INTENT(OUT) argument must not contain an allocatable coarray.
     type(hasCoarray), intent(out) :: x
   end subroutine
 
   subroutine s03(x) ! C846
-    ! ERROR: An INTENT(OUT) argument must not contain an allocatable coarray.
+    !ERROR: An INTENT(OUT) argument must not contain an allocatable coarray.
     type(extendsHasCoarray), intent(out) :: x
   end subroutine
 
   subroutine s04(x) ! C846
-    ! ERROR: An INTENT(OUT) argument must not contain an allocatable coarray.
+    !ERROR: An INTENT(OUT) argument must not contain an allocatable coarray.
     type(hasCoarray2), intent(out) :: x
   end subroutine
 
   subroutine s05(x) ! C846
-    ! ERROR: An INTENT(OUT) argument must not contain an allocatable coarray.
+    !ERROR: An INTENT(OUT) argument must not contain an allocatable coarray.
     type(extendsHasCoarray2), intent(out) :: x
   end subroutine
 
@@ -63,12 +63,12 @@ end module
 
 subroutine s06(x) ! C847
   use ISO_FORTRAN_ENV, only: lock_type
-  ! ERROR: A dummy argument of TYPE(LOCK_TYPE) cannot be INTENT(OUT).
+  !ERROR: A dummy argument of TYPE(LOCK_TYPE) cannot be INTENT(OUT).
   type(lock_type), intent(out) :: x
 end subroutine
 
 subroutine s07(x) ! C847
   use ISO_FORTRAN_ENV, only: event_type
-  ! ERROR: A dummy argument of TYPE(EVENT_TYPE) cannot be INTENT(OUT).
+  !ERROR: A dummy argument of TYPE(EVENT_TYPE) cannot be INTENT(OUT).
   type(event_type), intent(out) :: x
 end subroutine

--- a/test/semantics/call05.f90
+++ b/test/semantics/call05.f90
@@ -76,41 +76,41 @@ module m
     call sma(ma) ! ok
     call spp(pp) ! ok
     call spa(pa) ! ok
-    ! ERROR: If a dummy or effective argument is polymorphic, both must be so.
+    !ERROR: If a dummy or effective argument is polymorphic, both must be so.
     call smp(pp)
-    ! ERROR: If a dummy or effective argument is polymorphic, both must be so.
+    !ERROR: If a dummy or effective argument is polymorphic, both must be so.
     call sma(pp)
-    ! ERROR: If a dummy or effective argument is polymorphic, both must be so.
+    !ERROR: If a dummy or effective argument is polymorphic, both must be so.
     call spp(mp)
-    ! ERROR: If a dummy or effective argument is polymorphic, both must be so.
+    !ERROR: If a dummy or effective argument is polymorphic, both must be so.
     call spa(mp)
-    ! ERROR: If a dummy or effective argument is unlimited polymorphic, both must be so.
+    !ERROR: If a dummy or effective argument is unlimited polymorphic, both must be so.
     call sup(pp)
-    ! ERROR: If a dummy or effective argument is unlimited polymorphic, both must be so.
+    !ERROR: If a dummy or effective argument is unlimited polymorphic, both must be so.
     call sua(pa)
-    ! ERROR: If a dummy or effective argument is unlimited polymorphic, both must be so.
+    !ERROR: If a dummy or effective argument is unlimited polymorphic, both must be so.
     call spp(up)
-    ! ERROR: If a dummy or effective argument is unlimited polymorphic, both must be so.
+    !ERROR: If a dummy or effective argument is unlimited polymorphic, both must be so.
     call spa(ua)
-    ! ERROR: Dummy and effective arguments must have the same declared type.
+    !ERROR: Dummy and effective arguments must have the same declared type.
     call spp(pp2)
-    ! ERROR: Dummy and effective arguments must have the same declared type.
+    !ERROR: Dummy and effective arguments must have the same declared type.
     call spa(pa2)
-    ! ERROR: Dummy argument has rank 1, but effective argument has rank 2.
+    !ERROR: Dummy argument has rank 1, but effective argument has rank 2.
     call smp(mpmat)
-    ! ERROR: Dummy argument has rank 1, but effective argument has rank 2.
+    !ERROR: Dummy argument has rank 1, but effective argument has rank 2.
     call sma(mamat)
     call sdmp(dmp) ! ok
     call sdma(dma) ! ok
     call snmp(nmp) ! ok
     call snma(nma) ! ok
-    ! ERROR: Dummy and effective arguments must defer the same type parameters.
+    !ERROR: Dummy and effective arguments must defer the same type parameters.
     call sdmp(nmp)
-    ! ERROR: Dummy and effective arguments must defer the same type parameters.
+    !ERROR: Dummy and effective arguments must defer the same type parameters.
     call sdma(nma)
-    ! ERROR: Dummy and effective arguments must defer the same type parameters.
+    !ERROR: Dummy and effective arguments must defer the same type parameters.
     call snmp(dmp)
-    ! ERROR: Dummy and effective arguments must defer the same type parameters.
+    !ERROR: Dummy and effective arguments must defer the same type parameters.
     call snma(dma)
   end subroutine
 

--- a/test/semantics/call06.f90
+++ b/test/semantics/call06.f90
@@ -46,24 +46,24 @@ module m
   subroutine test(x)
     real :: scalar
     real, allocatable, intent(in) :: x
-    ! ERROR: ALLOCATABLE dummy argument must be associated with an ALLOCATABLE effective argument
+    !ERROR: ALLOCATABLE dummy argument must be associated with an ALLOCATABLE effective argument
     call s01(scalar)
-    ! ERROR: ALLOCATABLE dummy argument must be associated with an ALLOCATABLE effective argument
+    !ERROR: ALLOCATABLE dummy argument must be associated with an ALLOCATABLE effective argument
     call s01(1.)
-    ! ERROR: ALLOCATABLE dummy argument must be associated with an ALLOCATABLE effective argument
+    !ERROR: ALLOCATABLE dummy argument must be associated with an ALLOCATABLE effective argument
     call s01(allofunc()) ! subtle: ALLOCATABLE function result isn't
     call s02(cov) ! ok
     call s03(com) ! ok
-    ! ERROR: Dummy argument has corank 1, but effective argument has corank 2
+    !ERROR: Dummy argument has corank 1, but effective argument has corank 2
     call s02(com)
-    ! ERROR: Dummy argument has corank 2, but effective argument has corank 1
+    !ERROR: Dummy argument has corank 2, but effective argument has corank 1
     call s03(cov)
     call s04(cov[1]) ! ok
-    ! ERROR: Coindexed ALLOCATABLE effective argument must be associated with INTENT(IN) dummy argument
+    !ERROR: Coindexed ALLOCATABLE effective argument must be associated with INTENT(IN) dummy argument
     call s01(cov[1])
-    ! ERROR: Effective argument associated with INTENT(OUT) dummy is not definable.
+    !ERROR: Effective argument associated with INTENT(OUT) dummy is not definable.
     call s05(x)
-    ! ERROR: Effective argument associated with INTENT(IN OUT) dummy is not definable.
+    !ERROR: Effective argument associated with INTENT(IN OUT) dummy is not definable.
     call s06(x)
   end subroutine
 end module

--- a/test/semantics/call07.f90
+++ b/test/semantics/call07.f90
@@ -28,27 +28,27 @@ module m
   end subroutine
 
   subroutine test
-    ! ERROR: CONTIGUOUS pointer must be an array
+    !ERROR: CONTIGUOUS pointer must be an array
     real, pointer, contiguous :: a01 ! C830
     real, pointer :: a02(:)
     real, target :: a03(10)
     real :: a04(10) ! not TARGET
     call s01(a03) ! ok
-    ! ERROR: Effective argument associated with CONTIGUOUS POINTER dummy argument must be simply contiguous
+    !ERROR: Effective argument associated with CONTIGUOUS POINTER dummy argument must be simply contiguous
     call s01(a02)
-    ! ERROR: Effective argument associated with CONTIGUOUS POINTER dummy argument must be simply contiguous
+    !ERROR: Effective argument associated with CONTIGUOUS POINTER dummy argument must be simply contiguous
     call s01(a03(::2))
-    ! ERROR: Effective argument associated with CONTIGUOUS POINTER dummy argument must be simply contiguous
+    !ERROR: Effective argument associated with CONTIGUOUS POINTER dummy argument must be simply contiguous
     call s01(a03([1,2,4]))
     call s02(a02) ! ok
     call s03(a03) ! ok
-    ! ERROR: Effective argument associated with POINTER dummy argument must be POINTER unless INTENT(IN)
+    !ERROR: Effective argument associated with POINTER dummy argument must be POINTER unless INTENT(IN)
     call s02(a03)
-    ! ERROR: Effective argument associated with POINTER INTENT(IN) dummy argument must be a valid target if not a POINTER
+    !ERROR: Effective argument associated with POINTER INTENT(IN) dummy argument must be a valid target if not a POINTER
     call s03(a03([1,2,4]))
-    ! ERROR: Effective argument associated with POINTER INTENT(IN) dummy argument must be a valid target if not a POINTER
+    !ERROR: Effective argument associated with POINTER INTENT(IN) dummy argument must be a valid target if not a POINTER
     call s03([1.])
-    ! ERROR: Effective argument associated with POINTER INTENT(IN) dummy argument must be a valid target if not a POINTER
+    !ERROR: Effective argument associated with POINTER INTENT(IN) dummy argument must be a valid target if not a POINTER
     call s03(a04)
   end subroutine
 end module

--- a/test/semantics/call08.f90
+++ b/test/semantics/call08.f90
@@ -43,19 +43,19 @@ module m
     call s02(c2) ! ok
     call s03(c4) ! ok
     call s04(c4) ! ok
-    ! ERROR: Effective argument associated with a coarray dummy argument must be a coarray
+    !ERROR: Effective argument associated with a coarray dummy argument must be a coarray
     call s01(scalar)
-    ! ERROR: VOLATILE coarray cannot be associated with non-VOLATILE dummy argument
+    !ERROR: VOLATILE coarray cannot be associated with non-VOLATILE dummy argument
     call s01(c2)
-    ! ERROR: non-VOLATILE coarray cannot be associated with VOLATILE dummy argument
+    !ERROR: non-VOLATILE coarray cannot be associated with VOLATILE dummy argument
     call s02(c1)
-    ! ERROR: Effective argument associated with a CONTIGUOUS coarray dummy argument must be simply contiguous
+    !ERROR: Effective argument associated with a CONTIGUOUS coarray dummy argument must be simply contiguous
     call s03(c3)
-    ! ERROR: Effective argument associated with a CONTIGUOUS coarray dummy argument must be simply contiguous
+    !ERROR: Effective argument associated with a CONTIGUOUS coarray dummy argument must be simply contiguous
     call s03(x)
-    ! ERROR: Effective argument associated with a CONTIGUOUS coarray dummy argument must be simply contiguous
-    call s04(c3)
-    ! ERROR: Effective argument associated with a CONTIGUOUS coarray dummy argument must be simply contiguous
+    !ERROR: Effective argument associated with a CONTIGUOUS coarray dummy argument must be simply contiguous
+    call s04c3)
+    !ERROR: Effective argument associated with a CONTIGUOUS coarray dummy argument must be simply contiguous
     call s04(x)
   end subroutine
 end module

--- a/test/semantics/call09.f90
+++ b/test/semantics/call09.f90
@@ -39,13 +39,13 @@ module m
     call s01(null(p)) ! ok
     call s01(sin) ! ok
     call s02(p) ! ok
-    ! ERROR: Effective argument associated with dummy procedure pointer must be a procedure pointer unless INTENT(IN)
+    !ERROR: Effective argument associated with dummy procedure pointer must be a procedure pointer unless INTENT(IN)
     call s02(procptr())
-    ! ERROR: Effective argument associated with dummy procedure pointer must be a procedure pointer unless INTENT(IN)
+    !ERROR: Effective argument associated with dummy procedure pointer must be a procedure pointer unless INTENT(IN)
     call s02(null())
-    ! ERROR: Effective argument associated with dummy procedure pointer must be a procedure pointer unless INTENT(IN)
+    !ERROR: Effective argument associated with dummy procedure pointer must be a procedure pointer unless INTENT(IN)
     call s02(null(p))
-    ! ERROR: Effective argument associated with dummy procedure pointer must be a procedure pointer unless INTENT(IN)
+    !ERROR: Effective argument associated with dummy procedure pointer must be a procedure pointer unless INTENT(IN)
     call s02(sin)
   end subroutine
 

--- a/test/semantics/call10.f90
+++ b/test/semantics/call10.f90
@@ -47,14 +47,14 @@ module m
     real, value :: a ! ok
   end function
   pure real function f03(a) ! C1583
-    ! ERROR: non-POINTER dummy argument of PURE function must be INTENT(IN) or VALUE
+    !ERROR: non-POINTER dummy argument of PURE function must be INTENT(IN) or VALUE
     real :: a
   end function
   pure real function f03a(a)
     real, pointer :: a ! ok
   end function
   pure real function f04(a) ! C1583
-    ! ERROR: non-POINTER dummy argument of PURE function must be INTENT(IN) or VALUE
+    !ERROR: non-POINTER dummy argument of PURE function must be INTENT(IN) or VALUE
     real, intent(out) :: a
   end function
   pure real function f04a(a)
@@ -64,66 +64,66 @@ module m
     real, intent(out), value :: a ! weird, but ok
   end function
   pure function f06() ! C1584
-    ! ERROR: Result of PURE function cannot have an impure FINAL procedure
+    !ERROR: Result of PURE function cannot have an impure FINAL procedure
     type(impureFinal) :: f06
   end function
   pure function f07() ! C1585
-    ! ERROR: Result of PURE function cannot be both polymorphic and ALLOCATABLE
+    !ERROR: Result of PURE function cannot be both polymorphic and ALLOCATABLE
     class(t), allocatable :: f07
   end function
   pure function f08() ! C1585
-    ! ERROR: Result of PURE function cannot have a polymorphic ALLOCATABLE ultimate component
+    !ERROR: Result of PURE function cannot have a polymorphic ALLOCATABLE ultimate component
     type(polyAlloc) :: f08
   end function
 
   pure subroutine s01(a) ! C1586
-    ! ERROR: non-POINTER dummy argument of PURE subroutine must have INTENT() or VALUE attribute
+    !ERROR: non-POINTER dummy argument of PURE subroutine must have INTENT() or VALUE attribute
     real :: a
   end subroutine
   pure subroutine s01a(a)
     real, pointer :: a
   end subroutine
   pure subroutine s02(a) ! C1587
-    ! ERROR: An INTENT(OUT) dummy argument of a PURE procedure cannot have an impure FINAL procedure
+    !ERROR: An INTENT(OUT) dummy argument of a PURE procedure cannot have an impure FINAL procedure
     type(impureFinal), intent(out) :: a
   end subroutine
   pure subroutine s03(a) ! C1588
-    ! ERROR: An INTENT(OUT) dummy argument of a PURE procedure cannot be polymorphic
+    !ERROR: An INTENT(OUT) dummy argument of a PURE procedure cannot be polymorphic
     class(t), intent(out) :: a
   end subroutine
   pure subroutine s04(a) ! C1588
-    ! ERROR: An INTENT(OUT) dummy argument of a PURE procedure cannot have a polymorphic ultimate component
+    !ERROR: An INTENT(OUT) dummy argument of a PURE procedure cannot have a polymorphic ultimate component
     class(polyAlloc), intent(out) :: a
   end subroutine
   pure subroutine s05 ! C1589
-    ! ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
+    !ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
     real, save :: v1
-    ! ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
+    !ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
     real :: v2 = 0.
-    ! ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
+    !ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
     real :: v3
     data v3/0./
-    ! ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
+    !ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
     real :: v4
     common /blk/ v4
     block
-      ! ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
+      !ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
       real, save :: v5
-      ! ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
+      !ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
       real :: v6 = 0.
-      ! ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
+      !ERROR: A PURE subprogram cannot have local variables with the SAVE attribute
     end block
   end subroutine
   pure subroutine s06 ! C1589
-    ! ERROR: A PURE subprogram cannot have local variables with the VOLATILE attribute
+    !ERROR: A PURE subprogram cannot have local variables with the VOLATILE attribute
     real, volatile :: v1
     block
-      ! ERROR: A PURE subprogram cannot have local variables with the VOLATILE attribute
+      !ERROR: A PURE subprogram cannot have local variables with the VOLATILE attribute
       real, volatile :: v2
     end block
   end subroutine
   pure subroutine s07(p) ! C1590
-    ! ERROR: A dummy procedure of a PURE subprogram must be PURE.
+    !ERROR: A dummy procedure of a PURE subprogram must be PURE.
     procedure(impure) :: p
   end subroutine
   ! C1591 is tested in call11.f90.
@@ -131,10 +131,10 @@ module m
    contains
     pure subroutine pure ! ok
     end subroutine
-    ! ERROR: An internal subprogram of a PURE subprogram must also be PURE.
+    !ERROR: An internal subprogram of a PURE subprogram must also be PURE.
     subroutine impure1
     end subroutine
-    ! ERROR: An internal subprogram of a PURE subprogram must also be PURE.
+    !ERROR: An internal subprogram of a PURE subprogram must also be PURE.
     impure subroutine impure2
     end subroutine
   end subroutine
@@ -144,58 +144,58 @@ module m
   end function
   pure subroutine s09 ! C1593
     real :: x
-    ! ERROR: A VOLATILE variable may not appear in a PURE subprogram.
+    !ERROR: A VOLATILE variable may not appear in a PURE subprogram.
     x = volatile
-    ! ERROR: A VOLATILE variable may not appear in a PURE subprogram.
+    !ERROR: A VOLATILE variable may not appear in a PURE subprogram.
     x = volptr
   end subroutine
   ! C1594 is tested in call12.f90.
   pure subroutine s10 ! C1595
     integer :: n
-    ! ERROR: Any procedure referenced in a PURE subprogram must also be PURE.
+    !ERROR: Any procedure referenced in a PURE subprogram must also be PURE.
     n = notpure(1)
   end subroutine
   pure subroutine s11(to) ! C1596
     type(polyAlloc) :: auto, to
-    ! ERROR: Deallocation of a polymorphic object is not permitted in a PURE subprogram.
+    !ERROR: Deallocation of a polymorphic object is not permitted in a PURE subprogram.
     to = auto
     ! Implicit deallocation at the end of the subroutine:
-    ! ERROR: Deallocation of a polymorphic object is not permitted in a PURE subprogram.
+    !ERROR: Deallocation of a polymorphic object is not permitted in a PURE subprogram.
   end subroutine
   pure subroutine s12
     character(20) :: buff
     real :: x
     write(buff, *) 1.0 ! ok
     read(buff, *) x ! ok
-    ! ERROR: External I/O is not allowed in a PURE subprogram
+    !ERROR: External I/O is not allowed in a PURE subprogram
     print *, 'hi' ! C1597
-    ! ERROR: External I/O is not allowed in a PURE subprogram
+    !ERROR: External I/O is not allowed in a PURE subprogram
     open(1, file='launch-codes') ! C1597
-    ! ERROR: External I/O is not allowed in a PURE subprogram
+    !ERROR: External I/O is not allowed in a PURE subprogram
     close(1) ! C1597
-    ! ERROR: External I/O is not allowed in a PURE subprogram
+    !ERROR: External I/O is not allowed in a PURE subprogram
     backspace(1) ! C1597
-    ! ERROR: External I/O is not allowed in a PURE subprogram
+    !ERROR: External I/O is not allowed in a PURE subprogram
     endfile(1) ! C1597
-    ! ERROR: External I/O is not allowed in a PURE subprogram
+    !ERROR: External I/O is not allowed in a PURE subprogram
     rewind(1) ! C1597
-    ! ERROR: External I/O is not allowed in a PURE subprogram
+    !ERROR: External I/O is not allowed in a PURE subprogram
     flush(1) ! C1597
-    ! ERROR: External I/O is not allowed in a PURE subprogram
+    !ERROR: External I/O is not allowed in a PURE subprogram
     wait(1) ! C1597
-    ! ERROR: External I/O is not allowed in a PURE subprogram
+    !ERROR: External I/O is not allowed in a PURE subprogram
     inquire(1, name=buff) ! C1597
-    ! ERROR: External I/O is not allowed in a PURE subprogram
+    !ERROR: External I/O is not allowed in a PURE subprogram
     read(5, *) x ! C1598
-    ! ERROR: External I/O is not allowed in a PURE subprogram
+    !ERROR: External I/O is not allowed in a PURE subprogram
     read(*, *) x ! C1598
-    ! ERROR: External I/O is not allowed in a PURE subprogram
+    !ERROR: External I/O is not allowed in a PURE subprogram
     write(6, *) ! C1598
-    ! ERROR: External I/O is not allowed in a PURE subprogram
+    !ERROR: External I/O is not allowed in a PURE subprogram
     write(*, *) ! C1598
   end subroutine
   pure subroutine s13
-    ! ERROR: An image control statement is not allowed in a PURE subprogram.
+    !ERROR: An image control statement is not allowed in a PURE subprogram.
     sync all ! C1599
     ! TODO others from 11.6.1 (many)
   end subroutine

--- a/test/semantics/call11.f90
+++ b/test/semantics/call11.f90
@@ -22,7 +22,7 @@ module m
   end type
   type, extends(t) :: t2
    contains
-    ! ERROR: An overridden PURE type-bound procedure binding must also be PURE
+    !ERROR: An overridden PURE type-bound procedure binding must also be PURE
     procedure, nopass :: tbp => impure ! 7.5.7.3
   end type
 
@@ -39,15 +39,15 @@ module m
 
   subroutine test
     real :: a(pure(1)) ! ok
-    ! ERROR: A function referenced in a specification expression must be PURE.
+    !ERROR: A function referenced in a specification expression must be PURE.
     real :: b(impure(1)) ! 10.1.11(4)
     forall (j=1:1)
-      ! ERROR: A procedure referenced in a FORALL body must be PURE.
+      !ERROR: A procedure referenced in a FORALL body must be PURE.
       a(j) = impure(j) ! C1037
     end forall
-    ! ERROR: concurrent-header mask expression cannot reference an impure procedure
+    !ERROR: concurrent-header mask expression cannot reference an impure procedure
     do concurrent (j=1:1, impure(j) /= 0) ! C1121
-      ! ERROR: call to impure procedure in DO CONCURRENT not allowed
+      !ERROR: call to impure procedure in DO CONCURRENT not allowed
       a(j) = impure(j) ! C1139
     end do
   end subroutine

--- a/test/semantics/call12.f90
+++ b/test/semantics/call12.f90
@@ -25,7 +25,7 @@ module m
   end type
  contains
   pure subroutine msubr
-    ! ERROR: A PURE subprogram must not define a host-associated object.
+    !ERROR: A PURE subprogram must not define a host-associated object.
     x%a = 0.
   end subroutine
 end module
@@ -40,41 +40,41 @@ pure function test(ptr, in)
   type(hasPtr), allocatable :: alloc
   integer :: n
   common /block/ y
-  ! ERROR: A PURE subprogram must not define an object in COMMON.
+  !ERROR: A PURE subprogram must not define an object in COMMON.
   y%a = 0. ! C1594(1)
-  ! ERROR: A PURE subprogram must not define a USE-associated object.
+  !ERROR: A PURE subprogram must not define a USE-associated object.
   x%a = 0.  ! C1594(1)
-  ! ERROR: A PURE function must not define a pointer dummy argument.
+  !ERROR: A PURE function must not define a pointer dummy argument.
   ptr%a = 0. ! C1594(1)
-  ! ERROR: A PURE subprogram must not define an INTENT(IN) dummy argument.
+  !ERROR: A PURE subprogram must not define an INTENT(IN) dummy argument.
   in%a = 0. ! C1594(1)
-  ! ERROR: A PURE subprogram must not define a coindexed object.
+  !ERROR: A PURE subprogram must not define a coindexed object.
   co[1]%a = 0. ! C1594(1)
-  ! ERROR: A PURE function must not define a pointer dummy argument.
+  !ERROR: A PURE function must not define a pointer dummy argument.
   ptr => y ! C1594(2)
-  ! ERROR: A PURE subprogram must not define a pointer dummy argument.
+  !ERROR: A PURE subprogram must not define a pointer dummy argument.
   nullify(ptr) ! C1594(2), 19.6.8
-  ! ERROR: A PURE subprogram must not use a pointer dummy argument as the target of pointer assignment.
+  !ERROR: A PURE subprogram must not use a pointer dummy argument as the target of pointer assignment.
   ptr2 => ptr ! C1594(3)
-  ! ERROR: A PURE subprogram must not use an INTENT(IN) dummy argument as the target of pointer assignment.
+  !ERROR: A PURE subprogram must not use an INTENT(IN) dummy argument as the target of pointer assignment.
   ptr2 => in ! C1594(3)
-  ! ERROR: Externally visible object 'block' must not be associated with pointer component 'p' in a PURE procedure
+  !ERROR: Externally visible object 'block' must not be associated with pointer component 'p' in a PURE procedure
   n = size([hasPtr(y%a)]) ! C1594(4)
-  ! ERROR: Externally visible object 'x' must not be associated with pointer component 'p' in a PURE procedure
+  !ERROR: Externally visible object 'x' must not be associated with pointer component 'p' in a PURE procedure
   n = size([hasPtr(x%a)]) ! C1594(4)
-  ! ERROR: Externally visible object 'ptr' must not be associated with pointer component 'p' in a PURE procedure
+  !ERROR: Externally visible object 'ptr' must not be associated with pointer component 'p' in a PURE procedure
   n = size([hasPtr(ptr%a)]) ! C1594(4)
-  ! ERROR: A PURE subprogram must not use an INTENT(IN) dummy argument as the target of pointer assignment.
+  !ERROR: A PURE subprogram must not use an INTENT(IN) dummy argument as the target of pointer assignment.
   n = size([hasPtr(in%a)]) ! C1594(4)
-  ! ERROR: A PURE subprogram must not assign to a variable with a POINTER component.
+  !ERROR: A PURE subprogram must not assign to a variable with a POINTER component.
   hp = hp ! C1594(5)
-  ! ERROR: A PURE subprogram must not use a derived type with a POINTER component as a SOURCE=.
+  !ERROR: A PURE subprogram must not use a derived type with a POINTER component as a SOURCE=.
   allocate(alloc, source=hp)
  contains
   pure subroutine internal
-    ! ERROR: A PURE subprogram must not define a host-associated object.
+    !ERROR: A PURE subprogram must not define a host-associated object.
     z%a = 0.
-    ! ERROR: Externally visible object 'z' must not be associated with pointer component 'p' in a PURE procedure
+    !ERROR: Externally visible object 'z' must not be associated with pointer component 'p' in a PURE procedure
     hp = hasPtr(z%a)
   end subroutine
 end function


### PR DESCRIPTION
Defines a static declaration checker for things that don't have to be caught on the fly during name resolution; use it for for basic constraints on assumed-length `CHARACTER(*)` function definitions.  Rearrange some code in `semantics/expression.cc` to lay groundwork for semantic checking of call sites.  Get test `call01.f90` to pass, activate it.