### PR TITLE
Implement uint128_t for impoverished build environments

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 add_subdirectory(burnside)
 add_subdirectory(common)
-add_subdirectory(decimal)
 add_subdirectory(evaluate)
+add_subdirectory(decimal)
 add_subdirectory(parser)
 add_subdirectory(semantics)

--- a/lib/common/uint128.h
+++ b/lib/common/uint128.h
@@ -1,0 +1,253 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Portable 128-bit unsigned integer arithmetic
+
+#ifndef FORTRAN_COMMON_UINT128_H_
+#define FORTRAN_COMMON_UINT128_H_
+
+#define AVOID_NATIVE_UINT128 1  // for testing purposes
+
+#include "leading-zero-bit-count.h"
+#include <cstdint>
+#include <type_traits>
+
+namespace Fortran::common {
+
+class UnsignedInt128 {
+public:
+  constexpr UnsignedInt128() {}
+  constexpr UnsignedInt128(std::uint64_t n) : low_{n} {}
+  constexpr UnsignedInt128(std::int64_t n) : low_{static_cast<std::uint64_t>(n)}, high_{-static_cast<std::uint64_t>(n<0)} {}
+  constexpr UnsignedInt128(int n) : low_{static_cast<std::uint64_t>(n)}, high_{-static_cast<std::uint64_t>(n<0)} {}
+  constexpr UnsignedInt128(const UnsignedInt128 &) = default;
+  constexpr UnsignedInt128(UnsignedInt128 &&) = default;
+  constexpr UnsignedInt128 &operator=(const UnsignedInt128 &) = default;
+  constexpr UnsignedInt128 &operator=(UnsignedInt128 &&) = default;
+
+  constexpr UnsignedInt128 operator+() const { return *this; }
+  constexpr UnsignedInt128 operator~() const { return {~high_, ~low_}; }
+  constexpr UnsignedInt128 operator-() const { return ~*this + 1; }
+  constexpr bool operator!() const { return !low_ && !high_; }
+  constexpr explicit operator bool() const { return low_ || high_; }
+  constexpr explicit operator std::uint64_t() const { return low_; }
+  constexpr explicit operator int() const { return static_cast<int>(low_); }
+
+  constexpr std::uint64_t high() const { return high_; }
+  constexpr std::uint64_t low() const { return low_; }
+
+  constexpr UnsignedInt128 operator++(/*prefix*/) {
+    *this += 1;
+    return *this;
+  }
+  constexpr UnsignedInt128 operator++(int /*postfix*/) {
+    UnsignedInt128 result{*this};
+    *this += 1;
+    return result;
+  }
+  constexpr UnsignedInt128 operator--(/*prefix*/) {
+    *this -= 1;
+    return *this;
+  }
+  constexpr UnsignedInt128 operator--(int /*postfix*/) {
+    UnsignedInt128 result{*this};
+    *this -= 1;
+    return result;
+  }
+
+  constexpr UnsignedInt128 operator&(UnsignedInt128 that) const {
+    return {high_ & that.high_, low_ & that.low_};
+  }
+  constexpr UnsignedInt128 operator|(UnsignedInt128 that) const {
+    return {high_ | that.high_, low_ | that.low_};
+  }
+  constexpr UnsignedInt128 operator^(UnsignedInt128 that) const {
+    return {high_ ^ that.high_, low_ ^ that.low_};
+  }
+
+  constexpr UnsignedInt128 operator<<(UnsignedInt128 that) const {
+    if (that >= 128) {
+      return {};
+    } else {
+      std::uint64_t n{that.low_};
+      if (n >= 64) {
+        return {low_ << (n - 64), 0};
+      } else {
+        return {(high_ << n) | (low_ >> (64 - n)), low_ << n};
+      }
+    }
+  }
+  constexpr UnsignedInt128 operator>>(UnsignedInt128 that) const {
+    if (that >= 128) {
+      return {};
+    } else {
+      std::uint64_t n{that.low_};
+      if (n >= 64) {
+        return {0, high_ >> (n - 64)};
+      } else {
+        return {high_ >> n, (high_ << (64 - n)) | (low_ >> n)};
+      }
+    }
+  }
+
+  constexpr UnsignedInt128 operator+(UnsignedInt128 that) const {
+    std::uint64_t lower{(low_ & ~topBit) + (that.low_ & ~topBit)};
+    bool carry{((lower >> 63) + (low_ >> 63) + (that.low_ >> 63)) > 1};
+    return {high_ + that.high_ + carry, low_ + that.low_};
+  }
+  constexpr UnsignedInt128 operator-(UnsignedInt128 that) const {
+    return *this + -that;
+  }
+
+  constexpr UnsignedInt128 operator*(UnsignedInt128 that) const {
+    std::uint64_t mask32{0xffffffff};
+    if (high_ == 0 && that.high_ == 0) {
+      std::uint64_t x0{low_ & mask32}, x1{low_ >> 32};
+      std::uint64_t y0{that.low_ & mask32}, y1{that.low_ >> 32};
+      UnsignedInt128 x0y0{x0 * y0}, x0y1{x0 * y1};
+      UnsignedInt128 x1y0{x1 * y0}, x1y1{x1 * y1};
+      return x0y0 + ((x0y1 + x1y0) << 32) + (x1y1 << 64);
+    } else {
+      std::uint64_t x0{low_ & mask32}, x1{low_ >> 32}, x2{high_ & mask32}, x3{high_ >> 32};
+      std::uint64_t y0{that.low_ & mask32}, y1{that.low_ >> 32}, y2{that.high_ & mask32}, y3{that.high_ >> 32};
+      UnsignedInt128 x0y0{x0 * y0}, x0y1{x0 * y1}, x0y2{x0 * y2}, x0y3{x0 * y3};
+      UnsignedInt128 x1y0{x1 * y0}, x1y1{x1 * y1}, x1y2{x1 * y2};
+      UnsignedInt128 x2y0{x2 * y0}, x2y1{x2 * y1};
+      UnsignedInt128 x3y0{x3 * y0};
+      return x0y0 + ((x0y1 + x1y0) << 32) + ((x0y2 + x1y1 + x2y0) << 64) + ((x0y3 + x1y2 + x2y1 + x3y0) << 96);
+    }
+  }
+
+  constexpr UnsignedInt128 operator/(UnsignedInt128 that) const {
+    int j{high_ == 0 ? 64 + LeadingZeroBitCount(low_) : LeadingZeroBitCount(high_)};
+    UnsignedInt128 bits{*this};
+    bits <<= j;
+    UnsignedInt128 numerator{};
+    UnsignedInt128 quotient{};
+    for (; j < 128; ++j) {
+      numerator <<= 1;
+      if (bits.high_ & topBit) {
+        numerator.low_ |= 1;
+      }
+      bits <<= 1;
+      quotient <<= 1;
+      if (numerator >= that) {
+        ++quotient;
+        numerator -= that;
+      }
+    }
+    return quotient;
+  }
+
+  constexpr UnsignedInt128 operator%(UnsignedInt128 that) const {
+    int j{high_ == 0 ? 64 + LeadingZeroBitCount(low_) : LeadingZeroBitCount(high_)};
+    UnsignedInt128 bits{*this};
+    bits <<= j;
+    UnsignedInt128 remainder{};
+    for (; j < 128; ++j) {
+      remainder <<= 1;
+      if (bits.high_ & topBit) {
+        remainder.low_ |= 1;
+      }
+      bits <<= 1;
+      if (remainder >= that) {
+        remainder -= that;
+      }
+    }
+    return remainder;
+  }
+
+  constexpr bool operator<(UnsignedInt128 that) const {
+    return high_ < that.high_ || (high_ == that.high_ && low_ < that.low_);
+  }
+  constexpr bool operator<=(UnsignedInt128 that) const {
+    return !(*this > that);
+  }
+  constexpr bool operator==(UnsignedInt128 that) const {
+    return low_ == that.low_ && high_ == that.high_;
+  }
+  constexpr bool operator!=(UnsignedInt128 that) const {
+    return !(*this == that);
+  }
+  constexpr bool operator>=(UnsignedInt128 that) const {
+    return that <= *this;
+  }
+  constexpr bool operator>(UnsignedInt128 that) const {
+    return that < *this;
+  }
+
+  constexpr UnsignedInt128 &operator&=(const UnsignedInt128 &that) {
+    *this = *this & that;
+    return *this;
+  }
+  constexpr UnsignedInt128 &operator|=(const UnsignedInt128 &that) {
+    *this = *this | that;
+    return *this;
+  }
+  constexpr UnsignedInt128 &operator^=(const UnsignedInt128 &that) {
+    *this = *this ^ that;
+    return *this;
+  }
+  constexpr UnsignedInt128 &operator<<=(const UnsignedInt128 &that) {
+    *this = *this << that;
+    return *this;
+  }
+  constexpr UnsignedInt128 &operator>>=(const UnsignedInt128 &that) {
+    *this = *this >> that;
+    return *this;
+  }
+  constexpr UnsignedInt128 &operator+=(const UnsignedInt128 &that) {
+    *this = *this + that;
+    return *this;
+  }
+  constexpr UnsignedInt128 &operator-=(const UnsignedInt128 &that) {
+    *this = *this - that;
+    return *this;
+  }
+  constexpr UnsignedInt128 &operator*=(const UnsignedInt128 &that) {
+    *this = *this * that;
+    return *this;
+  }
+  constexpr UnsignedInt128 &operator/=(const UnsignedInt128 &that) {
+    *this = *this / that;
+    return *this;
+  }
+  constexpr UnsignedInt128 &operator%=(const UnsignedInt128 &that) {
+    *this = *this % that;
+    return *this;
+  }
+
+private:
+  constexpr UnsignedInt128(std::uint64_t hi, std::uint64_t lo) : low_{lo}, high_{hi} {}
+  static constexpr std::uint64_t topBit{std::uint64_t{1} << 63};
+  std::uint64_t low_{0}, high_{0};
+};
+
+#if (defined __GNUC__ || defined __clang__) && defined __SIZEOF_INT128__ && !AVOID_NATIVE_UINT128
+using uint128_t = __uint128_t;
+#else
+using uint128_t = UnsignedInt128;
+#endif
+
+template<int BITS> struct HostUnsignedIntTypeHelper {
+  using type = std::conditional_t<(BITS <= 8), std::uint8_t,
+      std::conditional_t<(BITS <= 16), std::uint16_t,
+          std::conditional_t<(BITS <= 32), std::uint32_t,
+              std::conditional_t<(BITS <= 64), std::uint64_t, uint128_t>>>>;
+};
+template<int BITS>
+using HostUnsignedIntType = typename HostUnsignedIntTypeHelper<BITS>::type;
+
+}
+#endif

