### PR TITLE
Resolve extended intrinsic operators

### DIFF
--- a/lib/common/CMakeLists.txt
+++ b/lib/common/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 add_library(FortranCommon
+  Fortran.cc
   default-kinds.cc
   idioms.cc
 )

--- a/lib/common/Fortran.cc
+++ b/lib/common/Fortran.cc
@@ -1,0 +1,56 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Fortran.h"
+
+namespace Fortran::common {
+
+const char *AsFortran(NumericOperator opr) {
+  switch (opr) {
+    SWITCH_COVERS_ALL_CASES
+  case NumericOperator::Power: return "**";
+  case NumericOperator::Multiply: return "*";
+  case NumericOperator::Divide: return "/";
+  case NumericOperator::Add: return "+";
+  case NumericOperator::Subtract: return "-";
+  }
+}
+
+const char *AsFortran(LogicalOperator opr) {
+  switch (opr) {
+    SWITCH_COVERS_ALL_CASES
+  case LogicalOperator::And: return ".and.";
+  case LogicalOperator::Or: return ".or.";
+  case LogicalOperator::Eqv: return ".eqv.";
+  case LogicalOperator::Neqv: return ".neqv.";
+  }
+}
+
+const char *AsFortran(RelationalOperator opr) {
+  return *AllFortranNames(opr).begin();
+}
+
+std::initializer_list<const char *> AllFortranNames(RelationalOperator opr) {
+  switch (opr) {
+    SWITCH_COVERS_ALL_CASES
+  case RelationalOperator::LT: return {"<", ".lt."};
+  case RelationalOperator::LE: return {"<=", ".le."};
+  case RelationalOperator::EQ: return {"==", ".eq."};
+  case RelationalOperator::NE: return {"/=", ".ne.", "<>"};
+  case RelationalOperator::GE: return {">=", ".ge."};
+  case RelationalOperator::GT: return {">", ".gt."};
+  }
+}
+
+}

--- a/lib/common/Fortran.h
+++ b/lib/common/Fortran.h
@@ -20,6 +20,7 @@
 
 #include "idioms.h"
 #include <cinttypes>
