### PR TITLE
More procedure reference semantics checking (mostly arguments)

### DIFF
--- a/lib/common/constexpr-bitset.h
+++ b/lib/common/constexpr-bitset.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -92,9 +92,9 @@ public:
   }
   constexpr bool operator==(BitSet &&that) const { return bits_ == that.bits_; }
   constexpr bool operator!=(const BitSet &that) const {
-    return bits_ == that.bits_;
+    return bits_ != that.bits_;
   }
-  constexpr bool operator!=(BitSet &&that) const { return bits_ == that.bits_; }
+  constexpr bool operator!=(BitSet &&that) const { return bits_ != that.bits_; }
 
   static constexpr std::size_t size() { return BITS; }
   constexpr bool test(std::size_t x) const {

--- a/lib/evaluate/CMakeLists.txt
+++ b/lib/evaluate/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_library(FortranEvaluate
   call.cc
   characteristics.cc
+  check-call.cc
   check-expression.cc
   common.cc
   complex.cc

--- a/lib/evaluate/call.cc
+++ b/lib/evaluate/call.cc
@@ -44,6 +44,8 @@ ActualArgument &ActualArgument::operator=(Expr<SomeType> &&expr) {
 std::optional<DynamicType> ActualArgument::GetType() const {
   if (const Expr<SomeType> *expr{UnwrapExpr()}) {
     return expr->GetType();
+  } else if (std::holds_alternative<AssumedType>(u_)) {
+    return DynamicType::AssumedType();
   } else {
     return std::nullopt;
   }
@@ -98,7 +100,8 @@ int ProcedureDesignator::Rank() const {
   if (const auto *intrinsic{std::get_if<SpecificIntrinsic>(&u)}) {
     if (const auto &result{intrinsic->characteristics.value().functionResult}) {
       if (const auto *typeAndShape{result->GetTypeAndShape()}) {
-        CHECK(!typeAndShape->IsAssumedRank());
+        CHECK(!typeAndShape->attrs().test(
+            characteristics::TypeAndShape::Attr::AssumedRank));
         return typeAndShape->Rank();
       }
     }

--- a/lib/evaluate/check-call.cc
+++ b/lib/evaluate/check-call.cc
@@ -1,0 +1,199 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "check-call.h"
+#include "characteristics.h"
+#include "shape.h"
+#include "tools.h"
+#include "../parser/message.h"
+#include <map>
+#include <string>
+
+using namespace Fortran::parser::literals;
+
+namespace Fortran::evaluate {
+
+static void CheckImplicitInterfaceArg(
+    ActualArgument &arg, parser::ContextualMessages &messages) {
+  if (const auto &kw{arg.keyword}) {
+    messages.Say(*kw,
+        "Keyword '%s=' cannot appear in a reference to a procedure with an implicit interface"_err_en_US,
+        *kw);
+  }
+  if (auto type{arg.GetType()}) {
+    if (type->IsAssumedType()) {
+      messages.Say(
+          "Assumed type argument requires an explicit interface"_err_en_US);
+    } else if (type->IsPolymorphic()) {
+      messages.Say(
+          "Polymorphic argument requires an explicit interface"_err_en_US);
+    } else if (type->category() == TypeCategory::Derived) {
+      auto &derived{type->GetDerivedTypeSpec()};
+      if (!derived.parameters().empty()) {
+        messages.Say(
+            "Parameterized derived type argument requires an explicit interface"_err_en_US);
+      }
+    }
+  }
+  if (const auto *expr{arg.UnwrapExpr()}) {
+    if (auto named{ExtractNamedEntity(*expr)}) {
+      const semantics::Symbol &symbol{named->GetLastSymbol()};
+      if (symbol.Corank() > 0) {
+        messages.Say(
+            "Coarray argument requires an explicit interface"_err_en_US);
+      }
+      if (const auto *details{
+              symbol.detailsIf<semantics::ObjectEntityDetails>()}) {
+        if (details->IsAssumedRank()) {
+          messages.Say(
+              "Assumed rank argument requires an explicit interface"_err_en_US);
+        }
+      }
+      if (symbol.attrs().test(semantics::Attr::ASYNCHRONOUS)) {
+        messages.Say(
+            "ASYNCHRONOUS argument requires an explicit interface"_err_en_US);
+      }
+      if (symbol.attrs().test(semantics::Attr::VOLATILE)) {
+        messages.Say(
+            "VOLATILE argument requires an explicit interface"_err_en_US);
+      }
+    }
+  }
+}
+
+static void CheckExplicitInterfaceArg(const ActualArgument &arg,
+    const characteristics::DummyArgument &dummy, FoldingContext &context) {
+  std::visit(
+      common::visitors{
+          [&](const characteristics::DummyDataObject &object) {
+            if (const auto *expr{arg.UnwrapExpr()}) {
+              if (auto type{characteristics::GetTypeAndShape(*expr, context)}) {
+                object.type.IsCompatibleWith(context.messages(), *type);
+              } else {
+                // TODO
+              }
+            } else {
+              // TODO
+            }
+          },
+          [&](const characteristics::DummyProcedure &) {
+            // TODO check effective procedure compatibility
+          },
+          [&](const characteristics::AlternateReturn &) {
+            // TODO check alternate return
+          },
+      },
+      dummy.u);
+}
+
+static void RearrangeArguments(const characteristics::Procedure &proc,
+    ActualArguments &actuals, parser::ContextualMessages &messages) {
+  CHECK(proc.HasExplicitInterface());
+  if (actuals.size() < proc.dummyArguments.size()) {
+    actuals.resize(proc.dummyArguments.size());
+  } else if (actuals.size() > proc.dummyArguments.size()) {
+    messages.Say(
+        "Too many actual arguments (%zd) passed to procedure that expects only %zd"_err_en_US,
+        actuals.size(), proc.dummyArguments.size());
+  }
+  std::map<std::string, ActualArgument> kwArgs;
+  for (auto &x : actuals) {
+    if (x.has_value()) {
+      if (x->keyword.has_value()) {
+        auto emplaced{
+            kwArgs.try_emplace(x->keyword->ToString(), std::move(*x))};
+        if (!emplaced.second) {
+          messages.Say(*x->keyword,
+              "Argument keyword '%s=' appears on more than one effective argument in this procedure reference"_err_en_US,
+              *x->keyword);
+        }
+        x.reset();
+      }
+    }
+  }
+  if (!kwArgs.empty()) {
+    int index{0};
+    for (const auto &dummy : proc.dummyArguments) {
+      if (!dummy.name.empty()) {
+        auto iter{kwArgs.find(dummy.name)};
+        if (iter != kwArgs.end()) {
+          ActualArgument &x{iter->second};
+          if (actuals[index].has_value()) {
+            messages.Say(*x.keyword,
+                "Keyword argument '%s=' has already been specified positionally (#%d) in this procedure reference"_err_en_US,
+                *x.keyword, index + 1);
+          } else {
+            actuals[index] = std::move(x);
+          }
+          kwArgs.erase(iter);
+        }
+      }
+      ++index;
+    }
+    for (auto &bad : kwArgs) {
+      ActualArgument &x{bad.second};
+      messages.Say(*x.keyword,
+          "Argument keyword '%s=' is not recognized for this procedure reference"_err_en_US,
+          *x.keyword);
+    }
+  }
+}
+
+void CheckArguments(const characteristics::Procedure &proc,
+    ActualArguments &actuals, FoldingContext &context,
+    bool treatingExternalAsImplicit) {
+  parser::Messages buffer;
+  parser::ContextualMessages messages{context.messages().at(), &buffer};
+  FoldingContext localContext{context, messages};
+  if (proc.HasExplicitInterface()) {
+    RearrangeArguments(proc, actuals, messages);
+    int index{0};
+    for (auto &x : actuals) {
+      const auto &dummy{proc.dummyArguments[index++]};
+      if (x.has_value()) {
+        CheckExplicitInterfaceArg(*x, dummy, localContext);
+      } else if (!dummy.IsOptional()) {
+        if (dummy.name.empty()) {
+          messages.Say(
+              "Dummy argument #%d is not OPTIONAL and is not associated with an effective argument in this procedure reference"_err_en_US,
+              index);
+        } else {
+          messages.Say(
+              "Dummy argument '%s' (#%d) is not OPTIONAL and is not associated with an effective argument in this procedure reference"_err_en_US,
+              dummy.name, index);
+        }
+      }
+      if (treatingExternalAsImplicit) {
+        CheckImplicitInterfaceArg(*x, context.messages());
+      }
+    }
+  } else {
+    for (auto &x : actuals) {
+      if (x.has_value()) {
+        CheckImplicitInterfaceArg(*x, context.messages());
+      }
+    }
+  }
+  if (!buffer.empty()) {
+    if (treatingExternalAsImplicit) {
+      if (auto *msg{context.messages().Say(
+              "Warning: if the procedure's interface were explicit, this reference would be in error:"_en_US)}) {
+        buffer.AttachTo(*msg);
+      }
+    } else if (auto *msgs{context.messages().messages()}) {
+      msgs->Merge(std::move(buffer));
+    }
+  }
+}
+}

--- a/lib/evaluate/check-call.h
+++ b/lib/evaluate/check-call.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Constraint checking for procedure references
+
+#ifndef FORTRAN_EVALUATE_CHECK_CALL_H_
+#define FORTRAN_EVALUATE_CHECK_CALL_H_
+
+#include "call.h"
+
+namespace Fortran::parser {
+class ContextualMessages;
+}
+namespace Fortran::evaluate::characteristics {
+struct Procedure;
+}
+
+namespace Fortran::evaluate {
+class FoldingContext;
+
+// The Boolean flag argument should be true when the called procedure
+// does not actually have an explicit interface at the call site, but
+// its characteristics are known because it is a subroutine or function
+// defined at the top level in the same source file.
+void CheckArguments(const characteristics::Procedure &, ActualArguments &,
+    FoldingContext &, bool treatingExternalAsImplicit = false);
+}
+#endif

--- a/lib/evaluate/check-expression.h
+++ b/lib/evaluate/check-expression.h
@@ -29,16 +29,18 @@ class Scope;
 }
 
 namespace Fortran::evaluate {
+class IntrinsicProcTable;
 
 // Predicate: true when an expression is a constant expression (in the
 // strict sense of the Fortran standard); it may not (yet) be a hard
 // constant value.
 template<typename A> bool IsConstantExpr(const A &);
 extern template bool IsConstantExpr(const Expr<SomeType> &);
+extern template bool IsConstantExpr(const Expr<SomeInteger> &);
 
-// Predicate: true when an expression is an object designator with
+// Checks whether an expression is an object designator with
 // constant addressing and no vector-valued subscript.
-bool IsInitialDataTarget(const Expr<SomeType> &);
+bool IsInitialDataTarget(const Expr<SomeType> &, parser::ContextualMessages &);
 
 // Check whether an expression is a specification expression
 // (10.1.11(2), C1010).  Constant expressions are always valid
@@ -54,5 +56,12 @@ extern template void CheckSpecificationExpr(
 extern template void CheckSpecificationExpr(
     const std::optional<Expr<SubscriptInteger>> &x,
     parser::ContextualMessages &, const semantics::Scope &);
+
+// Simple contiguity (9.5.4)
+template<typename A>
+bool IsSimplyContiguous(const A &, const IntrinsicProcTable &);
+extern template bool IsSimplyContiguous(
+    const Expr<SomeType> &, const IntrinsicProcTable &);
+
 }
 #endif

--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -440,26 +440,24 @@ std::string SomeDerived::AsFortran() const {
 }
 
 std::string DerivedTypeSpecAsFortran(const semantics::DerivedTypeSpec &spec) {
-  if (spec.HasActualParameters()) {
-    std::stringstream ss;
-    ss << spec.name().ToString();
-    char ch{'('};
-    for (const auto &[name, value] : spec.parameters()) {
-      ss << ch << name.ToString() << '=';
-      ch = ',';
-      if (value.isAssumed()) {
-        ss << '*';
-      } else if (value.isDeferred()) {
-        ss << ':';
-      } else {
-        value.GetExplicit()->AsFortran(ss);
-      }
+  std::stringstream ss;
+  ss << spec.name().ToString();
+  char ch{'('};
+  for (const auto &[name, value] : spec.parameters()) {
+    ss << ch << name.ToString() << '=';
+    ch = ',';
+    if (value.isAssumed()) {
+      ss << '*';
+    } else if (value.isDeferred()) {
+      ss << ':';
+    } else {
+      value.GetExplicit()->AsFortran(ss);
     }
-    ss << ')';
-    return ss.str();
-  } else {
-    return spec.name().ToString();
   }
+  if (ch != '(') {
+    ss << ')';
+  }
+  return ss.str();
 }
 
 std::ostream &EmitVar(std::ostream &o, const Symbol &symbol) {

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -67,10 +67,10 @@ static constexpr CategorySet IntOrRealType{IntType | RealType};
 static constexpr CategorySet FloatingType{RealType | ComplexType};
 static constexpr CategorySet NumericType{IntType | RealType | ComplexType};
 static constexpr CategorySet RelatableType{IntType | RealType | CharType};
+static constexpr CategorySet DerivedType{TypeCategory::Derived};
 static constexpr CategorySet IntrinsicType{
     IntType | RealType | ComplexType | CharType | LogicalType};
-static constexpr CategorySet AnyType{
-    IntrinsicType | CategorySet{TypeCategory::Derived}};
+static constexpr CategorySet AnyType{IntrinsicType | DerivedType};
 
 ENUM_CLASS(KindCode, none, defaultIntegerKind,
     defaultRealKind,  // is also the default COMPLEX kind
@@ -123,7 +123,8 @@ static constexpr TypePattern AnyChar{CharType, KindCode::any};
 static constexpr TypePattern AnyLogical{LogicalType, KindCode::any};
 static constexpr TypePattern AnyRelatable{RelatableType, KindCode::any};
 static constexpr TypePattern AnyIntrinsic{IntrinsicType, KindCode::any};
-static constexpr TypePattern Anything{AnyType, KindCode::any};
+static constexpr TypePattern ExtensibleDerived{DerivedType, KindCode::any};
+static constexpr TypePattern AnyData{AnyType, KindCode::any};
 
 // Type is irrelevant, but not BOZ (for PRESENT(), OPTIONAL(), &c.)
 static constexpr TypePattern Addressable{AnyType, KindCode::addressable};
@@ -264,8 +265,8 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
     {"aint", {{"a", SameReal}, MatchingDefaultKIND}, KINDReal},
     {"all", {{"mask", SameLogical, Rank::array}, OptionalDIM}, SameLogical,
         Rank::dimReduced},
-    {"allocated", {{"array", Anything, Rank::array}}, DefaultLogical},
-    {"allocated", {{"scalar", Anything, Rank::scalar}}, DefaultLogical},
+    {"allocated", {{"array", AnyData, Rank::array}}, DefaultLogical},
+    {"allocated", {{"scalar", AnyData, Rank::scalar}}, DefaultLogical},
     {"anint", {{"a", SameReal}, MatchingDefaultKIND}, KINDReal},
     {"any", {{"mask", SameLogical, Rank::array}, OptionalDIM}, SameLogical,
         Rank::dimReduced},
@@ -378,6 +379,10 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
     {"erfc_scaled", {{"x", SameReal}}, SameReal},
     {"exp", {{"x", SameFloating}}, SameFloating},
     {"exponent", {{"x", AnyReal}}, DefaultInt},
+    {"extends_type_of",
+        {{"a", ExtensibleDerived, Rank::anyOrAssumedRank},
+            {"mold", ExtensibleDerived, Rank::anyOrAssumedRank}},
+        DefaultLogical, Rank::scalar},
     {"findloc",
         {{"array", AnyNumeric, Rank::array},
             {"value", AnyNumeric, Rank::scalar}, RequiredDIM, OptionalMASK,
@@ -455,11 +460,11 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
     {"is_iostat_eor", {{"i", AnyInt}}, DefaultLogical},
     {"kind", {{"x", AnyIntrinsic}}, DefaultInt},
     {"lbound",
-        {{"array", Anything, Rank::anyOrAssumedRank}, RequiredDIM,
+        {{"array", AnyData, Rank::anyOrAssumedRank}, RequiredDIM,
             SubscriptDefaultKIND},
         KINDInt, Rank::scalar},
     {"lbound",
-        {{"array", Anything, Rank::anyOrAssumedRank}, SubscriptDefaultKIND},
+        {{"array", AnyData, Rank::anyOrAssumedRank}, SubscriptDefaultKIND},
         KINDInt, Rank::vector},
     {"leadz", {{"i", AnyInt}}, DefaultInt},
     {"len", {{"string", AnyChar, Rank::anyOrAssumedRank}, SubscriptDefaultKIND},
@@ -587,7 +592,7 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
         Rank::scalar},
     {"range", {{"x", AnyNumeric, Rank::anyOrAssumedRank}}, DefaultInt,
         Rank::scalar},
-    {"rank", {{"a", Anything, Rank::anyOrAssumedRank}}, DefaultInt,
+    {"rank", {{"a", AnyData, Rank::anyOrAssumedRank}}, DefaultInt,
         Rank::scalar},
     {"real", {{"a", AnyNumeric, Rank::elementalOrBOZ}, DefaultingKIND},
         KINDReal},
@@ -605,6 +610,10 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
             {"order", AnyInt, Rank::vector, Optionality::optional}},
         SameType, Rank::shaped},
     {"rrspacing", {{"x", SameReal}}, SameReal},
+    {"same_type_as",
+        {{"a", ExtensibleDerived, Rank::anyOrAssumedRank},
+            {"b", ExtensibleDerived, Rank::anyOrAssumedRank}},
+        DefaultLogical, Rank::scalar},
     {"scale", {{"x", SameReal}, {"i", AnyInt}}, SameReal},
     {"scan",
         {{"string", SameChar}, {"set", SameChar},
@@ -632,7 +641,7 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
         DefaultInt, Rank::scalar},
     {"set_exponent", {{"x", SameReal}, {"i", AnyInt}}, SameReal},
     {"shape",
-        {{"source", Anything, Rank::anyOrAssumedRank}, SubscriptDefaultKIND},
+        {{"source", AnyData, Rank::anyOrAssumedRank}, SubscriptDefaultKIND},
         KINDInt, Rank::vector},
     {"shifta", {{"i", SameInt}, {"shift", AnyInt}}, SameInt},
     {"shiftl", {{"i", SameInt}, {"shift", AnyInt}}, SameInt},
@@ -641,7 +650,7 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
     {"sin", {{"x", SameFloating}}, SameFloating},
     {"sinh", {{"x", SameFloating}}, SameFloating},
     {"size",
-        {{"array", Anything, Rank::anyOrAssumedRank}, OptionalDIM,
+        {{"array", AnyData, Rank::anyOrAssumedRank}, OptionalDIM,
             SubscriptDefaultKIND},
         KINDInt, Rank::scalar},
     {"spacing", {{"x", SameReal}}, SameReal},
@@ -651,8 +660,8 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
         SameType, Rank::rankPlus1},
     {"sqrt", {{"x", SameFloating}}, SameFloating},
     {"storage_size",
-        {{"a", Anything, Rank::anyOrAssumedRank}, SubscriptDefaultKIND},
-        KINDInt, Rank::scalar},
+        {{"a", AnyData, Rank::anyOrAssumedRank}, SubscriptDefaultKIND}, KINDInt,
+        Rank::scalar},
     {"sum", {{"array", SameNumeric, Rank::array}, OptionalDIM, OptionalMASK},
         SameNumeric, Rank::dimReduced},
     {"tan", {{"x", SameFloating}}, SameFloating},
@@ -660,24 +669,24 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
     {"tiny", {{"x", SameReal, Rank::anyOrAssumedRank}}, SameReal, Rank::scalar},
     {"trailz", {{"i", AnyInt}}, DefaultInt},
     {"transfer",
-        {{"source", Anything, Rank::known}, {"mold", SameType, Rank::scalar}},
+        {{"source", AnyData, Rank::known}, {"mold", SameType, Rank::scalar}},
         SameType, Rank::scalar},
     {"transfer",
-        {{"source", Anything, Rank::known}, {"mold", SameType, Rank::array}},
+        {{"source", AnyData, Rank::known}, {"mold", SameType, Rank::array}},
         SameType, Rank::vector},
     {"transfer",
-        {{"source", Anything, Rank::anyOrAssumedRank},
+        {{"source", AnyData, Rank::anyOrAssumedRank},
             {"mold", SameType, Rank::anyOrAssumedRank},
             {"size", AnyInt, Rank::scalar}},
         SameType, Rank::vector},
     {"transpose", {{"matrix", SameType, Rank::matrix}}, SameType, Rank::matrix},
     {"trim", {{"string", SameChar, Rank::scalar}}, SameChar, Rank::scalar},
     {"ubound",
-        {{"array", Anything, Rank::anyOrAssumedRank}, RequiredDIM,
+        {{"array", AnyData, Rank::anyOrAssumedRank}, RequiredDIM,
             SubscriptDefaultKIND},
         KINDInt, Rank::scalar},
     {"ubound",
-        {{"array", Anything, Rank::anyOrAssumedRank}, SubscriptDefaultKIND},
+        {{"array", AnyData, Rank::anyOrAssumedRank}, SubscriptDefaultKIND},
         KINDInt, Rank::vector},
     {"unpack",
         {{"vector", SameType, Rank::vector}, {"mask", AnyLogical, Rank::array},
@@ -695,7 +704,7 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
 //   NUM_IMAGES, STOPPED_IMAGES, TEAM_NUMBER, THIS_IMAGE,
 //   COSHAPE
 // TODO: Object characteristic inquiry functions
-//   EXTENDS_TYPE_OF, IS_CONTIGUOUS, SAME_TYPE
+//   IS_CONTIGUOUS
 // TODO: Non-standard intrinsic functions
 //  AND, OR, XOR, LSHIFT, RSHIFT, SHIFT, ZEXT, IZEXT,
 //  COSD, SIND, TAND, ACOSD, ASIND, ATAND, ATAN2D, COMPL,
@@ -886,11 +895,69 @@ static const SpecificIntrinsicInterface specificIntrinsicFunction[]{
     {{"tanh", {{"x", DefaultReal}}, DefaultReal}},
 };
 
-// TODO: Intrinsic subroutines
-//   MVBITS (elemental), CPU_TIME, DATE_AND_TIME, EVENT_QUERY,
-//   EXECUTE_COMMAND_LINE, GET_COMMAND, GET_COMMAND_ARGUMENT,
-//   GET_ENVIRONMENT_VARIABLE, MOVE_ALLOC, RANDOM_INIT, RANDOM_NUMBER,
-//   RANDOM_SEED, SYSTEM_CLOCK
+static const IntrinsicInterface intrinsicSubroutine[]{
+    {"cpu_time", {{"time", AnyReal, Rank::scalar}}, {}},
+    {"date_and_time",
+        {{"date", DefaultChar, Rank::scalar, Optionality::optional},
+            {"time", DefaultChar, Rank::scalar, Optionality::optional},
+            {"zone", DefaultChar, Rank::scalar, Optionality::optional},
+            {"values", AnyInt, Rank::vector, Optionality::optional}},
+        {}},
+    {"execute_command_line",
+        {{"command", DefaultChar, Rank::scalar},
+            {"wait", AnyLogical, Rank::scalar, Optionality::optional},
+            {"exitstat", AnyInt, Rank::scalar, Optionality::optional},
+            {"cmdstat", AnyInt, Rank::scalar, Optionality::optional},
+            {"cmdmsg", DefaultChar, Rank::scalar, Optionality::optional}},
+        {}},
+    {"get_command",
+        {{"command", DefaultChar, Rank::scalar, Optionality::optional},
+            {"length", AnyInt, Rank::scalar, Optionality::optional},
+            {"status", AnyInt, Rank::scalar, Optionality::optional},
+            {"errmsg", DefaultChar, Rank::scalar, Optionality::optional}},
+        {}},
+    {"get_command_argument",
+        {{"number", AnyInt, Rank::scalar},
+            {"value", DefaultChar, Rank::scalar, Optionality::optional},
+            {"length", AnyInt, Rank::scalar, Optionality::optional},
+            {"status", AnyInt, Rank::scalar, Optionality::optional},
+            {"errmsg", DefaultChar, Rank::scalar, Optionality::optional}},
+        {}},
+    {"get_environment_variable",
+        {{"name", DefaultChar, Rank::scalar},
+            {"value", DefaultChar, Rank::scalar, Optionality::optional},
+            {"length", AnyInt, Rank::scalar, Optionality::optional},
+            {"status", AnyInt, Rank::scalar, Optionality::optional},
+            {"trim_name", AnyLogical, Rank::scalar, Optionality::optional},
+            {"errmsg", DefaultChar, Rank::scalar, Optionality::optional}},
+        {}},
+    {"move_alloc",
+        {{"from", SameType, Rank::known}, {"to", SameType, Rank::known},
+            {"stat", AnyInt, Rank::scalar, Optionality::optional},
+            {"errmsg", DefaultChar, Rank::scalar, Optionality::optional}},
+        {}},
+    {"mvbits",
+        {{"from", SameInt}, {"frompos", AnyInt}, {"len", AnyInt},
+            {"to", SameInt}, {"topos", AnyInt}},
+        {}},  // elemental
+    {"random_init",
+        {{"repeatable", AnyLogical, Rank::scalar},
+            {"image_distinct", AnyLogical, Rank::scalar}},
+        {}},
+    {"random_number", {{"harvest", AnyReal, Rank::known}}, {}},
+    {"random_seed",
+        {{"size", DefaultInt, Rank::scalar, Optionality::optional},
+            {"put", DefaultInt, Rank::vector, Optionality::optional},
+            {"get", DefaultInt, Rank::vector, Optionality::optional}},
+        {}},  // TODO: at most one argument can be present
+    {"system_clock",
+        {{"count", AnyInt, Rank::scalar, Optionality::optional},
+            {"count_rate", AnyIntOrReal, Rank::scalar, Optionality::optional},
+            {"count_max", AnyInt, Rank::scalar, Optionality::optional}},
+        {}},
+};
+
+// TODO: Intrinsic subroutine EVENT_QUERY
 // TODO: Atomic intrinsic subroutines: ATOMIC_ADD &al.
 // TODO: Collective intrinsic subroutines: CO_BROADCAST &al.
 
@@ -1364,9 +1431,7 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
     }
   }
 
-  // Characterize the specific intrinsic function.
-  characteristics::TypeAndShape typeAndShape{resultType.value(), resultRank};
-  characteristics::FunctionResult funcResult{std::move(typeAndShape)};
+  // Characterize the specific intrinsic procedure.
   characteristics::DummyArguments dummyArgs;
   std::optional<int> sameDummyArg;
   for (std::size_t j{0}; j < dummies; ++j) {
@@ -1391,6 +1456,8 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
         }
       } else {
         CHECK(arg->GetAssumedTypeDummy() != nullptr);
+        dummyArgs.emplace_back(std::string{d.keyword},
+            characteristics::DummyDataObject{DynamicType::AssumedType()});
       }
     } else {
       // optional argument is absent
@@ -1411,11 +1478,19 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
   if (elementalRank > 0) {
     attrs.set(characteristics::Procedure::Attr::Elemental);
   }
-  characteristics::Procedure chars{
-      std::move(funcResult), std::move(dummyArgs), attrs};
-
-  return SpecificCall{
-      SpecificIntrinsic{name, std::move(chars)}, std::move(rearranged)};
+  if (call.isSubroutineCall) {
+    return SpecificCall{
+        SpecificIntrinsic{
+            name, characteristics::Procedure{std::move(dummyArgs), attrs}},
+        std::move(rearranged)};
+  } else {
+    characteristics::TypeAndShape typeAndShape{resultType.value(), resultRank};
+    characteristics::FunctionResult funcResult{std::move(typeAndShape)};
+    characteristics::Procedure chars{
+        std::move(funcResult), std::move(dummyArgs), attrs};
+    return SpecificCall{
+        SpecificIntrinsic{name, std::move(chars)}, std::move(rearranged)};
+  }
 }
 
 class IntrinsicProcTable::Implementation {
@@ -1427,6 +1502,9 @@ public:
     }
     for (const SpecificIntrinsicInterface &f : specificIntrinsicFunction) {
       specificFuncs_.insert(std::make_pair(std::string{f.name}, &f));
+    }
+    for (const IntrinsicInterface &f : intrinsicSubroutine) {
+      subroutines_.insert(std::make_pair(std::string{f.name}, &f));
     }
   }
 
@@ -1448,6 +1526,7 @@ private:
   common::IntrinsicTypeDefaultKinds defaults_;
   std::multimap<std::string, const IntrinsicInterface *> genericFuncs_;
   std::multimap<std::string, const SpecificIntrinsicInterface *> specificFuncs_;
+  std::multimap<std::string, const IntrinsicInterface *> subroutines_;
 };
 
 bool IntrinsicProcTable::Implementation::IsIntrinsic(
@@ -1458,6 +1537,10 @@ bool IntrinsicProcTable::Implementation::IsIntrinsic(
   }
   auto genericRange{genericFuncs_.equal_range(name)};
   if (genericRange.first != genericRange.second) {
+    return true;
+  }
+  auto subrRange{subroutines_.equal_range(name)};
+  if (subrRange.first != subrRange.second) {
     return true;
   }
   // special cases
@@ -1602,10 +1685,18 @@ static DynamicType GetReturnType(const SpecificIntrinsicInterface &interface,
 std::optional<SpecificCall> IntrinsicProcTable::Implementation::Probe(
     const CallCharacteristics &call, ActualArguments &arguments,
     FoldingContext &context, const IntrinsicProcTable &intrinsics) const {
+  std::string name{call.name.ToString()};
   if (call.isSubroutineCall) {
+    parser::Messages buffer;
+    auto subrRange{subroutines_.equal_range(name)};
+    for (auto iter{subrRange.first}; iter != subrRange.second; ++iter) {
+      if (auto specificCall{
+              iter->second->Match(call, defaults_, arguments, context)}) {
+        return specificCall;
+      }
+    }
     return std::nullopt;  // TODO
   }
-  std::string name{call.name.ToString()};
 
   // Special case: NULL()
   // All special cases handled here before the table probes below must
@@ -1829,6 +1920,10 @@ std::ostream &IntrinsicProcTable::Implementation::Dump(std::ostream &o) const {
       o << " -> " << g;
     }
     o << '\n';
+  }
+  o << "subroutines:\n";
+  for (const auto &iter : subroutines_) {
+    iter.second->Dump(o << iter.first << ": ") << '\n';
   }
   return o;
 }

--- a/lib/evaluate/shape.h
+++ b/lib/evaluate/shape.h
@@ -43,8 +43,6 @@ using Shape = std::vector<MaybeExtentExpr>;
 bool IsImpliedShape(const Symbol &);
 bool IsExplicitShape(const Symbol &);
 
-template<typename A> std::optional<Shape> GetShape(FoldingContext &, const A &);
-
 // Conversions between various representations of shapes.
 Shape AsShape(const Constant<ExtentType> &);
 std::optional<Shape> AsShape(FoldingContext &, ExtentExpr &&);
@@ -87,6 +85,8 @@ MaybeExtentExpr GetSize(Shape &&);
 bool ContainsAnyImpliedDoIndex(const ExtentExpr &);
 
 // GetShape()
+template<typename A> std::optional<Shape> GetShape(FoldingContext &, const A &);
+
 class GetShapeHelper
   : public AnyTraverse<GetShapeHelper, std::optional<Shape>> {
 public:

--- a/lib/evaluate/type.h
+++ b/lib/evaluate/type.h
@@ -55,7 +55,7 @@ template<TypeCategory CATEGORY, int KIND = 0> class Type;
 
 using SubscriptInteger = Type<TypeCategory::Integer, 8>;
 using CInteger = Type<TypeCategory::Integer, 4>;
-using LogicalResult = Type<TypeCategory::Logical, 1>;
+using LogicalResult = Type<TypeCategory::Logical, 4>;
 using LargestReal = Type<TypeCategory::Real, 16>;
 
 // A predicate that is true when a kind value is a kind that could possibly
@@ -161,7 +161,7 @@ public:
     return *derived_;
   }
 
-  // 7.3.2.3 type compatibility.
+  // 7.3.2.3 & 15.5.2.4 type compatibility.
   // x.IsTypeCompatibleWith(y) is true if "x => y" or passing actual y to
   // dummy argument x would be valid.  Be advised, this is not a reflexive
   // relation.
@@ -447,6 +447,9 @@ int SelectedCharKind(const std::string &, int defaultKind);
 int SelectedIntKind(std::int64_t precision = 0);
 int SelectedRealKind(
     std::int64_t precision = 0, std::int64_t range = 0, std::int64_t radix = 2);
+
+// Utilities
+bool IsKindTypeParameter(const semantics::Symbol &);
 
 // For generating "[extern] template class", &c. boilerplate
 #define EXPAND_FOR_EACH_INTEGER_KIND(M, P, S) \

--- a/lib/parser/prescan.cc
+++ b/lib/parser/prescan.cc
@@ -227,14 +227,12 @@ void Prescanner::Statement() {
 
 TokenSequence Prescanner::TokenizePreprocessorDirective() {
   CHECK(nextLine_ < limit_ && !inPreprocessorDirective_);
-  auto saveAt{at_};
   inPreprocessorDirective_ = true;
   BeginSourceLineAndAdvance();
   TokenSequence tokens;
   while (NextToken(tokens)) {
   }
   inPreprocessorDirective_ = false;
-  at_ = saveAt;
   return tokens;
 }
 
@@ -806,8 +804,10 @@ bool Prescanner::SkipCommentLine(bool afterAmpersand) {
       lineClass.kind == LineClassification::Kind::PreprocessorDirective) {
     // Allow conditional compilation directives (e.g., #ifdef) to affect
     // continuation lines.
-    // Allow other preprocessor directives, too, except #include,
-    // #define, & #undef.
+    // Allow other preprocessor directives, too, except #include
+    // (when it does not follow '&'), #define, and #undef (because
+    // they cannot be allowed to affect preceding text on a
+    // continued line).
     preprocessor_.Directive(TokenizePreprocessorDirective(), this);
     return true;
   } else if (afterAmpersand &&

--- a/lib/semantics/assignment.cc
+++ b/lib/semantics/assignment.cc
@@ -58,7 +58,8 @@ void CheckPointerAssignment(parser::ContextualMessages &messages,
   } else if (const auto *intrinsic{f.proc().GetSpecificIntrinsic()}) {
     funcName = intrinsic->name;
   }
-  if (auto proc{Characterize(f.proc(), intrinsics)}) {
+  if (auto proc{
+          characteristics::Procedure::Characterize(f.proc(), intrinsics)}) {
     std::optional<parser::MessageFixedText> error;
     if (const auto &funcResult{proc->functionResult}) {
       const auto *frProc{funcResult->IsProcedurePointer()};
@@ -189,13 +190,13 @@ void CheckPointerAssignment(parser::ContextualMessages &messages,
     const IntrinsicProcTable &intrinsics, const Symbol &lhs,
     const ProcedureDesignator &d) {
   CheckPointerAssignment(messages, intrinsics, lhs, d.GetName(), false,
-      Characterize(d, intrinsics));
+      characteristics::Procedure::Characterize(d, intrinsics));
 }
 
 void CheckPointerAssignment(parser::ContextualMessages &messages,
     const IntrinsicProcTable &intrinsics, const Symbol &lhs,
     const ProcedureRef &ref) {
-  auto chars{Characterize(ref, intrinsics)};
+  auto chars{characteristics::Procedure::Characterize(ref, intrinsics)};
   if (chars.has_value()) {
     if (chars->functionResult.has_value()) {
       if (const auto *proc{chars->functionResult->IsProcedurePointer()}) {

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -311,24 +311,31 @@ private:
   MaybeExpr TopLevelChecks(DataRef &&);
   std::optional<Expr<SubscriptInteger>> GetSubstringBound(
       const std::optional<parser::ScalarIntExpr> &);
-  std::optional<ProcedureDesignator> AnalyzeProcedureComponentRef(
-      const parser::ProcComponentRef &);
-  std::optional<ActualArgument> AnalyzeActualArgument(const parser::Expr &);
 
   struct CalleeAndArguments {
     ProcedureDesignator procedureDesignator;
     ActualArguments arguments;
   };
 
+  std::optional<CalleeAndArguments> AnalyzeProcedureComponentRef(
+      const parser::ProcComponentRef &, ActualArguments &&);
+  std::optional<ActualArgument> AnalyzeActualArgument(const parser::Expr &);
+
   MaybeExpr AnalyzeCall(const parser::Call &, bool isSubroutine);
   std::optional<ActualArguments> AnalyzeArguments(
       const parser::Call &, bool isSubroutine);
-  std::optional<CalleeAndArguments> Procedure(
-      const parser::ProcedureDesignator &, ActualArguments &);
+  std::optional<characteristics::Procedure> CheckCall(
+      parser::CharBlock, const ProcedureDesignator &, ActualArguments &);
+
+  std::optional<CalleeAndArguments> GetCalleeAndArguments(
+      const parser::ProcedureDesignator &, ActualArguments &&,
+      bool isSubroutine);
+
+  void CheckForBadRecursion(parser::CharBlock, const semantics::Symbol &);
   bool EnforceTypeConstraint(parser::CharBlock, const MaybeExpr &, TypeCategory,
       bool defaultKind = false);
-  MaybeExpr MakeFunctionRef(ProcedureDesignator &&, ActualArguments &&);
-  MaybeExpr MakeFunctionRef(CalleeAndArguments &&);
+  MaybeExpr MakeFunctionRef(
+      parser::CharBlock, ProcedureDesignator &&, ActualArguments &&);
   MaybeExpr MakeFunctionRef(parser::CharBlock intrinsic, ActualArguments &&);
 
   semantics::SemanticsContext &context_;
@@ -354,11 +361,6 @@ void ConformabilityCheck(
         left.Rank(), right.Rank());
   }
 }
-
-std::optional<characteristics::Procedure> Characterize(
-    const ProcedureDesignator &, const IntrinsicProcTable &);
-std::optional<characteristics::Procedure> Characterize(
-    const ProcedureRef &, const IntrinsicProcTable &);
 }  // namespace Fortran::evaluate
 
 namespace Fortran::semantics {

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -258,19 +258,6 @@ void Symbol::ReplaceName(const SourceName &name) {
   name_ = name;
 }
 
-Symbol &Symbol::GetUltimate() {
-  return const_cast<Symbol &>(const_cast<const Symbol *>(this)->GetUltimate());
-}
-const Symbol &Symbol::GetUltimate() const {
-  if (const auto *details{detailsIf<UseDetails>()}) {
-    return details->symbol().GetUltimate();
-  } else if (const auto *details{detailsIf<HostAssocDetails>()}) {
-    return details->symbol().GetUltimate();
-  } else {
-    return *this;
-  }
-}
-
 void Symbol::SetType(const DeclTypeSpec &type) {
   std::visit(
       common::visitors{

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -500,8 +500,19 @@ public:
   bool CanReplaceDetails(const Details &details) const;
 
   // Follow use-associations and host-associations to get the ultimate entity.
-  Symbol &GetUltimate();
-  const Symbol &GetUltimate() const;
+  Symbol &GetUltimate() {
+    return const_cast<Symbol &>(
+        const_cast<const Symbol *>(this)->GetUltimate());
+  }
+  const Symbol &GetUltimate() const {
+    if (const auto *details{detailsIf<UseDetails>()}) {
+      return details->symbol().GetUltimate();
+    } else if (const auto *details{detailsIf<HostAssocDetails>()}) {
+      return details->symbol().GetUltimate();
+    } else {
+      return *this;
+    }
+  }
 
   DeclTypeSpec *GetType() {
     return const_cast<DeclTypeSpec *>(

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -227,7 +227,7 @@ private:
 };
 std::ostream &operator<<(std::ostream &, const ArraySpec &);
 
-// Each DerivedTypeSpec has a typeSymbol that has DerivedTypeSpec.
+// Each DerivedTypeSpec has a typeSymbol that has DerivedTypeDetails.
 // The name may not match the symbol's name in case of a USE rename.
 class DerivedTypeSpec {
 public:
@@ -243,7 +243,6 @@ public:
   void ReplaceScope(const Scope &);
   const ParameterMapType &parameters() const { return parameters_; }
 
-  bool HasActualParameters() const { return !parameters_.empty(); }
   ParamValue &AddParamValue(SourceName, ParamValue &&);
   ParamValue *FindParameter(SourceName);
   const ParamValue *FindParameter(SourceName target) const {

--- a/module/ieee_arithmetic.f90
+++ b/module/ieee_arithmetic.f90
@@ -153,12 +153,13 @@ module ieee_arithmetic
     integer, parameter :: exponentBits = TOTALBITS - 1 - significand; \
     integer, parameter :: maxExpo = shiftl(1, exponentBits) - 1; \
     integer :: exponent, sign; \
-    logical :: nzSignificand, quiet; \
+    logical :: negative, nzSignificand, quiet; \
     raw = transfer(x, raw); \
     exponent = ibits(raw, significand, exponentBits); \
+    negative = btest(raw, TOTALBITS - 1); \
     nzSignificand = ibits(raw, 0, significand) /= 0; \
     quiet = btest(raw, significand - 1); \
-    ieee_class_a##RKIND = classify(exponent, maxExpo, nzSignificand, quiet); \
+    ieee_class_a##RKIND = classify(exponent, maxExpo, negative, nzSignificand, quiet); \
   end function ieee_class_a##RKIND
   _CLASSIFY(2,2,16,11,1)
   _CLASSIFY(3,2,16,8,1)

--- a/module/ieee_exceptions.f90
+++ b/module/ieee_exceptions.f90
@@ -25,13 +25,14 @@ module ieee_exceptions
     ieee_overflow = ieee_flag_type(2), &
     ieee_divide_by_zero = ieee_flag_type(4), &
     ieee_underflow = ieee_flag_type(8), &
-    ieee_inexact = ieee_flag_type(16)
+    ieee_inexact = ieee_flag_type(16), &
+    ieee_denorm = ieee_flag_type(32) ! PGI extension
 
   type(ieee_flag_type), parameter :: &
     ieee_usual(*) = [ &
       ieee_overflow, ieee_divide_by_zero, ieee_invalid ], &
     ieee_all(*) = [ &
-      ieee_usual, ieee_underflow, ieee_inexact ]
+      ieee_usual, ieee_underflow, ieee_inexact, ieee_denorm ]
 
   type :: ieee_modes_type ! Fortran 2018, 17.7
     private
@@ -40,6 +41,15 @@ module ieee_exceptions
   type :: ieee_status_type ! Fortran 2018, 17.7
     private
   end type ieee_status_type
+
+  private :: ieee_support_flag_2, ieee_support_flag_3, &
+      ieee_support_flag_4, ieee_support_flag_8, ieee_support_flag_10, &
+      ieee_support_flag_16
+  interface ieee_support_flag
+    module procedure :: ieee_support_flag_2, ieee_support_flag_3, &
+      ieee_support_flag_4, ieee_support_flag_8, ieee_support_flag_10, &
+      ieee_support_flag_16
+  end interface
 
  contains
   subroutine ieee_get_flag(flag, flag_value)
@@ -78,10 +88,36 @@ module ieee_exceptions
     type(ieee_status_type), intent(in) :: status
   end subroutine ieee_set_status
 
-  pure logical function ieee_support_flag(flag, x)
+  pure logical function ieee_support_flag_2(flag, x)
     type(ieee_flag_type), intent(in) :: flag
-    real, intent(in), optional :: x
-  end function ieee_support_flag
+    real(kind=2), intent(in) :: x(..)
+    ieee_support_flag_2 = .true.
+  end function
+  pure logical function ieee_support_flag_3(flag, x)
+    type(ieee_flag_type), intent(in) :: flag
+    real(kind=3), intent(in) :: x(..)
+    ieee_support_flag_3 = .true.
+  end function
+  pure logical function ieee_support_flag_4(flag, x)
+    type(ieee_flag_type), intent(in) :: flag
+    real(kind=4), intent(in) :: x(..)
+    ieee_support_flag_4 = .true.
+  end function
+  pure logical function ieee_support_flag_8(flag, x)
+    type(ieee_flag_type), intent(in) :: flag
+    real(kind=8), intent(in) :: x(..)
+    ieee_support_flag_8 = .true.
+  end function
+  pure logical function ieee_support_flag_10(flag, x)
+    type(ieee_flag_type), intent(in) :: flag
+    real(kind=10), intent(in) :: x(..)
+    ieee_support_flag_10 = .true.
+  end function
+  pure logical function ieee_support_flag_16(flag, x)
+    type(ieee_flag_type), intent(in) :: flag
+    real(kind=16), intent(in) :: x(..)
+    ieee_support_flag_16 = .true.
+  end function
 
   pure logical function ieee_support_halting(flag)
     type(ieee_flag_type), intent(in) :: flag

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -169,6 +169,7 @@ set(ERROR_TESTS
   blockconstruct03.f90
   call01.f90
   call02.f90
+  call13.f90
 )
 
 # These test files have expected symbols in the source

--- a/test/semantics/call08.f90
+++ b/test/semantics/call08.f90
@@ -54,7 +54,7 @@ module m
     !ERROR: Effective argument associated with a CONTIGUOUS coarray dummy argument must be simply contiguous
     call s03(x)
     !ERROR: Effective argument associated with a CONTIGUOUS coarray dummy argument must be simply contiguous
-    call s04c3)
+    call s04(c3)
     !ERROR: Effective argument associated with a CONTIGUOUS coarray dummy argument must be simply contiguous
     call s04(x)
   end subroutine

--- a/test/semantics/call13.f90
+++ b/test/semantics/call13.f90
@@ -1,0 +1,49 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test 15.4.2.2 constraints and restrictions for calls to implicit
+! interfaces
+
+subroutine s(assumedRank, coarray, class, classStar, typeStar)
+  type :: t
+  end type
+
+  real :: assumedRank(..), coarray[*]
+  class(t) :: class
+  class(*) :: classStar
+  type(*) :: typeStar
+
+  type :: pdt(len)
+    integer, len :: len
+  end type
+  type(pdt(1)) :: pdtx
+
+  !ERROR: Invalid specification expression: reference to impure function 'implicit01'
+  real :: array(implicit01())  ! 15.4.2.2(2)
+  !ERROR: Keyword 'keyword=' cannot appear in a reference to a procedure with an implicit interface
+  call implicit10(1, 2, keyword=3)  ! 15.4.2.2(1)
+  !ERROR: Assumed rank argument requires an explicit interface
+  call implicit11(assumedRank)  ! 15.4.2.2(3)(c)
+  !ERROR: Coarray argument requires an explicit interface
+  call implicit12(coarray)  ! 15.4.2.2(3)(d)
+  !ERROR: Parameterized derived type argument requires an explicit interface
+  call implicit13(pdtx)  ! 15.4.2.2(3)(e)
+  !ERROR: Polymorphic argument requires an explicit interface
+  call implicit14(class)  ! 15.4.2.2(3)(f)
+  !ERROR: Polymorphic argument requires an explicit interface
+  call implicit15(classStar)  ! 15.4.2.2(3)(f)
+  !ERROR: Assumed type argument requires an explicit interface
+  call implicit16(typeStar)  ! 15.4.2.2(3)(f)
+end subroutine
+

--- a/test/semantics/doconcurrent01.f90
+++ b/test/semantics/doconcurrent01.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
 ! C1137
 ! An image control statement shall not appear within a DO CONCURRENT construct.
 !
-! C1136 
+! C1136
 ! A RETURN statement shall not appear within a DO CONCURRENT construct.
 !
 ! (11.1.7.5), paragraph 4
@@ -45,8 +45,9 @@ subroutine do_concurrent_test2(i,j,n,flag)
   use ieee_exceptions
   use iso_fortran_env, only: team_type
   implicit none
-  integer :: i, n, flag, flag2
-  logical :: halting
+  integer :: i, n
+  type(ieee_flag_type) :: flag
+  logical :: flagValue, halting
   type(team_type) :: j
   do concurrent (i = 1:n)
 !ERROR: image control statement not allowed in DO CONCURRENT
@@ -55,7 +56,7 @@ subroutine do_concurrent_test2(i,j,n,flag)
       critical
 !ERROR: call to impure procedure in DO CONCURRENT not allowed
 !ERROR: IEEE_GET_FLAG not allowed in DO CONCURRENT
-        call ieee_get_flag(flag, flag2)
+        call ieee_get_flag(flag, flagValue)
 !ERROR: call to impure procedure in DO CONCURRENT not allowed
 !ERROR: IEEE_GET_HALTING_MODE not allowed in DO CONCURRENT
         call ieee_get_halting_mode(flag, halting)

--- a/test/semantics/expr-errors02.f90
+++ b/test/semantics/expr-errors02.f90
@@ -36,22 +36,22 @@ module m
     modulefunc1 = n
   end function
   subroutine test(out, optional)
-    !ERROR: The expression (foo()) cannot be used as a specification expression (reference to impure function 'foo')
+    !ERROR: Invalid specification expression: reference to impure function 'foo'
     type(t(foo())) :: x1
     integer :: local
-    !ERROR: The expression (local) cannot be used as a specification expression (reference to local entity 'local')
+    !ERROR: Invalid specification expression: reference to local entity 'local'
     type(t(local)) :: x2
     !ERROR: The internal function 'internal' cannot be referenced in a specification expression
     type(t(internal(0))) :: x3
     integer, intent(out) :: out
-    !ERROR: The expression (out) cannot be used as a specification expression (reference to INTENT(OUT) dummy argument 'out')
+    !ERROR: Invalid specification expression: reference to INTENT(OUT) dummy argument 'out'
     type(t(out)) :: x4
     integer, intent(in), optional :: optional
-    !ERROR: The expression (optional) cannot be used as a specification expression (reference to OPTIONAL dummy argument 'optional')
+    !ERROR: Invalid specification expression: reference to OPTIONAL dummy argument 'optional'
     type(t(optional)) :: x5
-    !ERROR: The expression (hasprocarg(realfunc)) cannot be used as a specification expression (dummy procedure argument)
+    !ERROR: Invalid specification expression: dummy procedure argument
     type(t(hasProcArg(realfunc))) :: x6
-    !ERROR: The expression (coarray[1_8]) cannot be used as a specification expression (coindexed reference)
+    !ERROR: Invalid specification expression: coindexed reference
     type(t(coarray[1])) :: x7
     type(t(kind(foo()))) :: x101 ! ok
     type(t(modulefunc1(0))) :: x102 ! ok

--- a/test/semantics/init01.f90
+++ b/test/semantics/init01.f90
@@ -21,13 +21,13 @@ subroutine test(j)
   real, save :: x3
   real, target :: x4
   real, target, save :: x5(10)
-!ERROR: Pointer 'p1' cannot be initialized with a reference to an allocatable 'x1'
+!ERROR: An initial data target may not be a reference to an ALLOCATABLE 'x1'
   real, pointer :: p1 => x1
-!ERROR: Pointer 'p2' cannot be initialized with a reference to a coarray 'x2'
+!ERROR: An initial data target may not be a reference to a coarray 'x2'
   real, pointer :: p2 => x2
-!ERROR: Pointer 'p3' cannot be initialized with a reference to an object 'x3' that lacks the TARGET attribute
+!ERROR: An initial data target may not be a reference to an object 'x3' that lacks the TARGET attribute
   real, pointer :: p3 => x3
-!ERROR: Pointer 'p4' cannot be initialized with a reference to an object 'x4' that lacks the SAVE attribute
+!ERROR: An initial data target may not be a reference to an object 'x4' that lacks the SAVE attribute
   real, pointer :: p4 => x4
 !ERROR: Pointer 'p5' cannot be initialized with a reference to a designator with non-constant subscripts
   real, pointer :: p5 => x5(j)

--- a/test/semantics/modfile08.f90
+++ b/test/semantics/modfile08.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ end
 !  type::t
 !    procedure(),nopass,pointer::e
 !    procedure(real(4)),nopass,pointer::f
-!    procedure(s),pointer,private::g
+!    procedure(s),pass(x),pointer,private::g
 !  end type
 !contains
 !  subroutine s(x)

--- a/test/semantics/modfile10.f90
+++ b/test/semantics/modfile10.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ end module
 !    integer(4)::x
 !  contains
 !    final::c
-!    procedure,non_overridable,private::d
+!    procedure,pass(x),non_overridable,private::d
 !    procedure(a),deferred,nopass::e
 !  end type
 !  type::t3

--- a/test/semantics/modfile14.f90
+++ b/test/semantics/modfile14.f90
@@ -51,7 +51,7 @@ end
 !  contains
 !    procedure,nopass::s2
 !    procedure,nopass::s3
-!    procedure::r
+!    procedure,pass(dtv)::r
 !    generic::foo=>s2
 !    generic::read(formatted)=>r
 !  end type

--- a/test/semantics/modfile15.f90
+++ b/test/semantics/modfile15.f90
@@ -31,7 +31,7 @@ end module
 !Expect: m.mod
 !module m
 !  type::t
-!    procedure(a),pass,pointer::c
+!    procedure(a),pass(x),pointer::c
 !    procedure(a),pass(x),pointer::d
 !  contains
 !    procedure,pass(y)::a


### PR DESCRIPTION
Implement checks of effective argument number, types, and ranks against the requirements of explicit and implicit interfaces.  Handles calls to external subprograms for which interfaces are known but not explicit gracefully with warnings.  Implements "same derived type" test for type compatibility (with some remaining TODO iterms).  Implements insertion of `PASS` arguments into argument lists, and the rearrangement of argument lists with keywords.  Implements a predicate for simple contiguity -- this will be used more in later work.

More argument checks are coming, but this branch was accumulating too many changes and is stable enough for review now.

Tested against f90_correct suite (and found some errors).