### PR TITLE
Prevent RESULT name from being the same as the function name

### DIFF
--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -2473,6 +2473,7 @@ void SubprogramVisitor::Post(const parser::FunctionStmt &stmt) {
   }
   const parser::Name *funcResultName;
   if (funcInfo_.resultName && funcInfo_.resultName->source != name.source) {
+    // Note that RESULT is ignored if it has the same name as the function.
     funcResultName = funcInfo_.resultName;
   } else {
     EraseSymbol(name);  // was added by PushSubprogramScope
@@ -2483,14 +2484,21 @@ void SubprogramVisitor::Post(const parser::FunctionStmt &stmt) {
   funcResultDetails.set_funcResult(true);
   funcInfo_.resultSymbol =
       &MakeSymbol(*funcResultName, std::move(funcResultDetails));
-  if (funcInfo_.resultName && funcInfo_.resultName->source == name.source) {
-    // C1560. TODO also enforce on entry names when entry implemented
-    Say(funcInfo_.resultName->source,
-        "'%s' is already the function name and cannot appear in RESULT"_err_en_US,
-        name.source);
-    context().SetError(*funcInfo_.resultSymbol);
-  }
   details.set_result(*funcInfo_.resultSymbol);
+
+  // C1560. TODO also enforce on entry names when entry implemented
+  if (funcInfo_.resultName && funcInfo_.resultName->source == name.source) {
+    Say(funcInfo_.resultName->source,
+        "The function name should not appear in RESULT, references to '%s' "
+        "inside"
+        " the function will be considered as references to the result only"_en_US,
+        name.source);
+    // RESULT name was ignored above, the only side effect from doing so will be
+    // the inability to make recursive calls. The related parser::Name is still
+    // resolved to the created function result symbol because every parser::Name
+    // should be resolved to avoid internal errors.
+    Resolve(*funcInfo_.resultName, funcInfo_.resultSymbol);
+  }
   name.symbol = currScope().symbol();  // must not be function result symbol
 }
 

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -2483,6 +2483,13 @@ void SubprogramVisitor::Post(const parser::FunctionStmt &stmt) {
   funcResultDetails.set_funcResult(true);
   funcInfo_.resultSymbol =
       &MakeSymbol(*funcResultName, std::move(funcResultDetails));
+  if (funcInfo_.resultName && funcInfo_.resultName->source == name.source) {
+    // C1560. TODO also enforce on entry names when entry implemented
+    Say(funcInfo_.resultName->source,
+        "'%s' is already the function name and cannot appear in RESULT"_err_en_US,
+        name.source);
+    context().SetError(*funcInfo_.resultSymbol);
+  }
   details.set_result(*funcInfo_.resultSymbol);
   name.symbol = currScope().symbol();  // must not be function result symbol
 }

--- a/test/semantics/resolve59.f90
+++ b/test/semantics/resolve59.f90
@@ -71,6 +71,17 @@ end module
 module m_with_result
 ! With RESULT, it refers to the function (recursive calls possible)
 contains
+  ! Sanity test C1560
+  !ERROR: 'f00' is already the function name and cannot appear in RESULT
+  function f00() result(f00)
+  end function
+  !ERROR: 'f0' is already the function name and cannot appear in RESULT
+  function f0(i) result(f0)
+    integer :: i
+    complex(4) :: f0
+    f0 = f0(i+1)*2.
+  end function
+
   ! testing with data object results
   function f1() result(r)
     real :: r

--- a/test/semantics/resolve59.f90
+++ b/test/semantics/resolve59.f90
@@ -66,21 +66,21 @@ contains
     !ERROR: Typeless item not allowed for 'x=' argument
     x = acos(f5)
   end function
+  ! Sanity test: f18 handles C1560 violation by ignoring RESULT
+  function f6() result(f6) !OKI (warning)
+  end function
+  function f7() result(f7) !OKI (warning)
+    real :: x, f7
+    !ERROR: Reference to array 'f7' with empty subscript list
+    x = acos(f7())
+    f7 = x
+    x = acos(f7) !OK
+  end function
 end module
 
 module m_with_result
 ! With RESULT, it refers to the function (recursive calls possible)
 contains
-  ! Sanity test C1560
-  !ERROR: 'f00' is already the function name and cannot appear in RESULT
-  function f00() result(f00)
-  end function
-  !ERROR: 'f0' is already the function name and cannot appear in RESULT
-  function f0(i) result(f0)
-    integer :: i
-    complex(4) :: f0
-    f0 = f0(i+1)*2.
-  end function
 
   ! testing with data object results
   function f1() result(r)


### PR DESCRIPTION
Fix #726.
Check and emit error message for such scenario. Also set error on the result symbol because it is unclear what it is inside the function.