### PR TITLE
Handle alternative names for relational operators

### DIFF
--- a/lib/semantics/resolve-names-utils.h
+++ b/lib/semantics/resolve-names-utils.h
@@ -21,6 +21,7 @@
 #include "symbol.h"
 #include "type.h"
 #include "../parser/message.h"
+#include <forward_list>
 
 namespace Fortran::parser {
 class CharBlock;
@@ -59,10 +60,15 @@ public:
   GenericSpecInfo(const parser::DefinedOpName &x) { Analyze(x); }
   GenericSpecInfo(const parser::GenericSpec &x) { Analyze(x); }
 
+  GenericKind kind() const { return kind_; }
   const SourceName &symbolName() const { return symbolName_.value(); }
+  // Some intrinsic operators have more than one name (e.g. `operator(.eq.)` and
+  // `operator(==)`). GetAllNames() returns them all, including symbolName.
+  std::forward_list<std::string> GetAllNames() const;
   // Set the GenericKind in this symbol and resolve the corresponding
   // name if there is one
-  void Resolve(Symbol *);
+  void Resolve(Symbol *) const;
+  Symbol *FindInScope(const Scope &) const;
 
 private:
   GenericKind kind_;

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -578,10 +578,7 @@ private:
   // The scope of the module during a UseStmt
   const Scope *useModuleScope_{nullptr};
 
-  Symbol &SetAccess(const SourceName &, Attr);
-  void AddUse(const parser::Rename::Names &);
-  void AddUse(const parser::Rename::Operators &);
-  Symbol *AddUse(const SourceName &);
+  Symbol &SetAccess(const SourceName &, Attr attr, Symbol * = nullptr);
   // A rename in a USE statement: local => use
   struct SymbolRename {
     Symbol *local{nullptr};
@@ -589,7 +586,9 @@ private:
   };
   // Record a use from useModuleScope_ of use Name/Symbol as local Name/Symbol
   SymbolRename AddUse(const SourceName &localName, const SourceName &useName);
+  SymbolRename AddUse(const SourceName &, const SourceName &, Symbol *);
   void AddUse(const SourceName &, Symbol &localSymbol, const Symbol &useSymbol);
+  void AddUse(const GenericSpecInfo &);
   Scope *FindModule(const parser::Name &, Scope *ancestor = nullptr);
 };
 
