### PR TITLE
Add support for logical abbreviations and .XOR.

### DIFF
--- a/lib/common/CMakeLists.txt
+++ b/lib/common/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_library(FortranCommon
   Fortran.cc
   default-kinds.cc
+  features.cc
   idioms.cc
 )
 

--- a/lib/common/Fortran.cc
+++ b/lib/common/Fortran.cc
@@ -34,22 +34,19 @@ const char *AsFortran(LogicalOperator opr) {
   case LogicalOperator::Or: return ".or.";
   case LogicalOperator::Eqv: return ".eqv.";
   case LogicalOperator::Neqv: return ".neqv.";
+  case LogicalOperator::Not: return ".not.";
   }
 }
 
 const char *AsFortran(RelationalOperator opr) {
-  return *AllFortranNames(opr).begin();
-}
-
-std::vector<const char *> AllFortranNames(RelationalOperator opr) {
   switch (opr) {
     SWITCH_COVERS_ALL_CASES
-  case RelationalOperator::LT: return {"<", ".lt."};
-  case RelationalOperator::LE: return {"<=", ".le."};
-  case RelationalOperator::EQ: return {"==", ".eq."};
-  case RelationalOperator::NE: return {"/=", ".ne.", "<>"};
-  case RelationalOperator::GE: return {">=", ".ge."};
-  case RelationalOperator::GT: return {">", ".gt."};
+  case RelationalOperator::LT: return "<";
+  case RelationalOperator::LE: return "<=";
+  case RelationalOperator::EQ: return "==";
+  case RelationalOperator::NE: return "/=";
+  case RelationalOperator::GE: return ">=";
+  case RelationalOperator::GT: return ">";
   }
 }
 

--- a/lib/common/Fortran.h
+++ b/lib/common/Fortran.h
@@ -41,13 +41,11 @@ ENUM_CLASS(TypeParamAttr, Kind, Len)
 ENUM_CLASS(NumericOperator, Power, Multiply, Divide, Add, Subtract)
 const char *AsFortran(NumericOperator);
 
-ENUM_CLASS(LogicalOperator, And, Or, Eqv, Neqv)
+ENUM_CLASS(LogicalOperator, And, Or, Eqv, Neqv, Not)
 const char *AsFortran(LogicalOperator);
 
 ENUM_CLASS(RelationalOperator, LT, LE, EQ, NE, GE, GT)
 const char *AsFortran(RelationalOperator);
-// Map EQ to {"==", ".eq."}, for example.
-std::vector<const char *> AllFortranNames(RelationalOperator);
 
 ENUM_CLASS(Intent, Default, In, Out, InOut)
 

--- a/lib/common/features.cc
+++ b/lib/common/features.cc
@@ -1,0 +1,63 @@
+// Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "features.h"
+#include "Fortran.h"
+#include "idioms.h"
+
+namespace Fortran::common {
+
+std::vector<const char *> LanguageFeatureControl::GetNames(
+    LogicalOperator opr) const {
+  std::vector<const char *> result;
+  result.push_back(AsFortran(opr));
+  if (opr == LogicalOperator::Neqv && IsEnabled(LanguageFeature::XOROperator)) {
+    result.push_back(".xor.");
+  }
+  if (IsEnabled(LanguageFeature::LogicalAbbreviations)) {
+    switch (opr) {
+      SWITCH_COVERS_ALL_CASES
+    case LogicalOperator::And: result.push_back(".a."); break;
+    case LogicalOperator::Or: result.push_back(".o."); break;
+    case LogicalOperator::Not: result.push_back(".n."); break;
+    case LogicalOperator::Neqv:
+      if (IsEnabled(LanguageFeature::XOROperator)) {
+        result.push_back(".x.");
+      }
+      break;
+    case LogicalOperator::Eqv: break;
+    }
+  }
+  return result;
+}
+
+std::vector<const char *> LanguageFeatureControl::GetNames(
+    RelationalOperator opr) const {
+  switch (opr) {
+    SWITCH_COVERS_ALL_CASES
+  case RelationalOperator::LT: return {".lt.", "<"};
+  case RelationalOperator::LE: return {".le.", "<="};
+  case RelationalOperator::EQ: return {".eq.", "=="};
+  case RelationalOperator::GE: return {".ge.", ">="};
+  case RelationalOperator::GT: return {".gt.", ">"};
+  case RelationalOperator::NE:
+    if (IsEnabled(LanguageFeature::AlternativeNE)) {
+      return {".ne.", "/=", "<>"};
+    } else {
+      return {".ne.", "/="};
+    }
+  }
+}
+
+}

--- a/lib/common/features.h
+++ b/lib/common/features.h
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef FORTRAN_PARSER_FEATURES_H_
-#define FORTRAN_PARSER_FEATURES_H_
+#ifndef FORTRAN_COMMON_FEATURES_H_
+#define FORTRAN_COMMON_FEATURES_H_
 
 #include "../common/enum-set.h"
 #include "../common/idioms.h"
 
