### PR TITLE
Improve flag dumping for -funparse-with-symbols

### DIFF
--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -540,10 +540,9 @@ std::ostream &DumpForUnparse(
     if (!symbol.attrs().empty()) {
       os << ' ' << symbol.attrs();
     }
-    DumpBool(os, "(implicit)", symbol.test(Symbol::Flag::Implicit));
-    DumpBool(os, "(local)", symbol.test(Symbol::Flag::LocalityLocal));
-    DumpBool(os, "(local_init)", symbol.test(Symbol::Flag::LocalityLocalInit));
-    DumpBool(os, "(shared)", symbol.test(Symbol::Flag::LocalityShared));
+    if (!symbol.flags().empty()) {
+      os << " (" << symbol.flags() << ')';
+    }
     os << ' ' << symbol.GetDetailsName();
     DumpType(os, symbol.GetType());
   }

--- a/test/semantics/procinterface01.f90
+++ b/test/semantics/procinterface01.f90
@@ -18,7 +18,7 @@
 !DEF: /module1 Module
 module module1
  abstract interface
-  !DEF: /module1/abstract1 ELEMENTAL, PUBLIC Subprogram REAL(4)
+  !DEF: /module1/abstract1 ELEMENTAL, PUBLIC (Function) Subprogram REAL(4)
   !DEF: /module1/abstract1/x INTENT(IN) ObjectEntity REAL(4)
   real elemental function abstract1(x)
    !REF: /module1/abstract1/x
@@ -27,19 +27,19 @@ module module1
  end interface
 
  interface
-  !DEF: /module1/explicit1 ELEMENTAL, EXTERNAL, PUBLIC Subprogram REAL(4)
+  !DEF: /module1/explicit1 ELEMENTAL, EXTERNAL, PUBLIC (Function) Subprogram REAL(4)
   !DEF: /module1/explicit1/x INTENT(IN) ObjectEntity REAL(4)
   real elemental function explicit1(x)
    !REF: /module1/explicit1/x
    real, intent(in) :: x
   end function explicit1
-  !DEF: /module1/logical EXTERNAL, PUBLIC Subprogram INTEGER(4)
+  !DEF: /module1/logical EXTERNAL, PUBLIC (Function) Subprogram INTEGER(4)
   !DEF: /module1/logical/x INTENT(IN) ObjectEntity REAL(4)
   integer function logical(x)
    !REF: /module1/logical/x
    real, intent(in) :: x
   end function logical
-  !DEF: /module1/tan EXTERNAL, PUBLIC Subprogram CHARACTER(1_4,1)
+  !DEF: /module1/tan EXTERNAL, PUBLIC (Function) Subprogram CHARACTER(1_4,1)
   !DEF: /module1/tan/x INTENT(IN) ObjectEntity REAL(4)
   character(len=1) function tan(x)
    !REF: /module1/tan/x
@@ -50,21 +50,21 @@ module module1
  !DEF: /module1/derived1 PUBLIC DerivedType
  type :: derived1
   !REF: /module1/abstract1
-  !DEF: /module1/derived1/p1 NOPASS, POINTER ProcEntity REAL(4)
-  !DEF: /module1/nested1 PUBLIC Subprogram REAL(4)
+  !DEF: /module1/derived1/p1 NOPASS, POINTER (Function) ProcEntity REAL(4)
+  !DEF: /module1/nested1 PUBLIC (Function) Subprogram REAL(4)
   procedure(abstract1), pointer, nopass :: p1 => nested1
   !REF: /module1/explicit1
-  !DEF: /module1/derived1/p2 NOPASS, POINTER ProcEntity REAL(4)
+  !DEF: /module1/derived1/p2 NOPASS, POINTER (Function) ProcEntity REAL(4)
   !REF: /module1/nested1
   procedure(explicit1), pointer, nopass :: p2 => nested1
-  !DEF: /module1/derived1/p3 NOPASS, POINTER ProcEntity LOGICAL(4)
-  !DEF: /module1/nested2 PUBLIC Subprogram LOGICAL(4)
+  !DEF: /module1/derived1/p3 NOPASS, POINTER (Function) ProcEntity LOGICAL(4)
+  !DEF: /module1/nested2 PUBLIC (Function) Subprogram LOGICAL(4)
   procedure(logical), pointer, nopass :: p3 => nested2
-  !DEF: /module1/derived1/p4 NOPASS, POINTER ProcEntity LOGICAL(4)
-  !DEF: /module1/nested3 PUBLIC Subprogram LOGICAL(4)
+  !DEF: /module1/derived1/p4 NOPASS, POINTER (Function) ProcEntity LOGICAL(4)
+  !DEF: /module1/nested3 PUBLIC (Function) Subprogram LOGICAL(4)
   procedure(logical(kind=4)), pointer, nopass :: p4 => nested3
