### PR TITLE
Enable clang warnings used by LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ if(BUILD_WITH_CLANG)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --gcc-toolchain=${GCC}")
   endif()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstring-conversion")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wcovered-switch-default")
 endif()
 
 # Set RPATH in every executable, overriding the default setting.

--- a/documentation/C++style.md
+++ b/documentation/C++style.md
@@ -171,6 +171,10 @@ We have an `ENUM_CLASS` macro that helps capture the names of constants.
 explicitly, it should contain either a `default:;` at its end or a
 `default:` label that obviously crashes; we have a `CRASH_NO_CASE` macro
 for such situations.
+1. On the other hand, when a `switch()` statement really does cover all of
+the values of an `enum class`, please insert a call to the `SWITCH_COVERS_ALL_CASES`
+macro at the top of the block.  This macro does the right thing for G++ and
+clang to ensure that no warning is emitted when the cases are indeed all covered.
 1. When using `std::optional` values, avoid unprotected access to their content.
 This is usually by means of `x.has_value()` guarding execution of `*x`.
 This is implicit when they are function results assigned to local variables

--- a/lib/common/idioms.h
+++ b/lib/common/idioms.h
@@ -76,7 +76,7 @@ template<typename... LAMBDAS> visitors(LAMBDAS... x)->visitors<LAMBDAS...>;
 
 // For switch statements whose cases have return statements for
 // all possibilities.  Clang emits warnings if the default: is
-// present, gcc emits warings if it is absent.
+// present, gcc emits warnings if it is absent.
 #if __clang__
 #define SWITCH_COVERS_ALL_CASES
 #else

--- a/lib/common/idioms.h
+++ b/lib/common/idioms.h
@@ -80,9 +80,8 @@ template<typename... LAMBDAS> visitors(LAMBDAS... x)->visitors<LAMBDAS...>;
 #if __clang__
 #define SWITCH_COVERS_ALL_CASES
 #else
-#define SWITCH_COVERS_ALL_CASES \
-  default: CRASH_NO_CASE; \
-           #endif
+#define SWITCH_COVERS_ALL_CASES default:;
+#endif
 
 // For cheap assertions that should be applied in production.
 // To disable, compile with '-DCHECK=(void)'

--- a/lib/common/idioms.h
+++ b/lib/common/idioms.h
@@ -74,6 +74,16 @@ template<typename... LAMBDAS> visitors(LAMBDAS... x)->visitors<LAMBDAS...>;
 // For switch statements without default: labels.
 #define CRASH_NO_CASE DIE("no case")
 
+// For switch statements whose cases have return statements for
+// all possibilities.  Clang emits warnings if the default: is
+// present, gcc emits warings if it is absent.
+#if __clang__
+#define SWITCH_COVERS_ALL_CASES
+#else
+#define SWITCH_COVERS_ALL_CASES \
+  default: CRASH_NO_CASE; \
+           #endif
+
 // For cheap assertions that should be applied in production.
 // To disable, compile with '-DCHECK=(void)'
 #ifndef CHECK

--- a/lib/common/idioms.h
+++ b/lib/common/idioms.h
@@ -71,17 +71,19 @@ template<typename... LAMBDAS> visitors(LAMBDAS... x)->visitors<LAMBDAS...>;
 
 #define DIE(x) Fortran::common::die(x " at " __FILE__ "(%d)", __LINE__)
 
-// For switch statements without default: labels.
+// For switch statement default: labels.
 #define CRASH_NO_CASE DIE("no case")
 
+// clang-format off
 // For switch statements whose cases have return statements for
 // all possibilities.  Clang emits warnings if the default: is
 // present, gcc emits warnings if it is absent.
 #if __clang__
 #define SWITCH_COVERS_ALL_CASES
 #else
-#define SWITCH_COVERS_ALL_CASES default:;
+#define SWITCH_COVERS_ALL_CASES default: CRASH_NO_CASE;
 #endif
+// clang-format on
 
 // For cheap assertions that should be applied in production.
 // To disable, compile with '-DCHECK=(void)'

