### PR TITLE
Added semantic checks for map clauses

### DIFF
--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -550,7 +550,11 @@ void OmpStructureChecker::Enter(
     PushContext(dir.source, OmpDirective::TASKYIELD);
   } break;
   case parser::OmpSimpleStandaloneDirective::Directive::TargetEnterData: {
-    // 2.10.2 target-enter-data
+    // 2.10.2 target-enter-data-clause -> if-clause |
+    //                                    device-clause |
+    //                                    map-clause |
+    //                                    depend-clause |
+    //                                    nowait-clause
     PushContext(dir.source, OmpDirective::TARGET_ENTER_DATA);
     OmpClauseSet allowed{OmpClause::MAP, OmpClause::DEPEND, OmpClause::NOWAIT};
     SetContextAllowed(allowed);
@@ -559,7 +563,11 @@ void OmpStructureChecker::Enter(
     SetContextRequired({OmpClause::MAP});
   } break;
   case parser::OmpSimpleStandaloneDirective::Directive::TargetExitData: {
-    // 2.10.3 target-exit-data
+    // 2.10.3  target-enter-data-clause -> if-clause |
+    //                                     device-clause |
+    //                                     map-clause |
+    //                                     depend-clause |
+    //                                     nowait-clause
     PushContext(dir.source, OmpDirective::TARGET_EXIT_DATA);
     OmpClauseSet allowed{OmpClause::MAP, OmpClause::DEPEND, OmpClause::NOWAIT};
     SetContextAllowed(allowed);

--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -437,9 +437,8 @@ void OmpStructureChecker::Enter(const parser::OpenMPBlockConstruct &x) {
     OmpClauseSet allowed{
         OmpClause::IF, OmpClause::MAP, OmpClause::USE_DEVICE_PTR};
     SetContextAllowed(allowed);
-    OmpClauseSet allowedOnce{OmpClause::DEVICE};
-    SetContextAllowedOnce(allowedOnce);
-    SetContextRequired(OmpClauseSet{OmpClause::MAP});
+    SetContextAllowedOnce({OmpClause::DEVICE});
+    SetContextRequired({OmpClause::MAP});
   } break;
   default:
     // TODO others
@@ -557,7 +556,7 @@ void OmpStructureChecker::Enter(
     SetContextAllowed(allowed);
     OmpClauseSet allowedOnce{OmpClause::DEVICE, OmpClause::IF};
     SetContextAllowedOnce(allowedOnce);
-    SetContextRequired(OmpClauseSet{OmpClause::MAP});
+    SetContextRequired({OmpClause::MAP});
   } break;
   case parser::OmpSimpleStandaloneDirective::Directive::TargetExitData: {
     // 2.10.3 target-exit-data
@@ -566,7 +565,7 @@ void OmpStructureChecker::Enter(
     SetContextAllowed(allowed);
     OmpClauseSet allowedOnce{OmpClause::DEVICE, OmpClause::IF};
     SetContextAllowedOnce(allowedOnce);
-    SetContextRequired(OmpClauseSet{OmpClause::MAP});
+    SetContextRequired({OmpClause::MAP});
   } break;
   case parser::OmpSimpleStandaloneDirective::Directive::TargetUpdate: {
     // 2.10.5 target-update
@@ -731,6 +730,9 @@ void OmpStructureChecker::Leave(const parser::OmpClauseList &) {
       }
     }
   }
+
+  GetContext().requiredClauses.IterateOverMembers(
+      [this](OmpClause c) { CheckRequired(c); });
 }
 
 void OmpStructureChecker::Enter(const parser::OmpClause &x) {
@@ -941,7 +943,7 @@ void OmpStructureChecker::Enter(const parser::OmpMapClause &x) {
       if (type != Type::To && type != Type::From && type != Type::Tofrom &&
           type != Type::Alloc) {
         context_.Say(GetContext().clauseSource,
-            "Only the TO, FROM, TOFROM or ALLOC map types are permitted "
+            "Only the TO, FROM, TOFROM, or ALLOC map types are permitted "
             "for MAP clauses on the %s directive"_err_en_US,
             ContextDirectiveAsFortran());
       }
@@ -957,7 +959,7 @@ void OmpStructureChecker::Enter(const parser::OmpMapClause &x) {
     case OmpDirective::TARGET_EXIT_DATA: {
       if (type != Type::Delete && type != Type::Release && type != Type::From) {
         context_.Say(GetContext().clauseSource,
-            "Only the FROM, RELEASE or DELETE map types are permitted "
+            "Only the FROM, RELEASE, or DELETE map types are permitted "
             "for MAP clauses on the %s directive"_err_en_US,
             ContextDirectiveAsFortran());
       }

--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -131,8 +131,7 @@ void OmpStructureChecker::CheckAllowed(OmpClause type) {
 }
 
 void OmpStructureChecker::CheckRequired(OmpClause c) {
-  auto *clause{FindClause(c)};
-  if (!clause) {
+  if (!FindClause(c)) {
     context_.Say(GetContext().directiveSource,
         "At least one %s clause must appear on the %s directive"_err_en_US,
         EnumToString(c), ContextDirectiveAsFortran());
@@ -935,14 +934,14 @@ void OmpStructureChecker::Enter(const parser::OmpMapClause &x) {
   CheckAllowed(OmpClause::MAP);
   if (const auto &maptype{std::get<std::optional<parser::OmpMapType>>(x.t)}) {
     using Type = parser::OmpMapType::Type;
-    const Type &type = std::get<Type>(maptype->t);
+    const Type &type{std::get<Type>(maptype->t)};
     switch (GetContext().directive) {
     case OmpDirective::TARGET:
     case OmpDirective::TARGET_DATA: {
       if (type != Type::To && type != Type::From && type != Type::Tofrom &&
           type != Type::Alloc) {
         context_.Say(GetContext().clauseSource,
-            "Only the to, from, tofrom or alloc map types are permitted "
+            "Only the TO, FROM, TOFROM or ALLOC map types are permitted "
             "for MAP clauses on the %s directive"_err_en_US,
             ContextDirectiveAsFortran());
       }
@@ -950,7 +949,7 @@ void OmpStructureChecker::Enter(const parser::OmpMapClause &x) {
     case OmpDirective::TARGET_ENTER_DATA: {
       if (type != Type::To && type != Type::Alloc) {
         context_.Say(GetContext().clauseSource,
-            "Only the to or alloc map types are permitted "
+            "Only the TO or ALLOC map types are permitted "
             "for MAP clauses on the %s directive"_err_en_US,
             ContextDirectiveAsFortran());
       }
@@ -958,7 +957,7 @@ void OmpStructureChecker::Enter(const parser::OmpMapClause &x) {
     case OmpDirective::TARGET_EXIT_DATA: {
       if (type != Type::Delete && type != Type::Release && type != Type::From) {
         context_.Say(GetContext().clauseSource,
-            "Only the from, release or delete map types are permitted "
+            "Only the FROM, RELEASE or DELETE map types are permitted "
             "for MAP clauses on the %s directive"_err_en_US,
             ContextDirectiveAsFortran());
       }

--- a/lib/semantics/check-omp-structure.h
+++ b/lib/semantics/check-omp-structure.h
@@ -152,8 +152,6 @@ private:
   // collected information for END directive
   void ResetPartialContext(const parser::CharBlock &source) {
     CHECK(!ompContext_.empty());
-    GetContext().requiredClauses.IterateOverMembers(
-        [this](OmpClause c) { CheckRequired(c); });
     SetContextDirectiveSource(source);
     GetContext().allowedClauses = {};
     GetContext().allowedOnceClauses = {};

--- a/lib/semantics/check-omp-structure.h
+++ b/lib/semantics/check-omp-structure.h
@@ -138,6 +138,7 @@ private:
     OmpClauseSet allowedClauses{};
     OmpClauseSet allowedOnceClauses{};
     OmpClauseSet allowedExclusiveClauses{};
+    OmpClauseSet requiredClauses{};
 
     const parser::OmpClause *clause{nullptr};
     std::multimap<OmpClause, const parser::OmpClause *> clauseInfo;
@@ -151,10 +152,13 @@ private:
   // collected information for END directive
   void ResetPartialContext(const parser::CharBlock &source) {
     CHECK(!ompContext_.empty());
+    GetContext().requiredClauses.IterateOverMembers(
+        [this](OmpClause c) { CheckRequired(c); });
     SetContextDirectiveSource(source);
     GetContext().allowedClauses = {};
     GetContext().allowedOnceClauses = {};
     GetContext().allowedExclusiveClauses = {};
+    GetContext().requiredClauses = {};
     GetContext().clauseInfo = {};
   }
   void SetContextDirectiveSource(const parser::CharBlock &directive) {
@@ -175,6 +179,9 @@ private:
   }
   void SetContextAllowedExclusive(const OmpClauseSet &allowedExclusive) {
     GetContext().allowedExclusiveClauses = allowedExclusive;
+  }
+  void SetContextRequired(const OmpClauseSet &required) {
+    GetContext().requiredClauses = required;
   }
   void SetContextClauseInfo(OmpClause type) {
     GetContext().clauseInfo.emplace(type, GetContext().clause);
@@ -199,6 +206,7 @@ private:
   bool HasInvalidWorksharingNesting(
       const parser::CharBlock &, const OmpDirectiveSet &);
   void CheckAllowed(OmpClause);
+  void CheckRequired(OmpClause);
   std::string ContextDirectiveAsFortran();
   void SayNotMatching(const parser::CharBlock &, const parser::CharBlock &);
   template<typename A, typename B, typename C>

--- a/test/semantics/omp-device-constructs.f90
+++ b/test/semantics/omp-device-constructs.f90
@@ -111,4 +111,43 @@ program main
   enddo
   !$omp end teams
 
+  !$omp target map(tofrom:a)
+  do i = 1, N
+     a = 3.14
+  enddo
+  !$omp end target
+
+  !ERROR: Only the to, from, tofrom or alloc map types are permitted for MAP clauses on the TARGET directive
+  !$omp target map(delete:a)
+  do i = 1, N
+     a = 3.14
+  enddo
+  !$omp end target
+
+  !$omp target data device(0) map(to:a)
+  do i = 1, N
+    a = 3.14
+  enddo
+  !$omp end target data
+
+  !ERROR: At least one MAP clause must appear on the TARGET DATA directive
+  !$omp target data device(0)
+  do i = 1, N
+     a = 3.14
+  enddo
+  !$omp end target data
+
+  !ERROR: At most one IF clause can appear on the TARGET ENTER DATA directive
+  !$omp target enter data map(to:a) if(.true.) if(.false.)
+
+  !ERROR: Only the to or alloc map types are permitted for MAP clauses on the TARGET ENTER DATA directive
+  !$omp target enter data map(from:a)
+
+  !$omp target exit data map(delete:a)
+
+  !ERROR: At most one DEVICE clause can appear on the TARGET EXIT DATA directive
+  !$omp target exit data map(from:a) device(0) device(1)
+
+  !ERROR: Only the from, release or delete map types are permitted for MAP clauses on the TARGET EXIT DATA directive
+  !$omp target exit data map(to:a)
 end program main

--- a/test/semantics/omp-device-constructs.f90
+++ b/test/semantics/omp-device-constructs.f90
@@ -117,7 +117,7 @@ program main
   enddo
   !$omp end target
 
-  !ERROR: Only the TO, FROM, TOFROM or ALLOC map types are permitted for MAP clauses on the TARGET directive
+  !ERROR: Only the TO, FROM, TOFROM, or ALLOC map types are permitted for MAP clauses on the TARGET directive
   !$omp target map(delete:a)
   do i = 1, N
      a = 3.14
@@ -148,6 +148,6 @@ program main
   !ERROR: At most one DEVICE clause can appear on the TARGET EXIT DATA directive
   !$omp target exit data map(from:a) device(0) device(1)
 
-  !ERROR: Only the FROM, RELEASE or DELETE map types are permitted for MAP clauses on the TARGET EXIT DATA directive
+  !ERROR: Only the FROM, RELEASE, or DELETE map types are permitted for MAP clauses on the TARGET EXIT DATA directive
   !$omp target exit data map(to:a)
 end program main

--- a/test/semantics/omp-device-constructs.f90
+++ b/test/semantics/omp-device-constructs.f90
@@ -117,7 +117,7 @@ program main
   enddo
   !$omp end target
 
-  !ERROR: Only the to, from, tofrom or alloc map types are permitted for MAP clauses on the TARGET directive
+  !ERROR: Only the TO, FROM, TOFROM or ALLOC map types are permitted for MAP clauses on the TARGET directive
   !$omp target map(delete:a)
   do i = 1, N
      a = 3.14
@@ -140,7 +140,7 @@ program main
   !ERROR: At most one IF clause can appear on the TARGET ENTER DATA directive
   !$omp target enter data map(to:a) if(.true.) if(.false.)
 
-  !ERROR: Only the to or alloc map types are permitted for MAP clauses on the TARGET ENTER DATA directive
+  !ERROR: Only the TO or ALLOC map types are permitted for MAP clauses on the TARGET ENTER DATA directive
   !$omp target enter data map(from:a)
 
   !$omp target exit data map(delete:a)
@@ -148,6 +148,6 @@ program main
   !ERROR: At most one DEVICE clause can appear on the TARGET EXIT DATA directive
   !$omp target exit data map(from:a) device(0) device(1)
 
-  !ERROR: Only the from, release or delete map types are permitted for MAP clauses on the TARGET EXIT DATA directive
+  !ERROR: Only the FROM, RELEASE or DELETE map types are permitted for MAP clauses on the TARGET EXIT DATA directive
   !$omp target exit data map(to:a)
 end program main


### PR DESCRIPTION
This patch adds semantic checks for map clauses, as well as the related checks for target data, target enter data and target exit data.