-  !DEF: /module1/derived1/p5 NOPASS, POINTER ProcEntity COMPLEX(4)
-  !DEF: /module1/nested4 PUBLIC Subprogram COMPLEX(4)
+  !DEF: /module1/derived1/p5 NOPASS, POINTER (Function) ProcEntity COMPLEX(4)
+  !DEF: /module1/nested4 PUBLIC (Function) Subprogram COMPLEX(4)
   procedure(complex), pointer, nopass :: p5 => nested4
   !DEF: /module1/sin INTRINSIC, PUBLIC ProcEntity
   !DEF: /module1/derived1/p6 NOPASS, POINTER ProcEntity
@@ -75,8 +75,8 @@ module module1
   !DEF: /module1/cos INTRINSIC, PUBLIC ProcEntity
   procedure(sin), pointer, nopass :: p7 => cos
   !REF: /module1/tan
-  !DEF: /module1/derived1/p8 NOPASS, POINTER ProcEntity CHARACTER(1_4,1)
-  !DEF: /module1/nested5 PUBLIC Subprogram CHARACTER(1_8,1)
+  !DEF: /module1/derived1/p8 NOPASS, POINTER (Function) ProcEntity CHARACTER(1_4,1)
+  !DEF: /module1/nested5 PUBLIC (Function) Subprogram CHARACTER(1_8,1)
   procedure(tan), pointer, nopass :: p8 => nested5
  end type derived1
 
@@ -118,7 +118,7 @@ contains
   !REF: /module1/nested4/x
   real, intent(in) :: x
   !DEF: /module1/nested4/nested4 ObjectEntity COMPLEX(4)
-  !DEF: /module1/nested4/cmplx INTRINSIC ProcEntity
+  !DEF: /module1/nested4/cmplx INTRINSIC (Function) ProcEntity
   !REF: /module1/nested4/x
   nested4 = cmplx(x+4., 6.)
  end function nested4
@@ -133,7 +133,7 @@ contains
  end function nested5
 end module module1
 
-!DEF: /explicit1 ELEMENTAL Subprogram REAL(4)
+!DEF: /explicit1 ELEMENTAL (Function) Subprogram REAL(4)
 !DEF: /explicit1/x INTENT(IN) ObjectEntity REAL(4)
 real elemental function explicit1(x)
  !REF: /explicit1/x
@@ -143,7 +143,7 @@ real elemental function explicit1(x)
  explicit1 = -x
 end function explicit1
 
-!DEF: /logical Subprogram INTEGER(4)
+!DEF: /logical (Function) Subprogram INTEGER(4)
 !DEF: /logical/x INTENT(IN) ObjectEntity REAL(4)
 integer function logical(x)
  !REF: /logical/x
@@ -153,7 +153,7 @@ integer function logical(x)
  logical = x+3.
 end function logical
 
-!DEF: /tan Subprogram REAL(4)
+!DEF: /tan (Function) Subprogram REAL(4)
 !DEF: /tan/x INTENT(IN) ObjectEntity REAL(4)
 real function tan(x)
  !REF: /tan/x

--- a/test/semantics/symbol01.f90
+++ b/test/semantics/symbol01.f90
@@ -16,19 +16,19 @@
 
 !DEF: /m Module
 module m
- !DEF: /m/f PRIVATE, PURE, RECURSIVE Subprogram REAL(4)
+ !DEF: /m/f PRIVATE, PURE, RECURSIVE (Function) Subprogram REAL(4)
  private :: f
 contains
- !DEF: /m/s BIND(C), PUBLIC, PURE Subprogram
- !DEF: /m/s/x INTENT(IN) (implicit) ObjectEntity REAL(4)
- !DEF: /m/s/y INTENT(INOUT) (implicit) ObjectEntity REAL(4)
+ !DEF: /m/s BIND(C), PUBLIC, PURE (Subroutine) Subprogram
+ !DEF: /m/s/x INTENT(IN) (Implicit) ObjectEntity REAL(4)
+ !DEF: /m/s/y INTENT(INOUT) (Implicit) ObjectEntity REAL(4)
  pure subroutine s (x, y) bind(c)
   !REF: /m/s/x
   intent(in) :: x
   !REF: /m/s/y
   intent(inout) :: y
  contains
-  !DEF: /m/s/ss PURE Subprogram
+  !DEF: /m/s/ss PURE (Subroutine) Subprogram
   pure subroutine ss
   end subroutine
  end subroutine

--- a/test/semantics/symbol02.f90
+++ b/test/semantics/symbol02.f90
@@ -23,7 +23,7 @@ module m
  !DEF: /m/x PUBLIC ObjectEntity TYPE(t)
  type(t) :: x
  interface
-  !DEF: /m/s3 MODULE, PUBLIC Subprogram
+  !DEF: /m/s3 MODULE, PUBLIC (Subroutine) Subprogram
   !DEF: /m/s3/y ObjectEntity TYPE(t)
   module subroutine s3(y)
    !REF: /m/t
@@ -32,7 +32,7 @@ module m
   end subroutine
  end interface
 contains
- !DEF: /m/s PUBLIC Subprogram
+ !DEF: /m/s PUBLIC (Subroutine) Subprogram
  subroutine s
   !REF: /m/t
   !DEF: /m/s/y ObjectEntity TYPE(t)