--- a/lib/common/template.h
+++ b/lib/common/template.h
@@ -112,8 +112,7 @@ std::optional<A> JoinOptional(std::optional<std::optional<A>> &&x) {
 }
 
 // Convert an std::optional to an ordinary pointer
-template<typename A>
-const A *GetPtrFromOptional(const std::optional<A> &x) {
+template<typename A> const A *GetPtrFromOptional(const std::optional<A> &x) {
   if (x.has_value()) {
     return &*x;
   } else {
@@ -192,8 +191,8 @@ constexpr bool AreSameType{AreSameTypeHelper<Ts...>::value()};
 
 template<typename> struct TupleToVariantHelper;
 template<typename... Ts> struct TupleToVariantHelper<std::tuple<Ts...>> {
-  static_assert(AreTypesDistinct<Ts...> ||
-      !"TupleToVariant: types are not pairwise distinct");
+  static_assert(AreTypesDistinct<Ts...>,
+      "TupleToVariant: types are not pairwise distinct");
   using type = std::variant<Ts...>;
 };
 template<typename TUPLE>

--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -265,9 +265,10 @@ std::ostream &Operation<D, R, O...>::AsFortran(std::ostream &o) const {
 template<typename TO, TypeCategory FROMCAT>
 std::ostream &Convert<TO, FROMCAT>::AsFortran(std::ostream &o) const {
   static_assert(TO::category == TypeCategory::Integer ||
-      TO::category == TypeCategory::Real ||
-      TO::category == TypeCategory::Character ||
-      TO::category == TypeCategory::Logical || !"Convert<> to bad category!");
+          TO::category == TypeCategory::Real ||
+          TO::category == TypeCategory::Character ||
+          TO::category == TypeCategory::Logical,
+      "Convert<> to bad category!");
   if constexpr (TO::category == TypeCategory::Character) {
     this->left().AsFortran(o << "achar(iachar(") << ')';
   } else if constexpr (TO::category == TypeCategory::Integer) {

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -1195,7 +1195,6 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
         common::die("INTERNAL: result-only rank code appears on argument '%s' "
                     "for intrinsic '%s'",
             d.keyword, name);
-      default: CRASH_NO_CASE;
       }
       if (!argOk) {
         messages.Say("'%s=' argument has unacceptable rank %d"_err_en_US,
@@ -1354,7 +1353,6 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
   case Rank::reduceOperation:
     common::die("INTERNAL: bad Rank code on intrinsic '%s' result", name);
     break;
-  default: CRASH_NO_CASE;
   }
   CHECK(resultRank >= 0);
 
@@ -1764,22 +1762,19 @@ IntrinsicProcTable IntrinsicProcTable::Configure(
 }
 
 bool IntrinsicProcTable::IsIntrinsic(const std::string &name) const {
-  CHECK(impl_ != nullptr || !"IntrinsicProcTable: not configured");
-  return impl_->IsIntrinsic(name);
+  return DEREF(impl_).IsIntrinsic(name);
 }
 
 std::optional<SpecificCall> IntrinsicProcTable::Probe(
     const CallCharacteristics &call, ActualArguments &arguments,
     FoldingContext &context) const {
-  CHECK(impl_ != nullptr || !"IntrinsicProcTable: not configured");
-  return impl_->Probe(call, arguments, context, *this);
+  return DEREF(impl_).Probe(call, arguments, context, *this);
 }
 
 std::optional<UnrestrictedSpecificIntrinsicFunctionInterface>
 IntrinsicProcTable::IsUnrestrictedSpecificIntrinsicFunction(
     const std::string &name) const {
-  CHECK(impl_ != nullptr || !"IntrinsicProcTable: not configured");
-  return impl_->IsUnrestrictedSpecificIntrinsicFunction(name);
+  return DEREF(impl_).IsUnrestrictedSpecificIntrinsicFunction(name);
 }
 
 std::ostream &TypePattern::Dump(std::ostream &o) const {

--- a/lib/evaluate/tools.cc
+++ b/lib/evaluate/tools.cc
@@ -592,7 +592,6 @@ std::optional<Expr<SomeType>> ConvertToType(
       }
     }
     break;
-  default: CRASH_NO_CASE;
   }
   return std::nullopt;
 }

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -498,7 +498,7 @@ std::optional<Expr<SomeComplex>> ConstructComplex(parser::ContextualMessages &,
 template<typename A> Expr<TypeOf<A>> ScalarConstantToExpr(const A &x) {
   using Ty = TypeOf<A>;
   static_assert(
-      std::is_same_v<Scalar<Ty>, std::decay_t<A>> || !"TypeOf<> is broken");
+      std::is_same_v<Scalar<Ty>, std::decay_t<A>>, "TypeOf<> is broken");
   return Expr<TypeOf<A>>{Constant<Ty>{x}};
 }
 

--- a/lib/parser/characters.cc
+++ b/lib/parser/characters.cc
@@ -123,7 +123,6 @@ EncodedCharacter EncodeCharacter(Encoding encoding, char32_t ucs) {
   switch (encoding) {
   case Encoding::LATIN_1: return EncodeCharacter<Encoding::LATIN_1>(ucs);
   case Encoding::UTF_8: return EncodeCharacter<Encoding::UTF_8>(ucs);
-  default: CRASH_NO_CASE;
   }
 }
 
@@ -255,7 +254,6 @@ DecodedCharacter DecodeCharacter(Encoding encoding, const char *cp,
     return DecodeCharacter<Encoding::LATIN_1>(cp, bytes, backslashEscapes);
   case Encoding::UTF_8:
     return DecodeCharacter<Encoding::UTF_8>(cp, bytes, backslashEscapes);
-  default: CRASH_NO_CASE;
   }
 }
 

--- a/lib/parser/characters.cc
+++ b/lib/parser/characters.cc
@@ -121,10 +121,9 @@ template<> EncodedCharacter EncodeCharacter<Encoding::UTF_8>(char32_t ucs) {
 
 EncodedCharacter EncodeCharacter(Encoding encoding, char32_t ucs) {
   switch (encoding) {
-  case Encoding::LATIN_1: return EncodeCharacter<Encoding::LATIN_1>(ucs);
-  case Encoding::UTF_8:
-    return EncodeCharacter<Encoding::UTF_8>(ucs);
     SWITCH_COVERS_ALL_CASES
+  case Encoding::LATIN_1: return EncodeCharacter<Encoding::LATIN_1>(ucs);
+  case Encoding::UTF_8: return EncodeCharacter<Encoding::UTF_8>(ucs);
   }
 }
 
@@ -252,11 +251,11 @@ template DecodedCharacter DecodeCharacter<Encoding::UTF_8>(
 DecodedCharacter DecodeCharacter(Encoding encoding, const char *cp,
     std::size_t bytes, bool backslashEscapes) {
   switch (encoding) {
+    SWITCH_COVERS_ALL_CASES
   case Encoding::LATIN_1:
     return DecodeCharacter<Encoding::LATIN_1>(cp, bytes, backslashEscapes);
   case Encoding::UTF_8:
     return DecodeCharacter<Encoding::UTF_8>(cp, bytes, backslashEscapes);
-    SWITCH_COVERS_ALL_CASES
   }
 }
 

--- a/lib/parser/characters.cc
+++ b/lib/parser/characters.cc
@@ -122,7 +122,9 @@ template<> EncodedCharacter EncodeCharacter<Encoding::UTF_8>(char32_t ucs) {
 EncodedCharacter EncodeCharacter(Encoding encoding, char32_t ucs) {
   switch (encoding) {
   case Encoding::LATIN_1: return EncodeCharacter<Encoding::LATIN_1>(ucs);
-  case Encoding::UTF_8: return EncodeCharacter<Encoding::UTF_8>(ucs);
+  case Encoding::UTF_8:
+    return EncodeCharacter<Encoding::UTF_8>(ucs);
+    SWITCH_COVERS_ALL_CASES
   }
 }
 
@@ -254,6 +256,7 @@ DecodedCharacter DecodeCharacter(Encoding encoding, const char *cp,
     return DecodeCharacter<Encoding::LATIN_1>(cp, bytes, backslashEscapes);
   case Encoding::UTF_8:
     return DecodeCharacter<Encoding::UTF_8>(cp, bytes, backslashEscapes);
+    SWITCH_COVERS_ALL_CASES
   }
 }
 

--- a/lib/parser/instrumented-parser.cc
+++ b/lib/parser/instrumented-parser.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ void ParsingLog::Dump(std::ostream &o, const CookedSource &cooked) const {
       Message{at, tagLog.first}.Emit(o, cooked, true);
       auto &entry{tagLog.second};
       o << "  " << (entry.pass ? "pass" : "fail") << " " << entry.count << '\n';
-      entry.messages.Emit(o, cooked, "      ");
+      entry.messages.Emit(o, cooked);
     }
   }
 }

--- a/lib/parser/prescan.cc
+++ b/lib/parser/prescan.cc
@@ -58,7 +58,7 @@ static void NormalizeCompilerDirectiveCommentMarker(TokenSequence &dir) {
       return;
     }
   }
-  CHECK(false && "compiler directive all blank");
+  DIE("compiler directive all blank");
 }
 
 void Prescanner::Prescan(ProvenanceRange range) {

--- a/lib/parser/prescan.cc
+++ b/lib/parser/prescan.cc
@@ -58,7 +58,7 @@ static void NormalizeCompilerDirectiveCommentMarker(TokenSequence &dir) {
       return;
     }
   }
