### PR TITLE
Enable and pass test call07.f90

### DIFF
--- a/lib/common/indirection.h
+++ b/lib/common/indirection.h
@@ -33,7 +33,7 @@
 
 namespace Fortran::common {
 
-// The default case does not support (deep) copy construction and assignment.
+// The default case does not support (deep) copy construction or assignment.
 template<typename A, bool COPY = false> class Indirection {
 public:
   using element_type = A;

--- a/lib/common/restorer.h
+++ b/lib/common/restorer.h
@@ -42,5 +42,11 @@ common::IfNoLvalue<Restorer<A>, B> ScopedSet(A &to, B &&from) {
   to = std::move(from);
   return result;
 }
+template<typename A, typename B>
+common::IfNoLvalue<Restorer<A>, B> ScopedSet(A &to, const B &from) {
+  Restorer<A> result{to};
+  to = from;
+  return result;
+}
 }
 #endif  // FORTRAN_COMMON_RESTORER_H_

--- a/lib/evaluate/characteristics.h
+++ b/lib/evaluate/characteristics.h
@@ -169,6 +169,7 @@ struct DummyArgument {
   DummyArgument(std::string &&name, DummyProcedure &&x)
     : name{std::move(name)}, u{std::move(x)} {}
   explicit DummyArgument(AlternateReturn &&x) : u{std::move(x)} {}
+  ~DummyArgument();
   bool operator==(const DummyArgument &) const;
   static std::optional<DummyArgument> Characterize(
       const semantics::Symbol &, const IntrinsicProcTable &);

--- a/lib/evaluate/traverse.h
+++ b/lib/evaluate/traverse.h
@@ -38,8 +38,6 @@
 //   expression leaf nodes.  They invoke the visitor's operator() for the
 //   subtrees of interior nodes, and the visitor's Combine() to merge their
 //   results together.
-// - The default operator() inherited into each visitor just reflects right
-//   back into Traverse<> to descend into subtrees.
 // - Overloads of operator() in each visitor handle the cases of interest.
 
 #include "expression.h"

--- a/lib/semantics/assignment.h
+++ b/lib/semantics/assignment.h
@@ -18,6 +18,7 @@
 #include "semantics.h"
 #include "../common/indirection.h"
 #include "../evaluate/expression.h"
+#include <string>
 
 namespace Fortran::parser {
 template<typename> struct Statement;
@@ -32,11 +33,18 @@ struct ForallStmt;
 struct ForallConstruct;
 }
 
+namespace Fortran::evaluate::characteristics {
+struct DummyDataObject;
+}
+
 namespace Fortran::evaluate {
 class IntrinsicProcTable;
 void CheckPointerAssignment(parser::ContextualMessages &,
-    const IntrinsicProcTable &, const Symbol &lhs,
-    const evaluate::Expr<evaluate::SomeType> &rhs);
+    const IntrinsicProcTable &, const Symbol &lhs, const Expr<SomeType> &rhs);
+void CheckPointerAssignment(parser::ContextualMessages &,
+    const IntrinsicProcTable &, parser::CharBlock source,
+    const std::string &description, const characteristics::DummyDataObject &,
+    const Expr<SomeType> &rhs);
 }
 
 namespace Fortran::semantics {

--- a/lib/semantics/check-declarations.cc
+++ b/lib/semantics/check-declarations.cc
@@ -138,7 +138,7 @@ void CheckHelper::Check(const Symbol &symbol) {
           "An assumed-length CHARACTER(*) function cannot be ELEMENTAL"_err_en_US);
     }
     if (const Symbol * result{FindFunctionResult(symbol)}) {
-      if (result->attrs().test(Attr::POINTER)) {
+      if (IsPointer(*result)) {
         messages_.Say(
             "An assumed-length CHARACTER(*) function cannot return a POINTER"_err_en_US);
       }
@@ -175,6 +175,10 @@ void CheckHelper::Check(const Symbol &symbol) {
   }
   if (symbol.attrs().test(Attr::VALUE)) {
     CheckValue(symbol, derived);
+  }
+  if (symbol.attrs().test(Attr::CONTIGUOUS) && IsPointer(symbol) &&
+      symbol.Rank() == 0) {  // C830
+    messages_.Say("CONTIGUOUS POINTER must be an array"_err_en_US);
   }
 }
 

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -178,6 +178,7 @@ set(ERROR_TESTS
   call04.f90
   call05.f90
   call06.f90
+  call07.f90
   call13.f90
   call14.f90
   misc-declarations.f90

--- a/test/semantics/call07.f90
+++ b/test/semantics/call07.f90
@@ -15,6 +15,7 @@
 ! Test 15.5.2.7 constraints and restrictions for POINTER dummy arguments.
 
 module m
+  real :: coarray(10)[*]
  contains
 
   subroutine s01(p)
@@ -28,27 +29,27 @@ module m
   end subroutine
 
   subroutine test
-    !ERROR: CONTIGUOUS pointer must be an array
+    !ERROR: CONTIGUOUS POINTER must be an array
     real, pointer, contiguous :: a01 ! C830
     real, pointer :: a02(:)
     real, target :: a03(10)
     real :: a04(10) ! not TARGET
     call s01(a03) ! ok
-    !ERROR: Effective argument associated with CONTIGUOUS POINTER dummy argument must be simply contiguous
+    !ERROR: Actual argument associated with CONTIGUOUS POINTER dummy argument 'p=' must be simply contiguous
     call s01(a02)
-    !ERROR: Effective argument associated with CONTIGUOUS POINTER dummy argument must be simply contiguous
+    !ERROR: Actual argument associated with CONTIGUOUS POINTER dummy argument 'p=' must be simply contiguous
     call s01(a03(::2))
-    !ERROR: Effective argument associated with CONTIGUOUS POINTER dummy argument must be simply contiguous
-    call s01(a03([1,2,4]))
     call s02(a02) ! ok
     call s03(a03) ! ok
-    !ERROR: Effective argument associated with POINTER dummy argument must be POINTER unless INTENT(IN)
+    !ERROR: Actual argument associated with POINTER dummy argument 'p=' must also be POINTER unless INTENT(IN)
     call s02(a03)
-    !ERROR: Effective argument associated with POINTER INTENT(IN) dummy argument must be a valid target if not a POINTER
+    !ERROR: An array section with a vector subscript may not be a pointer target
     call s03(a03([1,2,4]))
-    !ERROR: Effective argument associated with POINTER INTENT(IN) dummy argument must be a valid target if not a POINTER
+    !ERROR: A coindexed object may not be a pointer target
+    call s03(coarray(:)[1])
+    !ERROR: Target associated with dummy argument 'p=' must be a designator or a call to a pointer-valued function
     call s03([1.])
-    !ERROR: Effective argument associated with POINTER INTENT(IN) dummy argument must be a valid target if not a POINTER
+    !ERROR: In assignment to object dummy argument 'p=', the target 'a04' is not an object with POINTER or TARGET attributes
     call s03(a04)
   end subroutine
 end module

--- a/test/semantics/null01.f90
+++ b/test/semantics/null01.f90
@@ -75,16 +75,16 @@ subroutine test
   dt0x = dt0(ip0=null(ip0))
   dt0x = dt0(ip0=null(mold=ip0))
   !ERROR: TARGET type 'Real(4)' is not compatible with POINTER type 'Integer(4)'
-  !ERROR: Pointer 'ip0' was assigned the result of a reference to function 'null' whose pointer result has an incompatible type or shape
+  !ERROR: pointer 'ip0' is associated with the result of a reference to function 'null' whose pointer result has an incompatible type or shape
   dt0x = dt0(ip0=null(mold=rp0))
   !ERROR: TARGET type 'Real(4)' is not compatible with POINTER type 'Integer(4)'
-  !ERROR: Pointer 'ip1' was assigned the result of a reference to function 'null' whose pointer result has an incompatible type or shape
+  !ERROR: pointer 'ip1' is associated with the result of a reference to function 'null' whose pointer result has an incompatible type or shape
   dt1x = dt1(ip1=null(mold=rp1))
   dt2x = dt2(pps0=null())
   dt2x = dt2(pps0=null(mold=dt2x%pps0))
-  !ERROR: Procedure pointer 'pps0' assigned with result of reference to function 'null' that is an incompatible procedure pointer
+  !ERROR: Procedure pointer 'pps0' associated with result of reference to function 'null' that is an incompatible procedure pointer
   dt2x = dt2(pps0=null(mold=dt3x%pps1))
-  !ERROR: Procedure pointer 'pps1' assigned with result of reference to function 'null' that is an incompatible procedure pointer
+  !ERROR: Procedure pointer 'pps1' associated with result of reference to function 'null' that is an incompatible procedure pointer
   dt3x = dt3(pps1=null(mold=dt2x%pps0))
   dt3x = dt3(pps1=null(mold=dt3x%pps1))
 end subroutine test


### PR DESCRIPTION
More semantics checking for procedure references.  These checks are for `POINTER` dummy arguments when the corresponding actual argument is not a pointer.  The implementation of the checks reuses code for semantic analysis of pointer assignment statements, after generalizing it a bit.