@@ -40,10 +40,10 @@ contains
   !REF: /m/s/y
   !REF: /m/x
   y = x
-  !DEF: /m/s/s HostAssoc
+  !DEF: /m/s/s (Subroutine) HostAssoc
   call s
  contains
-  !DEF: /m/s/s2 Subprogram
+  !DEF: /m/s/s2 (Subroutine) Subprogram
   subroutine s2
    !REF: /m/x
    !REF: /m/s/y

--- a/test/semantics/symbol03.f90
+++ b/test/semantics/symbol03.f90
@@ -18,12 +18,12 @@
 program main
  !DEF: /main/x ObjectEntity INTEGER(4)
  integer x
- !DEF: /main/s Subprogram
+ !DEF: /main/s (Subroutine) Subprogram
  call s
 contains
  !REF: /main/s
  subroutine s
-  !DEF: /main/s/y (implicit) ObjectEntity REAL(4)
+  !DEF: /main/s/y (Implicit) ObjectEntity REAL(4)
   !REF: /main/x
   y = x
  end subroutine

--- a/test/semantics/symbol05.f90
+++ b/test/semantics/symbol05.f90
@@ -14,7 +14,7 @@
 
 ! Explicit and implicit entities in blocks
 
-!DEF: /s1 Subprogram
+!DEF: /s1 (Subroutine) Subprogram
 subroutine s1
  !DEF: /s1/x ObjectEntity INTEGER(4)
  integer x
@@ -34,26 +34,26 @@ subroutine s1
  end block
 end subroutine
 
-!DEF: /s2 Subprogram
+!DEF: /s2 (Subroutine) Subprogram
 subroutine s2
  implicit integer(w-x)
  block
-  !DEF: /s2/x (implicit) ObjectEntity INTEGER(4)
+  !DEF: /s2/x (Implicit) ObjectEntity INTEGER(4)
   x = 1
-  !DEF: /s2/y (implicit) ObjectEntity REAL(4)
+  !DEF: /s2/y (Implicit) ObjectEntity REAL(4)
   y = 2
  end block
 contains
- !DEF: /s2/s Subprogram
+ !DEF: /s2/s (Subroutine) Subprogram
  subroutine s
   !REF: /s2/x
   x = 1
-  !DEF: /s2/s/w (implicit) ObjectEntity INTEGER(4)
+  !DEF: /s2/s/w (Implicit) ObjectEntity INTEGER(4)
   w = 1
  end subroutine
 end subroutine
 
-!DEF: /s3 Subprogram
+!DEF: /s3 (Subroutine) Subprogram
 subroutine s3
  !DEF: /s3/j ObjectEntity INTEGER(8)
  integer(kind=8) j
@@ -61,7 +61,7 @@ subroutine s3
   !DEF: /s3/Block1/t DerivedType
   type :: t
    !DEF: /s3/Block1/t/x ObjectEntity REAL(4)
-   !DEF: /s3/Block1/t/ImpliedDos1/i (implicit) ObjectEntity INTEGER(4)
+   !DEF: /s3/Block1/t/ImpliedDos1/i (Implicit) ObjectEntity INTEGER(4)
    real :: x(10) = [(i, i=1,10)]
    !DEF: /s3/Block1/t/y ObjectEntity REAL(4)
    !DEF: /s3/Block1/t/ImpliedDos2/j ObjectEntity INTEGER(8)
@@ -70,34 +70,34 @@ subroutine s3
  end block
 end subroutine
 
-!DEF: /s4 Subprogram
+!DEF: /s4 (Subroutine) Subprogram
 subroutine s4
  implicit integer(x)
  interface
-  !DEF: /s4/s EXTERNAL Subprogram
-  !DEF: /s4/s/x (implicit) ObjectEntity REAL(4)
-  !DEF: /s4/s/y (implicit) ObjectEntity INTEGER(4)
+  !DEF: /s4/s EXTERNAL (Subroutine) Subprogram
+  !DEF: /s4/s/x (Implicit) ObjectEntity REAL(4)
+  !DEF: /s4/s/y (Implicit) ObjectEntity INTEGER(4)
   subroutine s (x, y)
    implicit integer(y)
   end subroutine
  end interface
 end subroutine
 
-!DEF: /s5 Subprogram
+!DEF: /s5 (Subroutine) Subprogram
 subroutine s5
  block
-  !DEF: /s5/Block1/x (implicit) ObjectEntity REAL(4)
+  !DEF: /s5/Block1/x (Implicit) ObjectEntity REAL(4)
   dimension :: x(2)
   block
-   !DEF: /s5/Block1/Block1/x (implicit) ObjectEntity REAL(4)
+   !DEF: /s5/Block1/Block1/x (Implicit) ObjectEntity REAL(4)
    dimension :: x(3)
   end block
  end block
- !DEF: /s5/x (implicit) ObjectEntity REAL(4)
+ !DEF: /s5/x (Implicit) ObjectEntity REAL(4)
  x = 1.0
 end subroutine
 
