### PR TITLE
Implementation of semantic checks C1135, C1167, and C1168

### DIFF
--- a/lib/common/template.h
+++ b/lib/common/template.h
@@ -111,6 +111,16 @@ std::optional<A> JoinOptional(std::optional<std::optional<A>> &&x) {
   return std::nullopt;
 }
 
+// Convert an std::optional to an ordinary pointer
+template<typename A>
+const A *GetPtrFromOptional(const std::optional<A> &x) {
+  if (x.has_value()) {
+    return &x.value();
+  } else {
+    return nullptr;
+  }
+}
+
 // Copy a value from one variant type to another.  The types allowed in the
 // source variant must all be allowed in the destination variant type.
 template<typename TOV, typename FROMV> TOV CopyVariant(const FROMV &u) {

--- a/lib/common/template.h
+++ b/lib/common/template.h
@@ -115,7 +115,7 @@ std::optional<A> JoinOptional(std::optional<std::optional<A>> &&x) {
 template<typename A>
 const A *GetPtrFromOptional(const std::optional<A> &x) {
   if (x.has_value()) {
-    return &x.value();
+    return &*x;
   } else {
     return nullptr;
   }

--- a/lib/semantics/check-do.h
+++ b/lib/semantics/check-do.h
@@ -16,6 +16,7 @@
 #define FORTRAN_SEMANTICS_CHECK_DO_H_
 
 #include "semantics.h"
+#include "../common/idioms.h"
 
 namespace Fortran::parser {
 struct DoConstruct;
@@ -24,6 +25,10 @@ struct ExitStmt;
 }
 
 namespace Fortran::semantics {
+
+// To specify CYCLE and EXIT statements in semantic checking that's common to
+// both of them.
+ENUM_CLASS(StmtType, CYCLE, EXIT)
 
 class DoChecker : public virtual BaseChecker {
 public:
@@ -35,11 +40,11 @@ public:
 private:
   SemanticsContext &context_;
 
-  void SayBadLeave(const char *stmtChecked, const char *enclosingStmt,
-      const ConstructNode &) const;
-  void CheckDoConcurrentExit(bool isExit, const ConstructNode &) const;
-  void CheckForBadLeave(const char *, const ConstructNode &) const;
-  void CheckNesting(bool isExit, const parser::Name *) const;
+  void SayBadLeave(
+      StmtType, const char *enclosingStmt, const ConstructNode &) const;
+  void CheckDoConcurrentExit(StmtType, const ConstructNode &) const;
+  void CheckForBadLeave(StmtType, const ConstructNode &) const;
+  void CheckNesting(StmtType, const parser::Name *) const;
 };
 }
 #endif  // FORTRAN_SEMANTICS_CHECK_DO_H_

--- a/lib/semantics/check-do.h
+++ b/lib/semantics/check-do.h
@@ -25,8 +25,6 @@ struct ExitStmt;
 
 namespace Fortran::semantics {
 
-using NamePtr = parser::Name const *;
-
 class DoChecker : public virtual BaseChecker {
 public:
   explicit DoChecker(SemanticsContext &context) : context_{context} {}
@@ -39,9 +37,9 @@ private:
 
   void SayBadLeave(const char *stmtChecked, const char *enclosingStmt,
       const ConstructNode &) const;
-  void CheckDoConcurrentExit(const char *s, const ConstructNode &) const;
+  void CheckDoConcurrentExit(bool isExit, const ConstructNode &) const;
   void CheckForBadLeave(const char *, const ConstructNode &) const;
-  void CheckNesting(const char *, NamePtr) const;
+  void CheckNesting(bool isExit, const parser::Name *) const;
 };
 }
 #endif  // FORTRAN_SEMANTICS_CHECK_DO_H_

--- a/lib/semantics/check-do.h
+++ b/lib/semantics/check-do.h
@@ -25,6 +25,8 @@ struct ExitStmt;
 
 namespace Fortran::semantics {
 
+using NamePtr = parser::Name const *;
+
 class DoChecker : public virtual BaseChecker {
 public:
   explicit DoChecker(SemanticsContext &context) : context_{context} {}
@@ -34,6 +36,12 @@ public:
 
 private:
   SemanticsContext &context_;
+
+  void SayBadLeave(const char *stmtChecked, const char *enclosingStmt,
+      const ConstructNode &) const;
+  void CheckDoConcurrentExit(const char *s, const ConstructNode &) const;
+  void CheckForBadLeave(const char *, const ConstructNode &) const;
+  void CheckNesting(const char *, NamePtr) const;
 };
 }
 #endif  // FORTRAN_SEMANTICS_CHECK_DO_H_

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -206,15 +206,6 @@ void SemanticsContext::PopConstruct() {
   constructStack_.pop_back();
 }
 
-bool SemanticsContext::InsideDoConstruct() const {
-  for (const ConstructNode construct : constructStack_) {
-    if (std::holds_alternative<const parser::DoConstruct *>(construct)) {
-      return true;
-    }
-  }
-  return false;
-}
-
 bool Semantics::Perform() {
   return ValidateLabels(context_, program_) &&
       parser::CanonicalizeDo(program_) &&  // force line break

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -36,9 +36,9 @@ struct AssociateConstruct;
 struct BlockConstruct;
 struct CaseConstruct;
 struct DoConstruct;
-struct CriticalConstruct;
 struct ChangeTeamConstruct;
-struct ForAllConstruct;
+struct CriticalConstruct;
+struct ForallConstruct;
 struct IfConstruct;
 struct SelectRankConstruct;
 struct SelectTypeConstruct;
@@ -52,7 +52,7 @@ class Symbol;
 using ConstructNode = std::variant<const parser::AssociateConstruct *,
     const parser::BlockConstruct *, const parser::CaseConstruct *,
     const parser::ChangeTeamConstruct *, const parser::CriticalConstruct *,
-    const parser::DoConstruct *, const parser::ForAllConstruct *,
+    const parser::DoConstruct *, const parser::ForallConstruct *,
     const parser::IfConstruct *, const parser::SelectRankConstruct *,
     const parser::SelectTypeConstruct *, const parser::WhereConstruct *>;
 using ConstructStack = std::vector<ConstructNode>;
@@ -144,7 +144,6 @@ public:
     constructStack_.emplace_back(&node);
   }
   void PopConstruct();
-  bool InsideDoConstruct() const;
 
 private:
   const common::IntrinsicTypeDefaultKinds &defaultKinds_;

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -137,16 +137,17 @@ set(ERROR_TESTS
   allocate12.f90
   allocate13.f90
   doconcurrent01.f90
+  dosemantics05.f90
+  dosemantics06.f90
   dosemantics01.f90
   dosemantics02.f90
   dosemantics03.f90
   dosemantics04.f90
-  dosemantics05.f90
-  dosemantics06.f90
   dosemantics07.f90
   dosemantics08.f90
   dosemantics09.f90
   dosemantics10.f90
+  dosemantics11.f90
   expr-errors01.f90
   null01.f90
   omp-clause-validity01.f90

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -137,12 +137,14 @@ set(ERROR_TESTS
   allocate12.f90
   allocate13.f90
   doconcurrent01.f90
-  dosemantics05.f90
-  dosemantics06.f90
+  doconcurrent05.f90
+  doconcurrent06.f90
   dosemantics01.f90
   dosemantics02.f90
   dosemantics03.f90
   dosemantics04.f90
+  dosemantics05.f90
+  dosemantics06.f90
   dosemantics07.f90
   dosemantics08.f90
   dosemantics09.f90
@@ -233,8 +235,6 @@ set(DOCONCURRENT_TESTS
   doconcurrent02.f90
   doconcurrent03.f90
   doconcurrent04.f90
-  doconcurrent05.f90
-  doconcurrent06.f90
   doconcurrent07.f90
   doconcurrent08.f90
 )

--- a/test/semantics/doconcurrent05.f90
+++ b/test/semantics/doconcurrent05.f90
@@ -11,14 +11,9 @@
 ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ! See the License for the specific language governing permissions and
 ! limitations under the License.
-
-! RUN: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
-! CHECK: exit from DO CONCURRENT construct \\(mydoc: do concurrent\\(j=1:n\\)\\) to construct with name 'mydoc'
-! CHECK: exit from DO CONCURRENT construct \\(mydoc: do concurrent\\(j=1:n\\)\\)
-! CHECK: exit from DO CONCURRENT construct \\(mydoc: do concurrent\\(j=1:n\\)\\) to construct with name 'mytest3'
-! CHECK: exit from DO CONCURRENT construct \\(do concurrent\\(k=1:n\\)\\)
-! CHECK: exit from DO CONCURRENT construct \\(do concurrent\\(k=1:n\\)\\) to construct with name 'mytest4'
-! CHECK: exit from DO CONCURRENT construct \\(mydoc: do concurrent\\(j=1:n\\)\\) to construct with name 'mytest4'
+!
+! C1167 -- An exit-stmt shall not appear within a DO CONCURRENT construct if 
+! it belongs to that construct or an outer construct.
 
 subroutine do_concurrent_test1(n)
   implicit none
@@ -26,6 +21,7 @@ subroutine do_concurrent_test1(n)
   integer :: j,k
   mydoc: do concurrent(j=1:n)
   mydo:    do k=1,n
+!ERROR: EXIT must not leave a DO CONCURRENT statement
              if (k==5) exit mydoc
              if (j==10) exit mydo
            end do mydo
@@ -36,6 +32,7 @@ subroutine do_concurrent_test2(n)
   implicit none
   integer :: j,k,n
   mydoc: do concurrent(j=1:n)
+!ERROR: EXIT must not leave a DO CONCURRENT statement
            if (k==5) exit
          end do mydoc
 end subroutine do_concurrent_test2
@@ -46,6 +43,7 @@ subroutine do_concurrent_test3(n)
   mytest3: if (n>0) then
   mydoc:    do concurrent(j=1:n)
               do k=1,n
+!ERROR: EXIT must not leave a DO CONCURRENT statement
                 if (j==10) exit mytest3
               end do
             end do mydoc
@@ -58,7 +56,10 @@ subroutine do_concurrent_test4(n)
   mytest4: if (n>0) then
   mydoc:    do concurrent(j=1:n)
               do concurrent(k=1:n)
+!ERROR: EXIT must not leave a DO CONCURRENT statement
                 if (k==5) exit
+!ERROR: EXIT must not leave a DO CONCURRENT statement
+!ERROR: EXIT must not leave a DO CONCURRENT statement
                 if (j==10) exit mytest4
               end do
             end do mydoc

--- a/test/semantics/doconcurrent06.f90
+++ b/test/semantics/doconcurrent06.f90
@@ -11,14 +11,9 @@
 ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ! See the License for the specific language governing permissions and
 ! limitations under the License.
-
-! RUN: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
-! CHECK: exit from DO CONCURRENT construct \\(nc5: do concurrent\\(i5=1:n\\)\\) to construct with name 'mytest1'
-! CHECK: exit from DO CONCURRENT construct \\(nc3: do concurrent\\(i3=1:n\\)\\) to construct with name 'mytest1'
-! CHECK: exit from DO CONCURRENT construct \\(nc1: do concurrent\\(i1=1:n\\)\\) to construct with name 'mytest1'
-! CHECK: exit from DO CONCURRENT construct \\(nc5: do concurrent\\(i5=1:n\\)\\) to construct with name 'nc3'
-! CHECK: exit from DO CONCURRENT construct \\(nc3: do concurrent\\(i3=1:n\\)\\) to construct with name 'nc3'
-! CHECK: exit from DO CONCURRENT construct \\(nc3: do concurrent\\(i3=1:n\\)\\) to construct with name 'nc2'
+!
+! C1167 -- An exit-stmt shall not appear within a DO CONCURRENT construct if 
+! it belongs to that construct or an outer construct.
 
 subroutine do_concurrent_test1(n)
   implicit none
@@ -30,6 +25,9 @@ subroutine do_concurrent_test1(n)
   nc4:             do i4=1,n
   nc5:               do concurrent(i5=1:n)
   nc6:                 do i6=1,n
+!ERROR: EXIT must not leave a DO CONCURRENT statement
+!ERROR: EXIT must not leave a DO CONCURRENT statement
+!ERROR: EXIT must not leave a DO CONCURRENT statement
                          if (i6==10) exit mytest1
                        end do nc6
                      end do nc5
@@ -50,6 +48,8 @@ subroutine do_concurrent_test2(n)
   nc4:             do i4=1,n
   nc5:               do concurrent(i5=1:n)
   nc6:                 do i6=1,n
+!ERROR: EXIT must not leave a DO CONCURRENT statement
+!ERROR: EXIT must not leave a DO CONCURRENT statement
                          if (i6==10) exit nc3
                        end do nc6
                      end do nc5
@@ -67,6 +67,7 @@ subroutine do_concurrent_test3(n)
   nc1:       do concurrent(i1=1:n)
   nc2:         do i2=1,n
   nc3:           do concurrent(i3=1:n)
+!ERROR: EXIT must not leave a DO CONCURRENT statement
                    if (i3==4) exit nc2
   nc4:             do i4=1,n
   nc5:               do concurrent(i5=1:n)

--- a/test/semantics/dosemantics10.f90
+++ b/test/semantics/dosemantics10.f90
@@ -36,13 +36,13 @@ subroutine s1()
     cycle
   end do outer
 
-!ERROR: No matching construct for CYCLE statement
+!ERROR: No matching DO construct for CYCLE statement
   cycle
 
 !ERROR: No matching construct for EXIT statement
   exit
 
-!ERROR: No matching construct for CYCLE statement
+!ERROR: No matching DO construct for CYCLE statement
   if(.true.) cycle
 
 !ERROR: No matching construct for EXIT statement

--- a/test/semantics/dosemantics10.f90
+++ b/test/semantics/dosemantics10.f90
@@ -36,16 +36,16 @@ subroutine s1()
     cycle
   end do outer
 
-!ERROR: CYCLE must be within a DO construct
+!ERROR: No matching construct for CYCLE statement
   cycle
 
-!ERROR: EXIT must be within a DO construct
+!ERROR: No matching construct for EXIT statement
   exit
 
-!ERROR: CYCLE must be within a DO construct
+!ERROR: No matching construct for CYCLE statement
   if(.true.) cycle
 
-!ERROR: EXIT must be within a DO construct
+!ERROR: No matching construct for EXIT statement
   if(.true.) exit
 
 end subroutine s1

--- a/test/semantics/dosemantics11.f90
+++ b/test/semantics/dosemantics11.f90
@@ -22,7 +22,7 @@
 ! construct if it belongs to an outer construct.
 
 subroutine s1()
-!ERROR: No matching construct for CYCLE statement
+!ERROR: No matching DO construct for CYCLE statement
   cycle
 end subroutine s1
 
@@ -33,7 +33,7 @@ end subroutine s2
 
 subroutine s3()
   level0: block
-!ERROR: No matching construct for CYCLE statement
+!ERROR: No matching DO construct for CYCLE statement
     cycle level0
   end block level0
 end subroutine s3

--- a/test/semantics/dosemantics11.f90
+++ b/test/semantics/dosemantics11.f90
@@ -1,0 +1,341 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+!
+! C1135 A cycle-stmt shall not appear within a CHANGE TEAM, CRITICAL, or DO 
+! CONCURRENT construct if it belongs to an outer construct.
+!
+! C1167 -- An exit-stmt shall not appear within a DO CONCURRENT construct if 
+! it belongs to that construct or an outer construct.
+!
+! C1168 -- An exit-stmt shall not appear within a CHANGE TEAM or CRITICAL 
+! construct if it belongs to an outer construct.
+
+subroutine s1()
+!ERROR: No matching construct for CYCLE statement
+  cycle
+end subroutine s1
+
+subroutine s2()
+!ERROR: No matching construct for EXIT statement
+  exit
+end subroutine s2
+
+subroutine s3()
+  level0: block
+!ERROR: No matching construct for CYCLE statement
+    cycle level0
+  end block level0
+end subroutine s3
+
+subroutine s4()
+  level0: do i = 1, 10
+    level1: do concurrent (j = 1:20)
+!ERROR: CYCLE must not leave a DO CONCURRENT statement
+      cycle level0
+    end do level1
+  end do level0
+end subroutine s4
+
+subroutine s5()
+  level0: do i = 1, 10
+    level1: do concurrent (j = 1:20)
+!ERROR: EXIT must not leave a DO CONCURRENT statement
+      exit level0
+    end do level1
+  end do level0
+end subroutine s5
+
+subroutine s6()
+  level0: do i = 1, 10
+    level1: critical
+!ERROR: CYCLE must not leave a CRITICAL statement
+      cycle level0
+    end critical level1
+  end do level0
+end subroutine s6
+
+subroutine s7()
+  level0: do i = 1, 10
+    level1: critical
+!ERROR: EXIT must not leave a CRITICAL statement
+      exit level0
+    end critical level1
+  end do level0
+end subroutine s7
+
+subroutine s8()
+  use :: iso_fortran_env
+  type(team_type) team_var
+
+  level0: do i = 1, 10
+    level1: change team(team_var)
+!ERROR: CYCLE must not leave a CHANGE TEAM statement
+      cycle level0
+    end team level1
+  end do level0
+end subroutine s8
+
+subroutine s9()
+  use :: iso_fortran_env
+  type(team_type) team_var
+
+  level0: do i = 1, 10
+    level1: change team(team_var)
+!ERROR: EXIT must not leave a CHANGE TEAM statement
+      exit level0
+    end team level1
+  end do level0
+end subroutine s9
+
+subroutine s10(table)
+! A complex, but all legal example
+
+  integer :: table(..)
+
+  type point
+    real :: x, y
+  end type point
+
+  type, extends(point) :: color_point
+    integer :: color
+  end type color_point
+
+  type(point), target :: target_var
+  class(point), pointer :: p_or_c
+
+  p_or_c => target_var
+  level0: do i = 1, 10
+    level1: associate (avar => ivar)
+      level2: block
+        level3: select case (l)
+          case default
+            print*, "default"
+          case (1)
+            level4: if (.true.) then
+              level5: select rank(table)
+                rank default
+                  level6: select type ( a => p_or_c )
+                  type is ( point )
+                    cycle level0
+                end select level6
+              end select level5
+            end if level4
+        end select level3
+      end block level2
+    end associate level1
+  end do level0
+end subroutine s10
+
+subroutine s11(table)
+! A complex, but all legal example with a CYCLE statement
+
+  integer :: table(..)
+
+  type point
+    real :: x, y
+  end type point
+
+  type, extends(point) :: color_point
+    integer :: color
+  end type color_point
+
+  type(point), target :: target_var
+  class(point), pointer :: p_or_c
+
+  p_or_c => target_var
+  level0: do i = 1, 10
+    level1: associate (avar => ivar)
+      level2: block
+        level3: select case (l)
+          case default
+            print*, "default"
+          case (1)
+            level4: if (.true.) then
+              level5: select rank(table)
+                rank default
+                  level6: select type ( a => p_or_c )
+                  type is ( point )
+                    cycle level0
+                end select level6
+              end select level5
+            end if level4
+        end select level3
+      end block level2
+    end associate level1
+  end do level0
+end subroutine s11
+
+subroutine s12(table)
+! A complex, but all legal example with an EXIT statement
+
+  integer :: table(..)
+
+  type point
+    real :: x, y
+  end type point
+
+  type, extends(point) :: color_point
+    integer :: color
+  end type color_point
+
+  type(point), target :: target_var
+  class(point), pointer :: p_or_c
+
+  p_or_c => target_var
+  level0: do i = 1, 10
+    level1: associate (avar => ivar)
+      level2: block
+        level3: select case (l)
+          case default
+            print*, "default"
+          case (1)
+            level4: if (.true.) then
+              level5: select rank(table)
+                rank default
+                  level6: select type ( a => p_or_c )
+                  type is ( point )
+                    exit level0
+                end select level6
+              end select level5
+            end if level4
+        end select level3
+      end block level2
+    end associate level1
+  end do level0
+end subroutine s12
+
+subroutine s13(table)
+! Similar example without construct names
+
+  integer :: table(..)
+
+  type point
+    real :: x, y
+  end type point
+
+  type, extends(point) :: color_point
+    integer :: color
+  end type color_point
+
+  type(point), target :: target_var
+  class(point), pointer :: p_or_c
+
+  p_or_c => target_var
+  do i = 1, 10
+    associate (avar => ivar)
+      block
+        select case (l)
+          case default
+            print*, "default"
+          case (1)
+            if (.true.) then
+              select rank(table)
+                rank default
+                  select type ( a => p_or_c )
+                  type is ( point )
+                    cycle
+                end select
+              end select
+            end if
+        end select
+      end block
+    end associate
+  end do
+end subroutine s13
+
+subroutine s14(table)
+
+  integer :: table(..)
+
+  type point
+    real :: x, y
+  end type point
+
+  type, extends(point) :: color_point
+    integer :: color
+  end type color_point
+
+  type(point), target :: target_var
+  class(point), pointer :: p_or_c
+
+  p_or_c => target_var
+  do i = 1, 10
+    associate (avar => ivar)
+      block
+        critical
+          select case (l)
+            case default
+              print*, "default"
+            case (1)
+              if (.true.) then
+                select rank(table)
+                  rank default
+                    select type ( a => p_or_c )
+                    type is ( point )
+!ERROR: CYCLE must not leave a CRITICAL statement
+                      cycle
+!ERROR: EXIT must not leave a CRITICAL statement
+                      exit
+                  end select
+                end select
+              end if
+          end select
+        end critical
+      end block
+    end associate
+  end do
+end subroutine s14
+
+subroutine s15(table)
+! Illegal EXIT to an intermediated construct
+
+  integer :: table(..)
+
+  type point
+    real :: x, y
+  end type point
+
+  type, extends(point) :: color_point
+    integer :: color
+  end type color_point
+
+  type(point), target :: target_var
+  class(point), pointer :: p_or_c
+
+  p_or_c => target_var
+  level0: do i = 1, 10
+    level1: associate (avar => ivar)
+      level2: block
+        level3: select case (l)
+          case default
+            print*, "default"
+          case (1)
+            level4: if (.true.) then
+              level5: critical
+                level6: select rank(table)
+                  rank default
+                    level7: select type ( a => p_or_c )
+                    type is ( point )
+                      exit level6
+!ERROR: EXIT must not leave a CRITICAL statement
+                      exit level4
+                  end select level7
+                end select level6
+              end critical level5
+            end if level4
+        end select level3
+      end block level2
+    end associate level1
+  end do level0
+end subroutine s15


### PR DESCRIPTION
These constraints state that CYCLE and EXIT statements should not leave DO
CONCURRENT, CRITICAL, or CHANGE TEAM constructs.

I added checking code to check-do.cc and removed some superseded code from
check-do.cc and semantics.cc.  The new code uses the construct stack
implemented in my previous pull request.

I also added a new test -- dosemantics11.f90 and modified the tests
dosemantics10.f90, doconcurrent05.f90, and doconcurrent06.f90 to adapt to
the new error messages.  I converted these latter two tests to use
test_error.sh since they only reported errors.