### PR TITLE
Create `common::Reference<>`, use it to replace non-nullable pointers

### DIFF
--- a/lib/common/reference.h
+++ b/lib/common/reference.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Implements a better std::reference_wrapper<> template class with
+// move semantics, equality testing, and member access.
+// Use Reference<A> in place of a real A& reference when assignability is
+// required; safer than a bare pointer because it's guaranteed to not be null.
+
+#ifndef FORTRAN_COMMON_REFERENCE_H_
+#define FORTRAN_COMMON_REFERENCE_H_
+#include <type_traits>
+namespace Fortran::common {
+template<typename A> class Reference {
+public:
+  using type = A;
+  Reference(type &x) : p_{&x} {}
+  Reference(const Reference &that) : p_{that.p_} {}
+  Reference(Reference &&that) : p_{that.p_} {}
+  Reference &operator=(const Reference &that) {
+    p_ = that.p_;
+    return *this;
+  }
+  Reference &operator=(Reference &&that) {
+    p_ = that.p_;
+    return *this;
+  }
+
+  // Implicit conversions to references are supported only for
+  // const-qualified types in order to avoid any pernicious
+  // creation of a temporary copy in cases like:
+  //   Reference<type> ref;
+  //   const Type &x{ref};  // creates ref to temp copy!
+  operator std::conditional_t<std::is_const_v<type>, type &, void>() const
+      noexcept {
+    if constexpr (std::is_const_v<type>) {
+      return *p_;
+    }
+  }
+
+  type &get() const noexcept { return *p_; }
+  type *operator->() const { return p_; }
+  type &operator*() const { return *p_; }
+  bool operator==(Reference that) const { return *p_ == *that.p_; }
+  bool operator!=(Reference that) const { return *p_ != *that.p_; }
+
+private:
+  type *p_;  // never null
+};
+template<typename A> Reference(A &)->Reference<A>;
+}
+#endif

--- a/lib/common/unwrap.h
+++ b/lib/common/unwrap.h
@@ -17,6 +17,7 @@
 
 #include "indirection.h"
 #include "reference-counted.h"
+#include "reference.h"
 #include <memory>
 #include <optional>
 #include <type_traits>