-!DEF: /s6 Subprogram
+!DEF: /s6 (Subroutine) Subprogram
 subroutine s6
   !DEF: /s6/i ObjectEntity INTEGER(4)
   !DEF: /s6/j ObjectEntity INTEGER(4)
@@ -110,7 +110,7 @@ subroutine s6
     asynchronous :: j
     !REF: /s6/Block1/i
     asynchronous :: i
-    !DEF: /s6/Block1/k TARGET(implicit) ObjectEntity INTEGER(4)
+    !DEF: /s6/Block1/k TARGET (Implicit) ObjectEntity INTEGER(4)
     target :: k
   end block
 end subroutine
@@ -121,7 +121,7 @@ module m7
   !DEF: /m7/j PUBLIC ObjectEntity INTEGER(4)
   integer i, j
 end module
-!DEF: /s7 Subprogram
+!DEF: /s7 (Subroutine) Subprogram
 subroutine s7
   !REF: /m7
   use :: m7

--- a/test/semantics/symbol06.f90
+++ b/test/semantics/symbol06.f90
@@ -46,7 +46,7 @@ program main
  i = x3%a1
  !REF: /main/i
  !REF: /main/x3
- !DEF: /main/t3/t2 ObjectEntity TYPE(t2)
+ !DEF: /main/t3/t2 (ParentComp) ObjectEntity TYPE(t2)
  !REF: /main/t2/a2
  i = x3%t2%a2
  !REF: /main/i
@@ -56,7 +56,7 @@ program main
  i = x3%t2%a1
  !REF: /main/i
  !REF: /main/x3
- !DEF: /main/t2/t1 ObjectEntity TYPE(t1)
+ !DEF: /main/t2/t1 (ParentComp) ObjectEntity TYPE(t1)
  !REF: /main/t1/a1
  i = x3%t1%a1
  !REF: /main/i
@@ -76,7 +76,7 @@ module m1
  end type
 end module
 
-!DEF: /s1 Subprogram
+!DEF: /s1 (Subroutine) Subprogram
 subroutine s1
  !REF: /m1
  !DEF: /s1/t2 Use
@@ -97,7 +97,7 @@ subroutine s1
  i = x%t1
  !REF: /s1/i
  !REF: /s1/x
- !DEF: /s1/t3/t2 ObjectEntity TYPE(t1)
+ !DEF: /s1/t3/t2 (ParentComp) ObjectEntity TYPE(t1)
  !REF: /m1/t1/t1
  i = x%t2%t1
 end subroutine

--- a/test/semantics/symbol07.f90
+++ b/test/semantics/symbol07.f90
@@ -36,7 +36,7 @@ program main
  !REF: /main/y
  !REF: /main/z1
  y = z1%im
- !DEF: /main/z2 (implicit) ObjectEntity COMPLEX(4)
+ !DEF: /main/z2 (Implicit) ObjectEntity COMPLEX(4)
  !REF: /main/x
  z2%re = x
  !REF: /main/z2

--- a/test/semantics/symbol08.f90
+++ b/test/semantics/symbol08.f90
@@ -18,11 +18,11 @@ program main
  pointer :: x
  !REF: /main/x
  real x
- !DEF: /main/y EXTERNAL, POINTER ProcEntity REAL(4)
+ !DEF: /main/y EXTERNAL, POINTER (Function) ProcEntity REAL(4)
  pointer :: y
  !REF: /main/y
  procedure (real) :: y
- !DEF: /main/z (implicit) ObjectEntity REAL(4)
+ !DEF: /main/z (Implicit) ObjectEntity REAL(4)
  !REF: /main/y
  z = y()
 end program

--- a/test/semantics/symbol09.f90
+++ b/test/semantics/symbol09.f90
@@ -12,7 +12,7 @@
 ! See the License for the specific language governing permissions and
 ! limitations under the License.
 
-!DEF: /s1 Subprogram
+!DEF: /s1 (Subroutine) Subprogram
 subroutine s1
  !DEF: /s1/a ObjectEntity REAL(4)
  !DEF: /s1/b ObjectEntity REAL(4)
@@ -32,7 +32,7 @@ subroutine s1
  forall(i=1:10)a(i) = b(i)
 end subroutine
 
-!DEF: /s2 Subprogram
+!DEF: /s2 (Subroutine) Subprogram
 subroutine s2
  !DEF: /s2/a ObjectEntity REAL(4)
  real a(10)
@@ -52,7 +52,7 @@ subroutine s2
  end do
 end subroutine
 
-!DEF: /s3 Subprogram
+!DEF: /s3 (Subroutine) Subprogram
 subroutine s3
  !DEF: /s3/n PARAMETER ObjectEntity INTEGER(4)
  integer, parameter :: n = 4
@@ -63,14 +63,14 @@ subroutine s3
  !DEF: /s3/x ObjectEntity REAL(4)
  real, dimension(n,n) :: x
  !REF: /s3/x
