### PR TITLE
Fix bug merging generics on USE

### DIFF
--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -2018,12 +2018,29 @@ void ModuleVisitor::AddUse(
         useSymbol.has<GenericDetails>()) {
       // use-associating generics with the same names: merge them into a
       // new generic in this scope
-      auto genericDetails{ultimate.get<GenericDetails>()};
-      genericDetails.set_useDetails(*useDetails);
-      genericDetails.CopyFrom(useSymbol.get<GenericDetails>());
+      auto generic1{ultimate.get<GenericDetails>()};
+      generic1.set_useDetails(*useDetails);
+      // useSymbol has specific g and so does generic1
+      auto &generic2{useSymbol.get<GenericDetails>()};
+      if (generic1.specific() && generic2.specific() &&
+          generic1.specific() != generic2.specific()) {
+        Say(location,
+            "Generic interface '%s' has ambiguous specific procedures"
+            " from modules '%s' and '%s'"_err_en_US,
+            localSymbol.name(), useDetails->module().name(),
+            useSymbol.owner().GetName().value());
+      } else if (generic1.derivedType() && generic2.derivedType() &&
+          generic1.derivedType() != generic2.derivedType()) {
+        Say(location,
+            "Generic interface '%s' has ambiguous derived types"
+            " from modules '%s' and '%s'"_err_en_US,
+            localSymbol.name(), useDetails->module().name(),
+            useSymbol.owner().GetName().value());
+      } else {
+        generic1.CopyFrom(generic2);
+      }
       EraseSymbol(localSymbol);
-      MakeSymbol(
-          localSymbol.name(), ultimate.attrs(), std::move(genericDetails));
+      MakeSymbol(localSymbol.name(), ultimate.attrs(), std::move(generic1));
     } else {
       ConvertToUseError(localSymbol, location, *useModuleScope_);
     }

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -187,8 +187,8 @@ void GenericDetails::CopyFrom(const GenericDetails &from) {
     derivedType_ = from.derivedType_;
   }
   for (const Symbol *symbol : from.specificProcs_) {
-    auto it{std::find(specificProcs_.begin(), specificProcs_.end(), symbol)};
-    if (it == specificProcs_.end()) {
+    if (std::find(specificProcs_.begin(), specificProcs_.end(), symbol) ==
+        specificProcs_.end()) {
       specificProcs_.push_back(symbol);
     }
   }

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -179,15 +179,19 @@ Symbol *GenericDetails::CheckSpecific() {
 
 void GenericDetails::CopyFrom(const GenericDetails &from) {
   if (from.specific_) {
-    CHECK(!specific_);
+    CHECK(!specific_ || specific_ == from.specific_);
     specific_ = from.specific_;
   }
   if (from.derivedType_) {
-    CHECK(!derivedType_);
+    CHECK(!derivedType_ || derivedType_ == from.derivedType_);
     derivedType_ = from.derivedType_;
   }
-  auto &procs{from.specificProcs_};
-  specificProcs_.insert(specificProcs_.end(), procs.begin(), procs.end());
+  for (const Symbol *symbol : from.specificProcs_) {
+    auto it{std::find(specificProcs_.begin(), specificProcs_.end(), symbol)};
+    if (it == specificProcs_.end()) {
+      specificProcs_.push_back(symbol);
+    }
+  }
 }
 
 // The name of the kind of details for this symbol.

--- a/test/semantics/resolve17.f90
+++ b/test/semantics/resolve17.f90
@@ -198,8 +198,23 @@ contains
     real :: x
   end
 end module
+module m9c
+  interface g
+    module procedure g
+  end interface
+contains
+  subroutine g(x)
+    real :: x
+  end
+end module
 ! Merge use-associated generics that have the same symbol (s1)
 subroutine s9
   use m9a
   use m9b
+end
+! Merge use-associate generics each with specific of same name
+subroutine s9c
+  use m9a
+  !ERROR: Generic interface 'g' has ambiguous specific procedures from modules 'm9a' and 'm9c'
+  use m9c
 end

--- a/test/semantics/resolve17.f90
+++ b/test/semantics/resolve17.f90
@@ -175,3 +175,31 @@ subroutine s8
   !ERROR: Reference to 'g' is ambiguous
   g = 1
 end
+
+module m9a
+  interface g
+    module procedure s1
+    module procedure g
+  end interface
+contains
+  subroutine g()
+  end
+  subroutine s1(x)
+    integer :: x
+  end
+end module
+module m9b
+  use m9a
+  interface g
+    module procedure s2
+  end interface
+contains
+  subroutine s2(x)
+    real :: x
+  end
+end module
+! Merge use-associated generics that have the same symbol (s1)
+subroutine s9
+  use m9a
+  use m9b
+end


### PR DESCRIPTION
When we use-associate the same generic name from two different modules
they are merged together. If the same specific procedure occurs in both
generics it should only occur once in the merged one.

Similarly, it's not an error if they both have a derived type or
specific procedure named the same as the generic, as long as they are
the same symbol.

Fixes #733.