@@ -1879,29 +1878,41 @@ bool ModuleVisitor::Pre(const parser::Only &x) {
   std::visit(
       common::visitors{
           [&](const Indirection<parser::GenericSpec> &generic) {
-            auto info{GenericSpecInfo{generic.value()}};
-            info.Resolve(AddUse(info.symbolName()));
+            AddUse(GenericSpecInfo{generic.value()});
           },
-          [&](const parser::Name &name) { Resolve(name, AddUse(name.source)); },
-          [&](const parser::Rename &rename) {
-            std::visit(
-                common::visitors{
-                    [&](const parser::Rename::Names &names) { AddUse(names); },
-                    [&](const parser::Rename::Operators &ops) { AddUse(ops); },
-                },
-                rename.u);
+          [&](const parser::Name &name) {
+            Resolve(name, AddUse(name.source, name.source).use);
           },
+          [&](const parser::Rename &rename) { Walk(rename); },
       },
       x.u);
   return false;
 }
 
 bool ModuleVisitor::Pre(const parser::Rename::Names &x) {
-  AddUse(x);
+  const auto &localName{std::get<0>(x.t)};
+  const auto &useName{std::get<1>(x.t)};
+  SymbolRename rename{AddUse(localName.source, useName.source)};
+  Resolve(useName, rename.use);
+  Resolve(localName, rename.local);
   return false;
 }
 bool ModuleVisitor::Pre(const parser::Rename::Operators &x) {
-  AddUse(x);
+  const parser::DefinedOpName &local{std::get<0>(x.t)};
+  const parser::DefinedOpName &use{std::get<1>(x.t)};
+  GenericSpecInfo localInfo{local};
+  GenericSpecInfo useInfo{use};
+  if (IsIntrinsicOperator(context(), local.v.source)) {
+    Say(local.v,
+        "Intrinsic operator '%s' may not be used as a defined operator"_err_en_US);
+  } else if (IsLogicalConstant(context(), local.v.source)) {
+    Say(local.v,
+        "Logical constant '%s' may not be used as a defined operator"_err_en_US);
+  } else {
+    SymbolRename rename{AddUse(localInfo.symbolName(), useInfo.symbolName())};
+    useInfo.Resolve(rename.use);
+    localInfo.Resolve(rename.local);
+  }
   return false;
 }
 
@@ -1943,42 +1954,16 @@ void ModuleVisitor::Post(const parser::UseStmt &x) {
   useModuleScope_ = nullptr;
 }
 
-void ModuleVisitor::AddUse(const parser::Rename::Names &names) {
-  const auto &localName{std::get<0>(names.t)};
-  const auto &useName{std::get<1>(names.t)};
-  SymbolRename rename{AddUse(localName.source, useName.source)};
-  Resolve(useName, rename.use);
-  Resolve(localName, rename.local);
-}
-
-void ModuleVisitor::AddUse(const parser::Rename::Operators &ops) {
-  const parser::DefinedOpName &local{std::get<0>(ops.t)};
-  const parser::DefinedOpName &use{std::get<1>(ops.t)};
-  GenericSpecInfo localInfo{local};
-  GenericSpecInfo useInfo{use};
-  if (IsIntrinsicOperator(context(), local.v.source)) {
-    Say(local.v,
-        "Intrinsic operator '%s' may not be used as a defined operator"_err_en_US);
-  } else if (IsLogicalConstant(context(), local.v.source)) {
-    Say(local.v,
-        "Logical constant '%s' may not be used as a defined operator"_err_en_US);
-  } else {
-    SymbolRename rename{AddUse(localInfo.symbolName(), useInfo.symbolName())};
-    useInfo.Resolve(rename.use);
-    localInfo.Resolve(rename.local);
-  }
-}
-
-Symbol *ModuleVisitor::AddUse(const SourceName &useName) {
-  return AddUse(useName, useName).use;
+ModuleVisitor::SymbolRename ModuleVisitor::AddUse(
+    const SourceName &localName, const SourceName &useName) {
+  return AddUse(localName, useName, FindInScope(*useModuleScope_, useName));
 }
 
 ModuleVisitor::SymbolRename ModuleVisitor::AddUse(
-    const SourceName &localName, const SourceName &useName) {
+    const SourceName &localName, const SourceName &useName, Symbol *useSymbol) {
   if (!useModuleScope_) {
     return {};  // error occurred finding module
   }
-  auto *useSymbol{FindInScope(*useModuleScope_, useName)};
   if (!useSymbol) {
     Say(useName,
         IsDefinedOperator(useName)
@@ -2074,6 +2059,14 @@ void ModuleVisitor::AddUse(
   }
 }
 
+void ModuleVisitor::AddUse(const GenericSpecInfo &info) {
+  if (useModuleScope_) {
+    const auto &name{info.symbolName()};
+    auto rename{AddUse(name, name, info.FindInScope(*useModuleScope_))};
+    info.Resolve(rename.use);
+  }
+}
+
 bool ModuleVisitor::BeginSubmodule(
     const parser::Name &name, const parser::ParentIdentifier &parentId) {
   auto &ancestorName{std::get<parser::Name>(parentId.t)};
@@ -2148,7 +2141,7 @@ void InterfaceVisitor::Post(const parser::EndInterfaceStmt &) {
 
 // Create a symbol in genericSymbol_ for this GenericSpec.
 bool InterfaceVisitor::Pre(const parser::GenericSpec &x) {
-  if (auto *symbol{currScope().FindSymbol(GenericSpecInfo{x}.symbolName())}) {
+  if (auto *symbol{GenericSpecInfo{x}.FindInScope(currScope())}) {
     SetGenericSymbol(*symbol);
   }
   return false;
@@ -3597,18 +3590,24 @@ bool DeclarationVisitor::Pre(const parser::TypeBoundGenericStmt &x) {
   const auto &genericSpec{std::get<Indirection<parser::GenericSpec>>(x.t)};
   const auto &bindingNames{std::get<std::list<parser::Name>>(x.t)};
   auto info{GenericSpecInfo{genericSpec.value()}};
-  const SourceName &symbolName{info.symbolName()};
+  SourceName symbolName{info.symbolName()};
   bool isPrivate{accessSpec ? accessSpec->v == parser::AccessSpec::Kind::Private
                             : derivedTypeInfo_.privateBindings};
-  auto *genericSymbol{FindInScope(currScope(), symbolName)};
+  auto *genericSymbol{info.FindInScope(currScope())};
   if (genericSymbol) {
     if (!genericSymbol->has<GenericBindingDetails>()) {
       genericSymbol = nullptr;  // MakeTypeSymbol will report the error below
     }
-  } else if (auto *inheritedSymbol{
-                 FindInTypeOrParents(currScope(), symbolName)}) {
+  } else {
     // look in parent types:
-    if (inheritedSymbol->has<GenericBindingDetails>()) {
+    Symbol *inheritedSymbol{nullptr};
+    for (const auto &name : info.GetAllNames()) {
+      inheritedSymbol = FindInTypeOrParents(currScope(), SourceName{name});
+      if (inheritedSymbol) {
+        break;
+      }
+    }
+    if (inheritedSymbol && inheritedSymbol->has<GenericBindingDetails>()) {
       CheckAccessibility(symbolName, isPrivate, *inheritedSymbol);  // C771
     }
   }
@@ -5363,7 +5362,14 @@ bool ModuleVisitor::Pre(const parser::AccessStmt &x) {
               },
               [=](const Indirection<parser::GenericSpec> &y) {
                 auto info{GenericSpecInfo{y.value()}};
-                info.Resolve(&SetAccess(info.symbolName(), accessAttr));
+                const auto &symbolName{info.symbolName()};
+                if (auto *symbol{info.FindInScope(currScope())}) {
+                  info.Resolve(&SetAccess(symbolName, accessAttr, symbol));
+                } else if (info.kind() == GenericKind::Name) {
+                  info.Resolve(&SetAccess(symbolName, accessAttr));
+                } else {
+                  Say(symbolName, "Generic spec '%s' not found"_err_en_US);
+                }
               },
           },
           accessId.u);
@@ -5372,10 +5378,13 @@ bool ModuleVisitor::Pre(const parser::AccessStmt &x) {
   return false;
 }
 
-// Set the access specification for this name.
-Symbol &ModuleVisitor::SetAccess(const SourceName &name, Attr attr) {
-  Symbol &symbol{MakeSymbol(name)};
-  Attrs &attrs{symbol.attrs()};
+// Set the access specification for this symbol.
+Symbol &ModuleVisitor::SetAccess(
+    const SourceName &name, Attr attr, Symbol *symbol) {
+  if (!symbol) {
+    symbol = &MakeSymbol(name);
+  }
+  Attrs &attrs{symbol->attrs()};
   if (attrs.HasAny({Attr::PUBLIC, Attr::PRIVATE})) {
     // PUBLIC/PRIVATE already set: make it a fatal error if it changed
     Attr prev = attrs.test(Attr::PUBLIC) ? Attr::PUBLIC : Attr::PRIVATE;
@@ -5386,7 +5395,7 @@ Symbol &ModuleVisitor::SetAccess(const SourceName &name, Attr attr) {
   } else {
     attrs.set(attr);
   }
-  return symbol;
+  return *symbol;
 }
 
 static bool NeedsExplicitType(const Symbol &symbol) {
@@ -5453,7 +5462,7 @@ void ResolveNamesVisitor::CreateGeneric(const parser::GenericSpec &x) {
     return;
   }
   GenericDetails genericDetails;
-  if (Symbol * existing{currScope().FindSymbol(symbolName)}) {
+  if (Symbol * existing{info.FindInScope(currScope())}) {
     if (existing->has<GenericDetails>()) {
       info.Resolve(existing);
       return;  // already have generic, add to it

--- a/test/semantics/modfile07.f90
+++ b/test/semantics/modfile07.f90
@@ -16,13 +16,34 @@
 module m1
   interface foo
     real function s1(x,y)
-      real x,y
+      real, intent(in) :: x
+      logical, intent(in) :: y
     end function
     complex function s2(x,y)
-      complex x,y
+      complex, intent(in) :: x
+      logical, intent(in) :: y
     end function
   end interface
   generic :: operator ( + ) => s1, s2
+  interface operator ( /= )
+    logical function f1(x, y)
+      real, intent(in) :: x
+      logical, intent(in) :: y
+    end function
+  end interface
+  interface
+    logical function f2(x, y)
+      complex, intent(in) :: x
+      logical, intent(in) :: y
+    end function
+    logical function f3(x, y)
+      integer, intent(in) :: x
+      logical, intent(in) :: y
+    end function
+  end interface
+  generic :: operator(.ne.) => f2
+  generic :: operator(<>) => f3
+  private :: operator( .ne. )
   interface bar
     procedure :: s1
     procedure :: s2
@@ -37,10 +58,10 @@ module m1
   end interface
 contains
   logical function s3(x,y)
-    logical x,y
+    logical, intent(in) :: x,y
   end function
   integer function s4(x,y)
-    integer x,y
+    integer, intent(in) :: x,y
   end function
 end
 !Expect: m1.mod
@@ -51,21 +72,48 @@ end
 ! end interface
 ! interface
 !  function s1(x,y)
-!   real(4)::x
-!   real(4)::y
+!   real(4),intent(in)::x
+!   logical(4),intent(in)::y
 !   real(4)::s1
 !  end
 ! end interface
 ! interface
 !  function s2(x,y)
-!   complex(4)::x
-!   complex(4)::y
+!   complex(4),intent(in)::x
+!   logical(4),intent(in)::y
 !   complex(4)::s2
 !  end
 ! end interface
 ! interface operator(+)
 !  procedure::s1
 !  procedure::s2
+! end interface
+! interface operator(/=)
+!  procedure::f1
+!  procedure::f2
+!  procedure::f3
+! end interface
+! private::operator(/=)
+! interface
+!  function f1(x,y)
+!   real(4),intent(in)::x
+!   logical(4),intent(in)::y
+!   logical(4)::f1
+!  end
+! end interface
+! interface
+!  function f2(x,y)
+!   complex(4),intent(in)::x
+!   logical(4),intent(in)::y
+!   logical(4)::f2
+!  end
+! end interface
+! interface
+!  function f3(x,y)
+!   integer(4),intent(in)::x
+!   logical(4),intent(in)::y
+!   logical(4)::f3
+!  end
 ! end interface
 ! interface bar
 !  procedure::s1
@@ -81,13 +129,13 @@ end
 ! end interface
 !contains
 ! function s3(x,y)
-!  logical(4)::x
-!  logical(4)::y
+!  logical(4),intent(in)::x
+!  logical(4),intent(in)::y
 !  logical(4)::s3
 ! end
 ! function s4(x,y)
-!  integer(4)::x
-!  integer(4)::y
+!  integer(4),intent(in)::x
+!  integer(4),intent(in)::y
 !  integer(4)::s4
 ! end
 !end
@@ -101,6 +149,9 @@ end
 ! use m1,only:s1
 ! use m1,only:s2
 ! use m1,only:operator(+)
+! use m1,only:f1
+! use m1,only:f2
+! use m1,only:f3
 ! use m1,only:bar
 ! use m1,only:operator(.bar.)
 ! use m1,only:s3
@@ -264,4 +315,33 @@ end
 !   integer(4)::f
 !  end
 ! end interface
+!end
+
+module m6a
+  interface operator(<)
+    logical function lt(x, y)
+      logical, intent(in) :: x, y
+    end function
+  end interface
+end
+!Expect: m6a.mod
+!module m6a
+! interface operator(<)
+!  procedure::lt
+! end interface
+! interface
+!  function lt(x,y)
+!   logical(4),intent(in)::x
+!   logical(4),intent(in)::y
+!   logical(4)::lt
+!  end
+! end interface
+!end
+
+module m6b
+  use m6a, only: operator(.lt.)
+end
+!Expect: m6b.mod
+!module m6b
+! use m6a,only:operator(.lt.)
 !end

--- a/test/semantics/resolve11.f90
+++ b/test/semantics/resolve11.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -39,3 +39,26 @@ contains
     integer, intent(in) :: x, y
   end
 end module
+
+module m3
+  type t
+  end type
+  private :: operator(.lt.)
+  interface operator(<)
+    logical function lt(x, y)
+      import t
+      type(t) :: x, y
+    end function
+  end interface
+  !ERROR: The accessibility of 'operator(<)' has already been specified as PRIVATE
+  public :: operator(<)
+  interface operator(.gt.)
+    logical function gt(x, y)
+      import t
+      type(t) :: x, y
+    end function
+  end interface
+  public :: operator(>)
+  !ERROR: The accessibility of 'operator(.gt.)' has already been specified as PUBLIC
+  private :: operator(.gt.)
+end

--- a/test/semantics/resolve25.f90
+++ b/test/semantics/resolve25.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -52,4 +52,22 @@ module m2
   generic :: operator(+)=> f
   !ERROR: Procedure 'f' is already specified in generic 'operator(+)'
   generic :: operator(+)=> f
+end
+
+module m3
+  interface operator(.ge.)
+    procedure f
+  end interface
+  interface operator(>=)
+    !ERROR: Procedure 'f' is already specified in generic 'operator(.ge.)'
+    procedure f
+  end interface
+  generic :: operator(>) => f
+  !ERROR: Procedure 'f' is already specified in generic 'operator(>)'
+  generic :: operator(.gt.) => f
+contains
+  logical function f(x, y) result(result)
+    logical, intent(in) :: x, y
+    result = .true.
+  end
 end

--- a/test/semantics/resolve38.f90
+++ b/test/semantics/resolve38.f90
@@ -117,3 +117,25 @@ contains
   subroutine s2(x)
   end
 end
+
+module m6
+  type t
+  contains
+    procedure :: f1
+    procedure :: f2
+    generic :: operator(.eq.) => f1
+    !ERROR: Binding name 'f1' was already specified for generic 'operator(.eq.)'
+    generic :: operator(==) => f2, f1
+  end type
+contains
+  logical function f1(x, y) result(result)
+    class(t), intent(in) :: x
+    real, intent(in) :: y
+    result = .true.
+  end
+  logical function f2(x, y) result(result)
+    class(t), intent(in) :: x
+    integer, intent(in) :: y
+    result = .true.
+  end
+end


### PR DESCRIPTION
10.1.6.2 says:
> The operators <, <=, >, >=, ==, and /= always have the same interpretations
> as the operators .LT., .LE., .GT., .GE., .EQ., and .NE., respectively.
That means we have to treat `operator(<)` like `operator(.lt.)`,
for example.

We can't just choose always to use one form (e.g. replacing `operator(.lt.)`
with `operator(<)`). This is because all symbols names are `CharBlock`s
referring to the cooked character stream so that they have proper source
provenance. Also, if a user prefers one style and uses it consistently,
that's the form they should see in messages.

So the fix is to use whatever form is found in the source, but also to
look up symbols by the other name when necessary. To assist this, add
`GenericSpecInfo::GetOtherName()` to return the other name for a generic
spec (i.e. the one not in the source) when there is one. Each place a
generic spec can occur we have to be careful to check for symbols with
the other name.

Fixes #746.