- !DEF: /s3/ImpliedDos1/k (implicit) ObjectEntity INTEGER(4)
+ !DEF: /s3/ImpliedDos1/k (Implicit) ObjectEntity INTEGER(4)
  !DEF: /s3/ImpliedDos1/j ObjectEntity INTEGER(8)
  !REF: /s3/n
  !REF: /s3/n2
  data ((x(k,j),integer(kind=8)::j=1,n),k=1,n)/n2*3.0/
 end subroutine
 
-!DEF: /s4 Subprogram
+!DEF: /s4 (Subroutine) Subprogram
 subroutine s4
  !DEF: /s4/t DerivedType
  !DEF: /s4/t/k TypeParam INTEGER(4)
@@ -91,7 +91,7 @@ subroutine s4
  x = t(1)(2)
 end subroutine
 
-!DEF: /s5 Subprogram
+!DEF: /s5 (Subroutine) Subprogram
 subroutine s5
  !DEF: /s5/t DerivedType
  !DEF: /s5/t/l TypeParam INTEGER(4)
@@ -111,16 +111,16 @@ subroutine s5
  allocate(real::y)
 end subroutine
 
-!DEF: /s6 Subprogram
+!DEF: /s6 (Subroutine) Subprogram
 subroutine s6
  !DEF: /s6/j ObjectEntity INTEGER(8)
  integer(kind=8) j
  !DEF: /s6/a ObjectEntity INTEGER(4)
  integer :: a(5) = 1
  !DEF: /s6/Block1/i ObjectEntity INTEGER(4)
- !DEF: /s6/Block1/j (local) ObjectEntity INTEGER(8)
- !DEF: /s6/Block1/k (implicit) (local_init) ObjectEntity INTEGER(4)
-  !DEF: /s6/Block1/a (shared) HostAssoc INTEGER(4)
+ !DEF: /s6/Block1/j (LocalityLocal) ObjectEntity INTEGER(8)
+ !DEF: /s6/Block1/k (Implicit, LocalityLocalInit) ObjectEntity INTEGER(4)
+  !DEF: /s6/Block1/a (LocalityShared) HostAssoc INTEGER(4)
  do concurrent(integer::i=1:5)local(j)local_init(k)shared(a)
   !REF: /s6/Block1/a
   !REF: /s6/Block1/i
@@ -129,7 +129,7 @@ subroutine s6
  end do
 end subroutine
 
-!DEF: /s7 Subprogram
+!DEF: /s7 (Subroutine) Subprogram
 subroutine s7
  !DEF: /s7/one PARAMETER ObjectEntity REAL(4)
  real, parameter :: one = 1.0
@@ -138,7 +138,7 @@ subroutine s7
  complex :: z = (one, -one)
 end subroutine
 
-!DEF: /s8 Subprogram
+!DEF: /s8 (Subroutine) Subprogram
 subroutine s8
  !DEF: /s8/one PARAMETER ObjectEntity REAL(4)
  real, parameter :: one = 1.0
@@ -146,10 +146,10 @@ subroutine s8
  !DEF: /s8/z ObjectEntity REAL(4)
  real y(10), z(10)
  !REF: /s8/y
- !DEF: /s8/ImpliedDos1/i (implicit) ObjectEntity INTEGER(4)
+ !DEF: /s8/ImpliedDos1/i (Implicit) ObjectEntity INTEGER(4)
  !REF: /s8/z
- !DEF: /s8/ImpliedDos2/i (implicit) ObjectEntity INTEGER(4)
- !DEF: /s8/x (implicit) ObjectEntity REAL(4)
+ !DEF: /s8/ImpliedDos2/i (Implicit) ObjectEntity INTEGER(4)
+ !DEF: /s8/x (Implicit) ObjectEntity REAL(4)
  !REF: /s8/one
  data (y(i),i=1,10),(z(i),i=1,10),x/21*one/
 end subroutine

--- a/test/semantics/symbol10.f90
+++ b/test/semantics/symbol10.f90
@@ -15,7 +15,7 @@
 !DEF: /m1 Module
 module m1
 contains
- !DEF: /m1/foo_complex PUBLIC Subprogram
+ !DEF: /m1/foo_complex PUBLIC (Subroutine) Subprogram
  !DEF: /m1/foo_complex/z ObjectEntity COMPLEX(4)
  subroutine foo_complex (z)
   !REF: /m1/foo_complex/z
@@ -26,13 +26,13 @@ end module
 module m2
  !REF: /m1
  use :: m1
- !DEF: /m2/foo PUBLIC Generic
+ !DEF: /m2/foo PUBLIC (Subroutine) Generic
  interface foo
-  !DEF: /m2/foo_int PUBLIC Subprogram
+  !DEF: /m2/foo_int PUBLIC (Subroutine) Subprogram
   module procedure :: foo_int
-  !DEF: /m2/foo_real EXTERNAL, PUBLIC Subprogram
+  !DEF: /m2/foo_real EXTERNAL, PUBLIC (Subroutine) Subprogram
   procedure :: foo_real
