### PR TITLE
Improve flag dumping for -funparse-with-symbols

### DIFF
--- a/test/semantics/symbol09.f90
+++ b/test/semantics/symbol09.f90
@@ -119,7 +119,7 @@ subroutine s6
  integer :: a(5) = 1
  !DEF: /s6/Block1/i ObjectEntity INTEGER(4)
  !DEF: /s6/Block1/j (local) ObjectEntity INTEGER(8)
- !DEF: /s6/Block1/k (implicit) (local_init) ObjectEntity INTEGER(4)
+ !DEF: /s6/Block1/k (implicit, local_init) ObjectEntity INTEGER(4)
   !DEF: /s6/Block1/a (shared) HostAssoc INTEGER(4)
  do concurrent(integer::i=1:5)local(j)local_init(k)shared(a)
   !REF: /s6/Block1/a


### PR DESCRIPTION
Addressing one of Tim's comments in #739, which is to dump the flags we care about along with the `Unparse` process. This commit gets rid of the hard-coded dump for four flags and replaces them with a separate dump function.