### PR TITLE
Fix #773: ambiguous REALA=3 should be an assignment, not a declaration

### DIFF
--- a/lib/parser/type-parsers.h
+++ b/lib/parser/type-parsers.h
@@ -87,7 +87,7 @@ constexpr Parser<TypeDeclarationStmt> typeDeclarationStmt;  // R801
 constexpr Parser<NullInit> nullInit;  // R806
 constexpr Parser<AccessSpec> accessSpec;  // R807
 constexpr Parser<LanguageBindingSpec> languageBindingSpec;  // R808, R1528
-constexpr Parser<EntityDecl> entityDecl;  // R803
+constexpr Parser<EntityDecl> entityDecl, entityDeclWithoutInit;  // R803
 constexpr Parser<CoarraySpec> coarraySpec;  // R809
 constexpr Parser<ArraySpec> arraySpec;  // R815
 constexpr Parser<ExplicitShapeSpec> explicitShapeSpec;  // R816


### PR DESCRIPTION
When parsing a type-declaration-stmt without doubled colons, don't allow an initializer (which is prohibited by C806).  This resolves the ambiguous `REALA=3` in favor of an assignment statement.