### PR TITLE
Replace access through union with reinterpret_cast.

### DIFF
--- a/lib/evaluate/intrinsics-library-templates.h
+++ b/lib/evaluate/intrinsics-library-templates.h
@@ -129,23 +129,13 @@ template<typename TR, typename... ArgInfo> struct CallableHostWrapper {
 template<typename TR, typename... TA>
 inline GenericFunctionPointer ToGenericFunctionPointer(
     FuncPointer<TR, TA...> f) {
-  union {
-    GenericFunctionPointer gp;
-    FuncPointer<TR, TA...> fp;
-  } u;
-  u.fp = f;
-  return u.gp;
+  return reinterpret_cast<GenericFunctionPointer>(f);
 }
 
 template<typename TR, typename... TA>
 inline FuncPointer<TR, TA...> FromGenericFunctionPointer(
     GenericFunctionPointer g) {
-  union {
-    GenericFunctionPointer gp;
-    FuncPointer<TR, TA...> fp;
-  } u;
-  u.gp = g;
-  return u.fp;
+  return reinterpret_cast<FuncPointer<TR, TA...>>(g);
 }
 
 template<typename TR, typename... ArgInfo>

--- a/lib/evaluate/intrinsics-library.h
+++ b/lib/evaluate/intrinsics-library.h
@@ -35,6 +35,7 @@ class FoldingContext;
 using TypeCode = unsigned char;
 
 template<typename TR, typename... TA> using FuncPointer = TR (*)(TA...);
+// This specific type signature prevents GCC complaining about function casts.
 using GenericFunctionPointer = void (*) (void);
 
 enum class PassBy { Ref, Val };

--- a/lib/evaluate/intrinsics-library.h
+++ b/lib/evaluate/intrinsics-library.h
@@ -35,7 +35,7 @@ class FoldingContext;
 using TypeCode = unsigned char;
 
 template<typename TR, typename... TA> using FuncPointer = TR (*)(TA...);
-using GenericFunctionPointer = FuncPointer<void *>;
+using GenericFunctionPointer = void (*) (void);
 
 enum class PassBy { Ref, Val };
 template<typename TA, PassBy Pass = PassBy::Ref> struct ArgumentInfo {


### PR DESCRIPTION
Fixes #747 
This avoids UB and doesn't cause warnings due to a special case in GCC for the type `void* (*) (void)`