@@ -124,6 +125,11 @@ struct UnwrapperHelper {
   static auto Unwrap(const std::variant<Bs...> &u) -> std::add_const_t<A> * {
     return std::visit(
         [](const auto &x) -> std::add_const_t<A> * { return Unwrap<A>(x); }, u);
+  }
+
+  template<typename A, typename B>
+  static auto Unwrap(const Reference<B> &ref) -> Constify<A, B> * {
+    return Unwrap<A>(*ref);
   }
 
   template<typename A, typename B, bool COPY>

--- a/lib/evaluate/call.cc
+++ b/lib/evaluate/call.cc
@@ -27,8 +27,8 @@ ActualArgument::ActualArgument(common::CopyableIndirection<Expr<SomeType>> &&v)
 ActualArgument::ActualArgument(AssumedType x) : u_{x} {}
 ActualArgument::~ActualArgument() {}
 
-ActualArgument::AssumedType::AssumedType(const semantics::Symbol &symbol)
-  : symbol_{&symbol} {
+ActualArgument::AssumedType::AssumedType(const Symbol &symbol)
+  : symbol_{symbol} {
   const semantics::DeclTypeSpec *type{symbol.GetType()};
   CHECK(
       type != nullptr && type->category() == semantics::DeclTypeSpec::TypeStar);
@@ -110,7 +110,7 @@ int ProcedureDesignator::Rank() const {
   return 0;
 }
 
-const semantics::Symbol *ProcedureDesignator::GetInterfaceSymbol() const {
+const Symbol *ProcedureDesignator::GetInterfaceSymbol() const {
   if (const Symbol * symbol{GetSymbol()}) {
     if (const auto *details{
             symbol->detailsIf<semantics::ProcEntityDetails>()}) {
@@ -149,7 +149,7 @@ const Component *ProcedureDesignator::GetComponent() const {
 const Symbol *ProcedureDesignator::GetSymbol() const {
   return std::visit(
       common::visitors{
-          [](const Symbol *sym) { return sym; },
+          [](SymbolRef symbol) { return &*symbol; },
           [](const common::CopyableIndirection<Component> &c) {
             return &c.value().GetLastSymbol();
           },
@@ -162,7 +162,7 @@ std::string ProcedureDesignator::GetName() const {
   return std::visit(
       common::visitors{
           [](const SpecificIntrinsic &i) { return i.name; },
-          [](const Symbol *sym) { return sym->name().ToString(); },
+          [](const Symbol &symbol) { return symbol.name().ToString(); },
           [](const common::CopyableIndirection<Component> &c) {
             return c.value().GetLastSymbol().name().ToString();
           },

--- a/lib/evaluate/constant.h
+++ b/lib/evaluate/constant.h
@@ -18,11 +18,19 @@
 #include "formatting.h"
 #include "type.h"
 #include "../common/default-kinds.h"
+#include "../common/reference.h"
 #include <map>
 #include <ostream>
 #include <vector>
 
+namespace Fortran::semantics {
+class Symbol;
+}
+
 namespace Fortran::evaluate {
+
+using semantics::Symbol;
+using SymbolRef = common::Reference<const Symbol>;
 
 // Wraps a constant value in a class templated by its resolved type.
 // This Constant<> template class should be instantiated only for
@@ -191,8 +199,8 @@ private:
 };
 
 class StructureConstructor;
-using StructureConstructorValues = std::map<const semantics::Symbol *,
-    common::CopyableIndirection<Expr<SomeType>>>;
+using StructureConstructorValues =
+    std::map<SymbolRef, common::CopyableIndirection<Expr<SomeType>>>;
 
 template<>
 class Constant<SomeDerived>

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -155,7 +155,7 @@ bool StructureConstructor::operator==(const StructureConstructor &that) const {
 DynamicType StructureConstructor::GetType() const { return result_.GetType(); }
 
 const Expr<SomeType> *StructureConstructor::Find(
-    const Symbol *component) const {
+    const Symbol &component) const {
   if (auto iter{values_.find(component)}; iter != values_.end()) {
     return &iter->second.value();
   } else {
@@ -165,7 +165,7 @@ const Expr<SomeType> *StructureConstructor::Find(
 
 StructureConstructor &StructureConstructor::Add(
     const Symbol &symbol, Expr<SomeType> &&expr) {
-  values_.emplace(&symbol, std::move(expr));
+  values_.emplace(symbol, std::move(expr));
   return *this;
 }
 

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -756,7 +756,7 @@ public:
     return values_.end();
   }
 
-  const Expr<SomeType> *Find(const Symbol *) const;  // can return null
+  const Expr<SomeType> *Find(const Symbol &) const;  // can return null
 
   StructureConstructor &Add(const semantics::Symbol &, Expr<SomeType> &&);
   int Rank() const { return 0; }

--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -481,6 +481,11 @@ template<typename A> std::ostream &EmitVar(std::ostream &o, const A &x) {
 }
 
 template<typename A>
+std::ostream &EmitVar(std::ostream &o, common::Reference<A> x) {
+  return EmitVar(o, *x);
+}
+
+template<typename A>
 std::ostream &EmitVar(std::ostream &o, const A *p, const char *kw = nullptr) {
   if (p != nullptr) {
     if (kw != nullptr) {
@@ -534,18 +539,18 @@ std::ostream &TypeParamInquiry<KIND>::AsFortran(std::ostream &o) const {
   if (base_.has_value()) {
     return base_->AsFortran(o) << '%';
   }
-  return EmitVar(o, *parameter_);
+  return EmitVar(o, parameter_);
 }
 
 std::ostream &Component::AsFortran(std::ostream &o) const {
   base_.value().AsFortran(o);
-  return EmitVar(o << '%', *symbol_);
+  return EmitVar(o << '%', symbol_);
 }
 
 std::ostream &NamedEntity::AsFortran(std::ostream &o) const {
   std::visit(
       common::visitors{
-          [&](const Symbol *s) { EmitVar(o, *s); },
+          [&](SymbolRef s) { EmitVar(o, s); },
           [&](const Component &c) { c.AsFortran(o); },
       },
       u_);
@@ -575,13 +580,13 @@ std::ostream &ArrayRef::AsFortran(std::ostream &o) const {
 
 std::ostream &CoarrayRef::AsFortran(std::ostream &o) const {
   bool first{true};
-  for (const Symbol *part : base_) {
+  for (const Symbol &part : base_) {
     if (first) {
       first = false;
     } else {
       o << '%';
     }
-    EmitVar(o, *part);
+    EmitVar(o, part);
   }
   char separator{'('};
   for (const auto &sscript : subscript_) {
@@ -629,7 +634,7 @@ template<typename T>
 std::ostream &Designator<T>::AsFortran(std::ostream &o) const {
   std::visit(
       common::visitors{
-          [&](const Symbol *sym) { EmitVar(o, *sym); },
+          [&](SymbolRef symbol) { EmitVar(o, symbol); },
           [&](const auto &x) { x.AsFortran(o); },
       },
       u);

--- a/lib/evaluate/traverse.h
+++ b/lib/evaluate/traverse.h
@@ -58,6 +58,9 @@ public:
   Result operator()(const common::Indirection<A, C> &x) const {
     return visitor_(x.value());
   }
+  template<typename A> Result operator()(SymbolRef x) const {
+    return visitor_(*x);
+  }
   template<typename A> Result operator()(const std::unique_ptr<A> &x) const {
     return visitor_(x.get());
   }
@@ -93,9 +96,7 @@ public:
   template<typename T> Result operator()(const Constant<T> &) const {
     return visitor_.Default();
   }
-  Result operator()(const semantics::Symbol &) const {
-    return visitor_.Default();
-  }
+  Result operator()(const Symbol &) const { return visitor_.Default(); }
   Result operator()(const StaticDataObject &) const {
     return visitor_.Default();
   }
@@ -151,7 +152,7 @@ public:
   Result operator()(const ProcedureDesignator &x) const {
     if (const Component * component{x.GetComponent()}) {
       return visitor_(*component);
-    } else if (const semantics::Symbol * symbol{x.GetSymbol()}) {
+    } else if (const Symbol * symbol{x.GetSymbol()}) {
       return visitor_(*symbol);
     } else {
       return visitor_(DEREF(x.GetSpecificIntrinsic()));

--- a/lib/evaluate/type.cc
+++ b/lib/evaluate/type.cc
@@ -47,8 +47,8 @@ static bool IsDescriptor(const ObjectEntityDetails &details) {
       if (const Scope * scope{typeSpec->scope()}) {
         if (const Symbol * symbol{scope->symbol()}) {
           if (const auto *details{symbol->detailsIf<DerivedTypeDetails>()}) {
-            for (const Symbol *param : details->paramDecls()) {
-              if (const auto *details{param->detailsIf<TypeParamDetails>()}) {
+            for (const Symbol &param : details->paramDecls()) {
+              if (const auto *details{param.detailsIf<TypeParamDetails>()}) {
                 if (details->attr() == common::TypeParamAttr::Len) {
                   return true;
                 }
@@ -146,7 +146,7 @@ static const semantics::Symbol *FindComponent(
   if (const auto *scope{derived.scope()}) {
     auto iter{scope->find(name)};
     if (iter != scope->end()) {
-      return iter->second;
+      return &*iter->second;
     } else if (const auto *parent{GetParentTypeSpec(derived)}) {
       return FindComponent(*parent, name);
     }
@@ -201,8 +201,7 @@ static bool AreSameDerivedType(const semantics::DerivedTypeSpec &x,
     const auto yLookup{ySymbol.scope()->find(*yComponentName)};
     if (xLookup == xSymbol.scope()->end() ||
         yLookup == ySymbol.scope()->end() ||
-        !AreSameComponent(
-            DEREF(xLookup->second), DEREF(yLookup->second), inProgress)) {
+        !AreSameComponent(*xLookup->second, *yLookup->second, inProgress)) {
       return false;
     }
   }

--- a/lib/parser/message.cc
+++ b/lib/parser/message.cc
@@ -73,22 +73,14 @@ const char *MessageFormattedText::Convert(std::string &&s) {
   return conversions_.front().c_str();
 }
 
-const char *MessageFormattedText::Convert(const CharBlock &x) {
-  return Convert(x.ToString());
-}
-
-const char *MessageFormattedText::Convert(CharBlock &x) {
-  return Convert(x.ToString());
-}
-
-const char *MessageFormattedText::Convert(CharBlock &&x) {
+const char *MessageFormattedText::Convert(CharBlock x) {
   return Convert(x.ToString());
 }
 
 std::string MessageExpectedText::ToString() const {
   return std::visit(
       common::visitors{
-          [](const CharBlock &cb) {
+          [](CharBlock cb) {
             return MessageFormattedText("expected '%s'"_err_en_US, cb)
                 .MoveString();
           },
@@ -145,14 +137,14 @@ bool Message::SortBefore(const Message &that) const {
   // before others for sorting.
   return std::visit(
       common::visitors{
-          [](const CharBlock &cb1, const CharBlock &cb2) {
+          [](CharBlock cb1, CharBlock cb2) {
             return cb1.begin() < cb2.begin();
           },
-          [](const CharBlock &, const ProvenanceRange &) { return false; },
+          [](CharBlock, const ProvenanceRange &) { return false; },
           [](const ProvenanceRange &pr1, const ProvenanceRange &pr2) {
             return pr1.start() < pr2.start();
           },
-          [](const ProvenanceRange &, const CharBlock &) { return true; },
+          [](const ProvenanceRange &, CharBlock) { return true; },
       },
       location_, that.location_);
 }
@@ -195,7 +187,7 @@ std::optional<ProvenanceRange> Message::GetProvenanceRange(
     const CookedSource &cooked) const {
   return std::visit(
       common::visitors{
-          [&](const CharBlock &cb) { return cooked.GetProvenanceRange(cb); },
+          [&](CharBlock cb) { return cooked.GetProvenanceRange(cb); },
           [](const ProvenanceRange &pr) { return std::make_optional(pr); },
       },
       location_);
@@ -263,7 +255,7 @@ Message &Message::Attach(std::unique_ptr<Message> &&m) {
 bool Message::AtSameLocation(const Message &that) const {
   return std::visit(
       common::visitors{
-          [](const CharBlock &cb1, const CharBlock &cb2) {
+          [](CharBlock cb1, CharBlock cb2) {
             return cb1.begin() == cb2.begin();
           },
           [](const ProvenanceRange &pr1, const ProvenanceRange &pr2) {

--- a/lib/parser/message.h
+++ b/lib/parser/message.h
@@ -47,7 +47,7 @@ public:
   constexpr MessageFixedText &operator=(const MessageFixedText &) = default;
   constexpr MessageFixedText &operator=(MessageFixedText &&) = default;
 
-  const CharBlock &text() const { return text_; }
+  CharBlock text() const { return text_; }
   bool isFatal() const { return isFatal_; }
 
 private:
@@ -106,9 +106,7 @@ private:
   const char *Convert(const std::string &);
   const char *Convert(std::string &);
   const char *Convert(std::string &&);
-  const char *Convert(const CharBlock &);
-  const char *Convert(CharBlock &);
-  const char *Convert(CharBlock &&);
+  const char *Convert(CharBlock);
 
   bool isFatal_{false};
   std::string string_;

--- a/lib/semantics/check-allocate.cc
+++ b/lib/semantics/check-allocate.cc
@@ -123,7 +123,7 @@ static std::optional<AllocateCheckerInfo> CheckAllocateOptions(
         context
             .Say("Type-spec in ALLOCATE must not specify a type with a coarray"
                  " ultimate component"_err_en_US)
-            .Attach((*it)->name(),
+            .Attach(it->name(),
                 "Type '%s' has coarray ultimate component '%s' declared here"_en_US,
                 info.typeSpec->AsFortran(), it.BuildResultDesignatorName());
       }
@@ -210,7 +210,7 @@ static std::optional<AllocateCheckerInfo> CheckAllocateOptions(
           context
               .Say(parserSourceExpr->source,
                   "SOURCE or MOLD expression must not have a type with a coarray ultimate component"_err_en_US)
-              .Attach((*it)->name(),
+              .Attach(it->name(),
                   "Type '%s' has coarray ultimate component '%s' declared here"_en_US,
                   info.sourceExprType.value().AsFortran(),
                   it.BuildResultDesignatorName());
@@ -226,7 +226,7 @@ static std::optional<AllocateCheckerInfo> CheckAllocateOptions(
                     "SOURCE expression type must not have potential subobject "
                     "component"
                     " of type EVENT_TYPE or LOCK_TYPE from ISO_FORTRAN_ENV"_err_en_US)
-                .Attach((*it)->name(),
+                .Attach(it->name(),
                     "Type '%s' has potential ultimate component '%s' declared here"_en_US,
                     info.sourceExprType.value().AsFortran(),
                     it.BuildResultDesignatorName());
@@ -357,13 +357,13 @@ static std::optional<std::int64_t> GetTypeParameterInt64Value(
 // type2 (except for kind type parameters)
 static bool HaveCompatibleKindParameters(
     const DerivedTypeSpec &derivedType1, const DerivedTypeSpec &derivedType2) {
-  for (const Symbol *symbol :
+  for (const Symbol &symbol :
       OrderParameterDeclarations(derivedType1.typeSymbol())) {
-    if (symbol->get<TypeParamDetails>().attr() == common::TypeParamAttr::Kind) {
+    if (symbol.get<TypeParamDetails>().attr() == common::TypeParamAttr::Kind) {
       // At this point, it should have been ensured that these contain integer
       // constants, so die if this is not the case.
-      if (GetTypeParameterInt64Value(*symbol, derivedType1).value() !=
-          GetTypeParameterInt64Value(*symbol, derivedType2).value()) {
+      if (GetTypeParameterInt64Value(symbol, derivedType1).value() !=
+          GetTypeParameterInt64Value(symbol, derivedType2).value()) {
         return false;
       }
     }

--- a/lib/semantics/check-call.cc
+++ b/lib/semantics/check-call.cc
@@ -165,10 +165,9 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
             dummyName);
       }
       if (const Symbol *
-          tbp{FindImmediateComponent(derived,
-              [](const Symbol &symbol) {
-                return symbol.has<ProcBindingDetails>();
-              })}) {  // 15.5.2.4(2)
+          tbp{FindImmediateComponent(derived, [](const Symbol &symbol) {
+            return symbol.has<ProcBindingDetails>();
+          })}) {  // 15.5.2.4(2)
         if (auto *msg{messages.Say(
                 "Actual argument associated with TYPE(*) %s may not have type-bound procedure '%s'"_err_en_US,
                 dummyName, tbp->name())}) {
@@ -176,10 +175,9 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
         }
       }
       if (const Symbol *
-          finalizer{FindImmediateComponent(derived,
-              [](const Symbol &symbol) {
-                return symbol.has<FinalProcDetails>();
-              })}) {  // 15.5.2.4(2)
+          finalizer{FindImmediateComponent(derived, [](const Symbol &symbol) {
+            return symbol.has<FinalProcDetails>();
+          })}) {  // 15.5.2.4(2)
         if (auto *msg{messages.Say(
                 "Actual argument associated with TYPE(*) %s may not have FINAL subroutine '%s'"_err_en_US,
                 dummyName, finalizer->name())}) {
@@ -192,29 +190,27 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
     if (actualIsCoindexed && dummy.intent != common::Intent::In &&
         !dummyIsValue) {
       if (auto iter{std::find_if(
-              ultimates.begin(), ultimates.end(), [](const Symbol *component) {
-                return IsAllocatable(DEREF(component));
+              ultimates.begin(), ultimates.end(), [](const Symbol &component) {
+                return IsAllocatable(component);
               })}) {  // 15.5.2.4(6)
         if (auto *msg{messages.Say(
                 "Coindexed actual argument with ALLOCATABLE ultimate component '%s' must be associated with a %s with VALUE or INTENT(IN) attributes"_err_en_US,
                 iter.BuildResultDesignatorName(), dummyName)}) {
           msg->Attach(
-              (*iter)->name(), "Declaration of ALLOCATABLE component"_en_US);
+              iter->name(), "Declaration of ALLOCATABLE component"_en_US);
         }
       }
     }
     if (actualIsVolatile != dummyIsVolatile) {  // 15.5.2.4(22)
       if (auto iter{std::find_if(
-              ultimates.begin(), ultimates.end(), [](const Symbol *component) {
-                const auto *object{
-                    DEREF(component).detailsIf<ObjectEntityDetails>()};
+              ultimates.begin(), ultimates.end(), [](const Symbol &component) {
+                const auto *object{component.detailsIf<ObjectEntityDetails>()};
                 return object && object->IsCoarray();
               })}) {
         if (auto *msg{messages.Say(
                 "VOLATILE attribute must match for %s when actual argument has a coarray ultimate component '%s'"_err_en_US,
                 dummyName, iter.BuildResultDesignatorName())}) {
-          msg->Attach(
-              (*iter)->name(), "Declaration of coarray component"_en_US);
+          msg->Attach(iter->name(), "Declaration of coarray component"_en_US);
         }
       }
     }

--- a/lib/semantics/check-declarations.cc
+++ b/lib/semantics/check-declarations.cc
@@ -131,10 +131,9 @@ void CheckHelper::Check(Symbol &symbol) {
     Check(object->shape());
     Check(object->coshape());
     if (object->isDummy() && symbol.attrs().test(Attr::INTENT_OUT)) {
-      if (FindUltimateComponent(symbol,
-              [](const Symbol &symbol) {
-                return IsCoarray(symbol) && IsAllocatable(symbol);
-              })) {  // C846
+      if (FindUltimateComponent(symbol, [](const Symbol &symbol) {
+            return IsCoarray(symbol) && IsAllocatable(symbol);
+          })) {  // C846
         messages_.Say(
             "An INTENT(OUT) dummy argument may not be, or contain, an ALLOCATABLE coarray"_err_en_US);
       }

--- a/lib/semantics/check-do.cc
+++ b/lib/semantics/check-do.cc
@@ -459,8 +459,8 @@ private:
   static SymbolSet GatherSymbolsFromExpression(const parser::Expr &expression) {
     SymbolSet result;
     if (const auto *expr{GetExpr(expression)}) {
-      for (const Symbol *symbol : evaluate::CollectSymbols(*expr)) {
-        if (const Symbol * root{GetAssociationRoot(DEREF(symbol))}) {
+      for (const Symbol &symbol : evaluate::CollectSymbols(*expr)) {
+        if (const Symbol * root{GetAssociationRoot(symbol)}) {
           result.insert(root);
         }
       }

--- a/lib/semantics/mod-file.h
+++ b/lib/semantics/mod-file.h
@@ -49,7 +49,7 @@ private:
   void Write(const Symbol &);
   std::string GetAsString(const Symbol &);
   void PutSymbols(const Scope &);
-  void PutSymbol(std::stringstream &, const Symbol *);
+  void PutSymbol(std::stringstream &, const Symbol &);
   void PutDerivedType(const Symbol &);
   void PutSubprogram(const Symbol &);
   void PutGeneric(const Symbol &);

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -77,7 +77,7 @@ Scope::size_type Scope::erase(const SourceName &name) {
 Symbol *Scope::FindSymbol(const SourceName &name) const {
   auto it{find(name)};
   if (it != end()) {
-    return it->second;
+    return &*it->second;
   } else if (CanImport(name)) {
     return parent_.FindSymbol(name);
   } else {
@@ -94,7 +94,7 @@ void Scope::add_equivalenceSet(EquivalenceSet &&set) {
 
 void Scope::add_crayPointer(const SourceName &name, Symbol &pointer) {
   CHECK(pointer.test(Symbol::Flag::CrayPointer));
-  crayPointers_.emplace(name, &pointer);
+  crayPointers_.emplace(name, pointer);
 }
 
 Symbol &Scope::MakeCommonBlock(const SourceName &name) {
@@ -103,13 +103,13 @@ Symbol &Scope::MakeCommonBlock(const SourceName &name) {
     return *it->second;
   } else {
     Symbol &symbol{MakeSymbol(name, Attrs{}, CommonBlockDetails{})};
-    commonBlocks_.emplace(name, &symbol);
+    commonBlocks_.emplace(name, symbol);
     return symbol;
   }
 }
 Symbol *Scope::FindCommonBlock(const SourceName &name) {
   const auto it{commonBlocks_.find(name)};
-  return it != commonBlocks_.end() ? it->second : nullptr;
+  return it != commonBlocks_.end() ? &*it->second : nullptr;
 }
 
 Scope *Scope::FindSubmodule(const SourceName &name) const {
@@ -117,11 +117,11 @@ Scope *Scope::FindSubmodule(const SourceName &name) const {
   if (it == submodules_.end()) {
     return nullptr;
   } else {
-    return it->second;
+    return &*it->second;
   }
 }
 bool Scope::AddSubmodule(const SourceName &name, Scope &submodule) {
-  return submodules_.emplace(name, &submodule).second;
+  return submodules_.emplace(name, submodule).second;
 }
 
 const DeclTypeSpec *Scope::FindType(const DeclTypeSpec &type) const {
@@ -248,8 +248,8 @@ std::ostream &operator<<(std::ostream &os, const Scope &scope) {
   }
   os << scope.children_.size() << " children\n";
   for (const auto &pair : scope.symbols_) {
-    const auto *symbol{pair.second};
-    os << "  " << *symbol << '\n';
+    const Symbol &symbol{*pair.second};
+    os << "  " << symbol << '\n';
   }
   if (!scope.equivalenceSets_.empty()) {
     os << "  Equivalence Sets:\n";
@@ -262,8 +262,8 @@ std::ostream &operator<<(std::ostream &os, const Scope &scope) {
     }
   }
   for (const auto &pair : scope.commonBlocks_) {
-    const auto *symbol{pair.second};
-    os << "  " << *symbol << '\n';
+    const Symbol &symbol{*pair.second};
+    os << "  " << symbol << '\n';
   }
   return os;
 }

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -19,6 +19,7 @@
 #include "symbol.h"
 #include "../common/Fortran.h"
 #include "../common/idioms.h"
+#include "../common/reference.h"
 #include "../parser/message.h"
 #include "../parser/provenance.h"
 #include <list>
@@ -50,7 +51,7 @@ struct EquivalenceObject {
 using EquivalenceSet = std::vector<EquivalenceObject>;
 
 class Scope {
-  using mapType = std::map<SourceName, Symbol *>;
+  using mapType = std::map<SourceName, common::Reference<Symbol>>;
 
 public:
   ENUM_CLASS(Kind, Global, Module, MainProgram, Subprogram, DerivedType, Block,
@@ -138,7 +139,7 @@ public:
   common::IfNoLvalue<std::pair<iterator, bool>, D> try_emplace(
       const SourceName &name, Attrs attrs, D &&details) {
     Symbol &symbol{MakeSymbol(name, attrs, std::move(details))};
-    return symbols_.emplace(name, &symbol);
+    return symbols_.emplace(name, symbol);
   }
 
   const std::list<EquivalenceSet> &equivalenceSets() const;
@@ -220,7 +221,7 @@ private:
   mapType commonBlocks_;
   std::list<EquivalenceSet> equivalenceSets_;
   mapType crayPointers_;
-  std::map<SourceName, Scope *> submodules_;
+  std::map<SourceName, common::Reference<Scope>> submodules_;
   std::list<DeclTypeSpec> declTypeSpecs_;
   std::string chars_;
   std::optional<ImportKind> importKind_;

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -40,17 +40,17 @@
 
 namespace Fortran::semantics {
 
-using NameToSymbolMap = std::map<const char *, const Symbol *>;
+using NameToSymbolMap = std::map<const char *, SymbolRef>;
 static void DoDumpSymbols(std::ostream &, const Scope &, int indent = 0);
 static void PutIndent(std::ostream &, int indent);
 
 static void GetSymbolNames(const Scope &scope, NameToSymbolMap &symbols) {
   // Finds all symbol names in the scope without collecting duplicates.
   for (const auto &pair : scope) {
-    symbols.emplace(pair.second->name().begin(), pair.second);
+    symbols.emplace(pair.second->name().begin(), *pair.second);
   }
   for (const auto &pair : scope.commonBlocks()) {
-    symbols.emplace(pair.second->name().begin(), pair.second);
+    symbols.emplace(pair.second->name().begin(), *pair.second);
   }
   for (const auto &child : scope.children()) {
     GetSymbolNames(child, symbols);
@@ -227,7 +227,7 @@ void Semantics::DumpSymbolsSources(std::ostream &os) const {
   NameToSymbolMap symbols;
   GetSymbolNames(context_.globalScope(), symbols);
   for (const auto pair : symbols) {
-    const Symbol &symbol{*pair.second};
+    const Symbol &symbol{pair.second};
     if (auto sourceInfo{cooked_.GetSourcePositionRange(symbol.name())}) {
       os << symbol.name().ToString() << ": " << sourceInfo->first.file.path()
          << ", " << sourceInfo->first.line << ", " << sourceInfo->first.column

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -35,8 +35,8 @@ static void DumpBool(std::ostream &os, const char *label, bool x) {
 
 static void DumpSymbolVector(std::ostream &os, const SymbolVector &list) {
   char sep{' '};
-  for (const auto *elem : list) {
-    os << sep << elem->name();
+  for (const Symbol &elem : list) {
+    os << sep << elem.name();
     sep = ',';
   }
 }
@@ -166,8 +166,8 @@ const Symbol *GenericDetails::CheckSpecific() const {
 }
 Symbol *GenericDetails::CheckSpecific() {
   if (specific_) {
-    for (const auto *proc : specificProcs_) {
-      if (proc == specific_) {
+    for (const Symbol &proc : specificProcs_) {
+      if (&proc == specific_) {
         return nullptr;
       }
     }
@@ -186,8 +186,9 @@ void GenericDetails::CopyFrom(const GenericDetails &from) {
     CHECK(!derivedType_ || derivedType_ == from.derivedType_);
     derivedType_ = from.derivedType_;
   }
-  for (const Symbol *symbol : from.specificProcs_) {
-    if (std::find(specificProcs_.begin(), specificProcs_.end(), symbol) ==
+  for (const Symbol &symbol : from.specificProcs_) {
+    if (std::find_if(specificProcs_.begin(), specificProcs_.end(),
+            [&](const Symbol &mySymbol) { return &mySymbol == &symbol; }) ==
         specificProcs_.end()) {
       specificProcs_.push_back(symbol);
     }


### PR DESCRIPTION
This PR is a proof-of-concept that some uses of non-nullable pointers can be replaced with `std::reference_wrapper<>` to gain some extra readability and remove some `DEREF()` checks (or places where we should have them but don't).

If this all seems good, I'll push ahead with this and use `reference_wrapper<>` in place of non-nullable pointers in more data structures.