### PR TITLE
Resolve defined operators to specifics

### DIFF
--- a/lib/semantics/check-call.h
+++ b/lib/semantics/check-call.h
@@ -46,5 +46,8 @@ void CheckArguments(const evaluate::characteristics::Procedure &,
 parser::Messages CheckExplicitInterface(
     const evaluate::characteristics::Procedure &, evaluate::ActualArguments &,
     const evaluate::FoldingContext &, const Scope &);
+// Check actual arguments for the purpose of resolving a generic interface.
+bool CheckInterfaceForGeneric(const evaluate::characteristics::Procedure &,
+    evaluate::ActualArguments &, const evaluate::FoldingContext &);
 }
 #endif

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -326,11 +326,12 @@ private:
       const parser::Call &, bool isSubroutine);
   std::optional<characteristics::Procedure> CheckCall(
       parser::CharBlock, const ProcedureDesignator &, ActualArguments &);
-  const Symbol *ResolveGeneric(
-      const Symbol &, ActualArguments &, const semantics::Scope &);
+  const Symbol *ResolveGeneric(const Symbol &, ActualArguments &);
+  std::optional<CalleeAndArguments> GetCalleeAndArguments(
+      const parser::Name &, ActualArguments &&, bool isSubroutine = false);
   std::optional<CalleeAndArguments> GetCalleeAndArguments(
       const parser::ProcedureDesignator &, ActualArguments &&,
-      bool isSubroutine, const semantics::Scope &);
+      bool isSubroutine);
 
   void CheckForBadRecursion(parser::CharBlock, const semantics::Symbol &);
   bool EnforceTypeConstraint(parser::CharBlock, const MaybeExpr &, TypeCategory,

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -17,6 +17,7 @@
 #include "scope.h"
 #include "semantics.h"
 #include "symbol.h"
+#include "tools.h"
 #include "../evaluate/tools.h"
 #include "../parser/message.h"
 #include "../parser/parsing.h"
@@ -356,11 +357,6 @@ void ModFileWriter::PutSubprogram(const Symbol &symbol) {
   }
 }
 
-static bool IsDefinedOp(const Symbol &symbol) {
-  const auto *details{symbol.GetUltimate().detailsIf<GenericDetails>()};
-  return details && details->kind() == GenericKind::DefinedOp;
-}
-
 static bool IsIntrinsicOp(const Symbol &symbol) {
   if (const auto *details{symbol.GetUltimate().detailsIf<GenericDetails>()}) {
     GenericKind kind{details->kind()};
@@ -371,7 +367,7 @@ static bool IsIntrinsicOp(const Symbol &symbol) {
 }
 
 static std::ostream &PutGenericName(std::ostream &os, const Symbol &symbol) {
-  if (IsDefinedOp(symbol)) {
+  if (IsGenericDefinedOp(symbol)) {
     return os << "operator(" << symbol.name() << ')';
   } else {
     return os << symbol.name();

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -80,6 +80,11 @@ const Scope *FindPureProcedureContaining(const Scope *scope) {
   return nullptr;
 }
 
+bool IsGenericDefinedOp(const Symbol &symbol) {
+  const auto *details{symbol.GetUltimate().detailsIf<GenericDetails>()};
+  return details && details->kind() == GenericKind::DefinedOp;
+}
+
 bool IsCommonBlockContaining(const Symbol &block, const Symbol &object) {
   const auto &objects{block.get<CommonBlockDetails>().objects()};
   auto found{std::find(objects.begin(), objects.end(), &object)};

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -50,6 +50,7 @@ const Symbol *FindFunctionResult(const Symbol &);
 // Return the Symbol of the variable of a construct association, if it exists
 const Symbol *GetAssociationRoot(const Symbol &);
 
+bool IsGenericDefinedOp(const Symbol &);
 bool IsCommonBlockContaining(const Symbol &block, const Symbol &object);
 bool DoesScopeContain(const Scope *maybeAncestor, const Scope &maybeDescendent);
 bool DoesScopeContain(const Scope *, const Symbol &);

--- a/test/semantics/resolve62.f90
+++ b/test/semantics/resolve62.f90
@@ -42,3 +42,50 @@ subroutine s2
   a = f(1.0)
   a = f(y)  !TODO: this should resolve to f2 -- should get error here
 end
+
+! Resolve named operator
+subroutine s3
+  interface operator(.foo.)
+    pure integer(8) function f_real(x, y)
+      real, intent(in) :: x, y
+    end
+    pure integer(8) function f_integer(x, y)
+      integer, intent(in) :: x, y
+    end
+  end interface
+  logical :: a, b, c
+  x = y .foo. z  ! OK: f_real
+  i = j .foo. k  ! OK: f_integer
+  !ERROR: No specific procedure of generic operator '.foo.' matches the actual arguments
+  a = b .foo. c
+end
+
+! Generic resolves successfully but error analyzing call
+module m4
+  real, protected :: x
+  real :: y
+  interface s
+    subroutine s1(x)
+      real, intent(out) :: x
+    end
+    subroutine s2(x, y)
+      real :: x, y
+    end
+  end interface
+end
+subroutine s4a
+  use m4
+  real :: z
+  !OK
+  call s(z)
+end
+subroutine s4b
+  use m4
+  !ERROR: Actual argument associated with INTENT(OUT) dummy argument 'x=' must be definable
+  call s(x)
+end
+pure subroutine s4c
+  use m4
+  !ERROR: Actual argument associated with INTENT(OUT) dummy argument 'x=' must be definable
+  call s(y)
+end


### PR DESCRIPTION
Most of these changes involve moving code around so that it case be
used for `DefinedUnary` and `DefinedBinary`. The functional changes are
in the `Analyze` member functions for those cases where the arguments
are now analyzed, the generic is resolved, and a `FunctionRef` is
created.

Add `ArgumentAnalyzer` to handling building of the `ActualArguments`
of a call. This allows the code to be shared with the defined unary
and defined binary cases. Move `AnalyzeActualArgument` and
`AnalyzeActualArgument` into that class (renaming both to `Analyze`).

Create an overload of `GetCalleeAndArguments` for the `Name` case so it
can be used for defined ops where we don't have a `ProcedureDesignator`.

Remove the `Scope` argument from `ResolveGeneric` and `GetCalleeAndArguments`
and instead use the symbol's owner to the scope. The requires being
careful not to call `GetUltimate` too early so that we get the right
scope.

Move `IsGenericDefinedOp` to `tools.h` to make it available to the
new code.