-  !DEF: /m2/foo_complex PUBLIC Use
+  !DEF: /m2/foo_complex PUBLIC (Subroutine) Use
   procedure :: foo_complex
  end interface
  interface

--- a/test/semantics/symbol11.f90
+++ b/test/semantics/symbol11.f90
@@ -12,7 +12,7 @@
 ! See the License for the specific language governing permissions and
 ! limitations under the License.
 
-!DEF: /s1 Subprogram
+!DEF: /s1 (Subroutine) Subprogram
 subroutine s1
  implicit none
  !DEF: /s1/x ObjectEntity REAL(8)
@@ -37,7 +37,7 @@ subroutine s1
  end associate
 end subroutine
 
-!DEF: /s2 Subprogram
+!DEF: /s2 (Subroutine) Subprogram
 subroutine s2
  !DEF: /s2/x ObjectEntity CHARACTER(4_4,1)
  !DEF: /s2/y ObjectEntity CHARACTER(4_4,1)
@@ -58,7 +58,7 @@ subroutine s2
  end associate
 end subroutine
 
-!DEF: /s3 Subprogram
+!DEF: /s3 (Subroutine) Subprogram
 subroutine s3
  !DEF: /s3/t1 DerivedType
  type :: t1
@@ -94,7 +94,7 @@ subroutine s3
  end select
 end subroutine
 
-!DEF: /s4 Subprogram
+!DEF: /s4 (Subroutine) Subprogram
 subroutine s4
  !DEF: /s4/t1 DerivedType
  type :: t1
@@ -120,7 +120,7 @@ subroutine s4
  end associate
 end subroutine
 
-!DEF: /s5 Subprogram
+!DEF: /s5 (Subroutine) Subprogram
 subroutine s5
  !DEF: /s5/t DerivedType
  type :: t
@@ -130,7 +130,7 @@ subroutine s5
  !DEF: /s5/b ObjectEntity REAL(4)
  real b
  !DEF: /s5/Block1/x AssocEntity TYPE(t)
- !DEF: /s5/f Subprogram TYPE(t)
+ !DEF: /s5/f (Function) Subprogram TYPE(t)
  associate(x => f())
   !REF: /s5/b
   !REF: /s5/Block1/x

--- a/test/semantics/symbol12.f90
+++ b/test/semantics/symbol12.f90
@@ -14,7 +14,7 @@
 
 ! Verify that SAVE attribute is propagated by EQUIVALENCE
 
-!DEF: /s1 Subprogram
+!DEF: /s1 (Subroutine) Subprogram
 subroutine s1
  !DEF: /s1/a SAVE ObjectEntity REAL(4)
  !DEF: /s1/b SAVE ObjectEntity REAL(4)

--- a/test/semantics/symbol13.f90
+++ b/test/semantics/symbol13.f90
@@ -14,7 +14,7 @@
 
 ! Old-style "*length" specifiers (R723)
 
-!DEF: /f1 Subprogram CHARACTER(1_8,1)
+!DEF: /f1 (Function) Subprogram CHARACTER(1_8,1)
 !DEF: /f1/x1 INTENT(IN) ObjectEntity CHARACTER(2_4,1)
 !DEF: /f1/x2 INTENT(IN) ObjectEntity CHARACTER(3_8,1)
 character*1 function f1(x1, x2)
@@ -23,7 +23,7 @@ character*1 function f1(x1, x2)
  !REF: /f1/n
  !REF: /f1/x1
  !REF: /f1/x2
- !DEF: /f1/len INTRINSIC ProcEntity
+ !DEF: /f1/len INTRINSIC (Function) ProcEntity
  character*(n), intent(in) :: x1, x2*(len(x1)+1)
  !DEF: /f1/t DerivedType
  type :: t

--- a/test/semantics/symbol14.f90
+++ b/test/semantics/symbol14.f90
@@ -30,7 +30,7 @@
   !REF: /MainProgram1/t1/k
   real :: b(k)
   !DEF: /MainProgram1/t2/c ObjectEntity REAL(4)
-  !DEF: /MainProgram1/size INTRINSIC ProcEntity
+  !DEF: /MainProgram1/size INTRINSIC (Function) ProcEntity
   !REF: /MainProgram1/t1/a
   real :: c(size(a))
   !REF: /MainProgram1/t1

--- a/test/semantics/symbol15.f90
+++ b/test/semantics/symbol15.f90
@@ -18,7 +18,7 @@
 module m
  implicit none
  abstract interface
-  !DEF: /m/iface PUBLIC Subprogram
+  !DEF: /m/iface PUBLIC (Subroutine) Subprogram
   subroutine iface
   end subroutine
  end interface
@@ -33,26 +33,26 @@ module m
  !DEF: /m/y PUBLIC, TARGET ObjectEntity REAL(4)
  real, pointer :: op4 => y(1)
  !REF: /m/iface
- !DEF: /m/pp1 EXTERNAL, POINTER, PUBLIC ProcEntity
+ !DEF: /m/pp1 EXTERNAL, POINTER, PUBLIC (Subroutine) ProcEntity
  procedure(iface), pointer :: pp1
  !REF: /m/iface
