### PR TITLE
Added basic sema checks for distribute construct

### DIFF
--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -306,6 +306,20 @@ void OmpStructureChecker::Enter(const parser::OpenMPLoopConstruct &x) {
     SetContextAllowedExclusive(allowedExclusive);
   } break;
 
+  // 2.10.8 distribute-clause -> private-clause |
+  //                             firstprivate-clause |
+  //                             lastprivate-clause |
+  //                             collapse-clause |
+  //                             dist-schedule-clause
+  case parser::OmpLoopDirective::Directive::Distribute: {
+    PushContext(beginDir.source, OmpDirective::DISTRIBUTE);
+    OmpClauseSet allowed{
+        OmpClause::PRIVATE, OmpClause::FIRSTPRIVATE, OmpClause::LASTPRIVATE};
+    SetContextAllowed(allowed);
+    OmpClauseSet allowedOnce{OmpClause::COLLAPSE, OmpClause::DIST_SCHEDULE};
+    SetContextAllowedOnce(allowedOnce);
+  } break;
+
   default:
     // TODO others
     break;

--- a/test/semantics/omp-device-constructs.f90
+++ b/test/semantics/omp-device-constructs.f90
@@ -150,4 +150,39 @@ program main
 
   !ERROR: Only the FROM, RELEASE, or DELETE map types are permitted for MAP clauses on the TARGET EXIT DATA directive
   !$omp target exit data map(to:a)
+
+  !$omp target
+  !$omp distribute
+  do i = 1, N
+     a = 3.14
+  enddo
+  !$omp end distribute
+  !$omp end target
+
+  !$omp target
+  !ERROR: At most one COLLAPSE clause can appear on the DISTRIBUTE directive
+  !$omp distribute collapse(2) collapse(3)
+  do i = 1, N
+     a = 3.14
+  enddo
+  !$omp end distribute
+  !$omp end target
+
+  !$omp target
+  !$omp distribute dist_schedule(static, 2)
+  do i = 1, N
+     a = 3.14
+  enddo
+  !$omp end distribute
+  !$omp end target
+
+  !$omp target
+  !ERROR: At most one DIST_SCHEDULE clause can appear on the DISTRIBUTE directive
+  !$omp distribute dist_schedule(static, 2) dist_schedule(static, 3)
+  do i = 1, N
+     a = 3.14
+  enddo
+  !$omp end distribute
+  !$omp end target
+
 end program main


### PR DESCRIPTION
Nesting checks are not yet implemented as that is a separate piece of work for a number of directives.