### PR TITLE
Import preprocessing tests

### DIFF
--- a/test/preprocessing/pp001.F
+++ b/test/preprocessing/pp001.F
@@ -1,0 +1,23 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* keyword macros
+      integer, parameter :: KWM = 666
+#define KWM 777
+      if (KWM .eq. 777) then
+        print *, 'pp001.F pass'
+      else
+        print *, 'pp001.F FAIL: ', KWM
+      end if
+      end

--- a/test/preprocessing/pp002.F
+++ b/test/preprocessing/pp002.F
@@ -1,0 +1,24 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* #undef
+      integer, parameter :: KWM = 777
+#define KWM 666
+#undef KWM
+      if (KWM .eq. 777) then
+        print *, 'pp002.F pass'
+      else
+        print *, 'pp002.F FAIL: ', KWM
+      end if
+      end

--- a/test/preprocessing/pp003.F
+++ b/test/preprocessing/pp003.F
@@ -1,0 +1,29 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* function-like macros
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFLM(666)
+      if (res .eq. 777) then
+        print *, 'pp003.F pass'
+      else
+        print *, 'pp003.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp004.F
+++ b/test/preprocessing/pp004.F
@@ -1,0 +1,23 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* KWMs case-sensitive
+      integer, parameter :: KWM = 777
+#define KWM 666
+      if (kwm .eq. 777) then
+        print *, 'pp004.F pass'
+      else
+        print *, 'pp004.F FAIL: ', kwm
+      end if
+      end

