### PR TITLE
Allow more argument types in some specific intrinsic

### DIFF
--- a/documentation/Extensions.md
+++ b/documentation/Extensions.md
@@ -96,6 +96,12 @@ Extensions, deletions, and legacy features supported by default
   and defining the result type accordingly.
 * DOUBLE COMPLEX intrinsics DREAL, DCMPLX, DCONJG and DIMAG.
 * INT_PTR_KIND intrinsic returns the kind of c_intptr_t.
+* Restricted specific conversion intrinsics FLOAT, SNGL, IDINT, IFIX, DREAL,
+  and DCMPLX accept arguments of any kind instead of only the default kind or
+  double precision kind. Their result kinds remain as specified.
+* Specific intrinsics AMAX0, AMAX1, AMIN0, AMIN1, DMAX1, DMIN1, MAX0, MAX1,
+  MIN0 and MIN1 accept more argument types than specified. They are replaced by
+  the related generics followed by conversions to the specified result types.
 
 Extensions supported when enabled by options
 --------------------------------------------
@@ -144,6 +150,10 @@ Extensions and legacy features deliberately not supported
 * Type parameter declarations must come first in a derived type definition;
   some compilers allow them to follow `PRIVATE`, or be intermixed with the
   component declarations.
+* Wrong argument types in calls to specific intrinsics that have different names than the
+  related generics. Some accepted exceptions are listed above in the allowed extensions.
+  PGI, Intel and XLF support this in ways that are not numerically equivalent.
+  PGI converts the arguments while Intel and XLF replace the specific by the related generic.
 
 Preprocessing behavior
 ======================

--- a/documentation/Extensions.md
+++ b/documentation/Extensions.md
@@ -94,13 +94,13 @@ Extensions, deletions, and legacy features supported by default
   we allow distinct types to be used, promoting
   the arguments as if they were operands to an intrinsic `+` operator,
   and defining the result type accordingly.
-* DOUBLE COMPLEX intrinsics DREAL, DCMPLX, DCONJG and DIMAG.
+* DOUBLE COMPLEX intrinsics DREAL, DCMPLX, DCONJG, and DIMAG.
 * INT_PTR_KIND intrinsic returns the kind of c_intptr_t.
 * Restricted specific conversion intrinsics FLOAT, SNGL, IDINT, IFIX, DREAL,
   and DCMPLX accept arguments of any kind instead of only the default kind or
   double precision kind. Their result kinds remain as specified.
 * Specific intrinsics AMAX0, AMAX1, AMIN0, AMIN1, DMAX1, DMIN1, MAX0, MAX1,
-  MIN0 and MIN1 accept more argument types than specified. They are replaced by
+  MIN0, and MIN1 accept more argument types than specified. They are replaced by
   the related generics followed by conversions to the specified result types.
 
 Extensions supported when enabled by options
@@ -152,7 +152,7 @@ Extensions and legacy features deliberately not supported
   component declarations.
 * Wrong argument types in calls to specific intrinsics that have different names than the
   related generics. Some accepted exceptions are listed above in the allowed extensions.
-  PGI, Intel and XLF support this in ways that are not numerically equivalent.
+  PGI, Intel, and XLF support this in ways that are not numerically equivalent.
   PGI converts the arguments while Intel and XLF replace the specific by the related generic.
 
 Preprocessing behavior

--- a/lib/evaluate/host.cc
+++ b/lib/evaluate/host.cc
@@ -89,7 +89,8 @@ void HostFloatingPointEnvironment::SetUpHostFloatingPointEnvironment(
   case RoundingMode::TiesAwayFromZero:
     fesetround(FE_TONEAREST);
     context.messages().Say(
-        "TiesAwayFromZero rounding mode is not available not available when folding constants with host runtime. Using TiesToEven instead."_en_US);
+        "TiesAwayFromZero rounding mode is not available when folding constants"
+        " with host runtime; using TiesToEven instead"_en_US);
     break;
   }
   flags_.clear();

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -715,8 +715,9 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
 // in Table 16.2 can be used as actual arguments, PROCEDURE() interfaces,
 // and procedure pointer targets.
 // Note that the restricted conversion functions dcmplx, dreal, float, idint,
-// ifix and sngl are extended to accept any argument kind because this a common
-// Fortran compilers behavior.
+// ifix, and sngl are extended to accept any argument kind because this is a
+// common Fortran compilers behavior, and as far as we can tell, is safe and
+// useful.
 struct SpecificIntrinsicInterface : public IntrinsicInterface {
   const char *generic{nullptr};
   bool isRestrictedSpecific{false};
@@ -1685,7 +1686,7 @@ std::optional<SpecificCall> IntrinsicProcTable::Implementation::Probe(
             localContext.messages().Say(
                 "Argument type does not match specific intrinsic '%s' "
                 "requirements, using '%s' generic instead and converting the "
-                "result to %s if needed."_en_US,
+                "result to %s if needed"_en_US,
                 name, genericName, newType.AsFortran());
             if (finalBuffer != nullptr) {
               finalBuffer->Annex(std::move(localBuffer));

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -1685,7 +1685,7 @@ std::optional<SpecificCall> IntrinsicProcTable::Implementation::Probe(
             DynamicType newType{GetReturnType(*specIter->second, defaults_)};
             context.messages().Say(
                 "Argument type does not match specific intrinsic '%s' "
-                "requirements, using '%s' generic instead and converting the "
+                "requirements; using '%s' generic instead and converting the "
                 "result to %s if needed"_en_US,
                 name, genericName, newType.AsFortran());
             specificCall->specificIntrinsic.characteristics.value()


### PR DESCRIPTION
Fix #724.

- Allow all type kinds for arguments in restricted specific intrinsic conversion functions. The result type remains as specified in the standard. No warning, this is ubiquitous and emitting a warning about type conversion when that is what the user request might be weird. Make `dcmplx` and `dreal` restricted intrinsic to avoid issues with this change. These are non-standard intrinsics so it is unspecified whether or not they are restricted, but all standard specific conversion functions are restricted.

- Allow MAX/MIN restricted intrinsic (AMAX0...) to be replaced by the related generic followed by a type conversion of the result to the type of the specific functions. Emit a warning because xlf and ifort are doing so but pgfortran is converting the arguments instead.

- For all the other specific intrinsic with a names that differ from the related generics, only accept the standard argument types because it is less clear what the behavior should be (arg type conversion vs using the generic).
