### PR TITLE
Fix #765

### DIFF
--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -706,7 +706,7 @@ public:
     Walk("(", std::get<std::optional<ArraySpec>>(x.t), ")");
   }
   void Unparse(const CommonStmt::Block &x) {
-    Walk("/", std::get<std::optional<Name>>(x.t), "/");
+    Word("/"), Walk(std::get<std::optional<Name>>(x.t)), Word("/");
     Walk(std::get<std::list<CommonBlockObject>>(x.t));
   }
 


### PR DESCRIPTION
Always emit `//` to indicate blank COMMON in `unparse.cc`.