- !DEF: /m/pp2 EXTERNAL, POINTER, PUBLIC ProcEntity
+ !DEF: /m/pp2 EXTERNAL, POINTER, PUBLIC (Subroutine) ProcEntity
  procedure(iface), pointer :: pp2 => null()
  !REF: /m/iface
- !DEF: /m/pp3 EXTERNAL, POINTER, PUBLIC ProcEntity
- !DEF: /m/ext1 EXTERNAL, PUBLIC ProcEntity
+ !DEF: /m/pp3 EXTERNAL, POINTER, PUBLIC (Subroutine) ProcEntity
+ !DEF: /m/ext1 EXTERNAL, PUBLIC (Subroutine) ProcEntity
  procedure(iface), pointer :: pp3 => ext1
  !REF: /m/iface
- !DEF: /m/pp4 EXTERNAL, POINTER, PUBLIC ProcEntity
- !DEF: /m/ext2 EXTERNAL, PUBLIC Subprogram
+ !DEF: /m/pp4 EXTERNAL, POINTER, PUBLIC (Subroutine) ProcEntity
+ !DEF: /m/ext2 EXTERNAL, PUBLIC (Subroutine) Subprogram
  procedure(iface), pointer :: pp4 => ext2
  !REF: /m/iface
- !DEF: /m/pp5 EXTERNAL, POINTER, PUBLIC ProcEntity
- !DEF: /m/ext3 EXTERNAL, PUBLIC ProcEntity
+ !DEF: /m/pp5 EXTERNAL, POINTER, PUBLIC (Subroutine) ProcEntity
+ !DEF: /m/ext3 EXTERNAL, PUBLIC (Subroutine) ProcEntity
  procedure(iface), pointer :: pp5 => ext3
  !REF: /m/iface
- !DEF: /m/pp6 EXTERNAL, POINTER, PUBLIC ProcEntity
- !DEF: /m/modproc1 PUBLIC Subprogram
+ !DEF: /m/pp6 EXTERNAL, POINTER, PUBLIC (Subroutine) ProcEntity
+ !DEF: /m/modproc1 PUBLIC (Subroutine) Subprogram
  procedure(iface), pointer :: pp6 => modproc1
  !DEF: /m/t1 PUBLIC DerivedType
  type :: t1
@@ -67,25 +67,25 @@ module m
   !REF: /m/y
   real, pointer :: opc4 => y(1)
   !REF: /m/iface
-  !DEF: /m/t1/ppc1 NOPASS, POINTER ProcEntity
+  !DEF: /m/t1/ppc1 NOPASS, POINTER (Subroutine) ProcEntity
   procedure(iface), nopass, pointer :: ppc1
   !REF: /m/iface
-  !DEF: /m/t1/ppc2 NOPASS, POINTER ProcEntity
+  !DEF: /m/t1/ppc2 NOPASS, POINTER (Subroutine) ProcEntity
   procedure(iface), nopass, pointer :: ppc2 => null()
   !REF: /m/iface
-  !DEF: /m/t1/ppc3 NOPASS, POINTER ProcEntity
+  !DEF: /m/t1/ppc3 NOPASS, POINTER (Subroutine) ProcEntity
   !REF: /m/ext1
   procedure(iface), nopass, pointer :: ppc3 => ext1
   !REF: /m/iface
-  !DEF: /m/t1/ppc4 NOPASS, POINTER ProcEntity
+  !DEF: /m/t1/ppc4 NOPASS, POINTER (Subroutine) ProcEntity
   !REF: /m/ext2
   procedure(iface), nopass, pointer :: ppc4 => ext2
   !REF: /m/iface
-  !DEF: /m/t1/ppc5 NOPASS, POINTER ProcEntity
+  !DEF: /m/t1/ppc5 NOPASS, POINTER (Subroutine) ProcEntity
   !REF: /m/ext3
   procedure(iface), nopass, pointer :: ppc5 => ext3
   !REF: /m/iface
-  !DEF: /m/t1/ppc6 NOPASS, POINTER ProcEntity
+  !DEF: /m/t1/ppc6 NOPASS, POINTER (Subroutine) ProcEntity
   !REF: /m/modproc1
   procedure(iface), nopass, pointer :: ppc6 => modproc1
  contains
@@ -116,25 +116,25 @@ module m
   !REF: /m/pdt1/k
   real, pointer :: opc4 => y(k)
   !REF: /m/iface
-  !DEF: /m/pdt1/ppc1 NOPASS, POINTER ProcEntity
+  !DEF: /m/pdt1/ppc1 NOPASS, POINTER (Subroutine) ProcEntity
   procedure(iface), nopass, pointer :: ppc1
   !REF: /m/iface
-  !DEF: /m/pdt1/ppc2 NOPASS, POINTER ProcEntity
+  !DEF: /m/pdt1/ppc2 NOPASS, POINTER (Subroutine) ProcEntity
   procedure(iface), nopass, pointer :: ppc2 => null()
   !REF: /m/iface