+#include <initializer_list>
 
 namespace Fortran::common {
 
@@ -37,7 +38,16 @@ ENUM_CLASS(ImportKind, Default, Only, None, All)
 // The attribute on a type parameter can be KIND or LEN.
 ENUM_CLASS(TypeParamAttr, Kind, Len)
 
+ENUM_CLASS(NumericOperator, Power, Multiply, Divide, Add, Subtract)
+const char *AsFortran(NumericOperator);
+
+ENUM_CLASS(LogicalOperator, And, Or, Eqv, Neqv)
+const char *AsFortran(LogicalOperator);
+
 ENUM_CLASS(RelationalOperator, LT, LE, EQ, NE, GE, GT)
+const char *AsFortran(RelationalOperator);
+// Map EQ to {"==", ".eq."}, for example.
+std::initializer_list<const char *> AllFortranNames(RelationalOperator);
 
 ENUM_CLASS(Intent, Default, In, Out, InOut)
 

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -41,6 +41,7 @@
 
 namespace Fortran::evaluate {
 
+using common::LogicalOperator;
 using common::RelationalOperator;
 
 // Expressions are represented by specializations of the class template Expr.
@@ -387,8 +388,6 @@ struct Concat
   using Base::Base;
   static const char *Infix() { return "//"; }
 };
-
-ENUM_CLASS(LogicalOperator, And, Or, Eqv, Neqv)
 
 template<int KIND>
 struct LogicalOperation

--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -204,12 +204,11 @@ static constexpr Precedence GetPrecedence(const Expr<T> &expr) {
         if constexpr (prec == Precedence::Or) {
           // Distinguish the four logical binary operations.
           switch (x.logicalOperator) {
+            SWITCH_COVERS_ALL_CASES
           case LogicalOperator::And: return Precedence::And;
           case LogicalOperator::Or: return Precedence::Or;
           case LogicalOperator::Eqv:
-          case LogicalOperator::Neqv:
-            return Precedence::Equivalence;
-            CRASH_NO_CASE;
+          case LogicalOperator::Neqv: return Precedence::Equivalence;
           }
         }
         return prec;
@@ -282,15 +281,7 @@ std::ostream &Convert<TO, FROMCAT>::AsFortran(std::ostream &o) const {
 }
 
 template<typename A> const char *Relational<A>::Infix() const {
-  switch (opr) {
-  case RelationalOperator::LT: return "<";
-  case RelationalOperator::LE: return "<=";
-  case RelationalOperator::EQ: return "==";
-  case RelationalOperator::NE: return "/=";
-  case RelationalOperator::GE: return ">=";
-  case RelationalOperator::GT: return ">";
-  }
-  return nullptr;
+  return common::AsFortran(opr);
 }
 
 std::ostream &Relational<SomeType>::AsFortran(std::ostream &o) const {
@@ -299,13 +290,7 @@ std::ostream &Relational<SomeType>::AsFortran(std::ostream &o) const {
 }
 
 template<int KIND> const char *LogicalOperation<KIND>::Infix() const {
-  switch (logicalOperator) {
-  case LogicalOperator::And: return ".and.";
-  case LogicalOperator::Or: return ".or.";
-  case LogicalOperator::Eqv: return ".eqv.";
-  case LogicalOperator::Neqv: return ".neqv.";
-  }
-  return nullptr;
+  return AsFortran(logicalOperator);
 }
 
 template<typename T>

--- a/lib/evaluate/tools.cc
+++ b/lib/evaluate/tools.cc
@@ -287,21 +287,21 @@ std::optional<Expr<SomeType>> NumericOperation(
             return Package(PromoteAndCombine<OPR, TypeCategory::Complex>(
                 std::move(zx), std::move(zy)));
           },
-          [&](Expr<SomeComplex> &&zx, Expr<SomeInteger> &&zy) {
+          [&](Expr<SomeComplex> &&zx, Expr<SomeInteger> &&iy) {
             return MixedComplexLeft<OPR>(
-                messages, std::move(zx), std::move(zy), defaultRealKind);
+                messages, std::move(zx), std::move(iy), defaultRealKind);
           },
-          [&](Expr<SomeComplex> &&zx, Expr<SomeReal> &&zy) {
+          [&](Expr<SomeComplex> &&zx, Expr<SomeReal> &&ry) {
             return MixedComplexLeft<OPR>(
-                messages, std::move(zx), std::move(zy), defaultRealKind);
+                messages, std::move(zx), std::move(ry), defaultRealKind);
           },
-          [&](Expr<SomeInteger> &&zx, Expr<SomeComplex> &&zy) {
+          [&](Expr<SomeInteger> &&ix, Expr<SomeComplex> &&zy) {
             return MixedComplexRight<OPR>(
-                messages, std::move(zx), std::move(zy), defaultRealKind);
+                messages, std::move(ix), std::move(zy), defaultRealKind);
           },
-          [&](Expr<SomeReal> &&zx, Expr<SomeComplex> &&zy) {
+          [&](Expr<SomeReal> &&rx, Expr<SomeComplex> &&zy) {
             return MixedComplexRight<OPR>(
-                messages, std::move(zx), std::move(zy), defaultRealKind);
+                messages, std::move(rx), std::move(zy), defaultRealKind);
           },
           // Operations with one typeless operand
           [&](BOZLiteralConstant &&bx, Expr<SomeInteger> &&iy) {
@@ -495,17 +495,7 @@ std::optional<Expr<LogicalResult>> Relate(parser::ContextualMessages &messages,
           },
           // Default case
           [&](auto &&, auto &&) {
-            // TODO: defined operator
-            auto xtype{x.GetType()};
-            auto ytype{y.GetType()};
-            if (xtype.has_value() && ytype.has_value()) {
-              messages.Say(
-                  "Relational operands do not have comparable types (%s vs. %s)"_err_en_US,
-                  xtype->AsFortran(), ytype->AsFortran());
-            } else {
-              messages.Say(
-                  "Relational operands do not have comparable types"_err_en_US);
-            }
+            DIE("invalid types for relational operator");
             return std::optional<Expr<LogicalResult>>{};
           },
       },

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -311,6 +311,8 @@ private:
   MaybeExpr TopLevelChecks(DataRef &&);
   std::optional<Expr<SubscriptInteger>> GetSubstringBound(
       const std::optional<parser::ScalarIntExpr> &);
+  MaybeExpr AnalyzeDefinedOp(
+      parser::Messages &, const parser::Name &, ActualArguments &&);
 
   struct CalleeAndArguments {
     ProcedureDesignator procedureDesignator;
@@ -344,6 +346,7 @@ private:
   FoldingContext &foldingContext_{context_.foldingContext()};
   std::map<parser::CharBlock, int> acImpliedDos_;  // values are INTEGER kinds
   bool fatalErrors_{false};
+  friend class ArgumentAnalyzer;
 };
 
 template<typename L, typename R>

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -99,6 +99,7 @@ set(ERROR_TESTS
   resolve60.f90
   resolve61.f90
   resolve62.f90
+  resolve63.f90
   stop01.f90
   structconst01.f90
   structconst02.f90
@@ -246,6 +247,7 @@ set(MODFILE_TESTS
   modfile30.f90
   modfile31.f90
   modfile32.f90
+  modfile33.f90
 )
 
 set(LABEL_TESTS

--- a/test/semantics/modfile33.f90
+++ b/test/semantics/modfile33.f90
@@ -1,0 +1,597 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Resolution of user-defined operators in expressions.
+! Test by using generic function in a specification expression that needs
+! to be written to a .mod file.
+
+! Numeric operators
+module m1
+  type :: t
+    sequence
+  end type
+  interface operator(+)
+    pure integer(8) function add_ll(x, y)
+      logical, intent(in) :: x, y
+    end
+    pure integer(8) function add_li(x, y)
+      logical, intent(in) :: x
+      integer, intent(in) :: y
+    end
+    pure integer(8) function add_tt(x, y)
+      import :: t
+      type(t), intent(in) :: x, y
+    end
+  end interface
+  interface operator(/)
+    pure integer(8) function div_tz(x, y)
+      import :: t
+      type(t), intent(in) :: x
+      complex, intent(in) :: y
+    end
+    pure integer(8) function div_ct(x, y)
+      import :: t
+      character(10), intent(in) :: x
+      type(t), intent(in) :: y
+    end
+  end interface
+contains
+  subroutine s1(x, y, z)
+    logical :: x, y
+    real :: z(x + y)  ! resolves to add_ll
+  end
+  subroutine s2(x, y, z)
+    logical :: x
+    integer :: y
+    real :: z(x + y)  ! resolves to add_li
+  end
+  subroutine s3(x, y, z)
+    type(t) :: x
+    complex :: y
+    real :: z(x / y)  ! resolves to div_tz
+  end
+  subroutine s4(x, y, z)
+    character(10) :: x
+    type(t) :: y
+    real :: z(x / y)  ! resolves to div_ct
+  end
+end
+
+!Expect: m1.mod
+!module m1
+! type :: t
+!  sequence
+! end type
+! interface operator(+)
+!  procedure :: add_ll
+!  procedure :: add_li
+!  procedure :: add_tt
+! end interface
+! interface
+!  pure function add_ll(x, y)
+!   logical(4), intent(in) :: x
+!   logical(4), intent(in) :: y
+!   integer(8) :: add_ll
+!  end
+! end interface
+! interface
+!  pure function add_li(x, y)
+!   logical(4), intent(in) :: x
+!   integer(4), intent(in) :: y
+!   integer(8) :: add_li
+!  end
+! end interface
+! interface
+!  pure function add_tt(x, y)
+!   import :: t
+!   type(t), intent(in) :: x
+!   type(t), intent(in) :: y
+!   integer(8) :: add_tt
+!  end
+! end interface
+! interface operator(/)
+!  procedure :: div_tz
+!  procedure :: div_ct
+! end interface
+! interface
+!  pure function div_tz(x, y)
+!   import :: t
+!   type(t), intent(in) :: x
+!   complex(4), intent(in) :: y
+!   integer(8) :: div_tz
+!  end
+! end interface
+! interface
+!  pure function div_ct(x, y)
+!   import :: t
+!   character(10_4, 1), intent(in) :: x
+!   type(t), intent(in) :: y
+!   integer(8) :: div_ct
+!  end
+! end interface
+!contains
+! subroutine s1(x, y, z)
+!  logical(4) :: x
+!  logical(4) :: y
+!  real(4) :: z(1_8:add_ll(x, y))
+! end
+! subroutine s2(x, y, z)
+!  logical(4) :: x
+!  integer(4) :: y
+!  real(4) :: z(1_8:add_li(x, y))
+! end
+! subroutine s3(x, y, z)
+!  type(t) :: x
+!  complex(4) :: y
+!  real(4) :: z(1_8:div_tz(x, y))
+! end
+! subroutine s4(x, y, z)
+!  character(10_4, 1) :: x
+!  type(t) :: y
+!  real(4) :: z(1_8:div_ct(x, y))
+! end
+!end
+
+! Logical operators
+module m2
+  type :: t
+    sequence
+  end type
+  interface operator(.And.)
+    pure integer(8) function and_ti(x, y)
+      import :: t
+      type(t), intent(in) :: x
+      integer, intent(in) :: y
+    end
+    pure integer(8) function and_li(x, y)
+      logical, intent(in) :: x
+      integer, intent(in) :: y
+    end
+    pure integer(8) function and_tt(x, y)
+      import :: t
+      type(t), intent(in) :: x, y
+    end
+  end interface
+contains
+  subroutine s1(x, y, z)
+    type(t) :: x
+    integer :: y
+    real :: z(x .and. y)  ! resolves to and_ti
+  end
+  subroutine s2(x, y, z)
+    logical :: x
+    integer :: y
+    real :: z(x .and. y)  ! resolves to and_li
+  end
+  subroutine s3(x, y, z)
+    type(t) :: x, y
+    real :: z(x .and. y)  ! resolves to and_tt
+  end
+end
+
+!Expect: m2.mod
+!module m2
+! type :: t
+!  sequence
+! end type
+! interface operator( .and.)
+!  procedure :: and_ti
+!  procedure :: and_li
+!  procedure :: and_tt
+! end interface
+! interface
+!  pure function and_ti(x, y)
+!   import :: t
+!   type(t), intent(in) :: x
+!   integer(4), intent(in) :: y
+!   integer(8) :: and_ti
+!  end
+! end interface
+! interface
+!  pure function and_li(x, y)
+!   logical(4), intent(in) :: x
+!   integer(4), intent(in) :: y
+!   integer(8) :: and_li
+!  end
+! end interface
+! interface
+!  pure function and_tt(x, y)
+!   import :: t
+!   type(t), intent(in) :: x
+!   type(t), intent(in) :: y
+!   integer(8) :: and_tt
+!  end
+! end interface
+!contains
+! subroutine s1(x, y, z)
+!  type(t) :: x
+!  integer(4) :: y
+!  real(4) :: z(1_8:and_ti(x, y))
+! end
+! subroutine s2(x, y, z)
+!  logical(4) :: x
+!  integer(4) :: y
+!  real(4) :: z(1_8:and_li(x, y))
+! end
+! subroutine s3(x, y, z)
+!  type(t) :: x
+!  type(t) :: y
+!  real(4) :: z(1_8:and_tt(x, y))
+! end
+!end
+
+! Relational operators
+module m3
+  type :: t
+    sequence
+  end type
+  interface operator(<>)
+    pure integer(8) function ne_it(x, y)
+      import :: t
+      integer, intent(in) :: x
+      type(t), intent(in) :: y
+    end
+  end interface
+  interface operator(/=)
+    pure integer(8) function ne_tt(x, y)
+      import :: t
+      type(t), intent(in) :: x, y
+    end
+  end interface
+  interface operator(.ne.)
+    pure integer(8) function ne_ci(x, y)
+      character(len=*), intent(in) :: x
+      integer, intent(in) :: y
+    end
+  end interface
+contains
+  subroutine s1(x, y, z)
+    integer :: x
+    type(t) :: y
+    real :: z(x /= y)  ! resolves to ne_it
+  end
+  subroutine s2(x, y, z)
+    type(t) :: x
+    type(t) :: y
+    real :: z(x .ne. y)  ! resolves to ne_tt
+  end
+  subroutine s3(x, y, z)
+    character(len=*) :: x
+    integer :: y
+    real :: z(x <> y)  ! resolves to ne_ci
+  end
+end
+
+!Expect: m3.mod
+!module m3
+! type :: t
+!  sequence
+! end type
+! interface operator(<>)
+!  procedure :: ne_it
+!  procedure :: ne_tt
+!  procedure :: ne_ci
+! end interface
+! interface
+!  pure function ne_it(x, y)
+!   import :: t
+!   integer(4), intent(in) :: x
+!   type(t), intent(in) :: y
+!   integer(8) :: ne_it
+!  end
+! end interface
+! interface
+!  pure function ne_tt(x, y)
+!   import :: t
+!   type(t), intent(in) :: x
+!   type(t), intent(in) :: y
+!   integer(8) :: ne_tt
+!  end
+! end interface
+! interface
+!  pure function ne_ci(x, y)
+!   character(*, 1), intent(in) :: x
+!   integer(4), intent(in) :: y
+!   integer(8) :: ne_ci
+!  end
+! end interface
+!contains
+! subroutine s1(x, y, z)
+!  integer(4) :: x
+!  type(t) :: y
+!  real(4) :: z(1_8:ne_it(x, y))
+! end
+! subroutine s2(x, y, z)
+!  type(t) :: x
+!  type(t) :: y
+!  real(4) :: z(1_8:ne_tt(x, y))
+! end
+! subroutine s3(x, y, z)
+!  character(*, 1) :: x
+!  integer(4) :: y
+!  real(4) :: z(1_8:ne_ci(x, y))
+! end
+!end
+
+! Concatenation
+module m4
+  type :: t
+    sequence
+  end type
+  interface operator(//)
+    pure integer(8) function concat_12(x, y)
+      character(len=*,kind=1), intent(in) :: x
+      character(len=*,kind=2), intent(in) :: y
+    end
+    pure integer(8) function concat_int_real(x, y)
+      integer, intent(in) :: x
+      real, intent(in) :: y
+    end
+  end interface
+contains
+  subroutine s1(x, y, z)
+    character(len=*,kind=1) :: x
+    character(len=*,kind=2) :: y
+    real :: z(x // y)  ! resolves to concat_12
+  end
+  subroutine s2(x, y, z)
+    integer :: x
+    real :: y
+    real :: z(x // y)  ! resolves to concat_int_real
+  end
+end
+!Expect: m4.mod
+!module m4
+! type :: t
+!  sequence
+! end type
+! interface operator(//)
+!  procedure :: concat_12
+!  procedure :: concat_int_real
+! end interface
+! interface
+!  pure function concat_12(x, y)
+!   character(*, 1), intent(in) :: x
+!   character(*, 2), intent(in) :: y
+!   integer(8) :: concat_12
+!  end
+! end interface
+! interface
+!  pure function concat_int_real(x, y)
+!   integer(4), intent(in) :: x
+!   real(4), intent(in) :: y
+!   integer(8) :: concat_int_real
+!  end
+! end interface
+!contains
+! subroutine s1(x, y, z)
+!  character(*, 1) :: x
+!  character(*, 2) :: y
+!  real(4) :: z(1_8:concat_12(x, y))
+! end
+! subroutine s2(x, y, z)
+!  integer(4) :: x
+!  real(4) :: y
+!  real(4) :: z(1_8:concat_int_real(x, y))
+! end
+!end
+
+! Unary operators
+module m5
+  type :: t
+  end type
+  interface operator(+)
+    pure integer(8) function plus_l(x)
+      logical, intent(in) :: x
+    end
+  end interface
+  interface operator(-)
+    pure integer(8) function minus_t(x)
+      import :: t
+      type(t), intent(in) :: x
+    end
+  end interface
+  interface operator(.not.)
+    pure integer(8) function not_t(x)
+      import :: t
+      type(t), intent(in) :: x
+    end
+    pure integer(8) function not_real(x)
+      real, intent(in) :: x
+    end
+  end interface
+contains
+  subroutine s1(x, y)
+    logical :: x
+    real :: y(+x)  ! resolves_to plus_l
+  end
+  subroutine s2(x, y)
+    type(t) :: x
+    real :: y(-x)  ! resolves_to minus_t
+  end
+  subroutine s3(x, y)
+    type(t) :: x
+    real :: y(.not. x)  ! resolves to not_t
+  end
+  subroutine s4(x, y)
+    real :: y(.not. x)  ! resolves to not_real
+  end
+end
+
+!Expect: m5.mod
+!module m5
+! type :: t
+! end type
+! interface operator(+)
+!  procedure :: plus_l
+! end interface
+! interface
+!  pure function plus_l(x)
+!   logical(4), intent(in) :: x
+!   integer(8) :: plus_l
+!  end
+! end interface
+! interface operator(-)
+!  procedure :: minus_t
+! end interface
+! interface
+!  pure function minus_t(x)
+!   import :: t
+!   type(t), intent(in) :: x
+!   integer(8) :: minus_t
+!  end
+! end interface
+! interface operator( .not.)
+!  procedure :: not_t
+!  procedure :: not_real
+! end interface
+! interface
+!  pure function not_t(x)
+!   import :: t
+!   type(t), intent(in) :: x
+!   integer(8) :: not_t
+!  end
+! end interface
+! interface
+!  pure function not_real(x)
+!   real(4), intent(in) :: x
+!   integer(8) :: not_real
+!  end
+! end interface
+!contains
+! subroutine s1(x, y)
+!  logical(4) :: x
+!  real(4) :: y(1_8:plus_l(x))
+! end
+! subroutine s2(x, y)
+!  type(t) :: x
+!  real(4) :: y(1_8:minus_t(x))
+! end
+! subroutine s3(x, y)
+!  type(t) :: x
+!  real(4) :: y(1_8:not_t(x))
+! end
+! subroutine s4(x, y)
+!  real(4) :: x
+!  real(4) :: y(1_8:not_real(x))
+! end
+!end
+
+! Resolved based on shape
+module m6
+  interface operator(+)
+    pure integer(8) function add(x, y)
+      real, intent(in) :: x(:, :)
+      real, intent(in) :: y(:, :, :)
+    end
+  end interface
+contains
+  subroutine s1(n, x, y, z, a, b)
+    integer(8) :: n
+    real :: x
+    real :: y(4, n)
+    real :: z(2, 2, 2)
+    real :: a(size(x+y))  ! intrinsic +
+    real :: b(y+z)  ! resolves to add
+  end
+end
+
+!Expect: m6.mod
+!module m6
+! interface operator(+)
+!  procedure :: add
+! end interface
+! interface
+!  pure function add(x, y)
+!   real(4), intent(in) :: x(:, :)
+!   real(4), intent(in) :: y(:, :, :)
+!   integer(8) :: add
+!  end
+! end interface
+!contains
+! subroutine s1(n, x, y, z, a, b)
+!  integer(8) :: n
+!  real(4) :: x
+!  real(4) :: y(1_8:4_8, 1_8:n)
+!  real(4) :: z(1_8:2_8, 1_8:2_8, 1_8:2_8)
+!  real(4) :: a(1_8:4_8*(n-1_8+1_8))
+!  real(4) :: b(1_8:add(y, z))
+! end
+!end
+
+! Parameterized derived type
+module m7
+  type :: t(k)
+    integer, kind :: k
+    real(k) :: a
+  end type
+  interface operator(+)
+    pure integer(8) function f1(x, y)
+      import :: t
+      type(t(4)), intent(in) :: x, y
+    end
+    pure integer(8) function f2(x, y)
+      import :: t
+      type(t(8)), intent(in) :: x, y
+    end
+  end interface
+contains
+  subroutine s1(x, y, z)
+    type(t(4)) :: x, y
+    real :: z(x + y)  ! resolves to f1
+  end
+  subroutine s2(x, y, z)
+    type(t(8)) :: x, y
+    real :: z(x + y)  ! resolves to f2
+  end
+end
+
+!Expect: m7.mod
+!module m7
+! type :: t(k)
+!  integer(4), kind :: k
+!  real(int(k, kind=8)) :: a
+! end type
+! interface operator(+)
+!  procedure :: f1
+!  procedure :: f2
+! end interface
+! interface
+!  pure function f1(x, y)
+!   import :: t
+!   type(t(k=4_4)), intent(in) :: x
+!   type(t(k=4_4)), intent(in) :: y
+!   integer(8) :: f1
+!  end
+! end interface
+! interface
+!  pure function f2(x, y)
+!   import :: t
+!   type(t(k=8_4)), intent(in) :: x
+!   type(t(k=8_4)), intent(in) :: y
+!   integer(8) :: f2
+!  end
+! end interface
+!contains
+! subroutine s1(x, y, z)
+!  type(t(k=4_4)) :: x
+!  type(t(k=4_4)) :: y
+!  real(4) :: z(1_8:f1(x, y))
+! end
+! subroutine s2(x, y, z)
+!  type(t(k=8_4)) :: x
+!  type(t(k=8_4)) :: y
+!  real(4) :: z(1_8:f2(x, y))
+! end
+!end

--- a/test/semantics/resolve63.f90
+++ b/test/semantics/resolve63.f90
@@ -1,0 +1,160 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Invalid operand types when user-defined operator is available
+module m1
+  type :: t
+  end type
+  interface operator(==)
+    logical function eq_tt(x, y)
+      import :: t
+      type(t), intent(in) :: x, y
+    end
+  end interface
+  interface operator(+)
+    logical function add_tr(x, y)
+      import :: t
+      type(t), intent(in) :: x
+      real, intent(in) :: y
+    end
+    logical function plus_t(x)
+      import :: t
+      type(t), intent(in) :: x
+    end
+    logical function add_12(x, y)
+      real, intent(in) :: x(:), y(:,:)
+    end
+  end interface
+  interface operator(.and.)
+    logical function and_tr(x, y)
+      import :: t
+      type(t), intent(in) :: x
+      real, intent(in) :: y
+    end
+  end interface
+  interface operator(//)
+    logical function concat_tt(x, y)
+      import :: t
+      type(t), intent(in) :: x, y
+    end
+  end interface
+  interface operator(.not.)
+    logical function not_r(x)
+      real, intent(in) :: x
+    end
+  end interface
+  type(t) :: x, y
+  real :: r
+  logical :: l
+contains
+  subroutine test_relational()
+    l = x == y  !OK
+    l = x .eq. y  !OK
+    !ERROR: No user-defined or intrinsic == operator matches operand types TYPE(t) and REAL(4)
+    l = x == r
+  end
+  subroutine test_numeric()
+    l = x + r  !OK
+    !ERROR: No user-defined or intrinsic + operator matches operand types REAL(4) and TYPE(t)
+    l = r + x
+  end
+  subroutine test_logical()
+    l = x .and. r  !OK
+    !ERROR: No user-defined or intrinsic .AND. operator matches operand types REAL(4) and TYPE(t)
+    l = r .and. x
+  end
+  subroutine test_unary()
+    l = +x  !OK
+    !ERROR: No user-defined or intrinsic + operator matches operand type LOGICAL(4)
+    l = +l
+    l = .not. r  !OK
+    !ERROR: No user-defined or intrinsic .NOT. operator matches operand type TYPE(t)
+    l = .not. x
+  end
+  subroutine test_concat()
+    l = x // y  !OK
+    !ERROR: No user-defined or intrinsic // operator matches operand types TYPE(t) and REAL(4)
+    l = x // r
+  end
+  subroutine test_conformability(x, y)
+    real :: x(10), y(10,10)
+    l = x + y  !OK
+    !ERROR: No user-defined or intrinsic + operator matches rank 2 array of REAL(4) and rank 1 array of REAL(4)
+    l = y + x
+  end
+end
+
+! Invalid operand types when user-defined operator is not available
+module m2
+  type :: t
+  end type
+  type(t) :: x, y
+  real :: r
+  logical :: l
+contains
+  subroutine test_relational()
+    !ERROR: Operands of == must have comparable types; have TYPE(t) and REAL(4)
+    l = x == r
+  end
+  subroutine test_numeric()
+    !ERROR: Operands of + must be numeric; have REAL(4) and TYPE(t)
+    l = r + x
+  end
+  subroutine test_logical()
+    !ERROR: Operands of .AND. must be LOGICAL; have REAL(4) and TYPE(t)
+    l = r .and. x
+  end
+  subroutine test_unary()
+    !ERROR: Operand of unary + must be numeric; have LOGICAL(4)
+    l = +l
+    !ERROR: Operand of .NOT. must be LOGICAL; have TYPE(t)
+    l = .not. x
+  end
+  subroutine test_concat(a, b)
+    character(4,kind=1) :: a
+    character(4,kind=2) :: b
+    character(4) :: c
+    !ERROR: Operands of // must be CHARACTER with the same kind; have CHARACTER(KIND=1) and CHARACTER(KIND=2)
+    c = a // b
+    !ERROR: Operands of // must be CHARACTER with the same kind; have TYPE(t) and REAL(4)
+    l = x // r
+  end
+  subroutine test_conformability(x, y)
+    real :: x(10), y(10,10)
+    !ERROR: Operands of + are not conformable; have rank 2 and rank 1
+    l = y + x
+  end
+end
+
+! Invalid untyped operands: user-defined operator doesn't affect errors
+module m3
+  interface operator(+)
+    logical function add(x, y)
+      logical :: x
+      integer :: y
+    end
+  end interface
+contains
+  subroutine s1(x, y) 
+    logical :: x
+    integer :: y
+    logical :: l
+    y = y + z'1'  !OK
+    y = +z'1'  !OK
+    !ERROR: Operands of + must be numeric; have LOGICAL(4) and untyped
+    y = x + z'1'
+    !ERROR: Operands of /= must have comparable types; have LOGICAL(4) and untyped
+    l = x /= null()
+  end
+end


### PR DESCRIPTION
Enhance `ArgumentAnalyzer` to do most of the work for this.
For each kind of operator that might have a user-defined form we follow
this process:
- analyze the arguments
- if the types and shapes match the intrinsic operator do the usual processing
- otherwise attempt to interpret it as a user-defined operator with `TryDefinedOp`

When we fail to resolve an operator, produce different errors depending
on whether there is a user-defined operator available or not.
If there is, report that neither user-defined nor intrinsic operator
worked. If there is not, describe the rules for the intrinsic operator.
In either case, include the type(s) of the operand(s).

Most of the uses of `ArgumentAnalyzer` are in helper functions that
apply to classes of operators.
For consistency, rename `BinaryOperationHelper` to `NumericBinaryOperator`
and `LogicalHelper` to `LogicalBinaryHelper` and introduce `NumericUnaryHelper`
for unary `+` and `-`.  `.NOT.` and `//` are not implemented in helpers.

Replace `success_` with `fatalErrors_` in `ArgumentAnalyzer` for
consistency with `ExpressionAnalyzer`.

Add `NumericOperator` and `LogicalOperator` enums to `Fortran.h` to go
with `RelationalOperator`. Add `AddFortran` functions to each to convert
to a Fortran source string. `RelationalOperator` also has `AllFortranNames`
because there are multiple names for each operator. This replaces
`LogicalOperator` in `expression.h` and the string representation of
the operators in `formatting.cc`.