--- a/lib/common/uint128.h
+++ b/lib/common/uint128.h
@@ -19,7 +19,7 @@
 #define FORTRAN_COMMON_UINT128_H_
 
 #ifndef AVOID_NATIVE_UINT128_T
-#define AVOID_NATIVE_UINT128_T 1  // for testing purposes (pmk!)
+#define AVOID_NATIVE_UINT128_T 1  // always use this code for now for testing
 #endif
 
 #include "leading-zero-bit-count.h"

--- a/lib/common/unsigned-const-division.h
+++ b/lib/common/unsigned-const-division.h
@@ -68,10 +68,10 @@ static_assert(FixedPointReciprocal<std::uint64_t>::For(10).Divide(
 
 template<typename UINT, std::uint64_t DENOM>
 inline constexpr UINT DivideUnsignedBy(UINT n) {
-  if constexpr (!std::is_same_v<UINT, uint128_t>) {
-    return FixedPointReciprocal<UINT>::For(DENOM).Divide(n);
-  } else {
+  if constexpr (std::is_same_v<UINT, uint128_t>) {
     return n / static_cast<UINT>(DENOM);
+  } else {
+    return FixedPointReciprocal<UINT>::For(DENOM).Divide(n);
   }
 }
 }

--- a/lib/common/unsigned-const-division.h
+++ b/lib/common/unsigned-const-division.h
@@ -22,6 +22,7 @@
 
 #include "bit-population-count.h"
 #include "leading-zero-bit-count.h"
+#include "uint128.h"
 #include <cinttypes>
 #include <type_traits>
 
@@ -35,7 +36,7 @@ private:
   static_assert(std::is_unsigned_v<type>);
   static const int bits{static_cast<int>(8 * sizeof(type))};
   static_assert(bits <= 64);
-  using Big = std::conditional_t<(bits <= 32), std::uint64_t, __uint128_t>;
+  using Big = std::conditional_t<(bits <= 32), std::uint64_t, uint128_t>;
 
 public:
   static constexpr FixedPointReciprocal For(type n) {
@@ -50,7 +51,7 @@ public:
   }
 
   constexpr type Divide(type n) const {
-    return (static_cast<Big>(reciprocal_) * n) >> shift_;
+    return static_cast<type>((static_cast<Big>(reciprocal_) * n) >> shift_);
   }
 
 private:
@@ -65,12 +66,12 @@ static_assert(FixedPointReciprocal<std::uint32_t>::For(5).Divide(2000000000u) ==
 static_assert(FixedPointReciprocal<std::uint64_t>::For(10).Divide(
                   10000000000000000u) == 1000000000000000u);
 
-template<typename UINT, UINT DENOM>
+template<typename UINT, std::uint64_t DENOM>
 inline constexpr UINT DivideUnsignedBy(UINT n) {
-  if constexpr (!std::is_same_v<UINT, __uint128_t>) {
+  if constexpr (!std::is_same_v<UINT, uint128_t>) {
     return FixedPointReciprocal<UINT>::For(DENOM).Divide(n);
   } else {
-    return n / DENOM;
+    return n / static_cast<UINT>(DENOM);
   }
 }
 }

--- a/lib/decimal/big-radix-floating-point.h
+++ b/lib/decimal/big-radix-floating-point.h
@@ -143,7 +143,7 @@ private:
     return digits_ == digitLimit_ && digit_[digits_ - 1] >= radix / 10;
   }
 
-  // Set to an unsigned integer value.
+  // Sets *this to an unsigned integer value.
   // Returns any remainder.
   template<typename UINT> UINT SetTo(UINT n) {
     static_assert(

--- a/lib/decimal/binary-floating-point.h
+++ b/lib/decimal/binary-floating-point.h
@@ -55,12 +55,14 @@ template<int PRECISION> struct BinaryFloatingPointNumber {
   static constexpr int RANGE{static_cast<int>(
       (exponentBias - 1) * ScaledLogBaseTenOfTwo / 1000000000000)};
 
-  BinaryFloatingPointNumber() {}  // zero
-  BinaryFloatingPointNumber(const BinaryFloatingPointNumber &that) = default;
-  BinaryFloatingPointNumber(BinaryFloatingPointNumber &&that) = default;
-  BinaryFloatingPointNumber &operator=(
+  constexpr BinaryFloatingPointNumber() {}  // zero
+  constexpr BinaryFloatingPointNumber(
       const BinaryFloatingPointNumber &that) = default;
-  BinaryFloatingPointNumber &operator=(
+  constexpr BinaryFloatingPointNumber(
+      BinaryFloatingPointNumber &&that) = default;
+  constexpr BinaryFloatingPointNumber &operator=(
+      const BinaryFloatingPointNumber &that) = default;
+  constexpr BinaryFloatingPointNumber &operator=(
       BinaryFloatingPointNumber &&that) = default;
 
   template<typename A> explicit constexpr BinaryFloatingPointNumber(A x) {

--- a/lib/decimal/decimal-to-binary.cc
+++ b/lib/decimal/decimal-to-binary.cc
@@ -151,7 +151,7 @@ bool BigRadixFloatingPointNumber<PREC, LOG10RADIX>::ParseNumber(
 template<int PREC> class IntermediateFloat {
 public:
   static constexpr int precision{PREC};
-  using IntType = HostUnsignedIntType<precision>;
+  using IntType = common::HostUnsignedIntType<precision>;
   static constexpr IntType topBit{IntType{1} << (precision - 1)};
   static constexpr IntType mask{topBit + (topBit - 1)};
 
@@ -227,7 +227,7 @@ ConversionToBinaryResult<PREC> IntermediateFloat<PREC>::ToBinary(
   // The value is nonzero; normalize it.
   while (fraction < topBit && expo > 1) {
     --expo;
-    fraction = 2 * fraction + (guard >> (guardBits - 2));
+    fraction = fraction * 2 + (guard >> (guardBits - 2));
     guard = (((guard >> (guardBits - 2)) & 1) << (guardBits - 1)) | (guard & 1);
   }
   // Apply rounding

--- a/lib/evaluate/check-expression.cc
+++ b/lib/evaluate/check-expression.cc
@@ -28,9 +28,9 @@ namespace Fortran::evaluate {
 // able to fold it (yet) into a known constant value; specifically,
 // the expression may reference derived type kind parameters whose values
 // are not yet known.
-class IsConstantExprHelper : public AllTraverse<IsConstantExprHelper> {
+class IsConstantExprHelper : public AllTraverse<IsConstantExprHelper, true> {
 public:
-  using Base = AllTraverse<IsConstantExprHelper>;
+  using Base = AllTraverse<IsConstantExprHelper, true>;
   IsConstantExprHelper() : Base{*this} {}
   using Base::operator();
 
@@ -76,8 +76,8 @@ template bool IsConstantExpr(const Expr<SomeInteger> &);
 // This code determines whether an expression is allowable as the static
 // data address used to initialize a pointer with "=> x".  See C765.
 struct IsInitialDataTargetHelper
-  : public AllTraverse<IsInitialDataTargetHelper> {
-  using Base = AllTraverse<IsInitialDataTargetHelper>;
+  : public AllTraverse<IsInitialDataTargetHelper, true> {
+  using Base = AllTraverse<IsInitialDataTargetHelper, true>;
   using Base::operator();
   explicit IsInitialDataTargetHelper(parser::ContextualMessages &m)
     : Base{*this}, messages_{m} {}

--- a/lib/evaluate/traverse.h
+++ b/lib/evaluate/traverse.h
@@ -247,11 +247,12 @@ private:
 
 // For validity checks across an expression: if any operator() result is
 // false, so is the overall result.
-template<typename Visitor, typename Base = Traverse<Visitor, bool>>
+template<typename Visitor, bool DefaultValue,
+    typename Base = Traverse<Visitor, bool>>
 struct AllTraverse : public Base {
   AllTraverse(Visitor &v) : Base{v} {}
   using Base::operator();
-  static bool Default() { return true; }
+  static bool Default() { return DefaultValue; }
   static bool Combine(bool x, bool y) { return x && y; }
 };
 

--- a/test/evaluate/CMakeLists.txt
+++ b/test/evaluate/CMakeLists.txt
@@ -64,6 +64,7 @@ add_executable(integer-test
 target_link_libraries(integer-test
   FortranEvaluateTesting
   FortranEvaluate
+  FortranSemantics
 )
 
 add_executable(intrinsics-test
@@ -85,6 +86,8 @@ add_executable(logical-test
 
 target_link_libraries(logical-test
   FortranEvaluateTesting
+  FortranEvaluate
+  FortranSemantics
 )
 
 # GCC -fno-exceptions breaks the fenv.h interfaces needed to capture

--- a/test/evaluate/CMakeLists.txt
+++ b/test/evaluate/CMakeLists.txt
@@ -23,8 +23,6 @@ add_executable(leading-zero-bit-count-test
 
 target_link_libraries(leading-zero-bit-count-test
   FortranEvaluateTesting
-  FortranEvaluate
-  FortranSemantics
 )
 
 add_executable(bit-population-count-test
@@ -33,9 +31,20 @@ add_executable(bit-population-count-test
 
 target_link_libraries(bit-population-count-test
   FortranEvaluateTesting
-  FortranEvaluate
-  FortranSemantics
 )
+
+add_executable(uint128-test
+  uint128.cc
+)
+
+target_link_libraries(uint128-test
+  FortranEvaluateTesting
+)
+
+# These routines live in lib/common but we test them here.
+add_test(UINT128 uint128-test)
+add_test(Leadz leading-zero-bit-count-test)
+add_test(PopPar bit-population-count-test)
 
 add_executable(expression-test
   expression.cc
@@ -55,7 +64,6 @@ add_executable(integer-test
 target_link_libraries(integer-test
   FortranEvaluateTesting
   FortranEvaluate
-  FortranSemantics
 )
 
 add_executable(intrinsics-test
@@ -77,8 +85,6 @@ add_executable(logical-test
 
 target_link_libraries(logical-test
   FortranEvaluateTesting
-  FortranEvaluate
-  FortranSemantics
 )
 
 # GCC -fno-exceptions breaks the fenv.h interfaces needed to capture
@@ -141,10 +147,7 @@ set(FOLDING_TESTS
   folding08.f90
 )
 
-
 add_test(Expression expression-test)
-add_test(Leadz leading-zero-bit-count-test)
-add_test(PopPar bit-population-count-test)
 add_test(Integer integer-test)
 add_test(Intrinsics intrinsics-test)
 add_test(Logical logical-test)

--- a/test/evaluate/uint128.cc
+++ b/test/evaluate/uint128.cc
@@ -1,0 +1,145 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define AVOID_NATIVE_UINT128_T 1
+#include "../../lib/common/uint128.h"
+#include "testing.h"
+#include <cinttypes>
+#include <iostream>
+
+#if (defined __GNUC__ || defined __clang__) && defined __SIZEOF_INT128__
+# define HAS_NATIVE_UINT128_T 1
+#else
+# undef HAS_NATIVE_UINT128_T
+#endif
+
+
+using U128 = Fortran::common::UnsignedInt128;
+
+static void Test(std::uint64_t x) {
+  U128 n{x};
+  MATCH(x, static_cast<std::uint64_t>(n));
+  MATCH(~x, static_cast<std::uint64_t>(~n));
+  MATCH(-x, static_cast<std::uint64_t>(-n));
+  MATCH(!x, static_cast<std::uint64_t>(!n));
+  TEST(n == n);
+  TEST(n + n == n * static_cast<U128>(2));
+  TEST(n - n == static_cast<U128>(0));
+  TEST(n + n == n << static_cast<U128>(1));
+  TEST(n + n == n << static_cast<U128>(1));
+  TEST((n + n) - n == n);
+  TEST(((n + n) >> static_cast<U128>(1)) == n);
+  if (x != 0) {
+    TEST(static_cast<U128>(0) / n == static_cast<U128>(0));
+    TEST(static_cast<U128>(n - 1) / n == static_cast<U128>(0));
+    TEST(static_cast<U128>(n) / n == static_cast<U128>(1));
+    TEST(static_cast<U128>(n + n - 1) / n == static_cast<U128>(1));
+    TEST(static_cast<U128>(n + n) / n == static_cast<U128>(2));
+  }
+}
+
+static void Test(std::uint64_t x, std::uint64_t y) {
+  U128 m{x}, n{y};
+  MATCH(x, static_cast<std::uint64_t>(m));
+  MATCH(y, static_cast<std::uint64_t>(n));
+  MATCH(x & y, static_cast<std::uint64_t>(m & n));
+  MATCH(x | y, static_cast<std::uint64_t>(m | n));
+  MATCH(x ^ y, static_cast<std::uint64_t>(m ^ n));
+  MATCH(x + y, static_cast<std::uint64_t>(m + n));
+  MATCH(x - y, static_cast<std::uint64_t>(m - n));
+  MATCH(x * y, static_cast<std::uint64_t>(m * n));
+  if (n != 0) {
+    MATCH(x / y, static_cast<std::uint64_t>(m / n));
+  }
+}
+
+#if HAS_NATIVE_UINT128_T
+static __uint128_t ToNative(U128 n) {
+  return static_cast<__uint128_t>(static_cast<std::uint64_t>(n >> 64)) << 64 | static_cast<std::uint64_t>(n);
+}
+
+static U128 FromNative(__uint128_t n) {
+  return U128{static_cast<std::uint64_t>(n >> 64)} << 64 | U128{static_cast<std::uint64_t>(n)};
+}
+
+static void TestVsNative(__uint128_t x, __uint128_t y) {
+  U128 m{FromNative(x)}, n{FromNative(y)};
+  TEST(ToNative(m) == x);
+  TEST(ToNative(n) == y);
+  TEST(ToNative(~m) == ~x);
+  TEST(ToNative(-m) == -x);
+  TEST(ToNative(!m) == !x);
+  TEST(ToNative(m <  n) == (x <  y));
+  TEST(ToNative(m <= n) == (x <= y));
+  TEST(ToNative(m == n) == (x == y));
+  TEST(ToNative(m != n) == (x != y));
+  TEST(ToNative(m >= n) == (x >= y));
+  TEST(ToNative(m >  n) == (x >  y));
+  TEST(ToNative(m & n) == (x & y));
+  TEST(ToNative(m | n) == (x | y));
+  TEST(ToNative(m ^ n) == (x ^ y));
+  if (y < 128) {
+    TEST(ToNative(m << n) == (x << y));
+    TEST(ToNative(m >> n) == (x >> y));
+  }
+  TEST(ToNative(m + n) == (x + y));
+  TEST(ToNative(m - n) == (x - y));
+  TEST(ToNative(m * n) == (x * y));
+  if (y > 0) {
+    TEST(ToNative(m / n) == (x / y));
+    TEST(ToNative(m % n) == (x % y));
+    TEST(ToNative(m - n * (m / n)) == (x / y));
+  }
+}
+
+static void TestVsNative() {
+  for (int j{0}; j < 128; ++j) {
+    for (int k{0}; k < 128; ++k) {
+      __uint128_t m{1}, n{1};
+      m <<= j, n <<= k;
+      TestVsNative(m, n);
+      TestVsNative(~m, n);
+      TestVsNative(m, ~n);
+      TestVsNative(~m, ~n);
+      TestVsNative(m ^ n, n);
+      TestVsNative(m, m ^ n);
+      TestVsNative(m ^ ~n, n);
+      TestVsNative(m, ~m ^ n);
+      TestVsNative(m ^ ~n, m ^ n);
+      TestVsNative(m ^ n, ~m ^ n);
+      TestVsNative(m ^ ~n, ~m ^ n);
+      Test(m, 10000000000000000);  // important case for decimal conversion
+      Test(~m, 10000000000000000);
+    }
+  }
+}
+#endif
+
+int main() {
+  for (std::uint64_t j{0}; j < 64; ++j) {
+    Test(j);
+    Test(~j);
+    Test(std::uint64_t(1) << j);
+    for (std::uint64_t k{0}; k < 64; ++k) {
+      Test(j, k);
+    }
+  }
+#if HAS_NATIVE_UINT128_T
+  std::cout << "Environment has native __uint128_t\n";
+  TestVsNative();
+#else
+  std::cout << "Environment lacks native __uint128_t\n";
+#endif
+  testing::Complete();
+}


### PR DESCRIPTION
Actually, for better testing, this implementation of `common::uint128_t` is enabled for all environments because it's fast enough and should get as much testing as possible.  We can use the native `__uint128_t` type later, where available, by flipping a `#define` if we want.