### PR TITLE
Relax the implementation of constraint C1302.

### DIFF
--- a/test/semantics/io07.f90
+++ b/test/semantics/io07.f90
@@ -30,6 +30,12 @@
 2011 format(:2L2)
 2012 format(2L2 : 2L2)
 
+     ! C1302 warnings; no errors
+2051 format(1X3/)
+2052 format(1X003/)
+2053 format(3P7I2)
+2054 format(3PI2)
+
      !ERROR: Expected ',' or ')' in format expression
 2101 format(3I83Z8, 'abc')
 
@@ -41,18 +47,6 @@
 
      !ERROR: Expected ',' or ')' in format expression
 2104 format(3I8 Z8)
-
-     !ERROR: Expected ',' or ')' in format expression
-2105 format(1X3/)
-
-     !ERROR: Expected ',' or ')' in format expression
-2106 format(1X003/)
-
-     !ERROR: Expected ',' or ')' in format expression
-2107 format(3P7I2)
-
-     !ERROR: Expected ',' or ')' in format expression
-2108 format(3PI2)
 
 3001 format(*(I3))
 3002 format(5X,*(2(A)))

--- a/test/semantics/io08.f90
+++ b/test/semantics/io08.f90
@@ -51,6 +51,11 @@
   write(*,'(\)')
   write(*,'(RZ,RU,RP,RN,RD,RC,SS,SP,S,3G15.3e2)')
 
+  ! C1302 warnings; no errors
+  write(*,'(3P7I2)')
+  write(*,'(5X i3)')
+  write(*,'(XEN)')
+
   !ERROR: Empty format expression
   write(*,"")
 
@@ -71,12 +76,6 @@
 
   !ERROR: 'P' edit descriptor must have a scale factor
   write(*,'(P7F' // '5.2)')
-
-  !ERROR: Expected ',' or ')' in format expression
-  write(*,'(3P7I2)')
-
-  !ERROR: Expected ',' or ')' in format expression
-  write(*,'(5X i3)')
 
   !ERROR: Unexpected integer constant
   write(*,'(X,3,3L4)')
@@ -186,9 +185,6 @@
   !ERROR: Unexpected 'M' in format expression
   write(*,'(MXY)')
 
-  !ERROR: Expected ',' or ')' in format expression
-  write(*,'(XEN)')
-
   !ERROR: Unexpected 'R' in format expression
   !ERROR: Unexpected 'R' in format expression
   write(*,"(RR, RV)")
@@ -265,9 +261,8 @@
   !ERROR: Unterminated format expression
   write(*,'(X')
 
-  !ERROR: Expected ',' or ')' in format expression
   !ERROR: Unterminated format expression
-  write(*,'(XX')
+  write(*,'(XX') ! C1302 warning is not an error
 
   !ERROR: Unexpected '@' in format expression
   !ERROR: Unexpected '#' in format expression

--- a/test/semantics/io10.f90
+++ b/test/semantics/io10.f90
@@ -35,4 +35,18 @@
 
   !WARNING: Legacy 'H' edit descriptor
   write(*, '(3Habc)')
+
+  !WARNING: 'X' edit descriptor must have a positive position value
+  !WARNING: Expected ',' or ')' in format expression
+  !WARNING: 'X' edit descriptor must have a positive position value
+  write(*,'(XX)')
+
+  !WARNING: Expected ',' or ')' in format expression
+  write(*,'(RZEN8.2)')
+
+  !WARNING: Expected ',' or ')' in format expression
+  write(*,'(3P7I2)')
+
+  !WARNING: Expected ',' or ')' in format expression
+  write(*,'(5X i3)')
 end


### PR DESCRIPTION
When a format item list can be unambiguously partitioned into individual
items even though one or more otherwise required comma separators are omitted,
generate a warning rather than an error.