--- a/test/preprocessing/pp005.F
+++ b/test/preprocessing/pp005.F
@@ -1,0 +1,26 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* KWM split across continuation, implicit padding
+      integer, parameter :: KWM = 666
+#define KWM 777
+      integer :: res
+      res = KW
+     +M
+      if (res .eq. 777) then
+        print *, 'pp005.F pass'
+      else
+        print *, 'pp005.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp006.F
+++ b/test/preprocessing/pp006.F
@@ -1,0 +1,27 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* ditto, but with intervening *comment line
+      integer, parameter :: KWM = 666
+#define KWM 777
+      integer :: res
+      res = KW
+*comment
+     +M
+      if (res .eq. 777) then
+        print *, 'pp006.F pass'
+      else
+        print *, 'pp006.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp007.F
+++ b/test/preprocessing/pp007.F
@@ -1,0 +1,29 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* KWM split across continuation, clipped after column 72
+      integer, parameter :: KWM = 666
+#define KWM 777
+      integer :: res
+* 'comment' is in column 73
+*        1         2         3         4         5         6         7
+*234567890123456789012345678901234567890123456789012345678901234567890123
+      res = KW                                                          comment
+     +M
+      if (res .eq. 777) then
+        print *, 'pp007.F pass'
+      else
+        print *, 'pp007.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp008.F
+++ b/test/preprocessing/pp008.F
@@ -1,0 +1,25 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* KWM with spaces in name at invocation NOT replaced
+      integer, parameter :: KWM = 777
+#define KWM 666
+      integer :: res
+      res = K W M
+      if (res .eq. 777) then
+        print *, 'pp008.F pass'
+      else
+        print *, 'pp008.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp009.F
+++ b/test/preprocessing/pp009.F
@@ -1,0 +1,30 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* FLM call split across continuation, implicit padding
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFL
+     +M(666)
+      if (res .eq. 777) then
+        print *, 'pp009.F pass'
+      else
+        print *, 'pp009.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp010.F
+++ b/test/preprocessing/pp010.F
@@ -1,0 +1,31 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* ditto, but with intervening *comment line
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFL
+*comment
+     +M(666)
+      if (res .eq. 777) then
+        print *, 'pp010.F pass'
+      else
+        print *, 'pp010.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp011.F
+++ b/test/preprocessing/pp011.F
@@ -1,0 +1,33 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* FLM call name split across continuation, clipped
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+* 'comment' is in column 73
+*        1         2         3         4         5         6         7
+*234567890123456789012345678901234567890123456789012345678901234567890123
+      res = IFL                                                         comment
+     +M(666)
+      if (res .eq. 777) then
+        print *, 'pp011.F pass'
+      else
+        print *, 'pp011.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp012.F
+++ b/test/preprocessing/pp012.F
@@ -1,0 +1,30 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* FLM call name split across continuation
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFL
+     +M(666)
+      if (res .eq. 777) then
+        print *, 'pp012.F pass'
+      else
+        print *, 'pp012.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp013.F
+++ b/test/preprocessing/pp013.F
@@ -1,0 +1,30 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* FLM call split between name and (
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFLM
+     +(666)
+      if (res .eq. 777) then
+        print *, 'pp013.F pass'
+      else
+        print *, 'pp013.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp014.F
+++ b/test/preprocessing/pp014.F
@@ -1,0 +1,31 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* FLM call split between name and (, with intervening *comment
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFLM
+*comment
+     +(666)
+      if (res .eq. 777) then
+        print *, 'pp014.F pass'
+      else
+        print *, 'pp014.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp015.F
+++ b/test/preprocessing/pp015.F
@@ -1,0 +1,33 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* FLM call split between name and (, clipped
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+* 'comment' is in column 73
+*        1         2         3         4         5         6         7
+*234567890123456789012345678901234567890123456789012345678901234567890123
+      res = IFLM                                                        comment
+     +(666)
+      if (res .eq. 777) then
+        print *, 'pp015.F pass'
+      else
+        print *, 'pp015.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp016.F
+++ b/test/preprocessing/pp016.F
@@ -1,0 +1,31 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* FLM call split between name and ( and in argument
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFLM
+     +(66
+     +6)
+      if (res .eq. 777) then
+        print *, 'pp016.F pass'
+      else
+        print *, 'pp016.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp017.F
+++ b/test/preprocessing/pp017.F
@@ -1,0 +1,24 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* KLM rescan
+      integer, parameter :: KWM = 666, KWM2 = 667
+#define KWM2 777
+#define KWM KWM2
+      if (KWM .eq. 777) then
+        print *, 'pp017.F pass'
+      else
+        print *, 'pp017.F FAIL: ', KWM
+      end if
+      end

--- a/test/preprocessing/pp018.F
+++ b/test/preprocessing/pp018.F
@@ -1,0 +1,25 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* KLM rescan with #undef (so rescan is after expansion)
+      integer, parameter :: KWM2 = 777, KWM = 667
+#define KWM2 666
+#define KWM KWM2
+#undef KWM2
+      if (KWM .eq. 777) then
+        print *, 'pp018.F pass'
+      else
+        print *, 'pp018.F FAIL: ', KWM
+      end if
+      end

--- a/test/preprocessing/pp019.F
+++ b/test/preprocessing/pp019.F
@@ -1,0 +1,31 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* FLM rescan
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+      integer, parameter :: KWM = 999
+#define KWM 111
+#define IFLM(x) ((x)+KWM)
+      integer :: res
+      res = IFLM(666)
+      if (res .eq. 777) then
+        print *, 'pp019.F pass'
+      else
+        print *, 'pp019.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp020.F
+++ b/test/preprocessing/pp020.F
@@ -1,0 +1,31 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* FLM expansion of argument
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+      integer, parameter :: KWM = 999
+#define KWM 111
+#define IFLM(x) ((x)+666)
+      integer :: res
+      res = IFLM(KWM)
+      if (res .eq. 777) then
+        print *, 'pp020.F pass'
+      else
+        print *, 'pp020.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp021.F
+++ b/test/preprocessing/pp021.F
@@ -1,0 +1,24 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* KWM NOT expanded in 'literal'
+#define KWM 666
+      character(len=3) :: ch
+      ch = 'KWM'
+      if (ch .eq. 'KWM') then
+        print *, 'pp021.F pass'
+      else
+        print *, 'pp021.F FAIL: ', ch
+      end if
+      end

--- a/test/preprocessing/pp022.F
+++ b/test/preprocessing/pp022.F
@@ -1,0 +1,24 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* KWM NOT expanded in "literal"
+#define KWM 666
+      character(len=3) :: ch
+      ch = "KWM"
+      if (ch .eq. 'KWM') then
+        print *, 'pp022.F pass'
+      else
+        print *, 'pp022.F FAIL: ', ch
+      end if
+      end

--- a/test/preprocessing/pp023.F
+++ b/test/preprocessing/pp023.F
@@ -1,0 +1,25 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* KWM NOT expanded in 9HHOLLERITH literal
+#define KWM 666
+#define HKWM 667
+      character(len=3) :: ch
+      ch = 3HKWM
+      if (ch .eq. 'KWM') then
+        print *, 'pp023.F pass'
+      else
+        print *, 'pp023.F FAIL: ', ch
+      end if
+      end

--- a/test/preprocessing/pp024.F
+++ b/test/preprocessing/pp024.F
@@ -1,0 +1,26 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* KWM NOT expanded in Hollerith in FORMAT
+#define KWM 666
+#define HKWM 667
+      character(len=3) :: ch
+ 100  format(3HKWM)
+      write(ch, 100)
+      if (ch .eq. 'KWM') then
+        print *, 'pp024.F pass'
+      else
+        print *, 'pp024.F FAIL: ', ch
+      end if
+      end

--- a/test/preprocessing/pp025.F
+++ b/test/preprocessing/pp025.F
@@ -1,0 +1,25 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* KWM expansion is before token pasting due to fixed-form space removal
+      integer, parameter :: IKWM2Z = 777
+#define KWM KWM2
+      integer :: res
+      res = I KWM Z
+      if (res .eq. 777) then
+        print *, 'pp025.F pass'
+      else
+        print *, 'pp025.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp026.F
+++ b/test/preprocessing/pp026.F
@@ -1,0 +1,33 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* ## token pasting works in FLM
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+      integer, parameter :: KWM = 668, KWM21 = 111, KWM1 = 669
+#define KWM1 111
+#define KWM2 33
+#define KWM KWM2
+#define IFLM(x) ((x##1)+6##6##6)
+      integer :: res
+      res = IFLM(KWM)
+      if (res .eq. 777) then
+        print *, 'pp026.F pass'
+      else
+        print *, 'pp026.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp027.F
+++ b/test/preprocessing/pp027.F
@@ -1,0 +1,23 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* #DEFINE works in fixed form
+      integer, parameter :: KWM = 666
+#DEFINE KWM 777
+      if (KWM .eq. 777) then
+        print *, 'pp027.F pass'
+      else
+        print *, 'pp027.F FAIL: ', KWM
+      end if
+      end

--- a/test/preprocessing/pp028.F
+++ b/test/preprocessing/pp028.F
@@ -1,0 +1,28 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* fixed-form clipping done before KWM expansion on source line
+      integer, parameter :: KW = 777
+#define KWM 666
+      integer :: res
+* 'M' is in column 73
+*        1         2         3         4         5         6         7
+*234567890123456789012345678901234567890123456789012345678901234567890123
+      res =                                                           KWM
+      if (res .eq. 777) then
+        print *, 'pp028.F pass'
+      else
+        print *, 'pp028.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp029.F
+++ b/test/preprocessing/pp029.F
@@ -1,0 +1,24 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* \ newline allowed in #define
+      integer, parameter :: KWM = 666
+#define KWM 77\
+ 7
+      if (KWM .eq. 777) then
+        print *, 'pp029.F pass'
+      else
+        print *, 'pp029.F FAIL: ', KWM
+      end if
+      end

--- a/test/preprocessing/pp030.F
+++ b/test/preprocessing/pp030.F
@@ -1,0 +1,23 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* /* C comment */ erased from #define
+      integer, parameter :: KWM = 666
+#define KWM 777 /* C comment */
+      if (KWM .eq. 777) then
+        print *, 'pp030.F pass'
+      else
+        print *, 'pp030.F FAIL: ', KWM
+      end if
+      end

--- a/test/preprocessing/pp031.F
+++ b/test/preprocessing/pp031.F
@@ -1,0 +1,23 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+*  // C++ comment NOT erased from #define
+      integer, parameter :: KWM = 666
+#define KWM 777 // C comment
+      if (KWM .eq. 777) then
+        print *, 'pp031.F FAIL (should not have compiled)'
+      else
+        print *, 'pp031.F FAIL: ', KWM
+      end if
+      end

--- a/test/preprocessing/pp032.F
+++ b/test/preprocessing/pp032.F
@@ -1,0 +1,24 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* /* C comment */ \ newline erased from #define
+      integer, parameter :: KWM = 666
+#define KWM 77/* C comment */\
+7
+      if (KWM .eq. 777) then
+        print *, 'pp032.F pass'
+      else
+        print *, 'pp032.F FAIL: ', KWM
+      end if
+      end

--- a/test/preprocessing/pp033.F
+++ b/test/preprocessing/pp033.F
@@ -1,0 +1,24 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* /* C comment \ newline */ erased from #define
+      integer, parameter :: KWM = 666
+#define KWM 77/* C comment \
+*/7
+      if (KWM .eq. 777) then
+        print *, 'pp033.F pass'
+      else
+        print *, 'pp033.F FAIL: ', KWM
+      end if
+      end

--- a/test/preprocessing/pp034.F
+++ b/test/preprocessing/pp034.F
@@ -1,0 +1,24 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* \ newline allowed in name on KWM definition
+      integer, parameter :: KWMC = 666
+#define KWM\
+C 777
+      if (KWMC .eq. 777) then
+        print *, 'pp034.F pass'
+      else
+        print *, 'pp034.F FAIL: ', KWMC
+      end if
+      end

--- a/test/preprocessing/pp035.F
+++ b/test/preprocessing/pp035.F
@@ -1,0 +1,27 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* #if 2 .LT. 3 works
+      integer, parameter :: KWM = 666
+#if 2 .LT. 3
+#define KWM 777
+#else
+#define KWM 667
+#endif
+      if (KWM .eq. 777) then
+        print *, 'pp035.F pass'
+      else
+        print *, 'pp035.F FAIL: ', KWM
+      end if
+      end

--- a/test/preprocessing/pp036.F
+++ b/test/preprocessing/pp036.F
@@ -1,0 +1,22 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* #define FALSE TRUE ...  .FALSE. -> .TRUE.
+#define FALSE TRUE
+      if (.FALSE.) then
+        print *, 'pp036.F pass'
+      else
+        print *, 'pp036.F FAIL: ', .FALSE.
+      end if
+      end

--- a/test/preprocessing/pp037.F
+++ b/test/preprocessing/pp037.F
@@ -1,0 +1,25 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* fixed-form clipping NOT applied to #define
+      integer, parameter :: KWM = 666
+*        1         2         3         4         5         6         7
+*234567890123456789012345678901234567890123456789012345678901234567890123
+#define KWM                                                          7777
+      if (KWM .eq. 777) then
+        print *, 'pp037.F pass'
+      else
+        print *, 'pp037.F FAIL: ', KWM
+      end if
+      end

--- a/test/preprocessing/pp038.F
+++ b/test/preprocessing/pp038.F
@@ -1,0 +1,30 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* FLM call with closing ')' on next line (not a continuation)
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFLM(666
+)
+      if (res .eq. 777) then
+        print *, 'pp038.F pass'
+      else
+        print *, 'pp038.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp039.F
+++ b/test/preprocessing/pp039.F
@@ -1,0 +1,30 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* FLM call with '(' on next line (not a continuation)
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFLM
+(666)
+      if (res .eq. 777) then
+        print *, 'pp039.F pass'
+      else
+        print *, 'pp039.F FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp040.F
+++ b/test/preprocessing/pp040.F
@@ -1,0 +1,19 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* #define KWM c, then KWM works as comment line initiator
+#define KWM c
+KWM   print *, 'pp040.F FAIL HARD!'; stop
+      print *, 'pp040.F pass'
+      end

--- a/test/preprocessing/pp041.F
+++ b/test/preprocessing/pp041.F
@@ -1,0 +1,27 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* use KWM expansion as continuation indicators
+#define KWM 0
+#define KWM2 1
+      integer :: j
+      j = 666
+     KWM j = j + 1
+     KWM2 11
+      if (j .eq. 777) then
+        print *, 'pp041.F pass'
+      else
+        print *, 'pp041.F FAIL', j
+      end if
+      end

--- a/test/preprocessing/pp042.F
+++ b/test/preprocessing/pp042.F
@@ -1,0 +1,20 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* #define c 1, then use c as label in fixed-form
+#define c 1
+c     print *, 'pp042.F pass'; goto 2
+      print *, 'pp042.F FAIL'
+2     continue
+      end

--- a/test/preprocessing/pp043.F
+++ b/test/preprocessing/pp043.F
@@ -1,0 +1,25 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* #define with # in column 6 is a continuation line in fixed-form
+      integer, parameter :: defineKWM666 = 555
+      integer, parameter :: KWM =
+     #define KWM 666
+     ++222
+      if (KWM .eq. 777) then
+        print *, 'pp043.F pass'
+      else
+        print *, 'pp043.F FAIL: ', KWM
+      end if
+      end

--- a/test/preprocessing/pp044.F
+++ b/test/preprocessing/pp044.F
@@ -1,0 +1,26 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+* #define directive amid continuations
+      integer, parameter :: KWM = 222, KWM111 = 333, KWM222 = 555
+      integer, parameter :: KWMKWM = 333
+      integer, parameter :: z = KWM
+#define KWM 111
+     +KWM+444
+      if (z .EQ. 777) then
+        print *, 'pass'
+      else
+        print *, 'FAIL', z
+      end if
+      end

--- a/test/preprocessing/pp101.F90
+++ b/test/preprocessing/pp101.F90
@@ -1,0 +1,23 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! keyword macros
+      integer, parameter :: KWM = 666
+#define KWM 777
+      if (KWM .eq. 777) then
+        print *, 'pp101.F90 pass'
+      else
+        print *, 'pp101.F90 FAIL: ', KWM
+      end if
+      end

--- a/test/preprocessing/pp102.F90
+++ b/test/preprocessing/pp102.F90
@@ -1,0 +1,24 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! #undef
+      integer, parameter :: KWM = 777
+#define KWM 666
+#undef KWM
+      if (KWM .eq. 777) then
+        print *, 'pp102.F90 pass'
+      else
+        print *, 'pp102.F90 FAIL: ', KWM
+      end if
+      end

--- a/test/preprocessing/pp103.F90
+++ b/test/preprocessing/pp103.F90
@@ -1,0 +1,29 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! function-like macros
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFLM(666)
+      if (res .eq. 777) then
+        print *, 'pp103.F90 pass'
+      else
+        print *, 'pp103.F90 FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp104.F90
+++ b/test/preprocessing/pp104.F90
@@ -1,0 +1,23 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! KWMs case-sensitive
+      integer, parameter :: KWM = 777
+#define KWM 666
+      if (kwm .eq. 777) then
+        print *, 'pp104.F90 pass'
+      else
+        print *, 'pp104.F90 FAIL: ', kwm
+      end if
+      end

--- a/test/preprocessing/pp105.F90
+++ b/test/preprocessing/pp105.F90
@@ -1,0 +1,26 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! KWM call name split across continuation, with leading &
+      integer, parameter :: KWM = 666
+#define KWM 777
+      integer :: res
+      res = KW&
+&M
+      if (res .eq. 777) then
+        print *, 'pp105.F90 pass'
+      else
+        print *, 'pp105.F90 FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp106.F90
+++ b/test/preprocessing/pp106.F90
@@ -1,0 +1,26 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! ditto, with & ! comment
+      integer, parameter :: KWM = 666
+#define KWM 777
+      integer :: res
+      res = KW& ! comment
+&M
+      if (res .eq. 777) then
+        print *, 'pp106.F90 pass'
+      else
+        print *, 'pp106.F90 FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp107.F90
+++ b/test/preprocessing/pp107.F90
@@ -1,0 +1,26 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! KWM call name split across continuation, no leading &, with & ! comment
+      integer, parameter :: KWM = 666
+#define KWM 777
+      integer :: res
+      res = KW& ! comment
+M
+      if (res .eq. 777) then
+        print *, 'pp107.F90 pass'
+      else
+        print *, 'pp107.F90 FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp108.F90
+++ b/test/preprocessing/pp108.F90
@@ -1,0 +1,26 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! ditto, but without & ! comment
+      integer, parameter :: KWM = 666
+#define KWM 777
+      integer :: res
+      res = KW&
+M
+      if (res .eq. 777) then
+        print *, 'pp108.F90 pass'
+      else
+        print *, 'pp108.F90 FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp109.F90
+++ b/test/preprocessing/pp109.F90
@@ -1,0 +1,30 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! FLM call name split with leading &
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFL&
+&M(666)
+      if (res .eq. 777) then
+        print *, 'pp109.F90 pass'
+      else
+        print *, 'pp109.F90 FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp110.F90
+++ b/test/preprocessing/pp110.F90
@@ -1,0 +1,30 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! ditto, with & ! comment
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFL& ! comment
+&M(666)
+      if (res .eq. 777) then
+        print *, 'pp110.F90 pass'
+      else
+        print *, 'pp110.F90 FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp111.F90
+++ b/test/preprocessing/pp111.F90
@@ -1,0 +1,30 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! FLM call name split across continuation, no leading &, with & ! comment
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFL& ! comment
+M(666)
+      if (res .eq. 777) then
+        print *, 'pp111.F90 pass'
+      else
+        print *, 'pp111.F90 FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp112.F90
+++ b/test/preprocessing/pp112.F90
@@ -1,0 +1,30 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! ditto, but without & ! comment
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFL&
+M(666)
+      if (res .eq. 777) then
+        print *, 'pp112.F90 pass'
+      else
+        print *, 'pp112.F90 FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp113.F90
+++ b/test/preprocessing/pp113.F90
@@ -1,0 +1,30 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! FLM call split across continuation between name and (, leading &
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFLM&
+&(666)
+      if (res .eq. 777) then
+        print *, 'pp113.F90 pass'
+      else
+        print *, 'pp113.F90 FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp114.F90
+++ b/test/preprocessing/pp114.F90
@@ -1,0 +1,30 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! ditto, with & ! comment, leading &
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFLM& ! comment
+&(666)
+      if (res .eq. 777) then
+        print *, 'pp114.F90 pass'
+      else
+        print *, 'pp114.F90 FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp115.F90
+++ b/test/preprocessing/pp115.F90
@@ -1,0 +1,30 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! ditto, with & ! comment, no leading &
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFLM& ! comment
+(666)
+      if (res .eq. 777) then
+        print *, 'pp115.F90 pass'
+      else
+        print *, 'pp115.F90 FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp116.F90
+++ b/test/preprocessing/pp116.F90
@@ -1,0 +1,30 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! FLM call split between name and (, no leading &
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFLM&
+(666)
+      if (res .eq. 777) then
+        print *, 'pp116.F90 pass'
+      else
+        print *, 'pp116.F90 FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp117.F90
+++ b/test/preprocessing/pp117.F90
@@ -1,0 +1,24 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! KWM rescan
+      integer, parameter :: KWM = 666, KWM2 = 667
+#define KWM2 777
+#define KWM KWM2
+      if (KWM .eq. 777) then
+        print *, 'pp117.F90 pass'
+      else
+        print *, 'pp117.F90 FAIL: ', KWM
+      end if
+      end

--- a/test/preprocessing/pp118.F90
+++ b/test/preprocessing/pp118.F90
@@ -1,0 +1,25 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! KWM rescan with #undef, proving rescan after expansion
+      integer, parameter :: KWM2 = 777, KWM = 667
+#define KWM2 666
+#define KWM KWM2
+#undef KWM2
+      if (KWM .eq. 777) then
+        print *, 'pp118.F90 pass'
+      else
+        print *, 'pp118.F90 FAIL: ', KWM
+      end if
+      end

--- a/test/preprocessing/pp119.F90
+++ b/test/preprocessing/pp119.F90
@@ -1,0 +1,31 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! FLM rescan
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+      integer, parameter :: KWM = 999
+#define KWM 111
+#define IFLM(x) ((x)+KWM)
+      integer :: res
+      res = IFLM(666)
+      if (res .eq. 777) then
+        print *, 'pp119.F90 pass'
+      else
+        print *, 'pp119.F90 FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp120.F90
+++ b/test/preprocessing/pp120.F90
@@ -1,0 +1,31 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! FLM expansion of argument
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+      integer, parameter :: KWM = 999
+#define KWM 111
+#define IFLM(x) ((x)+666)
+      integer :: res
+      res = IFLM(KWM)
+      if (res .eq. 777) then
+        print *, 'pp120.F90 pass'
+      else
+        print *, 'pp120.F90 FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp121.F90
+++ b/test/preprocessing/pp121.F90
@@ -1,0 +1,24 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! KWM NOT expanded in 'literal'
+#define KWM 666
+      character(len=3) :: ch
+      ch = 'KWM'
+      if (ch .eq. 'KWM') then
+        print *, 'pp121.F90 pass'
+      else
+        print *, 'pp121.F90 FAIL: ', ch
+      end if
+      end

--- a/test/preprocessing/pp122.F90
+++ b/test/preprocessing/pp122.F90
@@ -1,0 +1,24 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! KWM NOT expanded in "literal"
+#define KWM 666
+      character(len=3) :: ch
+      ch = "KWM"
+      if (ch .eq. 'KWM') then
+        print *, 'pp122.F90 pass'
+      else
+        print *, 'pp122.F90 FAIL: ', ch
+      end if
+      end

--- a/test/preprocessing/pp123.F90
+++ b/test/preprocessing/pp123.F90
@@ -1,0 +1,25 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! KWM NOT expanded in Hollerith literal
+#define KWM 666
+#define HKWM 667
+      character(len=3) :: ch
+      ch = 3HKWM
+      if (ch .eq. 'KWM') then
+        print *, 'pp123.F90 pass'
+      else
+        print *, 'pp123.F90 FAIL: ', ch
+      end if
+      end

--- a/test/preprocessing/pp124.F90
+++ b/test/preprocessing/pp124.F90
@@ -1,0 +1,26 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! KWM NOT expanded in Hollerith in FORMAT
+#define KWM 666
+#define HKWM 667
+      character(len=3) :: ch
+ 100  format(3HKWM)
+      write(ch, 100)
+      if (ch .eq. 'KWM') then
+        print *, 'pp124.F90 pass'
+      else
+        print *, 'pp124.F90 FAIL: ', ch
+      end if
+      end

--- a/test/preprocessing/pp125.F90
+++ b/test/preprocessing/pp125.F90
@@ -1,0 +1,23 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! #DEFINE works in free form
+      integer, parameter :: KWM = 666
+#DEFINE KWM 777
+      if (KWM .eq. 777) then
+        print *, 'pp125.F90 pass'
+      else
+        print *, 'pp125.F90 FAIL: ', KWM
+      end if
+      end

--- a/test/preprocessing/pp126.F90
+++ b/test/preprocessing/pp126.F90
@@ -1,0 +1,24 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! \ newline works in #define
+      integer, parameter :: KWM = 666
+#define KWM 77\
+7
+      if (KWM .eq. 777) then
+        print *, 'pp126.F90 pass'
+      else
+        print *, 'pp126.F90 FAIL: ', KWM
+      end if
+      end

--- a/test/preprocessing/pp127.F90
+++ b/test/preprocessing/pp127.F90
@@ -1,0 +1,30 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! FLM call with closing ')' on next line (not a continuation)
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFLM(666
+)
+      if (res .eq. 777) then
+        print *, 'pp127.F90 pass'
+      else
+        print *, 'pp127.F90 FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp128.F90
+++ b/test/preprocessing/pp128.F90
@@ -1,0 +1,30 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! FLM call with '(' on next line (not a continuation)
+      integer function IFLM(x)
+        integer :: x
+        IFLM = x
+      end function IFLM
+      program main
+#define IFLM(x) ((x)+111)
+      integer :: res
+      res = IFLM
+(666)
+      if (res .eq. 777) then
+        print *, 'pp128.F90 pass'
+      else
+        print *, 'pp128.F90 FAIL: ', res
+      end if
+      end

--- a/test/preprocessing/pp129.F90
+++ b/test/preprocessing/pp129.F90
@@ -1,0 +1,19 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! #define KWM !, then KWM works as comment line initiator
+#define KWM !
+KWM   print *, 'pp129.F90 FAIL HARD!'; stop
+      print *, 'pp129.F90 pass'
+      end

--- a/test/preprocessing/pp130.F90
+++ b/test/preprocessing/pp130.F90
@@ -1,0 +1,27 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! #define KWM &, use for continuation w/o pasting (ifort and nag seem to continue #define)
+#define KWM &
+
+      integer :: j
+      j = 666
+      j = j + KWM
+111
+      if (j .eq. 777) then
+        print *, 'pp130.F90 pass'
+      else
+        print *, 'pp130.F90 FAIL', j
+      end if
+      end


### PR DESCRIPTION
These are the 70-odd tests that I wrote to check how various Fortran compilers handle various cases that arise when preprocessing.  This PR just adds copyright declarations to them and brings them under source code control; they aren't run.