### PR TITLE
[OpenMP] Simplify `OmpObject` with `std::variant`

### DIFF
--- a/lib/parser/dump-parse-tree.h
+++ b/lib/parser/dump-parse-tree.h
@@ -495,7 +495,6 @@ public:
   NODE(parser, OmpMemoryClausePostList)
   NODE(parser, OmpNowait)
   NODE(parser, OmpObject)
-  NODE_ENUM(parser::OmpObject, Kind)
   NODE(parser, OmpObjectList)
   NODE(parser, OmpProcBindClause)
   NODE_ENUM(parser::OmpProcBindClause, Type)

--- a/lib/parser/openmp-grammar.h
+++ b/lib/parser/openmp-grammar.h
@@ -167,9 +167,8 @@ TYPE_CONTEXT_PARSER("Omp LINEAR clause"_en_US,
 TYPE_PARSER(construct<OmpAlignedClause>(
     nonemptyList(name), maybe(":" >> scalarIntConstantExpr)))
 
-TYPE_PARSER(construct<OmpObject>(pure(OmpObject::Kind::Object), designator) ||
-    construct<OmpObject>(
-        "/" >> pure(OmpObject::Kind::Common), designator / "/"))
+TYPE_PARSER(
+    construct<OmpObject>(designator) || construct<OmpObject>("/" >> name / "/"))
 
 TYPE_PARSER("ALIGNED" >>
         construct<OmpClause>(parenthesized(Parser<OmpAlignedClause>{})) ||

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -3290,9 +3290,8 @@ struct OmpDefaultClause {
 //     in slashes). An extended list item is a list item or a procedure Name.
 // variable-name | / common-block / | array-sections
 struct OmpObject {
-  TUPLE_CLASS_BOILERPLATE(OmpObject);
-  ENUM_CLASS(Kind, Object, Common)
-  std::tuple<Kind, Designator> t;
+  UNION_CLASS_BOILERPLATE(OmpObject);
+  std::variant<Designator, /*common block*/ Name> u;
 };
 
 WRAPPER_CLASS(OmpObjectList, std::list<OmpObject>);

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -1757,9 +1757,12 @@ public:
   }
   // OpenMP Clauses & Directives
   void Unparse(const OmpObject &x) {
-    bool isCommon{std::get<OmpObject::Kind>(x.t) == OmpObject::Kind::Common};
-    const char *slash{isCommon ? "/" : ""};
-    Put(slash), Walk(std::get<Designator>(x.t)), Put(slash);
+    std::visit(
+        common::visitors{
+            [&](const Designator &y) { Walk(y); },
+            [&](const Name &y) { Put("/"), Walk(y), Put("/"); },
+        },
+        x.u);
   }
   void Unparse(const OmpMapType::Always &) { Word("ALWAYS,"); }
   void Unparse(const OmpMapClause &x) {


### PR DESCRIPTION
Instead of using an `ENUM_CLASS Kind` to distinguish a `Designator`
or common-block name, change it to `std::variant`. If the `Name`
is available, then it is common-block name.

This arose from a comment in PR#739.