-  CHECK(!"compiler directive all blank");
+  CHECK(false && "compiler directive all blank");
 }
 
 void Prescanner::Prescan(ProvenanceRange range) {

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -679,7 +679,6 @@ public:
       break;
     case common::ImportKind::None: Word(", NONE"); break;
     case common::ImportKind::All: Word(", ALL"); break;
-    default: CRASH_NO_CASE;
     }
   }
   void Unparse(const NamelistStmt &x) {  // R868
@@ -1451,7 +1450,6 @@ public:
       FMT(A);
       FMT(D);
 #undef FMT
-    default: CRASH_NO_CASE;
     }
     Walk(x.width), Walk(".", x.digits), Walk("E", x.exponentWidth);
   }
@@ -1511,7 +1509,6 @@ public:
 #undef FMT
     case format::ControlEditDesc::Kind::Dollar: Put('$'); break;
     case format::ControlEditDesc::Kind::Backslash: Put('\\'); break;
-    default: CRASH_NO_CASE;
     }
   }
 
@@ -2049,7 +2046,6 @@ public:
     case OmpLoopDirective::Directive::TeamsDistributeSimd:
       Word("TEAMS DISTRIBUTE SIMD ");
       break;
-    default: CRASH_NO_CASE;
     }
   }
   void Unparse(const OmpObjectList &x) { Walk(x.v, ","); }

