### PR TITLE
Exit with error status in case of missing listed test

### DIFF
--- a/test/semantics/test_any.sh
+++ b/test/semantics/test_any.sh
@@ -63,6 +63,7 @@ function internal_check() {
 
 gr=0
 for input in ${srcdir}/$*; do
+  [[ ! -f $input ]] && die "File not found: $input"
   CMD=$(cat ${input} | egrep '^[[:space:]]*![[:space:]]*RUN:[[:space:]]*' | sed -e 's/^[[:space:]]*![[:space:]]*RUN:[[:space:]]*//')
   CMD=$(echo ${CMD} | sed -e "s:%s:${input}:g")
   if egrep -q -e '%t' <<< ${CMD} ; then


### PR DESCRIPTION
For `test_any` tests, if a test is listed in the `CMakeLists.txt` but actually missing the source file, throw an error and fail the test.