### PR TITLE
More semantic checks for calls & declarations

### DIFF
--- a/documentation/Extensions.md
+++ b/documentation/Extensions.md
@@ -106,6 +106,9 @@ Extensions, deletions, and legacy features supported by default
 * When a scalar CHARACTER actual argument of the same kind is known to
   have a length shorter than the associated dummy argument, it is extended
   on the right with blanks, similar to assignment.
+* When a dummy argument is `POINTER` or `ALLOCATABLE` and is `INTENT(IN)`, we
+  relax enforcement of some requirements on actual arguments that must otherwise
+  hold true for definable arguments.
 
 Extensions supported when enabled by options
 --------------------------------------------

--- a/lib/evaluate/characteristics.cc
+++ b/lib/evaluate/characteristics.cc
@@ -41,7 +41,8 @@ static void CopyAttrs(const semantics::Symbol &src, A &dst,
 }
 
 bool TypeAndShape::operator==(const TypeAndShape &that) const {
-  return type_ == that.type_ && shape_ == that.shape_ && attrs_ == that.attrs_;
+  return type_ == that.type_ && shape_ == that.shape_ &&
+      attrs_ == that.attrs_ && corank_ == that.corank_;
 }
 
 std::optional<TypeAndShape> TypeAndShape::Characterize(
@@ -142,6 +143,7 @@ bool TypeAndShape::IsCompatibleWith(parser::ContextualMessages &messages,
 
 void TypeAndShape::AcquireShape(const semantics::ObjectEntityDetails &object) {
   CHECK(shape_.empty() && !attrs_.test(Attr::AssumedRank));
+  corank_ = object.coshape().Rank();
   if (object.IsAssumedRank()) {
     attrs_.set(Attr::AssumedRank);
     return;

--- a/lib/evaluate/characteristics.h
+++ b/lib/evaluate/characteristics.h
@@ -102,6 +102,7 @@ public:
   }
   const Shape &shape() const { return shape_; }
   const Attrs &attrs() const { return attrs_; }
+  int corank() const { return corank_; }
 
   int Rank() const { return GetRank(shape_); }
   bool IsCompatibleWith(parser::ContextualMessages &, const TypeAndShape &that,
@@ -119,6 +120,7 @@ protected:
   std::optional<Expr<SomeInteger>> LEN_;
   Shape shape_;
   Attrs attrs_;
+  int corank_{0};
 };
 
 // 15.3.2.2

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -3137,8 +3137,10 @@ Symbol &DeclarationVisitor::HandleAttributeStmt(
   }
   auto *symbol{FindInScope(currScope(), name)};
   if (attr == Attr::ASYNCHRONOUS || attr == Attr::VOLATILE) {
-    // these can be set on a symbol that is host-assoc into block or use-assoc
-    if (!symbol && currScope().kind() == Scope::Kind::Block) {
+    // these can be set on a symbol that is host-assoc or use-assoc
+    if (!symbol &&
+        (currScope().kind() == Scope::Kind::Subprogram ||
+            currScope().kind() == Scope::Kind::Block)) {
       if (auto *hostSymbol{FindSymbol(name)}) {
         name.symbol = nullptr;
         symbol = &MakeSymbol(name, HostAssocDetails{*hostSymbol});

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -184,6 +184,24 @@ bool IsPureProcedure(const Scope &scope) {
   }
 }
 
+bool IsBindCProcedure(const Symbol &symbol) {
+  if (const auto *procDetails{symbol.detailsIf<ProcEntityDetails>()}) {
+    if (const Symbol * procInterface{procDetails->interface().symbol()}) {
+      // procedure component with a BIND(C) interface
+      return IsBindCProcedure(*procInterface);
+    }
+  }
+  return symbol.attrs().test(Attr::BIND_C) && IsProcedure(symbol);
+}
+
+bool IsBindCProcedure(const Scope &scope) {
+  if (const Symbol * symbol{scope.GetSymbol()}) {
+    return IsBindCProcedure(*symbol);
+  } else {
+    return false;
+  }
+}
+
 bool IsProcedure(const Symbol &symbol) {
   return std::visit(
       common::visitors{

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -54,13 +54,15 @@ bool IsGenericDefinedOp(const Symbol &);
 bool IsCommonBlockContaining(const Symbol &block, const Symbol &object);
 bool DoesScopeContain(const Scope *maybeAncestor, const Scope &maybeDescendent);
 bool DoesScopeContain(const Scope *, const Symbol &);
-bool IsUseAssociated(const Symbol *, const Scope &);
+bool IsUseAssociated(const Symbol &, const Scope &);
 bool IsHostAssociated(const Symbol &, const Scope &);
 bool IsDummy(const Symbol &);
 bool IsPointerDummy(const Symbol &);
 bool IsFunction(const Symbol &);
 bool IsPureProcedure(const Symbol &);
 bool IsPureProcedure(const Scope &);
+bool IsBindCProcedure(const Symbol &);
+bool IsBindCProcedure(const Scope &);
 bool IsProcedure(const Symbol &);
 bool IsProcName(const Symbol &symbol);  // proc-name
 bool IsVariableName(const Symbol &symbol);  // variable-name
@@ -110,6 +112,12 @@ inline bool IsOptional(const Symbol &symbol) {
 }
 inline bool IsIntentIn(const Symbol &symbol) {
   return symbol.attrs().test(Attr::INTENT_IN);
+}
+inline bool IsIntentInOut(const Symbol &symbol) {
+  return symbol.attrs().test(Attr::INTENT_INOUT);
+}
+inline bool IsIntentOut(const Symbol &symbol) {
+  return symbol.attrs().test(Attr::INTENT_OUT);
 }
 inline bool IsProtected(const Symbol &symbol) {
   return symbol.attrs().test(Attr::PROTECTED);

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -177,7 +177,10 @@ set(ERROR_TESTS
   call03.f90
   call04.f90
   call05.f90
+  call06.f90
   call13.f90
+  call14.f90
+  misc-declarations.f90
 )
 
 # These test files have expected symbols in the source

--- a/test/semantics/blockconstruct01.f90
+++ b/test/semantics/blockconstruct01.f90
@@ -50,7 +50,7 @@ subroutine s4_c1107
   end block
 end
 
-subroutine s5_c1107
+subroutine s5_c1107(x,y)
   integer x, y
   value x
   block

--- a/test/semantics/call03.f90
+++ b/test/semantics/call03.f90
@@ -33,7 +33,7 @@ module m01
     real, allocatable :: a(:)
   end type
   type :: ultimateCoarray
-    real, allocatable :: a[*]
+    real, allocatable :: a[:]
   end type
 
  contains
@@ -85,7 +85,7 @@ module m01
     real, pointer :: x(:)
   end subroutine
   subroutine valueassumedsize(x)
-    real, value :: x(*)
+    real, intent(in) :: x(*)
   end subroutine
   subroutine volatileassumedsize(x)
     real, volatile :: x(*)

--- a/test/semantics/call04.f90
+++ b/test/semantics/call04.f90
@@ -17,7 +17,7 @@
 module m
 
   type :: hasCoarray
-    real, allocatable :: a(:)[*]
+    real, allocatable :: a(:)[:]
   end type
   type, extends(hasCoarray) :: extendsHasCoarray
   end type
@@ -36,6 +36,7 @@ module m
   end subroutine
   subroutine s01b ! C846 - can only be caught at a call via explicit interface
     !ERROR: ALLOCATABLE coarray 'coarray' may not be associated with INTENT(OUT) dummy argument 'x='
+    !ERROR: ALLOCATABLE dummy argument 'x=' has corank 0 but actual argument has corank 1
     call s01a(coarray)
   end subroutine
 

--- a/test/semantics/call06.f90
+++ b/test/semantics/call06.f90
@@ -46,24 +46,24 @@ module m
   subroutine test(x)
     real :: scalar
     real, allocatable, intent(in) :: x
-    !ERROR: ALLOCATABLE dummy argument must be associated with an ALLOCATABLE effective argument
+    !ERROR: ALLOCATABLE dummy argument 'x=' must be associated with an ALLOCATABLE actual argument
     call s01(scalar)
-    !ERROR: ALLOCATABLE dummy argument must be associated with an ALLOCATABLE effective argument
+    !ERROR: ALLOCATABLE dummy argument 'x=' must be associated with an ALLOCATABLE actual argument
     call s01(1.)
-    !ERROR: ALLOCATABLE dummy argument must be associated with an ALLOCATABLE effective argument
+    !ERROR: ALLOCATABLE dummy argument 'x=' must be associated with an ALLOCATABLE actual argument
     call s01(allofunc()) ! subtle: ALLOCATABLE function result isn't
     call s02(cov) ! ok
     call s03(com) ! ok
-    !ERROR: Dummy argument has corank 1, but effective argument has corank 2
+    !ERROR: ALLOCATABLE dummy argument 'x=' has corank 1 but actual argument has corank 2
     call s02(com)
-    !ERROR: Dummy argument has corank 2, but effective argument has corank 1
+    !ERROR: ALLOCATABLE dummy argument 'x=' has corank 2 but actual argument has corank 1
     call s03(cov)
     call s04(cov[1]) ! ok
-    !ERROR: Coindexed ALLOCATABLE effective argument must be associated with INTENT(IN) dummy argument
+    !ERROR: ALLOCATABLE dummy argument 'x=' must have INTENT(IN) to be associated with a coindexed actual argument
     call s01(cov[1])
-    !ERROR: Effective argument associated with INTENT(OUT) dummy is not definable
+    !ERROR: Actual argument associated with INTENT(OUT) dummy argument 'x=' must be definable
     call s05(x)
-    !ERROR: Effective argument associated with INTENT(IN OUT) dummy is not definable
+    !ERROR: Actual argument associated with INTENT(IN OUT) dummy argument 'x=' must be definable
     call s06(x)
   end subroutine
 end module

--- a/test/semantics/call14.f90
+++ b/test/semantics/call14.f90
@@ -1,0 +1,51 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test 8.5.18 constraints on the VALUE attribute
+
+module m
+  type :: hasCoarray
+    real :: coarray[*]
+  end type
+ contains
+  !ERROR: VALUE attribute may apply only to a dummy data object
+  subroutine C863(notData,assumedSize,coarray,coarrayComponent)
+    external :: notData
+    !ERROR: VALUE attribute may apply only to a dummy argument
+    real, value :: notADummy
+    value :: notData
+    !ERROR: VALUE attribute may not apply to an assumed-size array
+    real, value :: assumedSize(10,*)
+    !ERROR: VALUE attribute may not apply to a coarray
+    real, value :: coarray[*]
+    !ERROR: VALUE attribute may not apply to a type with a coarray ultimate component
+    type(hasCoarray), value :: coarrayComponent
+  end subroutine
+  subroutine C864(allocatable, inout, out, pointer, volatile)
+    !ERROR: VALUE attribute may not apply to an ALLOCATABLE
+    real, value, allocatable :: allocatable
+    !ERROR: VALUE attribute may not apply to an INTENT(IN OUT) argument
+    real, value, intent(in out) :: inout
+    !ERROR: VALUE attribute may not apply to an INTENT(OUT) argument
+    real, value, intent(out) :: out
+    !ERROR: VALUE attribute may not apply to a POINTER
+    real, value, pointer :: pointer
+    !ERROR: VALUE attribute may not apply to a VOLATILE
+    real, value, volatile :: volatile
+  end subroutine
+  subroutine C865(optional) bind(c)
+    !ERROR: VALUE attribute may not apply to an OPTIONAL in a BIND(C) procedure
+    real, value, optional :: optional
+  end subroutine
+end module

--- a/test/semantics/doconcurrent01.f90
+++ b/test/semantics/doconcurrent01.f90
@@ -123,7 +123,7 @@ end subroutine s5
 subroutine s6()
   type :: type0
     integer, allocatable, dimension(:) :: type0_field
-    integer, allocatable, dimension(:), codimension[*] :: coarray_type0_field
+    integer, allocatable, dimension(:), codimension[:] :: coarray_type0_field
   end type
 
   type :: type1
@@ -134,7 +134,7 @@ subroutine s6()
   type(type1) :: qvar;
   integer, allocatable, dimension(:) :: array1
   integer, allocatable, dimension(:) :: array2
-  integer, allocatable, codimension[*] :: ca, cb
+  integer, allocatable, codimension[:] :: ca, cb
   integer, allocatable :: aa, ab
 
   ! All of the following are allowable outside a DO CONCURRENT

--- a/test/semantics/init01.f90
+++ b/test/semantics/init01.f90
@@ -17,7 +17,7 @@
 subroutine test(j)
   integer, intent(in) :: j
   real, allocatable, target, save :: x1
-  real, codimension[:], target, save :: x2
+  real, codimension[*], target, save :: x2
   real, save :: x3
   real, target :: x4
   real, target, save :: x5(10)

--- a/test/semantics/misc-declarations.f90
+++ b/test/semantics/misc-declarations.f90
@@ -1,0 +1,54 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Miscellaneous constraint and requirement checking on declarations:
+! - 8.5.6.2 & 8.5.6.3 constraints on coarrays
+! - 8.5.19 constraints on the VOLATILE attribute
+
+module m
+  !ERROR: ALLOCATABLE coarray must have a deferred coshape
+  real, allocatable :: mustBeDeferred[*]  ! C827
+  !ERROR: Non-ALLOCATABLE coarray must have an explicit coshape
+  real :: mustBeExplicit[:]  ! C828
+  type :: hasCoarray
+    real :: coarray[*]
+  end type
+  real :: coarray[*]
+  type(hasCoarray) :: coarrayComponent
+ contains
+  !ERROR: VOLATILE attribute may not apply to an INTENT(IN) argument
+  subroutine C866(x)
+    intent(in) :: x
+    volatile :: x
+    !ERROR: VOLATILE attribute may apply only to a variable
+    volatile :: notData
+    external :: notData
+  end subroutine
+  subroutine C867
+    !ERROR: VOLATILE attribute may not apply to a coarray accessed by USE or host association
+    volatile :: coarray
+    !ERROR: VOLATILE attribute may not apply to a type with a coarray ultimate component accessed by USE or host association
+    volatile :: coarrayComponent
+  end subroutine
+  subroutine C868(coarray,coarrayComponent)
+    real, volatile :: coarray[*]
+    type(hasCoarray) :: coarrayComponent
+    block
+      !ERROR: VOLATILE attribute may not apply to a coarray accessed by USE or host association
+      volatile :: coarray
+      !ERROR: VOLATILE attribute may not apply to a type with a coarray ultimate component accessed by USE or host association
+      volatile :: coarrayComponent
+    end block
+  end subroutine
+end module

--- a/test/semantics/modfile24.f90
+++ b/test/semantics/modfile24.f90
@@ -49,8 +49,8 @@ end
 ! coarray-spec in components and with non-constants bounds
 module m3
   type t
-    real, allocatable :: c(:)[1:10,1:*]
-    complex, allocatable, codimension[5,*] :: d
+    real :: c[1:10,1:*]
+    complex, codimension[5,*] :: d
   end type
   real, allocatable :: e[:,:,:]
 contains
@@ -63,8 +63,8 @@ end
 !Expect: m3.mod
 !module m3
 ! type::t
-!  real(4),allocatable::c(:)[1_8:10_8,1_8:*]
-!  complex(4),allocatable::d[1_8:5_8,1_8:*]
+!  real(4)::c[1_8:10_8,1_8:*]
+!  complex(4)::d[1_8:5_8,1_8:*]
 ! end type
 ! real(4),allocatable::e[:,:,:]
 !contains


### PR DESCRIPTION
`call06.f90` and two new tests (`call14.f90` and `misc-declarations.f90`) now pass.