--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -428,10 +428,10 @@ void OmpStructureChecker::Enter(const parser::OpenMPBlockConstruct &x) {
         OmpClause::NUM_TEAMS, OmpClause::THREAD_LIMIT, OmpClause::DEFAULT};
     SetContextAllowedOnce(allowedOnce);
   } break;
-      // 2.10.1 target-data-clause -> if-clause |
-      //                              device-clause |
-      //                              map-clause |
-      //                              use-device-ptr-clause
+    // 2.10.1 target-data-clause -> if-clause |
+    //                              device-clause |
+    //                              map-clause |
+    //                              use-device-ptr-clause
   case parser::OmpBlockDirective::Directive::TargetData: {
     PushContext(beginDir.source, OmpDirective::TARGET_DATA);
     OmpClauseSet allowed{
@@ -585,9 +585,6 @@ void OmpStructureChecker::Enter(
     OmpClauseSet allowed{OmpClause::DEPEND};
     SetContextAllowed(allowed);
   } break;
-  default:
-    // TODO others
-    break;
   }
 }
 

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -128,6 +128,7 @@ common::IfNoLvalue<MaybeExpr, WRAPPED> TypedWrapper(
         dyType.kind(), std::move(x));
   case TypeCategory::Derived:
     return AsGenericExpr(Expr<SomeDerived>{WRAPPER<SomeDerived>{std::move(x)}});