-  !DEF: /m/pdt1/ppc3 NOPASS, POINTER ProcEntity
+  !DEF: /m/pdt1/ppc3 NOPASS, POINTER (Subroutine) ProcEntity
   !REF: /m/ext1
   procedure(iface), nopass, pointer :: ppc3 => ext1
   !REF: /m/iface
-  !DEF: /m/pdt1/ppc4 NOPASS, POINTER ProcEntity
+  !DEF: /m/pdt1/ppc4 NOPASS, POINTER (Subroutine) ProcEntity
   !REF: /m/ext2
   procedure(iface), nopass, pointer :: ppc4 => ext2
   !REF: /m/iface
-  !DEF: /m/pdt1/ppc5 NOPASS, POINTER ProcEntity
+  !DEF: /m/pdt1/ppc5 NOPASS, POINTER (Subroutine) ProcEntity
   !REF: /m/ext3
   procedure(iface), nopass, pointer :: ppc5 => ext3
   !REF: /m/iface
-  !DEF: /m/pdt1/ppc6 NOPASS, POINTER ProcEntity
+  !DEF: /m/pdt1/ppc6 NOPASS, POINTER (Subroutine) ProcEntity
   !REF: /m/modproc1
   procedure(iface), nopass, pointer :: ppc6 => modproc1
  contains
@@ -174,11 +174,11 @@ module m
  !REF: /m/y
  real, pointer :: op11 => y(1)
  !REF: /m/iface
- !DEF: /m/pp10 EXTERNAL, POINTER, PUBLIC ProcEntity
+ !DEF: /m/pp10 EXTERNAL, POINTER, PUBLIC (Subroutine) ProcEntity
  !REF: /m/ext1
  procedure(iface), pointer :: pp10 => ext1
  !REF: /m/iface
- !DEF: /m/pp11 EXTERNAL, POINTER, PUBLIC ProcEntity
+ !DEF: /m/pp11 EXTERNAL, POINTER, PUBLIC (Subroutine) ProcEntity
  !REF: /m/ext2
  procedure(iface), pointer :: pp11 => ext2
  !DEF: /m/t2 PUBLIC DerivedType
@@ -190,11 +190,11 @@ module m
   !REF: /m/y
   real, pointer :: opc11 => y(1)
   !REF: /m/iface
-  !DEF: /m/t2/ppc10 NOPASS, POINTER ProcEntity
+  !DEF: /m/t2/ppc10 NOPASS, POINTER (Subroutine) ProcEntity
   !REF: /m/ext1
   procedure(iface), nopass, pointer :: ppc10 => ext1
   !REF: /m/iface
-  !DEF: /m/t2/ppc11 NOPASS, POINTER ProcEntity
+  !DEF: /m/t2/ppc11 NOPASS, POINTER (Subroutine) ProcEntity
   !REF: /m/ext2
   procedure(iface), nopass, pointer :: ppc11 => ext2
  contains
@@ -218,11 +218,11 @@ module m
   !REF: /m/pdt2/k
   real, pointer :: opc11 => y(k)
   !REF: /m/iface
-  !DEF: /m/pdt2/ppc10 NOPASS, POINTER ProcEntity
+  !DEF: /m/pdt2/ppc10 NOPASS, POINTER (Subroutine) ProcEntity
   !REF: /m/ext1
   procedure(iface), nopass, pointer :: ppc10 => ext1
   !REF: /m/iface
-  !DEF: /m/pdt2/ppc11 NOPASS, POINTER ProcEntity
+  !DEF: /m/pdt2/ppc11 NOPASS, POINTER (Subroutine) ProcEntity
   !REF: /m/ext2
   procedure(iface), nopass, pointer :: ppc11 => ext2
  contains
@@ -244,13 +244,13 @@ contains
  subroutine modproc1
  end subroutine
 end module
-!DEF: /ext1 Subprogram
+!DEF: /ext1 (Subroutine) Subprogram
 subroutine ext1
 end subroutine
-!DEF: /ext2 Subprogram
+!DEF: /ext2 (Subroutine) Subprogram
 subroutine ext2
 end subroutine
-!DEF: /ext3 Subprogram
+!DEF: /ext3 (Subroutine) Subprogram
 subroutine ext3
 end subroutine
 !DEF: /main MainProgram

--- a/test/semantics/symbol16.f90
+++ b/test/semantics/symbol16.f90
@@ -16,7 +16,7 @@
 
 !DEF: /p1 MainProgram
 program p1
- !DEF: /p1/f Subprogram INTEGER(4)
+ !DEF: /p1/f (Function) Subprogram INTEGER(4)
  !DEF: /p1/i ObjectEntity INTEGER(4)
  !DEF: /p1/j ObjectEntity INTEGER(4)
  integer f, i, j


### PR DESCRIPTION
(Sorry about the previous PR on this.)

Remove the hard-coded flag dumps and dump out all the marked flags for symbols instead during unparsing.