### PR TITLE
More semantic checking for DO constructs

### DIFF
--- a/lib/semantics/check-do.h
+++ b/lib/semantics/check-do.h
@@ -26,9 +26,8 @@ struct ExitStmt;
 
 namespace Fortran::semantics {
 
-// To specify CYCLE and EXIT statements in semantic checking that's common to
-// both of them.
-ENUM_CLASS(StmtType, CYCLE, EXIT)
+// To specify different statement types used in semantic checking.
+ENUM_CLASS(StmtType, CYCLE, EXIT, ALLOCATE, DEALLOCATE)
 
 class DoChecker : public virtual BaseChecker {
 public:


### PR DESCRIPTION
This time I'm adding to the checks for constraint C1137, which states
that image control statements cannot appear in a DO CONCURRENT.  The
checks I added test to see if the DO CONCURRENT contains an ALLOCATE or
DEALLOCATE that references a coarray.