### PR TITLE
Changes to check for calls to PURE procedure components

### DIFF
--- a/lib/semantics/check-do.cc
+++ b/lib/semantics/check-do.cc
@@ -167,7 +167,7 @@ public:
         }
       }
     } else {
-      // C1139: check for an impure procedure component
+      // C1139: this a procedure component
       auto &component{std::get<parser::ProcComponentRef>(procedureDesignator.u)
                           .v.thing.component};
       if (component.symbol && !IsPureProcedure(*component.symbol)) {

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -167,6 +167,12 @@ bool IsFunction(const Symbol &symbol) {
 }
 
 bool IsPureProcedure(const Symbol &symbol) {
+  if (const auto *procDetails{symbol.detailsIf<ProcEntityDetails>()}) {
+    if (const Symbol *procInterface{procDetails->interface().symbol()}) {
+      // procedure component with a PURE interface
+      return IsPureProcedure(*procInterface);
+    }
+  }
   return symbol.attrs().test(Attr::PURE) && IsProcedure(symbol);
 }
 


### PR DESCRIPTION
This addresses issue #781.  As far as I can tell, there's no way to
declare a PURE procedure component.  So I simplified the code in
check-do.cc to check for this condition and added a test for it.