### PR TITLE
[OpenMP] Test Infra update to support OpenMP symbol tests

### DIFF
--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -158,12 +158,6 @@ set(ERROR_TESTS
   omp-resolve02.f90
   omp-resolve03.f90
   omp-resolve04.f90
-  omp-symbol01.f90
-  omp-symbol02.f90
-  omp-symbol03.f90
-  omp-symbol04.f90
-  omp-symbol05.f90
-  omp-symbol06.f90
   omp-clause-validity01.f90
   omp-loop-association.f90
 #  omp-nested01.f90
@@ -203,6 +197,12 @@ set(SYMBOL_TESTS
   symbol14.f90
   symbol15.f90
   symbol16.f90
+  omp-symbol01.f90
+  omp-symbol02.f90
+  omp-symbol03.f90
+  omp-symbol04.f90
+  omp-symbol05.f90
+  omp-symbol06.f90
   kinds01.f90
   kinds03.f90
   procinterface01.f90

--- a/test/semantics/common.sh
+++ b/test/semantics/common.sh
@@ -14,8 +14,9 @@
 
 # Common functionality for test scripts
 # Process arguments, expecting source file as 1st; optional path to f18 as 2nd
-# Set: $F18 to the path to f18; $temp to an empty temp directory; and $src
-# to the full path of the single source argument
+# Set: $F18 to the path to f18; $temp to an empty temp directory; $src
+# to the full path of the single source argument; and $USER_OPTIONS to the
+# option list given in the $src file after string "OPTIONS:"
 
 PATH=/usr/bin:/bin
 
@@ -35,5 +36,7 @@ case $1 in
   (/*) src=$1 ;;
   (*) src=$(dirname $0)/$1 ;;
 esac
+USER_OPTIONS=`sed -n 's/^ *! *OPTIONS: *//p' $src`
+echo $USER_OPTIONS
 temp=`mktemp -d ./tmp.XXXXXX`
 [[ $KEEP ]] || trap "rm -rf $temp" EXIT

--- a/test/semantics/test_errors.sh
+++ b/test/semantics/test_errors.sh
@@ -25,14 +25,9 @@ log=$temp/log
 actual=$temp/actual
 expect=$temp/expect
 diffs=$temp/diffs
-options=$temp/options
-
-# See if there are additional options
-sed -n 's/^ *! *OPTIONS: *//p' $src > $options
-cat $options
 
 include=$(dirname $(dirname $F18))/include
-cmd="$F18 $F18_OPTIONS -I$include `cat $options` $src"
+cmd="$F18 $F18_OPTIONS $USER_OPTIONS -I$include $src"
 ( cd $temp; $cmd ) > $log 2>&1
 if [[ $? -ge 128 ]]; then
   cat $log

--- a/test/semantics/test_symbols.sh
+++ b/test/semantics/test_symbols.sh
@@ -28,13 +28,14 @@ src2=$temp/2.f90
 src3=$temp/3.f90
 diffs=$temp/diffs
 
-# Strip out blank lines and all comments except "!DEF:" and "!REF:"
-sed -e 's/!\([DR]EF:\)/KEEP \1/' \
+# Strip out blank lines and all comments except "!DEF:", "!REF:", and "!$omp"
+sed -e 's/!\([DR]EF:\)/KEEP \1/' -e 's/!\($omp\)/KEEP \1/' \
   -e 's/!.*//' -e 's/ *$//' -e '/^$/d' -e 's/KEEP \([DR]EF:\)/!\1/' \
+  -e 's/KEEP \($omp\)/!\1/' \
   $src > $src1
-egrep -v '^ *!' $src1 > $src2  # strip out meaningful comments
+egrep -v '![DR]EF:' $src1 > $src2  # strip out DEF and REF comments
 # compile, inserting comments for symbols:
-( cd $temp; $F18 $F18_OPTIONS $(basename $src2) ) > $src3
+( cd $temp; $F18 $F18_OPTIONS $USER_OPTIONS $(basename $src2) ) > $src3
 
 if diff -w -U999999 $src1 $src3 > $diffs; then
   echo PASS


### PR DESCRIPTION
During the symbol tests, OpenMP directives (start with `[!c*]$omp`) line needs to be saved for 1.f90 and 2.f90. Also moved `OPTIONS:` detection to common.sh as `$USER_OPTIONS`.