+    SWITCH_COVERS_ALL_CASES
   }
 }
 

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -128,7 +128,6 @@ common::IfNoLvalue<MaybeExpr, WRAPPED> TypedWrapper(
         dyType.kind(), std::move(x));
   case TypeCategory::Derived:
     return AsGenericExpr(Expr<SomeDerived>{WRAPPER<SomeDerived>{std::move(x)}});
-  default: CRASH_NO_CASE;
   }
 }
 
@@ -203,7 +202,7 @@ MaybeExpr ExpressionAnalyzer::ApplySubscripts(
                 ArrayRef{std::move(c), std::move(subscripts)});
           },
           [&](auto &&) -> MaybeExpr {
-            CHECK(!"bad base for ArrayRef");
+            DIE("bad base for ArrayRef");
             return std::nullopt;
           },
       },
@@ -902,7 +901,7 @@ MaybeExpr ExpressionAnalyzer::Analyze(const parser::StructureComponent &sc) {
       return MakeFunctionRef(
           name, ActualArguments{ActualArgument{std::move(*base)}});
     } else {
-      common::die("unexpected MiscDetails::Kind");
+      DIE("unexpected MiscDetails::Kind");
     }
   } else {
     Say(name, "derived type required before component reference"_err_en_US);

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -111,6 +111,7 @@ template<template<typename> typename WRAPPER, typename WRAPPED>
 common::IfNoLvalue<MaybeExpr, WRAPPED> TypedWrapper(
     const DynamicType &dyType, WRAPPED &&x) {
   switch (dyType.category()) {
+    SWITCH_COVERS_ALL_CASES
   case TypeCategory::Integer:
     return WrapperHelper<TypeCategory::Integer, WRAPPER, WRAPPED>(
         dyType.kind(), std::move(x));
@@ -128,7 +129,6 @@ common::IfNoLvalue<MaybeExpr, WRAPPED> TypedWrapper(
         dyType.kind(), std::move(x));
   case TypeCategory::Derived:
     return AsGenericExpr(Expr<SomeDerived>{WRAPPER<SomeDerived>{std::move(x)}});
-    SWITCH_COVERS_ALL_CASES
   }
 }
 

--- a/lib/semantics/resolve-names-utils.cc
+++ b/lib/semantics/resolve-names-utils.cc
@@ -176,6 +176,7 @@ void GenericSpecInfo::Analyze(const parser::GenericSpec &x) {
 // parser::DefinedOperator::IntrinsicOperator -> GenericKind
 static GenericKind MapIntrinsicOperator(IntrinsicOperator op) {
   switch (op) {
+    SWITCH_COVERS_ALL_CASES
   case IntrinsicOperator::Power: return GenericKind::OpPower;
   case IntrinsicOperator::Multiply: return GenericKind::OpMultiply;
   case IntrinsicOperator::Divide: return GenericKind::OpDivide;
@@ -193,9 +194,7 @@ static GenericKind MapIntrinsicOperator(IntrinsicOperator op) {
   case IntrinsicOperator::OR: return GenericKind::OpOR;
   case IntrinsicOperator::XOR: return GenericKind::OpXOR;
   case IntrinsicOperator::EQV: return GenericKind::OpEQV;
-  case IntrinsicOperator::NEQV:
-    return GenericKind::OpNEQV;
-    SWITCH_COVERS_ALL_CASES
+  case IntrinsicOperator::NEQV: return GenericKind::OpNEQV;
   }
 }
 

--- a/lib/semantics/resolve-names-utils.cc
+++ b/lib/semantics/resolve-names-utils.cc
@@ -194,7 +194,6 @@ static GenericKind MapIntrinsicOperator(IntrinsicOperator op) {
   case IntrinsicOperator::XOR: return GenericKind::OpXOR;
   case IntrinsicOperator::EQV: return GenericKind::OpEQV;
   case IntrinsicOperator::NEQV: return GenericKind::OpNEQV;
-  default: CRASH_NO_CASE;
   }
 }
 

--- a/lib/semantics/resolve-names-utils.cc
+++ b/lib/semantics/resolve-names-utils.cc
@@ -193,7 +193,9 @@ static GenericKind MapIntrinsicOperator(IntrinsicOperator op) {
   case IntrinsicOperator::OR: return GenericKind::OpOR;
   case IntrinsicOperator::XOR: return GenericKind::OpXOR;
   case IntrinsicOperator::EQV: return GenericKind::OpEQV;
-  case IntrinsicOperator::NEQV: return GenericKind::OpNEQV;
+  case IntrinsicOperator::NEQV:
+    return GenericKind::OpNEQV;
+    SWITCH_COVERS_ALL_CASES
   }
 }
 

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -4805,6 +4805,7 @@ void ConstructVisitor::PopAssociation() {
 const DeclTypeSpec &ConstructVisitor::ToDeclTypeSpec(
     evaluate::DynamicType &&type) {
   switch (type.category()) {
+    SWITCH_COVERS_ALL_CASES
   case common::TypeCategory::Integer:
   case common::TypeCategory::Real:
   case common::TypeCategory::Complex:
@@ -4824,7 +4825,7 @@ const DeclTypeSpec &ConstructVisitor::ToDeclTypeSpec(
 
       );
     }
-  case common::TypeCategory::Character: CRASH_NO_CASE; SWITCH_COVERS_ALL_CASES
+  case common::TypeCategory::Character: CRASH_NO_CASE;
   }
 }
 
@@ -5718,6 +5719,7 @@ void ResolveNamesVisitor::AddSubpNames(const ProgramTree &node) {
 // Push a new scope for this node or return false on error.
 bool ResolveNamesVisitor::BeginScope(const ProgramTree &node) {
   switch (node.GetKind()) {
+    SWITCH_COVERS_ALL_CASES
   case ProgramTree::Kind::Program:
     PushScope(Scope::Kind::MainProgram,
         &MakeSymbol(node.name(), MainProgramDetails{}));
@@ -5730,7 +5732,6 @@ bool ResolveNamesVisitor::BeginScope(const ProgramTree &node) {
   case ProgramTree::Kind::Module: BeginModule(node.name(), false); return true;
   case ProgramTree::Kind::Submodule:
     return BeginSubmodule(node.name(), node.GetParentId());
-    SWITCH_COVERS_ALL_CASES
   }
 }
 

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -910,7 +910,7 @@ private:
             "Declaration of '%s' conflicts with its use as internal procedure"_err_en_US,
             symbol, "Internal procedure definition"_en_US);
       } else {
-        CHECK(!"unexpected kind");
+        DIE("unexpected kind");
       }
     } else if (std::is_same_v<ObjectEntityDetails, T> &&
         symbol.has<ProcEntityDetails>()) {
@@ -4824,8 +4824,7 @@ const DeclTypeSpec &ConstructVisitor::ToDeclTypeSpec(
 
       );
     }
