### PR TITLE
Changes to check for constraint C1140 --  deallocation of polymorphic entities

### DIFF
--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -17,6 +17,7 @@
 
 #include "scope.h"
 #include "../common/Fortran-features.h"
+#include "symbol.h"
 #include "../evaluate/common.h"
 #include "../evaluate/intrinsics.h"
 #include "../parser/message.h"
@@ -137,6 +138,12 @@ public:
   }
   parser::Message &Say(parser::Message &&msg) {
     return messages_.Say(std::move(msg));
+  }
+  template<typename... A>
+  void SayWithDecl(const Symbol &symbol, const parser::CharBlock &at,
+      parser::MessageFixedText &&msg, A &&... args) {
+    auto &message{Say(at, std::move(msg), args...)};
+    evaluate::AttachDeclaration(&message, &symbol);
   }
 
   const Scope &FindScope(parser::CharBlock) const;

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -142,6 +142,7 @@ set(ERROR_TESTS
   doconcurrent01.f90
   doconcurrent05.f90
   doconcurrent06.f90
+  doconcurrent08.f90
   dosemantics01.f90
   dosemantics02.f90
   dosemantics03.f90

--- a/test/semantics/doconcurrent08.f90
+++ b/test/semantics/doconcurrent08.f90
@@ -1,0 +1,219 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+!
+! C1140 -- A statement that might result in the deallocation of a polymorphic 
+! entity shall not appear within a DO CONCURRENT construct.
+module m1
+  ! Base type with scalar components
+  type :: Base
+    integer :: baseField1
+  end type
+
+  ! Child type so we can allocate polymorphic entities
+  type, extends(Base) :: ChildType
+    integer :: childField
+  end type
+
+  ! Type with a polymorphic, allocatable component
+  type, extends(Base) :: HasAllocPolyType
+    class(Base), allocatable :: allocPolyField
+  end type
+
+  ! Type with a allocatable, coarray component
+  type :: HasAllocCoarrayType
+    type(Base), allocatable, codimension[:] :: allocCoarrayField
+  end type
+
+  ! Type with a polymorphic, allocatable, coarray component
+  type :: HasAllocPolyCoarrayType
+    class(Base), allocatable, codimension[:] :: allocPolyCoarrayField
+  end type
+
+  ! Type with a polymorphic, pointer component
+  type, extends(Base) :: HasPointerPolyType
+    class(Base), pointer :: pointerPolyField
+  end type
+
+  class(Base), allocatable :: baseVar1
+  type(Base) :: baseVar2
+end module m1
+
+subroutine s1()
+  ! Test deallocation of polymorphic entities caused by block exit
+  use m1
+
+  block
+    ! The following should not cause problems
+    integer :: outerInt
+
+    ! The following are OK since they're not in a DO CONCURRENT
+    class(Base), allocatable :: outerAllocatablePolyVar
+    class(Base), allocatable, codimension[:] :: outerAllocatablePolyCoarray
+    type(HasAllocPolyType), allocatable  :: outerAllocatableWithAllocPoly
+    type(HasAllocPolyCoarrayType), allocatable :: outerAllocWithAllocPolyCoarray
+
+    do concurrent (i = 1:10)
+      ! The following should not cause problems
+      block
+        integer, allocatable :: blockInt
+      end block
+      block
+        ! Test polymorphic entities
+        ! OK because it's a pointer to a polymorphic entity
+        class(Base), pointer :: pointerPoly
+
+        ! OK because it's not polymorphic
+        integer, allocatable :: intAllocatable
+
+        ! OK because it's not polymorphic
+        type(Base), allocatable :: allocatableNonPolyBlockVar
+
+        ! Bad because it's polymorphic and allocatable
+        class(Base), allocatable :: allocatablePoly
+
+        ! OK because it has the SAVE attribute
+        class(Base), allocatable, save :: allocatablePolySave
+
+        ! Bad because it's polymorphic and allocatable
+        class(Base), allocatable, codimension[:] :: allocatablePolyCoarray
+
+        ! OK because it's not polymorphic and allocatable
+        type(Base), allocatable, codimension[:] :: allocatableCoarray
+
+        ! Bad because it has a allocatable polymorphic component
+        type(HasAllocPolyType), allocatable  :: allocatableWithAllocPoly
+
+        ! OK because the declared variable is not allocatable
+        type(HasAllocPolyType) :: nonAllocatableWithAllocPoly
+
+        ! OK because the declared variable is not allocatable
+        type(HasAllocPolyCoarrayType) :: nonAllocatableWithAllocPolyCoarray
+
+        ! Bad because even though the declared the allocatable component is a coarray
+        type(HasAllocPolyCoarrayType), allocatable :: allocWithAllocPolyCoarray
+
+        ! OK since it has no polymorphic component
+        type(HasAllocCoarrayType) :: nonAllocWithAllocCoarray
+
+        ! OK since it has no component that's polymorphic, oops
+        type(HasPointerPolyType), allocatable :: allocatableWithPointerPoly
+
+!ERROR: Deallocation of a polymorphic entity caused by block exit not allowed in DO CONCURRENT
+!ERROR: Deallocation of a polymorphic entity caused by block exit not allowed in DO CONCURRENT
+!ERROR: Deallocation of a polymorphic entity caused by block exit not allowed in DO CONCURRENT
+!ERROR: Deallocation of a polymorphic entity caused by block exit not allowed in DO CONCURRENT
+      end block
+    end do
+  end block
+
+end subroutine s1
+
+subroutine s2()
+  ! Test deallocation of a polymorphic entity cause by intrinsic assignment
+  use m1
+
+  class(Base), allocatable :: localVar
+  class(Base), allocatable :: localVar1
+  type(Base), allocatable :: localVar2
+
+  type(HasAllocPolyType), allocatable :: polyComponentVar
+  type(HasAllocPolyType), allocatable :: polyComponentVar1
+
+  type(HasAllocPolyType) :: nonAllocPolyComponentVar
+  type(HasAllocPolyType) :: nonAllocPolyComponentVar1
+  class(HasAllocPolyCoarrayType), allocatable :: allocPolyCoarray
+  class(HasAllocPolyCoarrayType), allocatable :: allocPolyCoarray1
+
+  class(Base), allocatable, codimension[:] :: allocPolyComponentVar
+  class(Base), allocatable, codimension[:] :: allocPolyComponentVar1
+
+  allocate(ChildType :: localVar)
+  allocate(ChildType :: localVar1)
+  allocate(Base :: localVar2)
+  allocate(polyComponentVar)
+  allocate(polyComponentVar1)
+  allocate(allocPolyCoarray)
+  allocate(allocPolyCoarray1)
+
+  ! These are OK because they're not in a DO CONCURRENT
+  localVar = localVar1
+  nonAllocPolyComponentVar = nonAllocPolyComponentVar1
+  polyComponentVar = polyComponentVar1
+  allocPolyCoarray = allocPolyCoarray1
+
+  do concurrent (i = 1:10)
+    ! Test polymorphic entities
+    ! Bad because localVar is allocatable and polymorphic, 10.2.1.3, par. 3
+!ERROR: Deallocation of a polymorphic entity caused by assignment not allowed in DO CONCURRENT
+    localVar = localVar1
+
+    ! The next one should be OK since localVar2 is not polymorphic
+    localVar2 = localVar1
+
+    ! Bad because the copying of the components causes deallocation
+!ERROR: Deallocation of a polymorphic entity caused by assignment not allowed in DO CONCURRENT
+    nonAllocPolyComponentVar = nonAllocPolyComponentVar1
+
+    ! Bad because possible deallocation a variable with a polymorphic component
+!ERROR: Deallocation of a polymorphic entity caused by assignment not allowed in DO CONCURRENT
+    polyComponentVar = polyComponentVar1
+
+    ! Bad because deallocation upon assignment happens with allocatable
+    ! entities, even if they're coarrays.  The noncoarray restriction only
+    ! applies to components
+!ERROR: Deallocation of a polymorphic entity caused by assignment not allowed in DO CONCURRENT
+    allocPolyCoarray = allocPolyCoarray1
+
+  end do
+end subroutine s2
+
+subroutine s3()
+  ! Test direct deallocation
+  use m1
+
+  class(Base), allocatable :: polyVar
+  type(Base), allocatable :: nonPolyVar
+  type(HasAllocPolyType), allocatable :: polyComponentVar
+  type(HasAllocPolyType), pointer :: pointerPolyComponentVar
+
+  allocate(ChildType:: polyVar)
+  allocate(nonPolyVar)
+  allocate(polyComponentVar)
+  allocate(pointerPolyComponentVar)
+
+  ! These are all good because they're not in a do concurrent
+  deallocate(polyVar)
+  allocate(polyVar)
+  deallocate(polyComponentVar)
+  allocate(polyComponentVar)
+  deallocate(pointerPolyComponentVar)
+  allocate(pointerPolyComponentVar)
+
+  do concurrent (i = 1:10)
+    ! Bad because deallocation of a polymorphic entity
+!ERROR: Deallocation of a polymorphic entity not allowed in DO CONCURRENT
+    deallocate(polyVar)
+
+    ! Bad, deallocation of an entity with a polymorphic component
+!ERROR: Deallocation of a polymorphic entity not allowed in DO CONCURRENT
+    deallocate(polyComponentVar)
+
+    ! Bad, deallocation of a pointer to an entity with a polymorphic component
+!ERROR: Deallocation of a polymorphic entity not allowed in DO CONCURRENT
+    deallocate(pointerPolyComponentVar)
+
+    ! Deallocation of a nonpolymorphic entity
+    deallocate(nonPolyVar)
+  end do
+end subroutine s3

--- a/test/semantics/dosemantics05.f90
+++ b/test/semantics/dosemantics05.f90
@@ -62,22 +62,22 @@ subroutine s1()
   
   associate (avar => ivar)
     do concurrent (i = 1:2:0) default(none) shared(jvar) local(kvar)
-!ERROR: Variable 'ivar' from an enclosing scope referenced in a DO CONCURRENT with DEFAULT(NONE) must appear in a locality-spec
+!ERROR: Variable 'ivar' from an enclosing scope referenced in DO CONCURRENT with DEFAULT(NONE) must appear in a locality-spec
       ivar =  &
-!ERROR: Variable 'ivar' from an enclosing scope referenced in a DO CONCURRENT with DEFAULT(NONE) must appear in a locality-spec
+!ERROR: Variable 'ivar' from an enclosing scope referenced in DO CONCURRENT with DEFAULT(NONE) must appear in a locality-spec
         ivar + i
       block
         real :: bvar
-!ERROR: Variable 'avar' from an enclosing scope referenced in a DO CONCURRENT with DEFAULT(NONE) must appear in a locality-spec
+!ERROR: Variable 'avar' from an enclosing scope referenced in DO CONCURRENT with DEFAULT(NONE) must appear in a locality-spec
         avar = 4
-!ERROR: Variable 'x' from an enclosing scope referenced in a DO CONCURRENT with DEFAULT(NONE) must appear in a locality-spec
+!ERROR: Variable 'x' from an enclosing scope referenced in DO CONCURRENT with DEFAULT(NONE) must appear in a locality-spec
         x = 3.5
         bvar = 3.5 + i ! OK, bvar's scope is within the DO CONCURRENT
       end block
       jvar = 5 ! OK, jvar appears in a locality spec
       kvar = 5 ! OK, kvar appears in a locality spec
 
-!ERROR: Variable 'mvar' from an enclosing scope referenced in a DO CONCURRENT with DEFAULT(NONE) must appear in a locality-spec
+!ERROR: Variable 'mvar' from an enclosing scope referenced in DO CONCURRENT with DEFAULT(NONE) must appear in a locality-spec
       mvar = 3.5
     end do
   end associate
@@ -93,7 +93,7 @@ subroutine s1()
   select type ( a => p_or_c )
   type is ( point )
     do concurrent (i=1:5) default (none)
-!ERROR: Variable 'a' from an enclosing scope referenced in a DO CONCURRENT with DEFAULT(NONE) must appear in a locality-spec
+!ERROR: Variable 'a' from an enclosing scope referenced in DO CONCURRENT with DEFAULT(NONE) must appear in a locality-spec
       a%x = 3.5
     end do
   end select


### PR DESCRIPTION
Changes to check for constraint C1140 which prohibits deallocation of 
polymorphic entities in a DO CONCURRENT.  Deallocation can be caused by exiting
from a block where the entity is declared, from an assignment, and from direct
deallocation.

Section 9.7.3.2 specifies the situations that might cause deallocation of a polymorphic entity.  The ones that are applicable to a DO CONCURRENT are exiting from a block that declares such variables, intrinsic assignment, and an actual DEALLOCATE statement.  This section also specifies (paragraph 8) that deallocation of a derived type causes deallocation of all of its allocatable subobjects.

Section 10.2.1.3 specifies what happens during intrinsic assignment.  Paragraph 3 states If the variable is an allocated allocatable variable, it is deallocated if expr is an array of different shape, any corresponding length type parameter values of the variable and expr differ, or the variable is polymorphic and the dynamic type or any corresponding kind type parameter values of the variable and expr differ."  Thus, an allocatable polymorphic variable on the left hand side of an assignment statement gets deallocated.  Paragraph 13 states that "For a noncoarray allocatable component the
following sequence of operations is applied.
(1) If the component of the variable is allocated, it is deallocated."

Thus, a variable on the left-hand side of an assignment statement might have noncorray allocatable components.  Such components will be deallocated.

I added a function to tools.cc to check if a symbol is polymorphic.

I also added a function to check-do.cc to report errors along with a reference
to the declaration of the entity associated with error.  This function allows
for the possibility that the declaration of the entity is in a module.