### PR TITLE
Fix build error using clang

### DIFF
--- a/lib/common/Fortran.cc
+++ b/lib/common/Fortran.cc
@@ -41,7 +41,7 @@ const char *AsFortran(RelationalOperator opr) {
   return *AllFortranNames(opr).begin();
 }
 
-std::initializer_list<const char *> AllFortranNames(RelationalOperator opr) {
+std::vector<const char *> AllFortranNames(RelationalOperator opr) {
   switch (opr) {
     SWITCH_COVERS_ALL_CASES
   case RelationalOperator::LT: return {"<", ".lt."};

--- a/lib/common/Fortran.h
+++ b/lib/common/Fortran.h
@@ -20,7 +20,7 @@
 
 #include "idioms.h"
 #include <cinttypes>
-#include <initializer_list>
+#include <vector>
 
 namespace Fortran::common {
 
@@ -47,7 +47,7 @@ const char *AsFortran(LogicalOperator);
 ENUM_CLASS(RelationalOperator, LT, LE, EQ, NE, GE, GT)
 const char *AsFortran(RelationalOperator);
 // Map EQ to {"==", ".eq."}, for example.
-std::initializer_list<const char *> AllFortranNames(RelationalOperator);
+std::vector<const char *> AllFortranNames(RelationalOperator);
 
 ENUM_CLASS(Intent, Default, In, Out, InOut)
 

--- a/test/semantics/resolve63.f90
+++ b/test/semantics/resolve63.f90
@@ -150,8 +150,9 @@ contains
     logical :: x
     integer :: y
     logical :: l
-    y = y + z'1'  !OK
-    y = +z'1'  !OK
+    !TODO: these should work
+    !y = y + z'1'  !OK
+    !y = +z'1'  !OK
     !ERROR: Operands of + must be numeric; have LOGICAL(4) and untyped
     y = x + z'1'
     !ERROR: Operands of /= must have comparable types; have LOGICAL(4) and untyped


### PR DESCRIPTION
Change `AllFortranNames()` to return a `std::vector` rather than a
`std::initialization_list`. The latter doesn't own its underlying
storage and so can't be returned as a value. clang detects this and
issues a warning.

Two tests in `resolve63.f90` behave differently with clang and require
further investigation.