-  case common::TypeCategory::Character:
-  default: CRASH_NO_CASE;
+  case common::TypeCategory::Character: CRASH_NO_CASE;
   }
 }
 
@@ -5272,7 +5271,7 @@ void ResolveNamesVisitor::HandleProcedureName(
     ConvertToProcEntity(*symbol);
     SetProcFlag(name, *symbol, flag);
   } else if (symbol->has<UnknownDetails>()) {
-    CHECK(!"unexpected UnknownDetails");
+    DIE("unexpected UnknownDetails");
   } else if (CheckUseError(name)) {
     // error was reported
   } else {
@@ -5731,7 +5730,6 @@ bool ResolveNamesVisitor::BeginScope(const ProgramTree &node) {
   case ProgramTree::Kind::Module: BeginModule(node.name(), false); return true;
   case ProgramTree::Kind::Submodule:
     return BeginSubmodule(node.name(), node.GetParentId());
-  default: CRASH_NO_CASE;
   }
 }
 

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -4824,7 +4824,7 @@ const DeclTypeSpec &ConstructVisitor::ToDeclTypeSpec(
 
       );
     }
-  case common::TypeCategory::Character: CRASH_NO_CASE;
+  case common::TypeCategory::Character: CRASH_NO_CASE; SWITCH_COVERS_ALL_CASES
   }
 }
 
