### PR TITLE
Clean up temp dirs

### DIFF
--- a/test/semantics/test_any.sh
+++ b/test/semantics/test_any.sh
@@ -66,9 +66,7 @@ for input in ${srcdir}/$*; do
   CMD=$(cat ${input} | egrep '^[[:space:]]*![[:space:]]*RUN:[[:space:]]*' | sed -e 's/^[[:space:]]*![[:space:]]*RUN:[[:space:]]*//')
   CMD=$(echo ${CMD} | sed -e "s:%s:${input}:g")
   if egrep -q -e '%t' <<< ${CMD} ; then
-    temp=`mktemp`
-    trap "rm -f ${temp}" EXIT
-    CMD=$(echo ${CMD} | sed -e "s:%t:${temp}:g")
+    CMD=$(echo ${CMD} | sed -e "s:%t:$temp/t:g")
   fi
   if $(eval $CMD); then
     echo "PASS  ${input}"


### PR DESCRIPTION
A temp directory is created in `common.sh` and it is cleaned up by
`trap ... EXIT`. If the test script has its own trap, as this one does,
it seems to replace the first one. So the cleanup from `common.sh` was
not being executed when the `%t` feature was used and empty temp
directories were being left in the directory where the tests ran.

Since we already have a temp directory that is cleaned up, just use
that for `%t` and don't bother with another `mktemp`.