-namespace Fortran::parser {
+namespace Fortran::common {
 
 ENUM_CLASS(LanguageFeature, BackslashEscapes, OldDebugLines,
     FixedFormContinuationWithColumn1Ampersand, LogicalAbbreviations,
@@ -64,4 +64,4 @@ private:
   bool warnAll_{false};
 };
 }
-#endif  // FORTRAN_PARSER_FEATURES_H_
+#endif  // FORTRAN_COMMON_FEATURES_H_

--- a/lib/common/features.h
+++ b/lib/common/features.h
@@ -15,8 +15,9 @@
 #ifndef FORTRAN_COMMON_FEATURES_H_
 #define FORTRAN_COMMON_FEATURES_H_
 
-#include "../common/enum-set.h"
-#include "../common/idioms.h"
+#include "Fortran.h"
+#include "enum-set.h"
+#include "idioms.h"
 
 namespace Fortran::common {
 
@@ -34,8 +35,7 @@ ENUM_CLASS(LanguageFeature, BackslashEscapes, OldDebugLines,
     RealDoControls, EquivalenceNumericWithCharacter, AdditionalIntrinsics,
     AnonymousParents, OldLabelDoEndStatements)
 
-using LanguageFeatures =
-    common::EnumSet<LanguageFeature, LanguageFeature_enumSize>;
+using LanguageFeatures = EnumSet<LanguageFeature, LanguageFeature_enumSize>;
 
 class LanguageFeatureControl {
 public:
@@ -57,6 +57,9 @@ public:
   bool ShouldWarn(LanguageFeature f) const {
     return (warnAll_ && f != LanguageFeature::OpenMP) || warn_.test(f);
   }
+  // Return all spellings of operators names, depending on features enabled
+  std::vector<const char *> GetNames(LogicalOperator) const;
+  std::vector<const char *> GetNames(RelationalOperator) const;
 
 private:
   LanguageFeatures disable_;

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -2459,6 +2459,7 @@ Expr<Type<TypeCategory::Logical, KIND>> FoldOperation(
     case LogicalOperator::Or: result = xt || yt; break;
     case LogicalOperator::Eqv: result = xt == yt; break;
     case LogicalOperator::Neqv: result = xt != yt; break;
+    case LogicalOperator::Not: DIE("not a binary operator");
     }
     return Expr<LOGICAL>{Constant<LOGICAL>{result}};
   }

--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -207,6 +207,7 @@ static constexpr Precedence GetPrecedence(const Expr<T> &expr) {
             SWITCH_COVERS_ALL_CASES
           case LogicalOperator::And: return Precedence::And;
           case LogicalOperator::Or: return Precedence::Or;
+          case LogicalOperator::Not: return Precedence::Not;
           case LogicalOperator::Eqv:
           case LogicalOperator::Neqv: return Precedence::Equivalence;
           }

--- a/lib/evaluate/tools.cc
+++ b/lib/evaluate/tools.cc
@@ -504,6 +504,7 @@ std::optional<Expr<LogicalResult>> Relate(parser::ContextualMessages &messages,
 
 Expr<SomeLogical> BinaryLogicalOperation(
     LogicalOperator opr, Expr<SomeLogical> &&x, Expr<SomeLogical> &&y) {
+  CHECK(opr != LogicalOperator::Not);
   return std::visit(
       [=](auto &&xy) {
         using Ty = ResultType<decltype(xy[0])>;

--- a/lib/parser/basic-parsers.h
+++ b/lib/parser/basic-parsers.h
@@ -29,11 +29,11 @@
 // template functions.  See parser-combinators.txt for documentation.
 
 #include "char-block.h"
-#include "features.h"
 #include "message.h"
 #include "parse-state.h"
 #include "provenance.h"
 #include "user-state.h"
+#include "../common/features.h"
 #include "../common/idioms.h"
 #include "../common/indirection.h"
 #include <cstring>

--- a/lib/parser/dump-parse-tree.h
+++ b/lib/parser/dump-parse-tree.h
@@ -269,7 +269,6 @@ public:
   NODE(parser::Expr, OR)
   NODE(parser::Expr, EQV)
   NODE(parser::Expr, NEQV)
-  NODE(parser::Expr, XOR)
   NODE(parser::Expr, DefinedBinary)
   NODE(parser::Expr, ComplexConstructor)
   NODE(parser, External)

--- a/lib/parser/parse-state.h
+++ b/lib/parser/parse-state.h
@@ -22,10 +22,10 @@
 // and recovery during parsing!
 
 #include "characters.h"
-#include "features.h"
 #include "message.h"
 #include "provenance.h"
 #include "user-state.h"
+#include "../common/features.h"
 #include "../common/idioms.h"
 #include <cstddef>
 #include <cstring>
@@ -35,6 +35,8 @@
 #include <utility>
 
 namespace Fortran::parser {
+
+using common::LanguageFeature;
 
 class ParseState {
 public:

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -577,7 +577,7 @@ WRAPPER_CLASS(DefinedOpName, Name);
 struct DefinedOperator {
   UNION_CLASS_BOILERPLATE(DefinedOperator);
   ENUM_CLASS(IntrinsicOperator, Power, Multiply, Divide, Add, Subtract, Concat,
-      LT, LE, EQ, NE, GE, GT, NOT, AND, OR, XOR, EQV, NEQV)
+      LT, LE, EQ, NE, GE, GT, NOT, AND, OR, EQV, NEQV)
   std::variant<DefinedOpName, IntrinsicOperator> u;
 };
 
@@ -1690,9 +1690,6 @@ struct Expr {
   struct NEQV : public IntrinsicBinary {
     using IntrinsicBinary::IntrinsicBinary;
   };
-  struct XOR : public IntrinsicBinary {
-    using IntrinsicBinary::IntrinsicBinary;
-  };
 
   // PGI/XLF extension: (x,y), not both constant
   struct ComplexConstructor : public IntrinsicBinary {
@@ -1720,7 +1717,7 @@ struct Expr {
       LiteralConstant, common::Indirection<Designator>, ArrayConstructor,
       StructureConstructor, common::Indirection<FunctionReference>, Parentheses,
       UnaryPlus, Negate, NOT, PercentLoc, DefinedUnary, Power, Multiply, Divide,
-      Add, Subtract, Concat, LT, LE, EQ, NE, GE, GT, AND, OR, EQV, NEQV, XOR,
+      Add, Subtract, Concat, LT, LE, EQ, NE, GE, GT, AND, OR, EQV, NEQV,
       DefinedBinary, ComplexConstructor>
       u;
 };

--- a/lib/parser/parsing.cc
+++ b/lib/parser/parsing.cc
@@ -93,7 +93,7 @@ const SourceFile *Parsing::Prescan(const std::string &path, Options options) {
 }
 
 void Parsing::DumpCookedChars(std::ostream &out) const {
-  UserState userState{cooked_, LanguageFeatureControl{}};
+  UserState userState{cooked_, common::LanguageFeatureControl{}};
   ParseState parseState{cooked_};
   parseState.set_inFixedForm(options_.isFixedForm).set_userState(&userState);
   while (std::optional<const char *> p{parseState.GetNextChar()}) {

--- a/lib/parser/parsing.h
+++ b/lib/parser/parsing.h
@@ -16,11 +16,11 @@
 #define FORTRAN_PARSER_PARSING_H_
 
 #include "characters.h"
-#include "features.h"
 #include "instrumented-parser.h"
 #include "message.h"
 #include "parse-tree.h"
 #include "provenance.h"
+#include "../common/features.h"
 #include <optional>
 #include <ostream>
 #include <string>
@@ -36,7 +36,7 @@ struct Options {
 
   bool isFixedForm{false};
   int fixedFormColumns{72};
-  LanguageFeatureControl features;
+  common::LanguageFeatureControl features;
   std::vector<std::string> searchDirectories;
   std::vector<Predefinition> predefinitions;
   bool instrumentedParse{false};

--- a/lib/parser/prescan.cc
+++ b/lib/parser/prescan.cc
@@ -27,10 +27,12 @@
 
 namespace Fortran::parser {
 
+using common::LanguageFeature;
+
 static constexpr int maxPrescannerNesting{100};
 
 Prescanner::Prescanner(Messages &messages, CookedSource &cooked,
-    Preprocessor &preprocessor, LanguageFeatureControl lfc)
+    Preprocessor &preprocessor, common::LanguageFeatureControl lfc)
   : messages_{messages}, cooked_{cooked}, preprocessor_{preprocessor},
     features_{lfc}, encoding_{cooked.allSources().encoding()} {}
 

--- a/lib/parser/prescan.h
+++ b/lib/parser/prescan.h
@@ -23,10 +23,10 @@
 // inclusion, and driving the Fortran source preprocessor.
 
 #include "characters.h"
-#include "features.h"
 #include "message.h"
 #include "provenance.h"
 #include "token-sequence.h"
+#include "../common/features.h"
 #include <bitset>
 #include <optional>
 #include <string>
@@ -39,8 +39,8 @@ class Preprocessor;
 
 class Prescanner {
 public:
-  Prescanner(
-      Messages &, CookedSource &, Preprocessor &, LanguageFeatureControl);
+  Prescanner(Messages &, CookedSource &, Preprocessor &,
+      common::LanguageFeatureControl);
   Prescanner(const Prescanner &);
 
   Messages &messages() const { return messages_; }
@@ -145,7 +145,8 @@ private:
     return p[0] == '/' && p[1] == '*' &&
         (inPreprocessorDirective_ ||
             (!inCharLiteral_ &&
-                features_.IsEnabled(LanguageFeature::ClassicCComments)));
+                features_.IsEnabled(
+                    common::LanguageFeature::ClassicCComments)));
   }
 
   void LabelField(TokenSequence &, int outCol = 1);
@@ -184,7 +185,7 @@ private:
   Messages &messages_;
   CookedSource &cooked_;
   Preprocessor &preprocessor_;
-  LanguageFeatureControl features_;
+  common::LanguageFeatureControl features_;
   bool inFixedForm_{false};
   int fixedFormColumnLimit_{72};
   Encoding encoding_{Encoding::UTF_8};

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -834,7 +834,6 @@ public:
   void Unparse(const Expr::OR &x) { Walk(x.t, ".OR."); }
   void Unparse(const Expr::EQV &x) { Walk(x.t, ".EQV."); }
   void Unparse(const Expr::NEQV &x) { Walk(x.t, ".NEQV."); }
-  void Unparse(const Expr::XOR &x) { Walk(x.t, ".XOR."); }
   void Unparse(const Expr::ComplexConstructor &x) {
     Put('('), Walk(x.t, ","), Put(')');
   }

--- a/lib/parser/user-state.h
+++ b/lib/parser/user-state.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,8 +21,8 @@
 // state in static data.
 
 #include "char-block.h"
-#include "features.h"
 #include "parse-tree.h"
+#include "../common/features.h"
 #include "../common/idioms.h"
 #include <cinttypes>
 #include <optional>
@@ -40,11 +40,11 @@ class Success {};  // for when one must return something that's present
 
 class UserState {
 public:
-  UserState(const CookedSource &cooked, LanguageFeatureControl features)
+  UserState(const CookedSource &cooked, common::LanguageFeatureControl features)
     : cooked_{cooked}, features_{features} {}
 
   const CookedSource &cooked() const { return cooked_; }
-  const LanguageFeatureControl &features() const { return features_; }
+  const common::LanguageFeatureControl &features() const { return features_; }
 
   std::ostream *debugOutput() const { return debugOutput_; }
   UserState &set_debugOutput(std::ostream *out) {
@@ -107,7 +107,7 @@ private:
 
   std::set<CharBlock> oldStructureComponents_;
 
-  LanguageFeatureControl features_;
+  common::LanguageFeatureControl features_;
 };
 
 // Definitions of parser classes that manipulate the UserState.

--- a/lib/semantics/check-do.cc
+++ b/lib/semantics/check-do.cc
@@ -353,7 +353,7 @@ private:
 
   void CheckDoControl(const parser::CharBlock &sourceLocation, bool isReal) {
     const bool warn{context_.warnOnNonstandardUsage() ||
-        context_.ShouldWarn(parser::LanguageFeature::RealDoControls)};
+        context_.ShouldWarn(common::LanguageFeature::RealDoControls)};
     if (isReal && !warn) {
       // No messages for the default case
     } else if (isReal && warn) {

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -383,10 +383,10 @@ struct IntTypeVisitor {
         if (T::kind > kind) {
           if (!isDefaultKind ||
               !analyzer.context().IsEnabled(
-                  parser::LanguageFeature::BigIntLiterals)) {
+                  common::LanguageFeature::BigIntLiterals)) {
             return std::nullopt;
           } else if (analyzer.context().ShouldWarn(
-                         parser::LanguageFeature::BigIntLiterals)) {
+                         common::LanguageFeature::BigIntLiterals)) {
             analyzer.Say(digits,
                 "Integer literal is too large for default INTEGER(KIND=%d); "
                 "assuming INTEGER(KIND=%d)"_en_US,
@@ -1345,13 +1345,13 @@ MaybeExpr ExpressionAnalyzer::Analyze(
       // T(1) or T(PT=PT(1)).
       if (nextAnonymous == components.begin() && parentComponent != nullptr &&
           valueType == DynamicType::From(*parentComponent) &&
-          context().IsEnabled(parser::LanguageFeature::AnonymousParents)) {
+          context().IsEnabled(common::LanguageFeature::AnonymousParents)) {
         auto iter{
             std::find(components.begin(), components.end(), *parentComponent)};
         if (iter != components.end()) {
           symbol = parentComponent;
           nextAnonymous = ++iter;
-          if (context().ShouldWarn(parser::LanguageFeature::AnonymousParents)) {
+          if (context().ShouldWarn(common::LanguageFeature::AnonymousParents)) {
             Say(source,
                 "Whole parent component '%s' in structure "
                 "constructor should not be anonymous"_en_US,

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -283,7 +283,6 @@ private:
   MaybeExpr Analyze(const parser::Expr::OR &);
   MaybeExpr Analyze(const parser::Expr::EQV &);
   MaybeExpr Analyze(const parser::Expr::NEQV &);
-  MaybeExpr Analyze(const parser::Expr::XOR &);
   MaybeExpr Analyze(const parser::Expr::DefinedBinary &);
   template<typename A> MaybeExpr Analyze(const A &x) {
     return Analyze(x.u);  // default case

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -759,7 +759,7 @@ Scope *ModFileReader::Read(const SourceName &name, Scope *ancestor) {
   parser::Parsing parsing{context_.allSources()};
   parser::Options options;
   options.isModuleFile = true;
-  options.features.Enable(parser::LanguageFeature::BackslashEscapes);
+  options.features.Enable(common::LanguageFeature::BackslashEscapes);
   options.searchDirectories = context_.searchDirectories();
   auto path{ModFileName(name, ancestorName, context_.moduleFileSuffix())};
   const auto *sourceFile{parsing.Prescan(path, options)};

--- a/lib/semantics/resolve-labels.cc
+++ b/lib/semantics/resolve-labels.cc
@@ -900,7 +900,7 @@ void CheckLabelDoConstraints(const SourceStmtList &dos,
             ParentScope(scopes, doTarget.proxyForScope) == scope)) {
       if (context.warnOnNonstandardUsage() ||
           context.ShouldWarn(
-              parser::LanguageFeature::OldLabelDoEndStatements)) {
+              common::LanguageFeature::OldLabelDoEndStatements)) {
         context
             .Say(position,
                 parser::MessageFormattedText{

--- a/lib/semantics/resolve-names-utils.cc
+++ b/lib/semantics/resolve-names-utils.cc
@@ -16,13 +16,13 @@
 #include "expression.h"
 #include "semantics.h"
 #include "tools.h"
+#include "../common/features.h"
 #include "../common/idioms.h"
 #include "../common/indirection.h"
 #include "../evaluate/fold.h"
 #include "../evaluate/tools.h"
 #include "../evaluate/type.h"
 #include "../parser/char-block.h"
-#include "../parser/features.h"
 #include "../parser/parse-tree.h"
 #include <initializer_list>
 #include <ostream>
@@ -30,6 +30,7 @@
 
 namespace Fortran::semantics {
 
+using common::LanguageFeature;
 using IntrinsicOperator = parser::DefinedOperator::IntrinsicOperator;
 
 static GenericKind MapIntrinsicOperator(IntrinsicOperator);
@@ -64,11 +65,10 @@ bool IsIntrinsicOperator(
   if (intrinsics.count(str) > 0) {
     return true;
   }
-  if (context.IsEnabled(parser::LanguageFeature::XOROperator) &&
-      str == ".xor.") {
+  if (context.IsEnabled(LanguageFeature::XOROperator) && str == ".xor.") {
     return true;
   }
-  if (context.IsEnabled(parser::LanguageFeature::LogicalAbbreviations) &&
+  if (context.IsEnabled(LanguageFeature::LogicalAbbreviations) &&
       (str == ".n." || str == ".a" || str == ".o." || str == ".x.")) {
     return true;
   }
@@ -79,7 +79,7 @@ bool IsLogicalConstant(
     const SemanticsContext &context, const SourceName &name) {
   std::string str{name.ToString()};
   return str == ".true." || str == ".false." ||
-      (context.IsEnabled(parser::LanguageFeature::LogicalAbbreviations) &&
+      (context.IsEnabled(LanguageFeature::LogicalAbbreviations) &&
           (str == ".t" || str == ".f."));
 }
 
@@ -400,7 +400,7 @@ bool EquivalenceSets::CheckCanEquivalence(
   } else if (isNum1) {
     if (isChar2) {
       if (context_.ShouldWarn(
-              parser::LanguageFeature::EquivalenceNumericWithCharacter)) {
+              LanguageFeature::EquivalenceNumericWithCharacter)) {
         msg = "Equivalence set contains '%s' that is numeric sequence "
               "type and '%s' that is character"_en_US;
       }
@@ -411,7 +411,7 @@ bool EquivalenceSets::CheckCanEquivalence(
   } else if (isChar1) {
     if (isNum2) {
       if (context_.ShouldWarn(
-              parser::LanguageFeature::EquivalenceNumericWithCharacter)) {
+              LanguageFeature::EquivalenceNumericWithCharacter)) {
         msg = "Equivalence set contains '%s' that is character sequence "
               "type and '%s' that is numeric"_en_US;
       }

--- a/lib/semantics/resolve-names-utils.h
+++ b/lib/semantics/resolve-names-utils.h
@@ -64,11 +64,11 @@ public:
   const SourceName &symbolName() const { return symbolName_.value(); }
   // Some intrinsic operators have more than one name (e.g. `operator(.eq.)` and
   // `operator(==)`). GetAllNames() returns them all, including symbolName.
-  std::forward_list<std::string> GetAllNames() const;
+  std::forward_list<std::string> GetAllNames(SemanticsContext &) const;
   // Set the GenericKind in this symbol and resolve the corresponding
   // name if there is one
   void Resolve(Symbol *) const;
-  Symbol *FindInScope(const Scope &) const;
+  Symbol *FindInScope(SemanticsContext &, const Scope &) const;
 
 private:
   GenericKind kind_;

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -130,7 +130,7 @@ static bool PerformStatementSemantics(
 
 SemanticsContext::SemanticsContext(
     const common::IntrinsicTypeDefaultKinds &defaultKinds,
-    const parser::LanguageFeatureControl &languageFeatures,
+    const common::LanguageFeatureControl &languageFeatures,
     parser::AllSources &allSources)
   : defaultKinds_{defaultKinds}, languageFeatures_{languageFeatures},
     allSources_{allSources},
@@ -144,11 +144,11 @@ int SemanticsContext::GetDefaultKind(TypeCategory category) const {
   return defaultKinds_.GetDefaultKind(category);
 }
 
-bool SemanticsContext::IsEnabled(parser::LanguageFeature feature) const {
+bool SemanticsContext::IsEnabled(common::LanguageFeature feature) const {
   return languageFeatures_.IsEnabled(feature);
 }
 
-bool SemanticsContext::ShouldWarn(parser::LanguageFeature feature) const {
+bool SemanticsContext::ShouldWarn(common::LanguageFeature feature) const {
   return languageFeatures_.ShouldWarn(feature);
 }
 

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -16,9 +16,9 @@
 #define FORTRAN_SEMANTICS_SEMANTICS_H_
 
 #include "scope.h"
+#include "../common/features.h"
 #include "../evaluate/common.h"
 #include "../evaluate/intrinsics.h"
-#include "../parser/features.h"
 #include "../parser/message.h"
 #include <iosfwd>
 #include <string>
@@ -60,7 +60,7 @@ using ConstructStack = std::vector<ConstructNode>;
 class SemanticsContext {
 public:
   SemanticsContext(const common::IntrinsicTypeDefaultKinds &,
-      const parser::LanguageFeatureControl &, parser::AllSources &);
+      const common::LanguageFeatureControl &, parser::AllSources &);
   ~SemanticsContext();
 
   const common::IntrinsicTypeDefaultKinds &defaultKinds() const {
@@ -71,8 +71,8 @@ public:
     return defaultKinds_.doublePrecisionKind();
   }
   int quadPrecisionKind() const { return defaultKinds_.quadPrecisionKind(); }
-  bool IsEnabled(parser::LanguageFeature) const;
-  bool ShouldWarn(parser::LanguageFeature) const;
+  bool IsEnabled(common::LanguageFeature) const;
+  bool ShouldWarn(common::LanguageFeature) const;
   const std::optional<parser::CharBlock> &location() const { return location_; }
   const std::vector<std::string> &searchDirectories() const {
     return searchDirectories_;
@@ -147,7 +147,7 @@ public:
 
 private:
   const common::IntrinsicTypeDefaultKinds &defaultKinds_;
-  const parser::LanguageFeatureControl languageFeatures_;
+  const common::LanguageFeatureControl languageFeatures_;
   parser::AllSources &allSources_;
   std::optional<parser::CharBlock> location_;
   std::vector<std::string> searchDirectories_;

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -66,6 +66,9 @@ public:
   const common::IntrinsicTypeDefaultKinds &defaultKinds() const {
     return defaultKinds_;
   }
+  const common::LanguageFeatureControl &languageFeatures() const {
+    return languageFeatures_;
+  };
   int GetDefaultKind(TypeCategory) const;
   int doublePrecisionKind() const {
     return defaultKinds_.doublePrecisionKind();

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -274,7 +274,7 @@ ENUM_CLASS(GenericKind,  // Kinds of generic-spec
     Name, DefinedOp,  // these have a Name associated with them
     Assignment,  // user-defined assignment
     OpPower, OpMultiply, OpDivide, OpAdd, OpSubtract, OpConcat, OpLT, OpLE,
-    OpEQ, OpNE, OpGE, OpGT, OpNOT, OpAND, OpOR, OpXOR, OpEQV, OpNEQV,
+    OpEQ, OpNE, OpGE, OpGT, OpNOT, OpAND, OpOR, OpEQV, OpNEQV,  //
     ReadFormatted, ReadUnformatted, WriteFormatted, WriteUnformatted)
 
 class GenericBindingDetails {

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -100,6 +100,7 @@ set(ERROR_TESTS
   resolve61.f90
   resolve62.f90
   resolve63.f90
+  resolve64.f90
   stop01.f90
   structconst01.f90
   structconst02.f90

--- a/test/semantics/modfile33.f90
+++ b/test/semantics/modfile33.f90
@@ -16,6 +16,8 @@
 ! Test by using generic function in a specification expression that needs
 ! to be written to a .mod file.
 
+!OPTIONS: -flogical-abbreviations -fxor-operator
+
 ! Numeric operators
 module m1
   type :: t
@@ -158,9 +160,23 @@ module m2
       logical, intent(in) :: x
       integer, intent(in) :: y
     end
+  end interface
+  ! Alternative spelling of .AND.
+  interface operator(.a.)
     pure integer(8) function and_tt(x, y)
       import :: t
       type(t), intent(in) :: x, y
+    end
+  end interface
+  interface operator(.x.)
+    pure integer(8) function neqv_tt(x, y)
+      import :: t
+      type(t), intent(in) :: x, y
+    end
+  end interface
+  interface operator(.neqv.)
+    pure integer(8) function neqv_rr(x, y)
+      real, intent(in) :: x, y
     end
   end interface
 contains
@@ -172,11 +188,19 @@ contains
   subroutine s2(x, y, z)
     logical :: x
     integer :: y
-    real :: z(x .and. y)  ! resolves to and_li
+    real :: z(x .a. y)  ! resolves to and_li
   end
   subroutine s3(x, y, z)
     type(t) :: x, y
     real :: z(x .and. y)  ! resolves to and_tt
+  end
+  subroutine s4(x, y, z)
+    type(t) :: x, y
+    real :: z(x .neqv. y)  ! resolves to neqv_tt
+  end
+  subroutine s5(x, y, z)
+    real :: x, y
+    real :: z(x .xor. y)  ! resolves to neqv_rr
   end
 end
 
@@ -213,6 +237,25 @@ end
 !   integer(8) :: and_tt
 !  end
 ! end interface
+! interface operator(.x.)
+!  procedure :: neqv_tt
+!  procedure :: neqv_rr
+! end interface
+! interface
+!  pure function neqv_tt(x, y)
+!   import :: t
+!   type(t), intent(in) :: x
+!   type(t), intent(in) :: y
+!   integer(8) :: neqv_tt
+!  end
+! end interface
+! interface
+!  pure function neqv_rr(x, y)
+!   real(4), intent(in) :: x
+!   real(4), intent(in) :: y
+!   integer(8) :: neqv_rr
+!  end
+! end interface
 !contains
 ! subroutine s1(x, y, z)
 !  type(t) :: x
@@ -228,6 +271,16 @@ end
 !  type(t) :: x
 !  type(t) :: y
 !  real(4) :: z(1_8:and_tt(x, y))
+! end
+! subroutine s4(x, y, z)
+!  type(t) :: x
+!  type(t) :: y
+!  real(4) :: z(1_8:neqv_tt(x, y))
+! end
+! subroutine s5(x, y, z)
+!  real(4) :: x
+!  real(4) :: y
+!  real(4) :: z(1_8:neqv_rr(x, y))
 ! end
 !end
 

--- a/test/semantics/resolve63.f90
+++ b/test/semantics/resolve63.f90
@@ -104,7 +104,7 @@ module m2
   logical :: l
 contains
   subroutine test_relational()
-    !ERROR: Operands of == must have comparable types; have TYPE(t) and REAL(4)
+    !ERROR: Operands of .EQ. must have comparable types; have TYPE(t) and REAL(4)
     l = x == r
   end
   subroutine test_numeric()
@@ -150,12 +150,60 @@ contains
     logical :: x
     integer :: y
     logical :: l
-    !TODO: these should work
-    !y = y + z'1'  !OK
-    !y = +z'1'  !OK
+    complex :: z
+    y = y + z'1'  !OK
+    !ERROR: Operands of + must be numeric; have untyped and COMPLEX(4)
+    z = z'1' + z
+    y = +z'1'  !OK
+    !ERROR: Operand of unary - must be numeric; have untyped
+    y = -z'1'
     !ERROR: Operands of + must be numeric; have LOGICAL(4) and untyped
     y = x + z'1'
-    !ERROR: Operands of /= must have comparable types; have LOGICAL(4) and untyped
+    !ERROR: Operands of .NE. must have comparable types; have LOGICAL(4) and untyped
     l = x /= null()
+  end
+end
+
+! Test alternate operators. They aren't enabled by default so should be
+! treated as defined operators, not intrinsic ones.
+module m4
+contains
+  subroutine s1(x, y, z)
+    logical :: x
+    real :: y, z
+    !ERROR: Defined operator '.a.' not found
+    x = y .a. z
+    !ERROR: Defined operator '.o.' not found
+    x = y .o. z
+    !ERROR: Defined operator '.n.' not found
+    x = .n. y
+    !ERROR: Defined operator '.xor.' not found
+    x = y .xor. z
+    !ERROR: Defined operator '.x.' not found
+    x = .x. y
+  end
+end
+
+! Like m4 in resolve63 but compiled with different options.
+! .A. is a defined operator.
+module m5
+  interface operator(.A.)
+    logical function f1(x, y)
+      integer, intent(in) :: x, y
+    end
+  end interface
+  interface operator(.and.)
+    logical function f2(x, y)
+      real, intent(in) :: x, y
+    end
+  end interface
+contains
+  subroutine s1(x, y, z)
+    logical :: x
+    complex :: y, z
+    !ERROR: No user-defined or intrinsic .AND. operator matches operand types COMPLEX(4) and COMPLEX(4)
+    x = y .and. z
+    !ERROR: No specific procedure of generic operator '.a.' matches the actual arguments
+    x = y .a. z
   end
 end

--- a/test/semantics/resolve64.f90
+++ b/test/semantics/resolve64.f90
@@ -1,0 +1,59 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+!OPTIONS: -flogical-abbreviations -fxor-operator
+
+! Like m4 in resolve63 but compiled with different options.
+! Alternate operators are enabled so treat these as intrinsic.
+module m4
+contains
+  subroutine s1(x, y, z)
+    logical :: x
+    real :: y, z
+    !ERROR: Operands of .AND. must be LOGICAL; have REAL(4) and REAL(4)
+    x = y .a. z
+    !ERROR: Operands of .OR. must be LOGICAL; have REAL(4) and REAL(4)
+    x = y .o. z
+    !ERROR: Operand of .NOT. must be LOGICAL; have REAL(4)
+    x = .n. y
+    !ERROR: Operands of .NEQV. must be LOGICAL; have REAL(4) and REAL(4)
+    x = y .xor. z
+    !ERROR: Operands of .NEQV. must be LOGICAL; have REAL(4) and REAL(4)
+    x = y .x. y
+  end
+end
+
+! Like m4 in resolve63 but compiled with different options.
+! Alternate operators are enabled so treat .A. as .AND.
+module m5
+  interface operator(.A.)
+    logical function f1(x, y)
+      integer, intent(in) :: x, y
+    end
+  end interface
+  interface operator(.and.)
+    logical function f2(x, y)
+      real, intent(in) :: x, y
+    end
+  end interface
+contains
+  subroutine s1(x, y, z)
+    logical :: x
+    complex :: y, z
+    !ERROR: No user-defined or intrinsic .A. operator matches operand types COMPLEX(4) and COMPLEX(4)
+    x = y .and. z
+    !ERROR: No user-defined or intrinsic .A. operator matches operand types COMPLEX(4) and COMPLEX(4)
+    x = y .a. z
+  end
+end

--- a/test/semantics/test_modfile.sh
+++ b/test/semantics/test_modfile.sh
@@ -35,7 +35,7 @@ for src in "$@"; do
   (
     cd $temp
     ls -1 *.mod > prev_files
-    $F18 $F18_OPTIONS $src
+    $F18 $F18_OPTIONS $USER_OPTIONS $src
     ls -1 *.mod | comm -13 prev_files -
   ) > $actual_files
   expected_files=$(sed -n 's/^!Expect: \(.*\)/\1/p' $src | sort)

--- a/tools/f18/f18-parse-demo.cc
+++ b/tools/f18/f18-parse-demo.cc
@@ -28,9 +28,9 @@
 // F18 compiler under development.
 
 #include "../../lib/common/default-kinds.h"
+#include "../../lib/common/features.h"
 #include "../../lib/parser/characters.h"
 #include "../../lib/parser/dump-parse-tree.h"
-#include "../../lib/parser/features.h"
 #include "../../lib/parser/message.h"
 #include "../../lib/parser/parse-tree-visitor.h"
 #include "../../lib/parser/parse-tree.h"
@@ -226,7 +226,7 @@ std::string CompileFortran(
   if (driver.dumpUnparse) {
     Unparse(std::cout, parseTree, driver.encoding, true /*capitalize*/,
         options.features.IsEnabled(
-            Fortran::parser::LanguageFeature::BackslashEscapes));
+            Fortran::common::LanguageFeature::BackslashEscapes));
     return {};
   }
   if (driver.parseOnly) {
@@ -243,7 +243,7 @@ std::string CompileFortran(
     tmpSource.open(tmpSourcePath);
     Unparse(tmpSource, parseTree, driver.encoding, true /*capitalize*/,
         options.features.IsEnabled(
-            Fortran::parser::LanguageFeature::BackslashEscapes));
+            Fortran::common::LanguageFeature::BackslashEscapes));
   }
 
   if (ParentProcess()) {
@@ -308,7 +308,7 @@ int main(int argc, char *const argv[]) {
   options.predefinitions.emplace_back("__F18_PATCHLEVEL__", "1");
 
   options.features.Enable(
-      Fortran::parser::LanguageFeature::BackslashEscapes, true);
+      Fortran::common::LanguageFeature::BackslashEscapes, true);
 
   Fortran::common::IntrinsicTypeDefaultKinds defaultKinds;
 
@@ -356,27 +356,27 @@ int main(int argc, char *const argv[]) {
       options.fixedFormColumns = 132;
     } else if (arg == "-Mbackslash") {
       options.features.Enable(
-          Fortran::parser::LanguageFeature::BackslashEscapes, false);
+          Fortran::common::LanguageFeature::BackslashEscapes, false);
     } else if (arg == "-Mnobackslash") {
       options.features.Enable(
-          Fortran::parser::LanguageFeature::BackslashEscapes);
+          Fortran::common::LanguageFeature::BackslashEscapes);
     } else if (arg == "-Mstandard") {
       driver.warnOnNonstandardUsage = true;
     } else if (arg == "-fopenmp") {
-      options.features.Enable(Fortran::parser::LanguageFeature::OpenMP);
+      options.features.Enable(Fortran::common::LanguageFeature::OpenMP);
       options.predefinitions.emplace_back("_OPENMP", "201511");
     } else if (arg == "-Werror") {
       driver.warningsAreErrors = true;
     } else if (arg == "-ed") {
-      options.features.Enable(Fortran::parser::LanguageFeature::OldDebugLines);
+      options.features.Enable(Fortran::common::LanguageFeature::OldDebugLines);
     } else if (arg == "-E" || arg == "-fpreprocess-only") {
       driver.dumpCookedChars = true;
     } else if (arg == "-fbackslash") {
       options.features.Enable(
-          Fortran::parser::LanguageFeature::BackslashEscapes);
+          Fortran::common::LanguageFeature::BackslashEscapes);
     } else if (arg == "-fno-backslash") {
       options.features.Enable(
-          Fortran::parser::LanguageFeature::BackslashEscapes, false);
+          Fortran::common::LanguageFeature::BackslashEscapes, false);
     } else if (arg == "-fdump-provenance") {
       driver.dumpProvenance = true;
     } else if (arg == "-fdump-parse-tree") {
@@ -451,7 +451,7 @@ int main(int argc, char *const argv[]) {
     options.features.WarnOnAllNonstandard();
   }
   if (!options.features.IsEnabled(
-          Fortran::parser::LanguageFeature::BackslashEscapes)) {
+          Fortran::common::LanguageFeature::BackslashEscapes)) {
     driver.fcArgs.push_back("-fno-backslash");  // PGI "-Mbackslash"
   }
 

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -15,10 +15,10 @@
 // Temporary Fortran front end driver main program for development scaffolding.
 
 #include "../../lib/common/default-kinds.h"
+#include "../../lib/common/features.h"
 #include "../../lib/evaluate/expression.h"
 #include "../../lib/parser/characters.h"
 #include "../../lib/parser/dump-parse-tree.h"
-#include "../../lib/parser/features.h"
 #include "../../lib/parser/message.h"
 #include "../../lib/parser/parse-tree-visitor.h"
 #include "../../lib/parser/parse-tree.h"
@@ -301,7 +301,7 @@ std::string CompileFortran(std::string path, Fortran::parser::Options options,
   if (driver.dumpUnparse) {
     Unparse(std::cout, parseTree, driver.encoding, true /*capitalize*/,
         options.features.IsEnabled(
-            Fortran::parser::LanguageFeature::BackslashEscapes),
+            Fortran::common::LanguageFeature::BackslashEscapes),
         nullptr /* action before each statement */, &unparseExpression);
     return {};
   }
@@ -320,7 +320,7 @@ std::string CompileFortran(std::string path, Fortran::parser::Options options,
     Fortran::evaluate::formatForPGF90 = true;
     Unparse(tmpSource, parseTree, driver.encoding, true /*capitalize*/,
         options.features.IsEnabled(
-            Fortran::parser::LanguageFeature::BackslashEscapes),
+            Fortran::common::LanguageFeature::BackslashEscapes),
         nullptr /* action before each statement */,
         driver.unparseTypedExprsToPGF90 ? &unparseExpression : nullptr);
     Fortran::evaluate::formatForPGF90 = false;
@@ -437,27 +437,27 @@ int main(int argc, char *const argv[]) {
       options.fixedFormColumns = 132;
     } else if (arg == "-Mbackslash") {
       options.features.Enable(
-          Fortran::parser::LanguageFeature::BackslashEscapes, false);
+          Fortran::common::LanguageFeature::BackslashEscapes, false);
     } else if (arg == "-Mnobackslash") {
       options.features.Enable(
-          Fortran::parser::LanguageFeature::BackslashEscapes, true);
+          Fortran::common::LanguageFeature::BackslashEscapes, true);
     } else if (arg == "-Mstandard") {
       driver.warnOnNonstandardUsage = true;
     } else if (arg == "-fopenmp") {
-      options.features.Enable(Fortran::parser::LanguageFeature::OpenMP);
+      options.features.Enable(Fortran::common::LanguageFeature::OpenMP);
       options.predefinitions.emplace_back("_OPENMP", "201511");
     } else if (arg == "-Werror") {
       driver.warningsAreErrors = true;
     } else if (arg == "-ed") {
-      options.features.Enable(Fortran::parser::LanguageFeature::OldDebugLines);
+      options.features.Enable(Fortran::common::LanguageFeature::OldDebugLines);
     } else if (arg == "-E") {
       driver.dumpCookedChars = true;
     } else if (arg == "-fbackslash" || arg == "-fno-backslash") {
       options.features.Enable(
-          Fortran::parser::LanguageFeature::BackslashEscapes,
+          Fortran::common::LanguageFeature::BackslashEscapes,
           arg == "-fbackslash");
     } else if (arg == "-fxor-operator" || arg == "-fno-xor-operator") {
-      options.features.Enable(Fortran::parser::LanguageFeature::XOROperator,
+      options.features.Enable(Fortran::common::LanguageFeature::XOROperator,
           arg == "-fxor-operator");
     } else if (arg == "-fdebug-dump-provenance") {
       driver.dumpProvenance = true;
@@ -591,12 +591,12 @@ int main(int argc, char *const argv[]) {
   if (driver.warnOnNonstandardUsage) {
     options.features.WarnOnAllNonstandard();
   }
-  if (options.features.IsEnabled(Fortran::parser::LanguageFeature::OpenMP)) {
+  if (options.features.IsEnabled(Fortran::common::LanguageFeature::OpenMP)) {
     driver.pgf90Args.push_back("-mp");
   }
   if (isPGF90) {
     if (!options.features.IsEnabled(
-            Fortran::parser::LanguageFeature::BackslashEscapes)) {
+            Fortran::common::LanguageFeature::BackslashEscapes)) {
       driver.pgf90Args.push_back(
           "-Mbackslash");  // yes, this *disables* them in pgf90
     }

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -459,6 +459,11 @@ int main(int argc, char *const argv[]) {
     } else if (arg == "-fxor-operator" || arg == "-fno-xor-operator") {
       options.features.Enable(Fortran::common::LanguageFeature::XOROperator,
           arg == "-fxor-operator");
+    } else if (arg == "-flogical-abbreviations" ||
+        arg == "-fno-logical-abbreviations") {
+      options.features.Enable(
+          Fortran::parser::LanguageFeature::LogicalAbbreviations,
+          arg == "-flogical-abbreviations");
     } else if (arg == "-fdebug-dump-provenance") {
       driver.dumpProvenance = true;
       options.needProvenanceRangeToCharBlockMappings = true;
@@ -546,6 +551,8 @@ int main(int argc, char *const argv[]) {
           << "  -f[no-]backslash     enable[disable] \\escapes in literals\n"
           << "  -M[no]backslash      disable[enable] \\escapes in literals\n"
           << "  -Mstandard           enable conformance warnings\n"
+          << "  -fenable=<feature>   enable a language feature\n"
+          << "  -fdisable=<feature>  disable a language feature\n"
           << "  -r8 | -fdefault-real-8 | -i8 | -fdefault-integer-8  "
              "change default kinds of intrinsic types\n"
           << "  -Werror              treat warnings as errors\n"


### PR DESCRIPTION
Update the grammar to handle logical abbreviations (e.g. `.A.` for `.AND.`)
when the feature is enabled. Only support `.X.` when both XOR and
logical abbreviations are enabled.

Fix the driver to enable logical abbreviations with the
`-flogical-abbreviations` option. This was already documented in
`documentation/Extensions.md`.

Remove `parser::Expr::XOR` from the parse tree and immediately map
`.XOR.` to `.NEQV.` if that feature is enabled. This was already being
done during expression analysis anyway.

Add `LanguageFeatureControl::GetNames` to return all of the names of
a logical or relational operator, depending on which features are
enabled. Use these in both name resolution and expression analysis.
Add `Not` to `LogicalOperator` to help in those cases.

Fix handling of BOZ literals: A numeric operation with one real or
integer operand and the other a BOZ literal is intrinsic.
Also, unary plus with a BOZ literal operand is also intrinsic.
