### PR TITLE
Throw error in case of missing test source file

### DIFF
--- a/test/semantics/test_any.sh
+++ b/test/semantics/test_any.sh
@@ -20,6 +20,7 @@
 
 srcdir=$(dirname $0)
 source $srcdir/common.sh
+[[ ! -f $src ]] && echo "File not found: $src" && exit 1
 
 FileCheck=${FileCheck:=internal_check}
 


### PR DESCRIPTION
This is for tests using `test_any.sh` script.