@@ -5730,6 +5730,7 @@ bool ResolveNamesVisitor::BeginScope(const ProgramTree &node) {
   case ProgramTree::Kind::Module: BeginModule(node.name(), false); return true;
   case ProgramTree::Kind::Submodule:
     return BeginSubmodule(node.name(), node.GetParentId());
+    SWITCH_COVERS_ALL_CASES
   }
 }
 

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -212,12 +212,11 @@ bool Scope::CanImport(const SourceName &name) const {
     return false;
   }
   switch (GetImportKind()) {
+    SWITCH_COVERS_ALL_CASES
   case ImportKind::None: return false;
   case ImportKind::All:
   case ImportKind::Default: return true;
-  case ImportKind::Only:
-    return importNames_.count(name) > 0;
-    SWITCH_COVERS_ALL_CASES
+  case ImportKind::Only: return importNames_.count(name) > 0;
   }
 }
 

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -216,7 +216,6 @@ bool Scope::CanImport(const SourceName &name) const {
   case ImportKind::All:
   case ImportKind::Default: return true;
   case ImportKind::Only: return importNames_.count(name) > 0;
-  default: CRASH_NO_CASE;
   }
 }
 

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -215,7 +215,9 @@ bool Scope::CanImport(const SourceName &name) const {
   case ImportKind::None: return false;
   case ImportKind::All:
   case ImportKind::Default: return true;
-  case ImportKind::Only: return importNames_.count(name) > 0;
+  case ImportKind::Only:
+    return importNames_.count(name) > 0;
+    SWITCH_COVERS_ALL_CASES
   }
 }
 

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -166,6 +166,7 @@ std::string ParamValue::AsFortran() const {
     } else {
       return "";
     }
+    SWITCH_COVERS_ALL_CASES
   }
 }
 
@@ -251,7 +252,7 @@ std::string DeclTypeSpec::AsFortran() const {
   case TypeDerived: return "TYPE(" + derivedTypeSpec().AsFortran() + ')';
   case ClassDerived: return "CLASS(" + derivedTypeSpec().AsFortran() + ')';
   case TypeStar: return "TYPE(*)";
-  case ClassStar: return "CLASS(*)";
+  case ClassStar: return "CLASS(*)"; SWITCH_COVERS_ALL_CASES
   }
 }
 

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -166,7 +166,6 @@ std::string ParamValue::AsFortran() const {
     } else {
       return "";
     }
-  default: CRASH_NO_CASE;
   }
 }
 
@@ -253,7 +252,6 @@ std::string DeclTypeSpec::AsFortran() const {
   case ClassDerived: return "CLASS(" + derivedTypeSpec().AsFortran() + ')';
   case TypeStar: return "TYPE(*)";
   case ClassStar: return "CLASS(*)";
-  default: CRASH_NO_CASE;
   }
 }
 

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -246,13 +246,14 @@ bool DeclTypeSpec::operator==(const DeclTypeSpec &that) const {
 
 std::string DeclTypeSpec::AsFortran() const {
   switch (category_) {
+    SWITCH_COVERS_ALL_CASES
   case Numeric: return numericTypeSpec().AsFortran();
   case Logical: return logicalTypeSpec().AsFortran();
   case Character: return characterTypeSpec().AsFortran();
   case TypeDerived: return "TYPE(" + derivedTypeSpec().AsFortran() + ')';
   case ClassDerived: return "CLASS(" + derivedTypeSpec().AsFortran() + ')';
   case TypeStar: return "TYPE(*)";
-  case ClassStar: return "CLASS(*)"; SWITCH_COVERS_ALL_CASES
+  case ClassStar: return "CLASS(*)";
   }
 }
 

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -156,6 +156,7 @@ void ParamValue::SetExplicit(SomeIntExpr &&x) {
 
 std::string ParamValue::AsFortran() const {
   switch (category_) {
+    SWITCH_COVERS_ALL_CASES
   case Category::Assumed: return "*";
   case Category::Deferred: return ":";
   case Category::Explicit:
@@ -166,7 +167,6 @@ std::string ParamValue::AsFortran() const {
     } else {
       return "";
     }
-    SWITCH_COVERS_ALL_CASES
   }
 }
 


### PR DESCRIPTION
Enable `-Wstring-conversion` and `-Wcovered-switch-default` warnings when building with clang.  Patch sources to dodge the warnings.