### PR TITLE
Added tests for image control statements in DO CONCURRENT

### DIFF
--- a/lib/semantics/check-do.cc
+++ b/lib/semantics/check-do.cc
@@ -138,7 +138,6 @@ public:
   void Post(const parser::LockStmt &) { NoImageControl(); }
   void Post(const parser::UnlockStmt &) { NoImageControl(); }
   void Post(const parser::StopStmt &) { NoImageControl(); }
-  void Post(const parser::EndProgramStmt &) { NoImageControl(); }
 
   void Post(const parser::AllocateStmt &) {
     if (anyObjectIsCoarray()) {

--- a/test/semantics/doconcurrent01.f90
+++ b/test/semantics/doconcurrent01.f90
@@ -34,6 +34,8 @@ subroutine do_concurrent_test1(i,n)
      SYNC ALL
 !ERROR: image control statement not allowed in DO CONCURRENT
      SYNC IMAGES (*)
+!ERROR: image control statement not allowed in DO CONCURRENT
+     SYNC MEMORY
 !ERROR: RETURN not allowed in DO CONCURRENT
      return
 10 continue
@@ -47,18 +49,75 @@ subroutine do_concurrent_test2(i,j,n,flag)
   logical :: halting
   type(team_type) :: j
   do concurrent (i = 1:n)
+!ERROR: image control statement not allowed in DO CONCURRENT
+    sync team (j)
     change team (j)
+      critical
 !ERROR: call to impure procedure in DO CONCURRENT not allowed
 !ERROR: IEEE_GET_FLAG not allowed in DO CONCURRENT
-      call ieee_get_flag(flag, flag2)
+        call ieee_get_flag(flag, flag2)
 !ERROR: call to impure procedure in DO CONCURRENT not allowed
 !ERROR: IEEE_GET_HALTING_MODE not allowed in DO CONCURRENT
-      call ieee_get_halting_mode(flag, halting)
+        call ieee_get_halting_mode(flag, halting)
 !ERROR: IEEE_SET_HALTING_MODE not allowed in DO CONCURRENT
-      call ieee_set_halting_mode(flag, halting)
+        call ieee_set_halting_mode(flag, halting)
+!ERROR: image control statement not allowed in DO CONCURRENT
+      end critical
 !ERROR: image control statement not allowed in DO CONCURRENT
     end team
 !ERROR: ADVANCE specifier not allowed in DO CONCURRENT
     write(*,'(a35)',advance='no')
   end do
 end subroutine do_concurrent_test2
+
+subroutine s1()
+  use iso_fortran_env
+  type(event_type) :: x
+  do concurrent (i = 1:n)
+!ERROR: image control statement not allowed in DO CONCURRENT
+    event post (x)
+  end do
+end subroutine s1
+
+subroutine s2()
+  use iso_fortran_env
+  type(event_type) :: x
+  do concurrent (i = 1:n)
+!ERROR: image control statement not allowed in DO CONCURRENT
+    event wait (x)
+  end do
+end subroutine s2
+
+subroutine s3()
+  use iso_fortran_env
+  type(team_type) :: t
+
+  do concurrent (i = 1:n)
+!ERROR: image control statement not allowed in DO CONCURRENT
+    form team(1, t)
+  end do
+end subroutine s3
+
+subroutine s4()
+  use iso_fortran_env
+  type(lock_type) :: l
+
+  do concurrent (i = 1:n)
+!ERROR: image control statement not allowed in DO CONCURRENT
+    lock(l)
+!ERROR: image control statement not allowed in DO CONCURRENT
+    unlock(l)
+  end do
+end subroutine s4
+
+subroutine s5()
+  use iso_fortran_env
+  type(lock_type) :: l
+
+  do concurrent (i = 1:n)
+!ERROR: image control statement not allowed in DO CONCURRENT
+    lock(l)
+!ERROR: image control statement not allowed in DO CONCURRENT
+    unlock(l)
+  end do
+end subroutine s5


### PR DESCRIPTION
There was already code in check-do.cc to test for the presence of a
variety of different image control statements, but several of them did
not have associated tests.  This change adds tests for most of them.

Also, I removed the check for the END PROGRAM statement, since its
presence causes a syntax error which prevents the semantic check from
ever being reached.