### PR TITLE
Remove explicit comparisons to `nullptr` and most usage of `has_value()`

### DIFF
--- a/documentation/C++style.md
+++ b/documentation/C++style.md
@@ -188,6 +188,11 @@ contents, and it is assumed that the contents are present, validate that
 assumption by using `x.value()` instead.
 1. We use `c_str()` rather than `data()` when converting a `std::string`
 to a `const char *` when the result is expected to be NUL-terminated.
+1. Avoid explicit comparisions of pointers to `nullptr` and tests of
+presence of `optional<>` values with `.has_value()` in the predicate
+expressions of control flow statements, but prefer them to implicit
+conversions to `bool` when initializing `bool` variables and arguments,
+and to the use of the idiom `!!`.
 
 #### Classes
 1. Define POD structures with `struct`.

--- a/lib/common/idioms.h
+++ b/lib/common/idioms.h
@@ -145,7 +145,7 @@ template<typename A> struct ListItemCount {
 #define DEREF(p) Fortran::common::Deref(p, __FILE__, __LINE__)
 
 template<typename T> constexpr T &Deref(T *p, const char *file, int line) {
-  if (p == nullptr) {
+  if (!p) {
     Fortran::common::die("nullptr dereference at %s(%d)", file, line);
   }
   return *p;

--- a/lib/common/template.h
+++ b/lib/common/template.h
@@ -105,7 +105,7 @@ constexpr bool HasMember{
 // std::optional<std::optional<A>> -> std::optional<A>
 template<typename A>
 std::optional<A> JoinOptional(std::optional<std::optional<A>> &&x) {
-  if (x.has_value()) {
+  if (x) {
     return std::move(*x);
   }
   return std::nullopt;
@@ -113,7 +113,7 @@ std::optional<A> JoinOptional(std::optional<std::optional<A>> &&x) {
 
 // Convert an std::optional to an ordinary pointer
 template<typename A> const A *GetPtrFromOptional(const std::optional<A> &x) {
-  if (x.has_value()) {
+  if (x) {
     return &*x;
   } else {
     return nullptr;
@@ -258,7 +258,7 @@ template<typename A>
 std::optional<std::vector<A>> AllElementsPresent(
     std::vector<std::optional<A>> &&v) {
   for (const auto &maybeA : v) {
-    if (!maybeA.has_value()) {
+    if (!maybeA) {
       return std::nullopt;
     }
   }

--- a/lib/common/unwrap.h
+++ b/lib/common/unwrap.h
@@ -64,7 +64,7 @@ struct UnwrapperHelper {
   // Implementations of specializations
   template<typename A, typename B>
   static auto Unwrap(B *p) -> Constify<A, B> * {
-    if (p != nullptr) {
+    if (p) {
       return Unwrap<A>(*p);
     } else {
       return nullptr;
@@ -73,7 +73,7 @@ struct UnwrapperHelper {
 
   template<typename A, typename B>
   static auto Unwrap(const std::unique_ptr<B> &p) -> Constify<A, B> * {
-    if (p.get() != nullptr) {
+    if (p.get()) {
       return Unwrap<A>(*p);
     } else {
       return nullptr;
@@ -82,7 +82,7 @@ struct UnwrapperHelper {
 
   template<typename A, typename B>
   static auto Unwrap(const std::shared_ptr<B> &p) -> Constify<A, B> * {
-    if (p.get() != nullptr) {
+    if (p.get()) {
       return Unwrap<A>(*p);
     } else {
       return nullptr;
@@ -91,7 +91,7 @@ struct UnwrapperHelper {
 
   template<typename A, typename B>
   static auto Unwrap(std::optional<B> &x) -> Constify<A, B> * {
-    if (x.has_value()) {
+    if (x) {
       return Unwrap<A>(*x);
     } else {
       return nullptr;
@@ -100,7 +100,7 @@ struct UnwrapperHelper {
 
   template<typename A, typename B>
   static auto Unwrap(const std::optional<B> &x) -> Constify<A, B> * {
-    if (x.has_value()) {
+    if (x) {
       return Unwrap<A>(*x);
     } else {
       return nullptr;
@@ -139,7 +139,7 @@ struct UnwrapperHelper {
 
   template<typename A, typename B>
   static auto Unwrap(const CountedReference<B> &p) -> Constify<A, B> * {
-    if (p.get() != nullptr) {
+    if (p.get()) {
       return Unwrap<A>(*p);
     } else {
       return nullptr;

--- a/lib/decimal/decimal-to-binary.cc
+++ b/lib/decimal/decimal-to-binary.cc
@@ -55,7 +55,7 @@ bool BigRadixFloatingPointNumber<PREC, LOG10RADIX>::ParseNumber(
   // the first character afterward.
   p = q;
   // Strip off trailing zeroes
-  if (point != nullptr) {
+  if (point) {
     while (q[-1] == '0') {
       --q;
     }
@@ -64,7 +64,7 @@ bool BigRadixFloatingPointNumber<PREC, LOG10RADIX>::ParseNumber(
       --q;
     }
   }
-  if (point == nullptr) {
+  if (!point) {
     while (q > first && q[-1] == '0') {
       --q;
       ++exponent_;
@@ -78,12 +78,12 @@ bool BigRadixFloatingPointNumber<PREC, LOG10RADIX>::ParseNumber(
       q = point;
       point = nullptr;
     }
-    if (point == nullptr) {
+    if (!point) {
       exponent_ += q - limit;
     }
     q = limit;
   }
-  if (point != nullptr) {
+  if (point) {
     exponent_ -= static_cast<int>(q - point - 1);
   }
   if (q == first) {

--- a/lib/evaluate/call.cc
+++ b/lib/evaluate/call.cc
@@ -30,8 +30,7 @@ ActualArgument::~ActualArgument() {}
 ActualArgument::AssumedType::AssumedType(const Symbol &symbol)
   : symbol_{symbol} {
   const semantics::DeclTypeSpec *type{symbol.GetType()};
-  CHECK(
-      type != nullptr && type->category() == semantics::DeclTypeSpec::TypeStar);
+  CHECK(type && type->category() == semantics::DeclTypeSpec::TypeStar);
 }
 
 int ActualArgument::AssumedType::Rank() const { return symbol_->Rank(); }
@@ -179,7 +178,7 @@ std::optional<Expr<SubscriptInteger>> ProcedureRef::LEN() const {
           UnwrapExpr<Expr<SomeCharacter>>(arguments_[0].value())};
       const auto *nCopiesArg{
           UnwrapExpr<Expr<SomeInteger>>(arguments_[1].value())};
-      CHECK(stringArg != nullptr && nCopiesArg != nullptr);
+      CHECK(stringArg && nCopiesArg);
       if (auto stringLen{stringArg->LEN()}) {
         auto converted{ConvertTo(*stringLen, common::Clone(*nCopiesArg))};
         return *std::move(stringLen) * std::move(converted);

--- a/lib/evaluate/characteristics.cc
+++ b/lib/evaluate/characteristics.cc
@@ -186,9 +186,9 @@ void TypeAndShape::AcquireShape(const semantics::ObjectEntityDetails &object) {
     attrs_.set(Attr::Coarray);
   }
   for (const semantics::ShapeSpec &dim : object.shape()) {
-    if (dim.ubound().GetExplicit().has_value()) {
+    if (dim.ubound().GetExplicit()) {
       Expr<SubscriptInteger> extent{*dim.ubound().GetExplicit()};
-      if (dim.lbound().GetExplicit().has_value()) {
+      if (dim.lbound().GetExplicit()) {
         extent = std::move(extent) +
             common::Clone(*dim.lbound().GetExplicit()) -
             Expr<SubscriptInteger>{1};
@@ -212,7 +212,7 @@ void TypeAndShape::AcquireLEN() {
 
 std::ostream &TypeAndShape::Dump(std::ostream &o) const {
   std::stringstream LENstr;
-  if (LEN_.has_value()) {
+  if (LEN_) {
     LEN_->AsFortran(LENstr);
   }
   o << type_.AsFortran(LENstr.str());
@@ -223,7 +223,7 @@ std::ostream &TypeAndShape::Dump(std::ostream &o) const {
     for (const auto &expr : shape_) {
       o << sep;
       sep = ',';
-      if (expr.has_value()) {
+      if (expr) {
         expr->AsFortran(o);
       } else {
         o << ':';
@@ -698,7 +698,7 @@ bool Procedure::CanBeCalledViaImplicitInterface() const {
 
 std::ostream &Procedure::Dump(std::ostream &o) const {
   attrs.Dump(o, EnumToString);
-  if (functionResult.has_value()) {
+  if (functionResult) {
     functionResult->Dump(o << "TYPE(") << ") FUNCTION";
   } else {
     o << "SUBROUTINE";

--- a/lib/evaluate/characteristics.h
+++ b/lib/evaluate/characteristics.h
@@ -66,7 +66,7 @@ public:
     AcquireLEN();
   }
   TypeAndShape(DynamicType t, std::optional<Shape> &&s) : type_{t} {
-    if (s.has_value()) {
+    if (s) {
       shape_ = std::move(*s);
     }
     AcquireLEN();

--- a/lib/evaluate/check-expression.cc
+++ b/lib/evaluate/check-expression.cc
@@ -192,7 +192,7 @@ public:
                    symbol.detailsIf<semantics::ObjectEntityDetails>()}) {
       // TODO: what about EQUIVALENCE with data in COMMON?
       // TODO: does this work for blank COMMON?
-      if (object->commonBlock() != nullptr) {
+      if (object->commonBlock()) {
         return std::nullopt;
       }
     }
@@ -298,7 +298,7 @@ public:
   template<typename T> Result operator()(const FunctionRef<T> &x) const {
     if (auto chars{
             characteristics::Procedure::Characterize(x.proc(), table_)}) {
-      if (chars->functionResult.has_value()) {
+      if (chars->functionResult) {
         const auto &result{*chars->functionResult};
         return !result.IsProcedurePointer() &&
             result.attrs.test(characteristics::FunctionResult::Attr::Pointer) &&
@@ -317,7 +317,7 @@ private:
         if (!triplet->IsStrideOne()) {
           return false;
         } else if (anyTriplet) {
-          if (triplet->lower().has_value() || triplet->upper().has_value()) {
+          if (triplet->lower() || triplet->upper()) {
             return false;  // all triplets before the last one must be just ":"
           }
         } else {

--- a/lib/evaluate/fold.h
+++ b/lib/evaluate/fold.h
@@ -41,8 +41,8 @@ template<typename T> Expr<T> Fold(FoldingContext &context, Expr<T> &&expr) {
 template<typename T>
 std::optional<Expr<T>> Fold(
     FoldingContext &context, std::optional<Expr<T>> &&expr) {
-  if (expr.has_value()) {
-    return {Fold(context, std::move(*expr))};
+  if (expr) {
+    return Fold(context, std::move(*expr));
   } else {
     return std::nullopt;
   }
@@ -96,7 +96,7 @@ std::optional<std::int64_t> ToInt64(const Expr<SomeType> &);
 
 template<typename A>
 std::optional<std::int64_t> ToInt64(const std::optional<A> &x) {
-  if (x.has_value()) {
+  if (x) {
     return ToInt64(*x);
   } else {
     return std::nullopt;

--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -109,7 +109,7 @@ std::ostream &ActualArgument::AssumedType::AsFortran(std::ostream &o) const {
 }
 
 std::ostream &ActualArgument::AsFortran(std::ostream &o) const {
-  if (keyword.has_value()) {
+  if (keyword) {
     o << keyword->ToString() << '=';
   }
   if (isAlternateReturn) {
@@ -130,7 +130,7 @@ std::ostream &ProcedureRef::AsFortran(std::ostream &o) const {
   proc_.AsFortran(o);
   char separator{'('};
   for (const auto &arg : arguments_) {
-    if (arg.has_value()) {
+    if (arg) {
       arg->AsFortran(o << separator);
       separator = ',';
     }
@@ -382,10 +382,10 @@ std::ostream &StructureConstructor::AsFortran(std::ostream &o) const {
 }
 
 std::string DynamicType::AsFortran() const {
-  if (derived_ != nullptr) {
+  if (derived_) {
     CHECK(category_ == TypeCategory::Derived);
     return DerivedTypeSpecAsFortran(*derived_);
-  } else if (charLength_ != nullptr) {
+  } else if (charLength_) {
     std::string result{"CHARACTER(KIND="s + std::to_string(kind_) + ",LEN="};
     if (charLength_->isAssumed()) {
       result += '*';
@@ -473,8 +473,8 @@ std::ostream &EmitVar(std::ostream &o, common::Reference<A> x) {
 
 template<typename A>
 std::ostream &EmitVar(std::ostream &o, const A *p, const char *kw = nullptr) {
-  if (p != nullptr) {
-    if (kw != nullptr) {
+  if (p) {
+    if (kw) {
       o << kw;
     }
     EmitVar(o, *p);
@@ -485,8 +485,8 @@ std::ostream &EmitVar(std::ostream &o, const A *p, const char *kw = nullptr) {
 template<typename A>
 std::ostream &EmitVar(
     std::ostream &o, const std::optional<A> &x, const char *kw = nullptr) {
-  if (x.has_value()) {
-    if (kw != nullptr) {
+  if (x) {
+    if (kw) {
       o << kw;
     }
     EmitVar(o, *x);
@@ -497,7 +497,7 @@ std::ostream &EmitVar(
 template<typename A, bool COPY>
 std::ostream &EmitVar(std::ostream &o, const common::Indirection<A, COPY> &p,
     const char *kw = nullptr) {
-  if (kw != nullptr) {
+  if (kw) {
     o << kw;
   }
   EmitVar(o, p.value());
@@ -506,7 +506,7 @@ std::ostream &EmitVar(std::ostream &o, const common::Indirection<A, COPY> &p,
 
 template<typename A>
 std::ostream &EmitVar(std::ostream &o, const std::shared_ptr<A> &p) {
-  CHECK(p != nullptr);
+  CHECK(p);
   return EmitVar(o, *p);
 }
 
@@ -522,7 +522,7 @@ std::ostream &BaseObject::AsFortran(std::ostream &o) const {
 
 template<int KIND>
 std::ostream &TypeParamInquiry<KIND>::AsFortran(std::ostream &o) const {
-  if (base_.has_value()) {
+  if (base_) {
     return base_->AsFortran(o) << '%';
   }
   return EmitVar(o, parameter_);
@@ -587,11 +587,11 @@ std::ostream &CoarrayRef::AsFortran(std::ostream &o) const {
     EmitVar(o << separator, css);
     separator = ',';
   }
-  if (stat_.has_value()) {
+  if (stat_) {
     EmitVar(o << separator, stat_, "STAT=");
     separator = ',';
   }
-  if (team_.has_value()) {
+  if (team_) {
     EmitVar(
         o << separator, team_, teamIsTeamNumber_ ? "TEAM_NUMBER=" : "TEAM=");
   }

--- a/lib/evaluate/formatting.h
+++ b/lib/evaluate/formatting.h
@@ -54,7 +54,7 @@ auto operator<<(
 template<typename A>
 auto operator<<(std::ostream &o, const std::optional<A> &x)
     -> decltype(o << *x) {
-  if (x.has_value()) {
+  if (x) {
     o << *x;
   } else {
     o << "(nullopt)";

--- a/lib/evaluate/real.cc
+++ b/lib/evaluate/real.cc
@@ -272,7 +272,7 @@ RealFlags Real<W, P, IM>::Normalize(bool negative, int exponent,
     const Fraction &fraction, Rounding rounding, RoundingBits *roundingBits) {
   int lshift{fraction.LEADZ()};
   if (lshift == fraction.bits /* fraction is zero */ &&
-      (roundingBits == nullptr || roundingBits->empty())) {
+      (!roundingBits || roundingBits->empty())) {
     // No fraction, no rounding bits -> +/-0.0
     exponent = lshift = 0;
   } else if (lshift < exponent) {
@@ -309,7 +309,7 @@ RealFlags Real<W, P, IM>::Normalize(bool negative, int exponent,
   word_ = Word::ConvertUnsigned(fraction).value;
   if (lshift > 0) {
     word_ = word_.SHIFTL(lshift);
-    if (roundingBits != nullptr) {
+    if (roundingBits) {
       for (; lshift > 0; --lshift) {
         if (roundingBits->ShiftLeft()) {
           word_ = word_.IBSET(lshift - 1);

--- a/lib/evaluate/tools.cc
+++ b/lib/evaluate/tools.cc
@@ -106,7 +106,7 @@ std::optional<Expr<SomeType>> Package(Expr<SomeKind<CAT>> &&catExpr) {
 template<TypeCategory CAT>
 std::optional<Expr<SomeType>> Package(
     std::optional<Expr<SomeKind<CAT>>> &&catExpr) {
-  if (catExpr.has_value()) {
+  if (catExpr) {
     return {AsGenericExpr(std::move(*catExpr))};
   }
   return NoExpr();
@@ -553,7 +553,7 @@ std::optional<Expr<SomeType>> ConvertToType(
     if (auto *cx{UnwrapExpr<Expr<SomeCharacter>>(x)}) {
       auto converted{
           ConvertToKind<TypeCategory::Character>(type.kind(), std::move(*cx))};
-      if (type.charLength() != nullptr) {
+      if (type.charLength()) {
         if (const auto &len{type.charLength()->GetExplicit()}) {
           Expr<SomeInteger> lenParam{*len};
           Expr<SubscriptInteger> length{Convert<SubscriptInteger>{lenParam}};
@@ -590,7 +590,7 @@ std::optional<Expr<SomeType>> ConvertToType(
 
 std::optional<Expr<SomeType>> ConvertToType(
     const DynamicType &to, std::optional<Expr<SomeType>> &&x) {
-  if (x.has_value()) {
+  if (x) {
     return ConvertToType(to, std::move(*x));
   } else {
     return std::nullopt;
@@ -612,7 +612,7 @@ std::optional<Expr<SomeType>> ConvertToType(
 
 std::optional<Expr<SomeType>> ConvertToType(
     const Symbol &to, std::optional<Expr<SomeType>> &&x) {
-  if (x.has_value()) {
+  if (x) {
     return ConvertToType(to, std::move(*x));
   } else {
     return std::nullopt;
@@ -633,7 +633,7 @@ bool IsAssumedRank(const ActualArgument &arg) {
     return IsAssumedRank(*expr);
   } else {
     const Symbol *assumedTypeDummy{arg.GetAssumedTypeDummy()};
-    CHECK(assumedTypeDummy != nullptr);
+    CHECK(assumedTypeDummy);
     return IsAssumedRank(*assumedTypeDummy);
   }
 }

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -52,7 +52,7 @@ std::optional<Variable<A>> AsVariable(const Expr<A> &expr) {
 
 template<typename A>
 std::optional<Variable<A>> AsVariable(const std::optional<Expr<A>> &expr) {
-  if (expr.has_value()) {
+  if (expr) {
     return AsVariable(*expr);
   } else {
     return std::nullopt;
@@ -116,7 +116,7 @@ template<typename T> bool IsAssumedRank(const Expr<T> &expr) {
   return std::visit([](const auto &x) { return IsAssumedRank(x); }, expr.u);
 }
 template<typename A> bool IsAssumedRank(const std::optional<A> &x) {
-  return x.has_value() && IsAssumedRank(*x);
+  return x && IsAssumedRank(*x);
 }
 
 // Generalizing packagers: these take operations and expressions of more
@@ -195,7 +195,7 @@ auto UnwrapExpr(B &x) -> common::Constify<A, B> * {
 
 template<typename A, typename B>
 const A *UnwrapExpr(const std::optional<B> &x) {
-  if (x.has_value()) {
+  if (x) {
     return UnwrapExpr<A>(*x);
   } else {
     return nullptr;
@@ -203,7 +203,7 @@ const A *UnwrapExpr(const std::optional<B> &x) {
 }
 
 template<typename A, typename B> A *UnwrapExpr(std::optional<B> &x) {
-  if (x.has_value()) {
+  if (x) {
     return UnwrapExpr<A>(*x);
   } else {
     return nullptr;
@@ -232,7 +232,7 @@ std::optional<DataRef> ExtractDataRef(const Expr<T> &expr) {
 }
 template<typename A>
 std::optional<DataRef> ExtractDataRef(const std::optional<A> &x) {
-  if (x.has_value()) {
+  if (x) {
     return ExtractDataRef(*x);
   } else {
     return std::nullopt;
@@ -748,7 +748,7 @@ template<typename T> std::optional<BaseObject> GetBaseObject(const Expr<T> &x) {
 }
 template<typename A>
 std::optional<BaseObject> GetBaseObject(const std::optional<A> &x) {
-  if (x.has_value()) {
+  if (x) {
     return GetBaseObject(*x);
   } else {
     return std::nullopt;

--- a/lib/evaluate/traverse.h
+++ b/lib/evaluate/traverse.h
@@ -66,14 +66,14 @@ public:
     return visitor_(x.get());
   }
   template<typename A> Result operator()(const A *x) const {
-    if (x != nullptr) {
+    if (x) {
       return visitor_(*x);
     } else {
       return visitor_.Default();
     }
   }
   template<typename A> Result operator()(const std::optional<A> &x) const {
-    if (x.has_value()) {
+    if (x) {
       return visitor_(*x);
     } else {
       return visitor_.Default();

--- a/lib/evaluate/type.cc
+++ b/lib/evaluate/type.cc
@@ -93,7 +93,7 @@ bool IsDescriptor(const Symbol &symbol0) {
 namespace Fortran::evaluate {
 
 template<typename A> inline bool PointeeComparison(const A *x, const A *y) {
-  return x == y || (x != nullptr && y != nullptr && *x == *y);
+  return x == y || (x && y && *x == *y);
 }
 
 bool DynamicType::operator==(const DynamicType &that) const {
@@ -103,7 +103,7 @@ bool DynamicType::operator==(const DynamicType &that) const {
 }
 
 bool DynamicType::IsAssumedLengthCharacter() const {
-  return category_ == TypeCategory::Character && charLength_ != nullptr &&
+  return category_ == TypeCategory::Character && charLength_ &&
       charLength_->isAssumed();
 }
 
@@ -192,7 +192,7 @@ static bool AreSameDerivedType(const semantics::DerivedTypeSpec &x,
   for (auto xComponentName{xDetails.componentNames().cbegin()};
        xComponentName != xEnd; ++xComponentName, ++yComponentName) {
     if (yComponentName == yEnd || *xComponentName != *yComponentName ||
-        xSymbol.scope() == nullptr || ySymbol.scope() == nullptr) {
+        !xSymbol.scope() || !ySymbol.scope()) {
       return false;
     }
     const auto xLookup{xSymbol.scope()->find(*xComponentName)};
@@ -237,7 +237,7 @@ else {
 
 static bool AreCompatibleDerivedTypes(const semantics::DerivedTypeSpec *x,
     const semantics::DerivedTypeSpec *y, bool isPolymorphic) {
-  if (x == nullptr || y == nullptr) {
+  if (!x || !y) {
     return false;
   } else {
     SetOfDerivedTypePairs inProgress;
@@ -262,7 +262,7 @@ static bool IsKindTypeParameter(
 }
 
 bool DynamicType::IsTypeCompatibleWith(const DynamicType &that) const {
-  if (derived_ != nullptr) {
+  if (derived_) {
     if (!AreCompatibleDerivedTypes(derived_, that.derived_, IsPolymorphic())) {
       return false;
     }

--- a/lib/evaluate/type.h
+++ b/lib/evaluate/type.h
@@ -156,7 +156,7 @@ public:
     return kind_ == ClassKind || IsAssumedType();
   }
   constexpr bool IsUnlimitedPolymorphic() const {  // TYPE(*) or CLASS(*)
-    return IsPolymorphic() && derived_ == nullptr;
+    return IsPolymorphic() && !derived_;
   }
   constexpr const semantics::DerivedTypeSpec &GetDerivedTypeSpec() const {
     return DEREF(derived_);
@@ -179,7 +179,7 @@ public:
     return x.GetType();
   }
   template<typename A> static std::optional<DynamicType> From(const A *p) {
-    if (p == nullptr) {
+    if (!p) {
       return std::nullopt;
     } else {
       return From(*p);
@@ -187,7 +187,7 @@ public:
   }
   template<typename A>
   static std::optional<DynamicType> From(const std::optional<A> &x) {
-    if (x.has_value()) {
+    if (x) {
       return From(*x);
     } else {
       return std::nullopt;
@@ -392,16 +392,16 @@ public:
     : SomeKind(dt.GetDerivedTypeSpec()) {}
   CONSTEXPR_CONSTRUCTORS_AND_ASSIGNMENTS(SomeKind)
 
-  bool IsUnlimitedPolymorphic() const { return derivedTypeSpec_ == nullptr; }
+  bool IsUnlimitedPolymorphic() const { return !derivedTypeSpec_; }
   constexpr DynamicType GetType() const {
-    if (derivedTypeSpec_ == nullptr) {
+    if (!derivedTypeSpec_) {
       return DynamicType::UnlimitedPolymorphic();
     } else {
       return DynamicType{*derivedTypeSpec_};
     }
   }
   const semantics::DerivedTypeSpec &derivedTypeSpec() const {
-    CHECK(derivedTypeSpec_ != nullptr);
+    CHECK(derivedTypeSpec_);
     return *derivedTypeSpec_;
   }
   bool operator==(const SomeKind &) const;

--- a/lib/parser/message.cc
+++ b/lib/parser/message.cc
@@ -47,7 +47,7 @@ void MessageFormattedText::Format(const MessageFixedText *text, ...) {
   CHECK(need >= 0);
   char *buffer{
       static_cast<char *>(std::malloc(static_cast<std::size_t>(need) + 1))};
-  CHECK(buffer != nullptr);
+  CHECK(buffer);
   va_end(ap);
   va_start(ap, text);
   int need2{vsnprintf(buffer, need + 1, p, ap)};
@@ -204,7 +204,7 @@ void Message::Emit(
   const AllSources &sources{cooked.allSources()};
   sources.EmitMessage(o, provenanceRange, text, echoSourceLine);
   if (attachmentIsContext_) {
-    for (const Message *context{attachment_.get()}; context != nullptr;
+    for (const Message *context{attachment_.get()}; context;
          context = context->attachment_.get()) {
       std::optional<ProvenanceRange> contextProvenance{
           context->GetProvenanceRange(cooked)};
@@ -217,7 +217,7 @@ void Message::Emit(
       provenanceRange = contextProvenance;
     }
   } else {
-    for (const Message *attachment{attachment_.get()}; attachment != nullptr;
+    for (const Message *attachment{attachment_.get()}; attachment;
          attachment = attachment->attachment_.get()) {
       sources.EmitMessage(o, attachment->GetProvenanceRange(cooked),
           attachment->ToString(), echoSourceLine);

--- a/lib/parser/parse-state.h
+++ b/lib/parser/parse-state.h
@@ -158,12 +158,12 @@ public:
   void Nonstandard(
       CharBlock range, LanguageFeature lf, const MessageFixedText &msg) {
     anyConformanceViolation_ = true;
-    if (userState_ != nullptr && userState_->features().ShouldWarn(lf)) {
+    if (userState_ && userState_->features().ShouldWarn(lf)) {
       Say(range, msg);
     }
   }
   bool IsNonstandardOk(LanguageFeature lf, const MessageFixedText &msg) {
-    if (userState_ != nullptr && !userState_->features().IsEnabled(lf)) {
+    if (userState_ && !userState_->features().IsEnabled(lf)) {
       return false;
     }
     Nonstandard(lf, msg);

--- a/lib/parser/parse-tree-visitor.h
+++ b/lib/parser/parse-tree-visitor.h
@@ -66,12 +66,12 @@ template<typename M> void Walk(format::IntrinsicTypeDataEditDesc &, M &);
 // Traversal of needed STL template classes (optional, list, tuple, variant)
 template<typename T, typename V>
 void Walk(const std::optional<T> &x, V &visitor) {
-  if (x.has_value()) {
+  if (x) {
     Walk(*x, visitor);
   }
 }
 template<typename T, typename M> void Walk(std::optional<T> &x, M &mutator) {
-  if (x.has_value()) {
+  if (x) {
     Walk(*x, mutator);
   }
 }

--- a/lib/parser/parse-tree.cc
+++ b/lib/parser/parse-tree.cc
@@ -67,7 +67,7 @@ DataRef::DataRef(std::list<PartRef> &&prl) : u{std::move(prl.front().name)} {
       u = common::Indirection<ArrayElement>::Make(
           std::move(*this), std::move(pr.subscripts));
     }
-    if (pr.imageSelector.has_value()) {
+    if (pr.imageSelector) {
       u = common::Indirection<CoindexedNamedObject>::Make(
           std::move(*this), std::move(*pr.imageSelector));
     }
@@ -193,7 +193,7 @@ Substring ArrayElement::ConvertToSubstring() {
   auto iter{subscripts.begin()};
   CHECK(iter != subscripts.end());
   auto &triplet{std::get<SubscriptTriplet>(iter->u)};
-  CHECK(!std::get<2>(triplet.t).has_value());
+  CHECK(!std::get<2>(triplet.t));
   CHECK(++iter == subscripts.end());
   return Substring{std::move(base),
       SubstringRange{std::get<0>(std::move(triplet.t)),

--- a/lib/parser/parsing.cc
+++ b/lib/parser/parsing.cc
@@ -68,7 +68,7 @@ const SourceFile *Parsing::Prescan(const std::string &path, Options options) {
 
   Preprocessor preprocessor{allSources};
   for (const auto &predef : options.predefinitions) {
-    if (predef.second.has_value()) {
+    if (predef.second) {
       preprocessor.Define(predef.first, *predef.second);
     } else {
       preprocessor.Undefine(predef.first);

--- a/lib/parser/preprocessor.cc
+++ b/lib/parser/preprocessor.cc
@@ -582,7 +582,7 @@ void Preprocessor::Directive(const TokenSequence &dir, Prescanner *prescanner) {
     }
     std::stringstream error;
     const SourceFile *included{allSources_.Open(include, &error)};
-    if (included == nullptr) {
+    if (!included) {
       prescanner->Say(dir.GetTokenProvenanceRange(dirOffset),
           "#include: %s"_err_en_US, error.str());
     } else if (included->bytes() > 0) {
@@ -808,7 +808,7 @@ static std::int64_t ExpressionValue(const TokenSequence &token,
   ++*atToken;
   if (op != CONST) {
     left = ExpressionValue(token, operandPrecedence[op], atToken, error);
-    if (error->has_value()) {
+    if (*error) {
       return 0;
     }
     switch (op) {
@@ -856,7 +856,7 @@ static std::int64_t ExpressionValue(const TokenSequence &token,
 
     std::int64_t right{
         ExpressionValue(token, operandPrecedence[op], atToken, error)};
-    if (error->has_value()) {
+    if (*error) {
       return 0;
     }
 
@@ -1007,7 +1007,7 @@ bool Preprocessor::IsIfPredicateTrue(const TokenSequence &expr,
   std::size_t atToken{0};
   std::optional<Message> error;
   bool result{ExpressionValue(expr3, 0, &atToken, &error) != 0};
-  if (error.has_value()) {
+  if (error) {
     prescanner->Say(std::move(*error));
   } else if (atToken < expr3.SizeInTokens() &&
       expr3.TokenAt(atToken).ToString() != "!") {

--- a/lib/parser/prescan.cc
+++ b/lib/parser/prescan.cc
@@ -68,7 +68,7 @@ void Prescanner::Prescan(ProvenanceRange range) {
   startProvenance_ = range.start();
   std::size_t offset{0};
   const SourceFile *source{allSources.GetSourceFile(startProvenance_, &offset)};
-  CHECK(source != nullptr);
+  CHECK(source);
   start_ = source->content() + offset;
   limit_ = start_ + range.size();
   nextLine_ = start_;
@@ -241,7 +241,7 @@ TokenSequence Prescanner::TokenizePreprocessorDirective() {
 void Prescanner::NextLine() {
   void *vstart{static_cast<void *>(const_cast<char *>(nextLine_))};
   void *v{std::memchr(vstart, '\n', limit_ - nextLine_)};
-  if (v == nullptr) {
+  if (!v) {
     nextLine_ = limit_;
   } else {
     const char *nl{const_cast<const char *>(static_cast<char *>(v))};
@@ -746,14 +746,14 @@ void Prescanner::FortranInclude(const char *firstQuote) {
   Provenance provenance{GetProvenance(nextLine_)};
   AllSources &allSources{cooked_.allSources()};
   const SourceFile *currentFile{allSources.GetSourceFile(provenance)};
-  if (currentFile != nullptr) {
+  if (currentFile) {
     allSources.PushSearchPathDirectory(DirectoryName(currentFile->path()));
   }
   const SourceFile *included{allSources.Open(path, &error)};
-  if (currentFile != nullptr) {
+  if (currentFile) {
     allSources.PopSearchPathDirectory();
   }
-  if (included == nullptr) {
+  if (!included) {
     Say(provenance, "INCLUDE: %s"_err_en_US, error.str());
   } else if (included->bytes() > 0) {
     ProvenanceRange includeLineRange{

--- a/lib/parser/prescan.h
+++ b/lib/parser/prescan.h
@@ -73,7 +73,7 @@ public:
   template<typename... A> Message &Say(A &&... a) {
     Message &m{messages_.Say(std::forward<A>(a)...)};
     std::optional<ProvenanceRange> range{m.GetProvenanceRange(cooked_)};
-    CHECK(!range.has_value() || cooked_.IsValid(*range));
+    CHECK(!range || cooked_.IsValid(*range));
     return m;
   }
 

--- a/lib/parser/provenance.cc
+++ b/lib/parser/provenance.cc
@@ -46,7 +46,7 @@ std::optional<std::size_t> ProvenanceRangeToOffsetMappings::Map(
     ProvenanceRange that{iter->first};
     if (that.Contains(range)) {
       std::size_t offset{iter->second + that.MemberOffset(range.start())};
-      if (!result.has_value() || offset < *result) {
+      if (!result || offset < *result) {
         result = offset;
       }
     }
@@ -215,7 +215,7 @@ ProvenanceRange AllSources::AddCompilerInsertion(std::string text) {
 void AllSources::EmitMessage(std::ostream &o,
     const std::optional<ProvenanceRange> &range, const std::string &message,
     bool echoSourceLine) const {
-  if (!range.has_value()) {
+  if (!range) {
     o << message << '\n';
     return;
   }
@@ -286,7 +286,7 @@ const SourceFile *AllSources::GetSourceFile(
   return std::visit(
       common::visitors{
           [&](const Inclusion &inc) {
-            if (offset != nullptr) {
+            if (offset) {
               *offset = origin.covers.MemberOffset(at);
             }
             return &inc.source;
@@ -295,7 +295,7 @@ const SourceFile *AllSources::GetSourceFile(
             return GetSourceFile(origin.replaces.start(), offset);
           },
           [offset](const CompilerInsertion &) {
-            if (offset != nullptr) {
+            if (offset) {
               *offset = 0;
             }
             return static_cast<const SourceFile *>(nullptr);

--- a/lib/parser/source.cc
+++ b/lib/parser/source.cc
@@ -65,7 +65,7 @@ void SourceFile::RecordLineStarts() {
 void SourceFile::IdentifyPayload() {
   content_ = address_;
   bytes_ = size_;
-  if (content_ != nullptr) {
+  if (content_) {
     static constexpr int BOMBytes{3};
     static const char UTF8_BOM[]{"\xef\xbb\xbf"};
     if (bytes_ >= BOMBytes && std::memcmp(content_, UTF8_BOM, BOMBytes) == 0) {
@@ -103,7 +103,7 @@ static std::size_t RemoveCarriageReturns(char *buffer, std::size_t bytes) {
     void *vp{static_cast<void *>(p)};
     void *crvp{std::memchr(vp, '\r', bytes)};
     char *crcp{static_cast<char *>(crvp)};
-    if (crcp == nullptr) {
+    if (!crcp) {
       std::memmove(buffer + wrote, p, bytes);
       wrote += bytes;
       break;
@@ -243,7 +243,7 @@ void SourceFile::Close() {
     isMemoryMapped_ = false;
   } else if (!normalized_.empty()) {
     normalized_.clear();
-  } else if (address_ != nullptr) {
+  } else if (address_) {
     delete[] address_;
   }
   address_ = content_ = nullptr;

--- a/lib/parser/token-parsers.h
+++ b/lib/parser/token-parsers.h
@@ -140,16 +140,16 @@ public:
           continue;  // redundant; ignore
         }
       }
-      if (!at.has_value()) {
+      if (!at) {
         at = nextCh.Parse(state);
-        if (!at.has_value()) {
+        if (!at) {
           return std::nullopt;
         }
       }
       if (spaceSkipping) {
         if (**at == ' ') {
           at = nextCh.Parse(state);
-          if (!at.has_value()) {
+          if (!at) {
             return std::nullopt;
           }
         } else if constexpr (MandatoryFreeFormSpace) {
@@ -259,7 +259,7 @@ template<char quote> struct CharLiteral {
         str += '\\';
       } else if (ch->first == quote) {
         static constexpr auto doubled{attempt(AnyOfChars{SetOfChars{quote}})};
-        if (!doubled.Parse(state).has_value()) {
+        if (!doubled.Parse(state)) {
           return str;
         }
       }
@@ -289,7 +289,7 @@ struct BOZLiteral {
     space.Parse(state);
     const char *start{state.GetLocation()};
     std::optional<const char *> at{nextCh.Parse(state)};
-    if (!at.has_value()) {
+    if (!at) {
       return std::nullopt;
     }
     if (**at == 'x' &&
@@ -299,7 +299,7 @@ struct BOZLiteral {
     }
     if (baseChar(**at)) {
       at = nextCh.Parse(state);
-      if (!at.has_value()) {
+      if (!at) {
         return std::nullopt;
       }
     }
@@ -312,7 +312,7 @@ struct BOZLiteral {
     std::string content;
     while (true) {
       at = nextCh.Parse(state);
-      if (!at.has_value()) {
+      if (!at) {
         return std::nullopt;
       }
       if (**at == quote) {
@@ -329,7 +329,7 @@ struct BOZLiteral {
 
     if (!base) {
       // extension: base allowed to appear as suffix, too
-      if (!(at = nextCh.Parse(state)).has_value() || !baseChar(**at) ||
+      if (!(at = nextCh.Parse(state)) || !baseChar(**at) ||
           !state.IsNonstandardOk(LanguageFeature::BOZExtensions,
               "nonstandard BOZ literal"_en_US)) {
         return std::nullopt;
@@ -371,7 +371,7 @@ struct SignedIntLiteralConstantWithoutKind {
   static std::optional<resultType> Parse(ParseState &state) {
     resultType result{state.GetLocation()};
     static constexpr auto sign{maybe("+-"_ch / space)};
-    if (sign.Parse(state).has_value()) {
+    if (sign.Parse(state)) {
       if (auto digits{digitString.Parse(state)}) {
         result.ExtendToCover(*digits);
         return result;
@@ -385,7 +385,7 @@ constexpr struct DigitString64 {
   using resultType = std::uint64_t;
   static std::optional<std::uint64_t> Parse(ParseState &state) {
     std::optional<const char *> firstDigit{digit.Parse(state)};
-    if (!firstDigit.has_value()) {
+    if (!firstDigit) {
       return std::nullopt;
     }
     std::uint64_t value = **firstDigit - '0';
@@ -416,7 +416,7 @@ constexpr struct DigitString64 {
 static std::optional<std::int64_t> SignedInteger(
     const std::optional<std::uint64_t> &x, Location at, bool negate,
     ParseState &state) {
-  if (!x.has_value()) {
+  if (!x) {
     return std::nullopt;
   }
   std::uint64_t limit{std::numeric_limits<std::int64_t>::max()};
@@ -437,7 +437,7 @@ struct SignedDigitString {
   using resultType = std::int64_t;
   static std::optional<std::int64_t> Parse(ParseState &state) {
     std::optional<const char *> sign{state.PeekAtNextChar()};
-    if (!sign.has_value()) {
+    if (!sign) {
       return std::nullopt;
     }
     bool negate{**sign == '-'};
@@ -455,7 +455,7 @@ struct DigitStringIgnoreSpaces {
   static std::optional<std::uint64_t> Parse(ParseState &state) {
     static constexpr auto getFirstDigit{space >> digit};
     std::optional<const char *> firstDigit{getFirstDigit.Parse(state)};
-    if (!firstDigit.has_value()) {
+    if (!firstDigit) {
       return std::nullopt;
     }
     std::uint64_t value = **firstDigit - '0';
@@ -510,12 +510,12 @@ struct HollerithLiteral {
     const char *start{state.GetLocation()};
     std::optional<std::uint64_t> charCount{
         DigitStringIgnoreSpaces{}.Parse(state)};
-    if (!charCount.has_value() || *charCount < 1) {
+    if (!charCount || *charCount < 1) {
       return std::nullopt;
     }
     static constexpr auto letterH{"h"_ch};
     std::optional<const char *> h{letterH.Parse(state)};
-    if (!h.has_value()) {
+    if (!h) {
       return std::nullopt;
     }
     std::string content;

--- a/lib/parser/tools.h
+++ b/lib/parser/tools.h
@@ -41,7 +41,7 @@ const Name &GetLastName(const AllocateObject &);
 struct UnwrapperHelper {
 
   template<typename A, typename B> static const A *Unwrap(B *p) {
-    if (p != nullptr) {
+    if (p) {
       return Unwrap<A>(*p);
     } else {
       return nullptr;
@@ -60,7 +60,7 @@ struct UnwrapperHelper {
 
   template<typename A, typename B>
   static const A *Unwrap(const std::optional<B> &o) {
-    if (o.has_value()) {
+    if (o) {
       return Unwrap<A>(*o);
     } else {
       return nullptr;

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -245,7 +245,7 @@ public:
                 decls.begin(), decls.end(), [](const ComponentDecl &d) {
                   const auto &init{
                       std::get<std::optional<Initialization>>(d.t)};
-                  return init.has_value() &&
+                  return init &&
                       std::holds_alternative<
                           std::list<common::Indirection<DataStmtValue>>>(
                           init->u);
@@ -408,12 +408,12 @@ public:
     static const auto hasAssignmentInitializer{[](const EntityDecl &d) {
       // Does a declaration have a new-style =x initializer?
       const auto &init{std::get<std::optional<Initialization>>(d.t)};
-      return init.has_value() && !isInitializerOldStyle(*init);
+      return init && !isInitializerOldStyle(*init);
     }};
     static const auto hasSlashDelimitedInitializer{[](const EntityDecl &d) {
       // Does a declaration have an old-style /x/ initializer?
       const auto &init{std::get<std::optional<Initialization>>(d.t)};
-      return init.has_value() && isInitializerOldStyle(*init);
+      return init && isInitializerOldStyle(*init);
     }};
     const auto useDoubledColons{[&]() {
       bool isRecord{std::holds_alternative<DeclarationTypeSpec::Record>(dts.u)};
@@ -665,7 +665,7 @@ public:
   void Unparse(const LetterSpec &x) {  // R865
     Put(*std::get<const char *>(x.t));
     auto second{std::get<std::optional<const char *>>(x.t)};
-    if (second.has_value()) {
+    if (second) {
       Put('-'), Put(**second);
     }
   }
@@ -803,7 +803,7 @@ public:
 
   // R1001 - R1022
   bool Pre(const Expr &x) {
-    if (typedExprAsFortran_ != nullptr && x.typedExpr.get() != nullptr) {
+    if (typedExprAsFortran_ && x.typedExpr.get()) {
       // Format the expression representation from semantics
       (*typedExprAsFortran_)(out_, *x.typedExpr);
       return false;
@@ -1417,7 +1417,7 @@ public:
     Walk("*(", x.unlimitedItems, ",", ")"), Put(')');
   }
   void Unparse(const format::FormatItem &x) {  // R1304, R1306, R1321
-    if (x.repeatCount.has_value()) {
+    if (x.repeatCount) {
       Walk(*x.repeatCount);
     }
     std::visit(
@@ -2449,7 +2449,7 @@ private:
   template<typename A>
   void Walk(
       const char *prefix, const std::optional<A> &x, const char *suffix = "") {
-    if (x.has_value()) {
+    if (x) {
       Word(prefix), Walk(*x), Word(suffix);
     }
   }

--- a/lib/parser/user-state.cc
+++ b/lib/parser/user-state.cc
@@ -27,7 +27,7 @@ std::optional<Success> StartNewSubprogram::Parse(ParseState &state) {
   if (auto *ustate{state.userState()}) {
     ustate->NewSubprogram();
   }
-  return {Success{}};
+  return Success{};
 }
 
 std::optional<CapturedLabelDoStmt::resultType> CapturedLabelDoStmt::Parse(
@@ -47,7 +47,7 @@ EndDoStmtForCapturedLabelDoStmt::Parse(ParseState &state) {
   static constexpr auto parser{
       statement(indirect(construct<EndDoStmt>("END DO" >> maybe(name))))};
   if (auto enddo{parser.Parse(state)}) {
-    if (enddo->label.has_value()) {
+    if (enddo->label) {
       if (const auto *ustate{state.userState()}) {
         if (ustate->IsDoLabel(enddo->label.value())) {
           return enddo;
@@ -87,7 +87,7 @@ std::optional<DataComponentDefStmt> StructureComponents::Parse(
     ParseState &state) {
   static constexpr auto stmt{Parser<DataComponentDefStmt>{}};
   std::optional<DataComponentDefStmt> defs{stmt.Parse(state)};
-  if (defs.has_value()) {
+  if (defs) {
     if (auto *ustate{state.userState()}) {
       for (const auto &decl : std::get<std::list<ComponentDecl>>(defs->t)) {
         ustate->NoteOldStructureComponent(std::get<Name>(decl.t).source);

--- a/lib/semantics/assignment.cc
+++ b/lib/semantics/assignment.cc
@@ -99,7 +99,7 @@ public:
         error =
             "%s is associated with the non-existent result of reference to procedure"_err_en_US;
       }
-      if (error.has_value()) {
+      if (error) {
         auto save{common::ScopedSet(pointer_, symbol)};
         Say(*error, description_, funcName);
       }
@@ -126,7 +126,7 @@ public:
               "%s associated with object '%s' with incompatible type or shape"_err_en_US;
         }
       }
-      if (error.has_value()) {
+      if (error) {
         auto save{common::ScopedSet(pointer_, last)};
         Say(*error, description_, last->name());
       }
@@ -209,9 +209,9 @@ void PointerAssignmentChecker::Check(const ProcedureDesignator &d) {
 void PointerAssignmentChecker::Check(const ProcedureRef &ref) {
   const characteristics::Procedure *procedure{nullptr};
   auto chars{characteristics::Procedure::Characterize(ref, intrinsics_)};
-  if (chars.has_value()) {
+  if (chars) {
     procedure = &*chars;
-    if (chars->functionResult.has_value()) {
+    if (chars->functionResult) {
       if (const auto *proc{chars->functionResult->IsProcedurePointer()}) {
         procedure = proc;
       }

--- a/lib/semantics/canonicalize-do.cc
+++ b/lib/semantics/canonicalize-do.cc
@@ -103,7 +103,7 @@ private:
   template<typename T>
   void CanonicalizeIfMatch(Block &originalBlock, std::vector<LabelInfo> &stack,
       Block::iterator &i, Statement<T> &statement) {
-    if (!stack.empty() && statement.label.has_value() &&
+    if (!stack.empty() && statement.label &&
         stack.back().label == *statement.label) {
       auto currentLabel{stack.back().label};
       if constexpr (std::is_same_v<T, common::Indirection<EndDoStmt>>) {

--- a/lib/semantics/canonicalize-omp.cc
+++ b/lib/semantics/canonicalize-omp.cc
@@ -85,7 +85,7 @@ private:
     nextIt = it;
     if (++nextIt != block.end()) {
       if (auto *doCons{GetConstructIf<parser::DoConstruct>(*nextIt)}) {
-        if (doCons->GetLoopControl().has_value()) {
+        if (doCons->GetLoopControl()) {
           // move DoConstruct
           std::get<std::optional<parser::DoConstruct>>(x.t) =
               std::move(*doCons);

--- a/lib/semantics/check-allocate.cc
+++ b/lib/semantics/check-allocate.cc
@@ -194,7 +194,7 @@ static std::optional<AllocateCheckerInfo> CheckAllocateOptions(
   if (info.gotSrc || info.gotMold) {
     if (const auto *expr{GetExpr(DEREF(parserSourceExpr))}) {
       info.sourceExprType = expr->GetType();
-      if (!info.sourceExprType.has_value()) {
+      if (!info.sourceExprType) {
         context.Say(parserSourceExpr->source,
             "Typeless item not allowed as SOURCE or MOLD in ALLOCATE"_err_en_US);
         return std::nullopt;
@@ -252,7 +252,7 @@ static bool IsTypeCompatible(
     if (type1.category() == DeclTypeSpec::Category::TypeDerived) {
       return &derivedType1->typeSymbol() == &derivedType2.typeSymbol();
     } else if (type1.category() == DeclTypeSpec::Category::ClassDerived) {
-      for (const DerivedTypeSpec *parent{&derivedType2}; parent != nullptr;
+      for (const DerivedTypeSpec *parent{&derivedType2}; parent;
            parent = parent->typeSymbol().GetParentTypeSpec()) {
         if (&derivedType1->typeSymbol() == &parent->typeSymbol()) {
           return true;
@@ -404,7 +404,7 @@ static bool HaveCompatibleKindParameters(
 }
 
 bool AllocationCheckerHelper::RunChecks(SemanticsContext &context) {
-  if (symbol_ == nullptr) {
+  if (!symbol_) {
     CHECK(context.AnyFatalError());
     return false;
   }
@@ -413,7 +413,7 @@ bool AllocationCheckerHelper::RunChecks(SemanticsContext &context) {
         "Name in ALLOCATE statement must be a variable name"_err_en_US);
     return false;
   }
-  if (type_ == nullptr) {
+  if (!type_) {
     // This is done after variable check because a user could have put
     // a subroutine name in allocate for instance which is a symbol with
     // no type.
@@ -535,7 +535,7 @@ bool AllocationCheckerHelper::RunChecks(SemanticsContext &context) {
 
 bool AllocationCheckerHelper::RunCoarrayRelatedChecks(
     SemanticsContext &context) const {
-  if (symbol_ == nullptr) {
+  if (!symbol_) {
     CHECK(context.AnyFatalError());
     return false;
   }

--- a/lib/semantics/check-arithmeticif.cc
+++ b/lib/semantics/check-arithmeticif.cc
@@ -21,8 +21,7 @@ namespace Fortran::semantics {
 
 bool IsNumericExpr(const SomeExpr &expr) {
   auto dynamicType{expr.GetType()};
-  return dynamicType.has_value() &&
-      common::IsNumericTypeCategory(dynamicType->category());
+  return dynamicType && common::IsNumericTypeCategory(dynamicType->category());
 }
 
 void ArithmeticIfStmtChecker::Leave(

--- a/lib/semantics/check-call.cc
+++ b/lib/semantics/check-call.cc
@@ -94,7 +94,7 @@ static void PadShortCharacterActual(evaluate::Expr<evaluate::SomeType> &actual,
               "Actual length '%jd' is less than expected length '%jd'"_en_US,
               *actualLEN, *dummyLEN);
           auto converted{ConvertToType(dummyType.type(), std::move(actual))};
-          CHECK(converted.has_value());
+          CHECK(converted);
           actual = std::move(*converted);
         }
       }
@@ -606,8 +606,8 @@ static void RearrangeArguments(const characteristics::Procedure &proc,
   }
   std::map<std::string, evaluate::ActualArgument> kwArgs;
   for (auto &x : actuals) {
-    if (x.has_value()) {
-      if (x->keyword.has_value()) {
+    if (x) {
+      if (x->keyword) {
         auto emplaced{
             kwArgs.try_emplace(x->keyword->ToString(), std::move(*x))};
         if (!emplaced.second) {
@@ -626,7 +626,7 @@ static void RearrangeArguments(const characteristics::Procedure &proc,
         auto iter{kwArgs.find(dummy.name)};
         if (iter != kwArgs.end()) {
           evaluate::ActualArgument &x{iter->second};
-          if (actuals[index].has_value()) {
+          if (actuals[index]) {
             messages.Say(*x.keyword,
                 "Keyword argument '%s=' has already been specified positionally (#%d) in this procedure reference"_err_en_US,
                 *x.keyword, index + 1);
@@ -658,7 +658,7 @@ static parser::Messages CheckExplicitInterface(
     int index{0};
     for (auto &actual : actuals) {
       const auto &dummy{proc.dummyArguments.at(index++)};
-      if (actual.has_value()) {
+      if (actual) {
         CheckExplicitInterfaceArg(*actual, dummy, proc, localContext, scope);
       } else if (!dummy.IsOptional()) {
         if (dummy.name.empty()) {
@@ -708,7 +708,7 @@ void CheckArguments(const characteristics::Procedure &proc,
   }
   if (!explicitInterface || treatingExternalAsImplicit) {
     for (auto &actual : actuals) {
-      if (actual.has_value()) {
+      if (actual) {
         CheckImplicitInterfaceArg(*actual, context.messages());
       }
     }

--- a/lib/semantics/check-declarations.cc
+++ b/lib/semantics/check-declarations.cc
@@ -95,7 +95,7 @@ void CheckHelper::Check(const Symbol &symbol) {
   }
   const DeclTypeSpec *type{symbol.GetUltimate().GetType()};
   const DerivedTypeSpec *derived{nullptr};
-  if (type != nullptr) {
+  if (type) {
     derived = type->AsDerived();
   }
   auto save{messages_.SetLocation(symbol.name())};
@@ -107,7 +107,7 @@ void CheckHelper::Check(const Symbol &symbol) {
   if (isAssociated) {
     return;  // only care about checking VOLATILE on associated symbols
   }
-  if (type != nullptr) {
+  if (type) {
     bool canHaveAssumedParameter{IsNamedConstant(symbol) ||
         IsAssumedLengthCharacterFunction(symbol) ||
         symbol.test(Symbol::Flag::ParentComp)};
@@ -234,7 +234,7 @@ void CheckHelper::CheckValue(
     messages_.Say(
         "VALUE attribute may not apply to an OPTIONAL in a BIND(C) procedure"_err_en_US);
   }
-  if (derived != nullptr) {
+  if (derived) {
     if (FindCoarrayUltimateComponent(*derived)) {
       messages_.Say(
           "VALUE attribute may not apply to a type with a coarray ultimate component"_err_en_US);
@@ -257,7 +257,7 @@ void CheckHelper::CheckVolatile(const Symbol &symbol, bool isAssociated,
       messages_.Say(
           "VOLATILE attribute may not apply to a coarray accessed by USE or host association"_err_en_US);
     }
-    if (derived != nullptr) {
+    if (derived) {
       if (FindCoarrayUltimateComponent(*derived)) {
         messages_.Say(
             "VOLATILE attribute may not apply to a type with a coarray ultimate component accessed by USE or host association"_err_en_US);

--- a/lib/semantics/check-do.cc
+++ b/lib/semantics/check-do.cc
@@ -81,7 +81,7 @@ public:
 
   template<typename T> bool Pre(const parser::Statement<T> &statement) {
     currentStatementSourcePosition_ = statement.source;
-    if (statement.label.has_value()) {
+    if (statement.label) {
       labels_.insert(*statement.label);
     }
     return true;
@@ -402,7 +402,7 @@ private:
     CheckDoVariable(bounds.name);
     CheckDoExpression(bounds.lower);
     CheckDoExpression(bounds.upper);
-    if (bounds.step.has_value()) {
+    if (bounds.step) {
       CheckDoExpression(bounds.step.value());
     }
   }
@@ -605,7 +605,7 @@ private:
     const auto &header{std::get<parser::ConcurrentHeader>(concurrent.t)};
     const auto &mask{
         std::get<std::optional<parser::ScalarLogicalExpr>>(header.t)};
-    if (mask.has_value()) {
+    if (mask) {
       CheckMaskIsPure(*mask);
     }
     CheckConcurrentHeader(header);
@@ -689,8 +689,8 @@ void DoChecker::CheckForBadLeave(
 static bool StmtMatchesConstruct(const parser::Name *stmtName,
     StmtType stmtType, const parser::Name *constructName,
     const ConstructNode &construct) {
-  bool inDoConstruct{MaybeGetDoConstruct(construct) != nullptr};
-  if (stmtName == nullptr) {
+  bool inDoConstruct{MaybeGetDoConstruct(construct)};
+  if (!stmtName) {
     return inDoConstruct;  // Unlabeled statements match all DO constructs
   } else if (constructName && constructName->source == stmtName->source) {
     return stmtType == StmtType::EXIT || inDoConstruct;

--- a/lib/semantics/check-io.cc
+++ b/lib/semantics/check-io.cc
@@ -61,7 +61,7 @@ bool FormatErrorReporter::Say(const common::FormatMessage &msg) {
 
 void IoChecker::Enter(
     const parser::Statement<common::Indirection<parser::FormatStmt>> &stmt) {
-  if (!stmt.label.has_value()) {
+  if (!stmt.label) {
     context_.Say("Format statement must be labeled"_err_en_US);  // C1301
   }
   const char *formatStart{static_cast<const char *>(
@@ -222,7 +222,7 @@ void IoChecker::Enter(const parser::IdExpr &) { SetSpecifier(IoSpecKind::Id); }
 void IoChecker::Enter(const parser::IdVariable &spec) {
   SetSpecifier(IoSpecKind::Id);
   auto expr{GetExpr(spec)};
-  if (expr == nullptr || !expr->GetType()) {
+  if (!expr || !expr->GetType()) {
     return;
   }
   int kind{expr->GetType()->kind()};

--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -691,7 +691,7 @@ void OmpStructureChecker::Leave(const parser::OmpClauseList &) {
       const auto &orderedClause{
           std::get<parser::OmpClause::Ordered>(clause->u)};
 
-      if (orderedClause.v.has_value()) {
+      if (orderedClause.v) {
         if (FindClause(OmpClause::LINEAR)) {
           context_.Say(clause->source,
               "A loop directive may not have both a LINEAR clause and "
@@ -1003,14 +1003,13 @@ bool OmpStructureChecker::ScheduleModifierHasType(
     const parser::OmpScheduleModifierType::ModType &type) {
   const auto &modifier{
       std::get<std::optional<parser::OmpScheduleModifier>>(x.t)};
-  if (modifier.has_value()) {
+  if (modifier) {
     const auto &modType1{
         std::get<parser::OmpScheduleModifier::Modifier1>(modifier->t)};
     const auto &modType2{
         std::get<std::optional<parser::OmpScheduleModifier::Modifier2>>(
             modifier->t)};
-    if (modType1.v.v == type ||
-        (modType2.has_value() && modType2->v.v == type)) {
+    if (modType1.v.v == type || (modType2 && modType2->v.v == type)) {
       return true;
     }
   }
@@ -1023,7 +1022,7 @@ void OmpStructureChecker::Enter(const parser::OmpScheduleClause &x) {
   if (doSet.test(GetContext().directive)) {
     const auto &kind{std::get<1>(x.t)};
     const auto &chunk{std::get<2>(x.t)};
-    if (chunk.has_value()) {
+    if (chunk) {
       if (kind == parser::OmpScheduleClause::ScheduleType::Runtime ||
           kind == parser::OmpScheduleClause::ScheduleType::Auto) {
         context_.Say(GetContext().clauseSource,

--- a/lib/semantics/check-return.cc
+++ b/lib/semantics/check-return.cc
@@ -40,13 +40,12 @@ void ReturnStmtChecker::Leave(const parser::ReturnStmt &returnStmt) {
   // subroutine subprogram.
   const auto &scope{context_.FindScope(context_.location().value())};
   const auto *subprogramScope{FindContainingSubprogram(scope)};
-  if (subprogramScope == nullptr) {
+  if (!subprogramScope) {
     context_.Say(
         "RETURN must in the inclusive scope of a SUBPROGRAM"_err_en_US);
     return;
   }
-  if (returnStmt.v.has_value() &&
-      subprogramScope->kind() == Scope::Kind::Subprogram) {
+  if (returnStmt.v && subprogramScope->kind() == Scope::Kind::Subprogram) {
     if (IsFunction(*subprogramScope->GetSymbol())) {
       context_.Say(
           "RETURN with expression is only allowed in SUBROUTINE subprogram"_err_en_US);

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -165,7 +165,7 @@ public:
     return Analyze(x.value());
   }
   template<typename A> MaybeExpr Analyze(const std::optional<A> &x) {
-    if (x.has_value()) {
+    if (x) {
       return Analyze(*x);
     } else {
       return std::nullopt;
@@ -175,7 +175,7 @@ public:
   // Implement constraint-checking wrappers from the Fortran grammar.
   template<typename A> MaybeExpr Analyze(const parser::Scalar<A> &x) {
     auto result{Analyze(x.thing)};
-    if (result.has_value()) {
+    if (result) {
       if (int rank{result->Rank()}; rank != 0) {
         SayAt(x, "Must be a scalar value, but is a rank-%d array"_err_en_US,
             rank);
@@ -189,7 +189,7 @@ public:
     auto save{
         GetFoldingContext().messages().SetLocation(FindSourceLocation(x))};
     auto result{Analyze(x.thing)};
-    if (result.has_value()) {
+    if (result) {
       *result = Fold(GetFoldingContext(), std::move(*result));
       if (!IsConstantExpr(*result)) {
         SayAt(x, "Must be a constant value"_err_en_US);

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -218,7 +218,7 @@ void ModFileWriter::PutSymbol(
             }
             PutPassName(typeBindings, x.passName());
             auto attrs{symbol.attrs()};
-            if (x.passName().has_value()) {
+            if (x.passName()) {
               attrs.reset(Attr::PASS);
             }
             PutAttrs(typeBindings, attrs);
@@ -508,7 +508,7 @@ void PutProcEntity(std::ostream &os, const Symbol &symbol) {
   const auto &details{symbol.get<ProcEntityDetails>()};
   const ProcInterface &interface{details.interface()};
   Attrs attrs{symbol.attrs()};
-  if (details.passName().has_value()) {
+  if (details.passName()) {
     attrs.reset(Attr::PASS);
   }
   PutEntity(os, symbol,
@@ -763,7 +763,7 @@ Scope *ModFileReader::Read(const SourceName &name, Scope *ancestor) {
   options.searchDirectories = context_.searchDirectories();
   auto path{ModFileName(name, ancestorName, context_.moduleFileSuffix())};
   const auto *sourceFile{parsing.Prescan(path, options)};
-  if (sourceFile == nullptr) {
+  if (!sourceFile) {
     return nullptr;
   } else if (parsing.messages().AnyFatalError()) {
     for (auto &msg : parsing.messages().messages()) {
@@ -781,7 +781,7 @@ Scope *ModFileReader::Read(const SourceName &name, Scope *ancestor) {
   parsing.Parse(nullptr);
   auto &parseTree{parsing.parseTree()};
   if (!parsing.messages().empty() || !parsing.consumedWholeFile() ||
-      !parseTree.has_value()) {
+      !parseTree) {
     Say(name, ancestorName, "Module file is corrupt: %s"_err_en_US,
         sourceFile->path());
     return nullptr;

--- a/lib/semantics/resolve-labels.cc
+++ b/lib/semantics/resolve-labels.cc
@@ -195,7 +195,7 @@ const parser::CharBlock *GetStmtName(const parser::Statement<A> &stmt) {
   } else {
     name = &std::get<std::optional<parser::Name>>(stmt.statement.t);
   }
-  if (name && name->has_value()) {
+  if (name && *name) {
     return &(*name)->source;
   }
   return nullptr;
@@ -219,7 +219,7 @@ public:
 
   template<typename A> bool Pre(const parser::Statement<A> &statement) {
     currentPosition_ = statement.source;
-    if (statement.label.has_value()) {
+    if (statement.label) {
       auto label{statement.label.value()};
       auto targetFlags{ConstructBranchTargetFlags(statement)};
       if constexpr (std::is_same_v<A, parser::AssociateStmt> ||
@@ -378,14 +378,14 @@ public:
     if (const auto *optionalGenericSpecPointer{
             std::get_if<std::optional<parser::GenericSpec>>(
                 &interfaceStmt.statement.u)}) {
-      if (optionalGenericSpecPointer->has_value()) {
+      if (*optionalGenericSpecPointer) {
         if (const auto *namePointer{
                 std::get_if<parser::Name>(&(*optionalGenericSpecPointer)->u)}) {
           auto &optionalGenericSpec{
               std::get<parser::Statement<parser::EndInterfaceStmt>>(
                   interfaceBlock.t)
                   .statement.v};
-          if (optionalGenericSpec.has_value()) {
+          if (optionalGenericSpec) {
             if (const auto *otherPointer{
                     std::get_if<parser::Name>(&optionalGenericSpec->u)}) {
               if (namePointer->source != otherPointer->source) {
@@ -489,12 +489,12 @@ public:
     }
   }
   void Post(const parser::CycleStmt &cycleStmt) {
-    if (cycleStmt.v.has_value()) {
+    if (cycleStmt.v) {
       CheckLabelContext("CYCLE", cycleStmt.v->source);
     }
   }
   void Post(const parser::ExitStmt &exitStmt) {
-    if (exitStmt.v.has_value()) {
+    if (exitStmt.v) {
       CheckLabelContext("EXIT", exitStmt.v->source);
     }
   }
@@ -528,7 +528,7 @@ private:
 
   template<typename A> bool PushConstructName(const A &a) {
     const auto &optionalName{std::get<0>(std::get<0>(a.t).statement.t)};
-    if (optionalName.has_value()) {
+    if (optionalName) {
       constructNames_.emplace_back(optionalName->ToString());
     }
     return PushSubscope();
@@ -537,14 +537,14 @@ private:
     const auto &optionalName{
         std::get<parser::Statement<parser::BlockStmt>>(blockConstruct.t)
             .statement.v};
-    if (optionalName.has_value()) {
+    if (optionalName) {
       constructNames_.emplace_back(optionalName->ToString());
     }
     return PushSubscope();
   }
   template<typename A> bool PushConstructNameWithoutBlock(const A &a) {
     const auto &optionalName{std::get<0>(std::get<0>(a.t).statement.t)};
-    if (optionalName.has_value()) {
+    if (optionalName) {
       constructNames_.emplace_back(optionalName->ToString());
     }
     return true;
@@ -556,7 +556,7 @@ private:
   }
   template<typename A> void PopConstructNameIfPresent(const A &a) {
     const auto &optionalName{std::get<0>(std::get<0>(a.t).statement.t)};
-    if (optionalName.has_value()) {
+    if (optionalName) {
       constructNames_.pop_back();
     }
   }
@@ -564,7 +564,7 @@ private:
     const auto &optionalName{
         std::get<parser::Statement<parser::BlockStmt>>(blockConstruct.t)
             .statement.v};
-    if (optionalName.has_value()) {
+    if (optionalName) {
       constructNames_.pop_back();
     }
   }

--- a/lib/semantics/resolve-names-utils.cc
+++ b/lib/semantics/resolve-names-utils.cc
@@ -625,7 +625,7 @@ bool EquivalenceSets::CheckArrayBound(const parser::Expr &bound) {
     return false;
   }
   auto subscript{evaluate::ToInt64(*expr)};
-  if (!subscript.has_value()) {
+  if (!subscript) {
     context_.Say(bound.source,  // C8109
         "Array with nonconstant subscript '%s' is not allowed in an equivalence set"_err_en_US,
         bound.source);
@@ -643,7 +643,7 @@ bool EquivalenceSets::CheckSubstringBound(
     return false;
   }
   auto subscript{evaluate::ToInt64(*expr)};
-  if (!subscript.has_value()) {
+  if (!subscript) {
     context_.Say(bound.source,  // C8109
         "Substring with nonconstant bound '%s' is not allowed in an equivalence set"_err_en_US,
         bound.source);
@@ -665,7 +665,7 @@ bool EquivalenceSets::CheckSubstringBound(
 bool EquivalenceSets::IsCharacterSequenceType(const DeclTypeSpec *type) {
   return IsSequenceType(type, [&](const IntrinsicTypeSpec &type) {
     auto kind{evaluate::ToInt64(type.kind())};
-    return type.category() == TypeCategory::Character && kind.has_value() &&
+    return type.category() == TypeCategory::Character && kind &&
         kind.value() == context_.GetDefaultKind(TypeCategory::Character);
   });
 }

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -183,7 +183,7 @@ Scope::ImportKind Scope::GetImportKind() const {
 }
 
 std::optional<parser::MessageFixedText> Scope::SetImportKind(ImportKind kind) {
-  if (!importKind_.has_value()) {
+  if (!importKind_) {
     importKind_ = kind;
     return std::nullopt;
   }
@@ -298,10 +298,10 @@ const DeclTypeSpec *Scope::FindInstantiatedDerivedType(
 }
 
 const Symbol *Scope::GetSymbol() const {
-  if (symbol_ != nullptr) {
+  if (symbol_) {
     return symbol_;
   }
-  if (derivedTypeSpec_ != nullptr) {
+  if (derivedTypeSpec_) {
     return &derivedTypeSpec_->typeSymbol();
   }
   return nullptr;

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -207,7 +207,7 @@ public:
       DeclTypeSpec::Category = DeclTypeSpec::TypeDerived) const;
 
   bool IsModuleFile() const {
-    return kind_ == Kind::Module && symbol_ != nullptr &&
+    return kind_ == Kind::Module && symbol_ &&
         symbol_->test(Symbol::Flag::ModFile);
   }
 

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -128,7 +128,7 @@ public:
   void SetError(Symbol &, bool = true);
 
   template<typename... A> parser::Message &Say(A &&... args) {
-    CHECK(location_.has_value());
+    CHECK(location_);
     return messages_.Say(*location_, std::forward<A>(args)...);
   }
   template<typename... A>

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -552,8 +552,8 @@ const DerivedTypeSpec *Symbol::GetParentTypeSpec(const Scope *scope) const {
 
 const Symbol *Symbol::GetParentComponent(const Scope *scope) const {
   if (const auto *dtDetails{detailsIf<DerivedTypeDetails>()}) {
-    if (scope == nullptr) {
-      CHECK(scope_ != nullptr);
+    if (!scope) {
+      CHECK(scope_);
       scope = scope_;
     }
     return dtDetails->GetParentComponent(*scope);
@@ -582,7 +582,7 @@ const Symbol *DerivedTypeDetails::GetParentComponent(const Scope &scope) const {
 }
 
 void TypeParamDetails::set_type(const DeclTypeSpec &type) {
-  CHECK(type_ == nullptr);
+  CHECK(!type_);
   type_ = &type;
 }
 

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -72,7 +72,7 @@ public:
     return *result_;
   }
   void set_result(Symbol &result) {
-    CHECK(result_ == nullptr);
+    CHECK(!result_);
     result_ = &result;
   }
   const std::vector<Symbol *> &dummyArgs() const { return dummyArgs_; }
@@ -495,7 +495,7 @@ public:
   }
   template<typename D> const D &get() const {
     const auto *p{detailsIf<D>()};
-    CHECK(p != nullptr);
+    CHECK(p);
     return *p;
   }
 

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -214,7 +214,7 @@ struct GetExprHelper {
     return Get(x.value());
   }
   template<typename T> const SomeExpr *Get(const std::optional<T> &x) {
-    return x.has_value() ? Get(x.value()) : nullptr;
+    return x ? Get(*x) : nullptr;
   }
   template<typename T> const SomeExpr *Get(const T &x) {
     if constexpr (ConstraintTrait<T>) {

--- a/runtime/ISO_Fortran_binding.cc
+++ b/runtime/ISO_Fortran_binding.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ void *CFI_address(
 
 int CFI_allocate(CFI_cdesc_t *descriptor, const CFI_index_t lower_bounds[],
     const CFI_index_t upper_bounds[], std::size_t elem_len) {
-  if (descriptor == nullptr) {
+  if (!descriptor) {
     return CFI_INVALID_DESCRIPTOR;
   }
   if (descriptor->version != CFI_VERSION) {
@@ -53,7 +53,7 @@ int CFI_allocate(CFI_cdesc_t *descriptor, const CFI_index_t lower_bounds[],
     return CFI_INVALID_ATTRIBUTE;
   }
   if (descriptor->attribute == CFI_attribute_allocatable &&
-      descriptor->base_addr != nullptr) {
+      descriptor->base_addr) {
     return CFI_ERROR_BASE_ADDR_NOT_NULL;
   }
   if (descriptor->rank > CFI_MAX_RANK) {
@@ -82,7 +82,7 @@ int CFI_allocate(CFI_cdesc_t *descriptor, const CFI_index_t lower_bounds[],
     byteSize *= extent;
   }
   void *p{new char[byteSize]};
-  if (p == nullptr) {
+  if (!p) {
     return CFI_ERROR_MEM_ALLOCATION;
   }
   descriptor->base_addr = p;
@@ -91,7 +91,7 @@ int CFI_allocate(CFI_cdesc_t *descriptor, const CFI_index_t lower_bounds[],
 }
 
 int CFI_deallocate(CFI_cdesc_t *descriptor) {
-  if (descriptor == nullptr) {
+  if (!descriptor) {
     return CFI_INVALID_DESCRIPTOR;
   }
   if (descriptor->version != CFI_VERSION) {
@@ -102,7 +102,7 @@ int CFI_deallocate(CFI_cdesc_t *descriptor) {
     // Non-interoperable object
     return CFI_INVALID_DESCRIPTOR;
   }
-  if (descriptor->base_addr == nullptr) {
+  if (!descriptor->base_addr) {
     return CFI_ERROR_BASE_ADDR_NULL;
   }
   delete[] static_cast<char *>(descriptor->base_addr);
@@ -162,16 +162,16 @@ int CFI_establish(CFI_cdesc_t *descriptor, void *base_addr,
   if (rank > CFI_MAX_RANK) {
     return CFI_INVALID_RANK;
   }
-  if (base_addr != nullptr && attribute == CFI_attribute_allocatable) {
+  if (base_addr && attribute == CFI_attribute_allocatable) {
     return CFI_ERROR_BASE_ADDR_NOT_NULL;
   }
-  if (rank > 0 && base_addr != nullptr && extents == nullptr) {
+  if (rank > 0 && base_addr && !extents) {
     return CFI_INVALID_EXTENT;
   }
   if (type < CFI_type_signed_char || type > CFI_type_struct) {
     return CFI_INVALID_TYPE;
   }
-  if (descriptor == nullptr) {
+  if (!descriptor) {
     return CFI_INVALID_DESCRIPTOR;
   }
   std::size_t minElemLen{MinElemLen(type)};
@@ -189,7 +189,7 @@ int CFI_establish(CFI_cdesc_t *descriptor, void *base_addr,
   descriptor->f18Addendum = 0;
   std::size_t byteSize{elem_len};
   constexpr std::size_t lower_bound{0};
-  if (base_addr != nullptr) {
+  if (base_addr) {
     for (std::size_t j{0}; j < rank; ++j) {
       descriptor->dim[j].lower_bound = lower_bound;
       descriptor->dim[j].extent = extents[j];
@@ -218,13 +218,13 @@ int CFI_section(CFI_cdesc_t *result, const CFI_cdesc_t *source,
   CFI_index_t actualStride[CFI_MAX_RANK];
   CFI_rank_t resRank{0};
 
-  if (result == nullptr || source == nullptr) {
+  if (!result || !source) {
     return CFI_INVALID_DESCRIPTOR;
   }
   if (source->rank == 0) {
     return CFI_INVALID_RANK;
   }
-  if (IsAssumedSize(source) && upper_bounds == nullptr) {
+  if (IsAssumedSize(source) && !upper_bounds) {
     return CFI_INVALID_DESCRIPTOR;
   }
   if ((result->type != source->type) ||
@@ -234,7 +234,7 @@ int CFI_section(CFI_cdesc_t *result, const CFI_cdesc_t *source,
   if (result->attribute == CFI_attribute_allocatable) {
     return CFI_INVALID_ATTRIBUTE;
   }
-  if (source->base_addr == nullptr) {
+  if (!source->base_addr) {
     return CFI_ERROR_BASE_ADDR_NULL;
   }
 
@@ -244,9 +244,9 @@ int CFI_section(CFI_cdesc_t *result, const CFI_cdesc_t *source,
     const CFI_dim_t &dim{source->dim[j]};
     const CFI_index_t srcLB{dim.lower_bound};
     const CFI_index_t srcUB{srcLB + dim.extent - 1};
-    const CFI_index_t lb{lower_bounds != nullptr ? lower_bounds[j] : srcLB};
-    const CFI_index_t ub{upper_bounds != nullptr ? upper_bounds[j] : srcUB};
-    const CFI_index_t stride{strides != nullptr ? strides[j] : 1};
+    const CFI_index_t lb{lower_bounds ? lower_bounds[j] : srcLB};
+    const CFI_index_t ub{upper_bounds ? upper_bounds[j] : srcUB};
+    const CFI_index_t stride{strides ? strides[j] : 1};
 
     if (stride == 0 && lb != ub) {
       return CFI_ERROR_OUT_OF_BOUNDS;
@@ -285,7 +285,7 @@ int CFI_section(CFI_cdesc_t *result, const CFI_cdesc_t *source,
 
 int CFI_select_part(CFI_cdesc_t *result, const CFI_cdesc_t *source,
     std::size_t displacement, std::size_t elem_len) {
-  if (result == nullptr || source == nullptr) {
+  if (!result || !source) {
     return CFI_INVALID_DESCRIPTOR;
   }
   if (result->rank != source->rank) {
@@ -294,7 +294,7 @@ int CFI_select_part(CFI_cdesc_t *result, const CFI_cdesc_t *source,
   if (result->attribute == CFI_attribute_allocatable) {
     return CFI_INVALID_ATTRIBUTE;
   }
-  if (source->base_addr == nullptr) {
+  if (!source->base_addr) {
     return CFI_ERROR_BASE_ADDR_NULL;
   }
   if (IsAssumedSize(source)) {
@@ -320,13 +320,13 @@ int CFI_select_part(CFI_cdesc_t *result, const CFI_cdesc_t *source,
 
 int CFI_setpointer(CFI_cdesc_t *result, const CFI_cdesc_t *source,
     const CFI_index_t lower_bounds[]) {
-  if (result == nullptr) {
+  if (!result) {
     return CFI_INVALID_DESCRIPTOR;
   }
   if (result->attribute != CFI_attribute_pointer) {
     return CFI_INVALID_ATTRIBUTE;
   }
-  if (source == nullptr) {
+  if (!source) {
     result->base_addr = nullptr;
     return CFI_SUCCESS;
   }
@@ -339,17 +339,16 @@ int CFI_setpointer(CFI_cdesc_t *result, const CFI_cdesc_t *source,
   if (source->elem_len != result->elem_len) {
     return CFI_INVALID_ELEM_LEN;
   }
-  if (source->base_addr == nullptr &&
-      source->attribute != CFI_attribute_pointer) {
+  if (!source->base_addr && source->attribute != CFI_attribute_pointer) {
     return CFI_ERROR_BASE_ADDR_NULL;
   }
   if (IsAssumedSize(source)) {
     return CFI_INVALID_DESCRIPTOR;
   }
 
-  const bool copySrcLB{lower_bounds == nullptr};
+  const bool copySrcLB{!lower_bounds};
   result->base_addr = source->base_addr;
-  if (source->base_addr != nullptr) {
+  if (source->base_addr) {
     for (int j{0}; j < result->rank; ++j) {
       result->dim[j].extent = source->dim[j].extent;
       result->dim[j].sm = source->dim[j].sm;

--- a/runtime/derived-type.h
+++ b/runtime/derived-type.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ public:
   }
 
   const Descriptor *GetDescriptor(const char *dtInstance) const {
-    if (staticDescriptor_ != nullptr) {
+    if (staticDescriptor_) {
       return staticDescriptor_;
     } else if (IsDescriptor()) {
       return Locate<const Descriptor>(dtInstance);

--- a/runtime/descriptor.cc
+++ b/runtime/descriptor.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ void Descriptor::Establish(const DerivedType &dt, void *p, int rank,
             dt.SizeInBytes(), rank, extent) == CFI_SUCCESS);
   raw_.f18Addendum = true;
   DescriptorAddendum *a{Addendum()};
-  CHECK(a != nullptr);
+  CHECK(a);
   new (a) DescriptorAddendum{&dt};
 }
 
@@ -70,7 +70,7 @@ std::unique_ptr<Descriptor> Descriptor::Create(TypeCode t,
     ISO::CFI_attribute_t attribute) {
   std::size_t bytes{SizeInBytes(rank, true)};
   Descriptor *result{reinterpret_cast<Descriptor *>(new char[bytes])};
-  CHECK(result != nullptr);
+  CHECK(result);
   result->Establish(t, elementBytes, p, rank, extent, attribute, true);
   return std::unique_ptr<Descriptor>{result};
 }
@@ -80,7 +80,7 @@ std::unique_ptr<Descriptor> Descriptor::Create(TypeCategory c, int kind,
     ISO::CFI_attribute_t attribute) {
   std::size_t bytes{SizeInBytes(rank, true)};
   Descriptor *result{reinterpret_cast<Descriptor *>(new char[bytes])};
-  CHECK(result != nullptr);
+  CHECK(result);
   result->Establish(c, kind, p, rank, extent, attribute, true);
   return std::unique_ptr<Descriptor>{result};
 }
@@ -89,7 +89,7 @@ std::unique_ptr<Descriptor> Descriptor::Create(const DerivedType &dt, void *p,
     int rank, const SubscriptValue *extent, ISO::CFI_attribute_t attribute) {
   std::size_t bytes{SizeInBytes(rank, true, dt.lenParameters())};
   Descriptor *result{reinterpret_cast<Descriptor *>(new char[bytes])};
-  CHECK(result != nullptr);
+  CHECK(result);
   result->Establish(dt, p, rank, extent, attribute);
   return std::unique_ptr<Descriptor>{result};
 }
@@ -119,14 +119,14 @@ int Descriptor::Allocate(
 }
 
 int Descriptor::Deallocate(bool finalize) {
-  if (raw_.base_addr != nullptr) {
+  if (raw_.base_addr) {
     Destroy(static_cast<char *>(raw_.base_addr), finalize);
   }
   return ISO::CFI_deallocate(&raw_);
 }
 
 void Descriptor::Destroy(char *data, bool finalize) const {
-  if (data != nullptr) {
+  if (data) {
     if (const DescriptorAddendum * addendum{Addendum()}) {
       if (addendum->flags() & DescriptorAddendum::DoNotFinalize) {
         finalize = false;

--- a/runtime/descriptor.h
+++ b/runtime/descriptor.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ public:
   const std::uint64_t &flags() const { return flags_; }
 
   std::size_t LenParameters() const {
-    if (derivedType_ != nullptr) {
+    if (derivedType_) {
       return derivedType_->lenParameters();
     }
     return 0;

--- a/runtime/transformational.cc
+++ b/runtime/transformational.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+// Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ std::unique_ptr<Descriptor> RESHAPE(const Descriptor &source,
   // Extract and check the optional ORDER= argument, which must be a
   // permutation of [1..resultRank].
   int dimOrder[maxRank];
-  if (order != nullptr) {
+  if (order) {
     CHECK(order->rank() == 1);
     CHECK(order->type().IsInteger());
     CHECK(order->GetDimension(0).Extent() == resultRank);
@@ -97,7 +97,7 @@ std::unique_ptr<Descriptor> RESHAPE(const Descriptor &source,
   const DerivedType *sourceDerivedType{
       sourceAddendum ? sourceAddendum->derivedType() : nullptr};
   std::unique_ptr<Descriptor> result;
-  if (sourceDerivedType != nullptr) {
+  if (sourceDerivedType) {
     result = Descriptor::Create(*sourceDerivedType, nullptr, resultRank,
         resultExtent, CFI_attribute_allocatable);
   } else {
@@ -106,9 +106,9 @@ std::unique_ptr<Descriptor> RESHAPE(const Descriptor &source,
         CFI_attribute_allocatable);  // TODO rearrange these arguments
   }
   DescriptorAddendum *resultAddendum{result->Addendum()};
-  CHECK(resultAddendum != nullptr);
+  CHECK(resultAddendum);
   resultAddendum->flags() |= DescriptorAddendum::DoNotFinalize;
-  if (sourceDerivedType != nullptr) {
+  if (sourceDerivedType) {
     std::size_t lenParameters{sourceDerivedType->lenParameters()};
     for (std::size_t j{0}; j < lenParameters; ++j) {
       resultAddendum->SetLenParameterValue(

--- a/tools/f18/f18-parse-demo.cc
+++ b/tools/f18/f18-parse-demo.cc
@@ -213,7 +213,7 @@ std::string CompileFortran(
   }
   if ((!parsing.messages().empty() &&
           (driver.warningsAreErrors || parsing.messages().AnyFatalError())) ||
-      !parsing.parseTree().has_value()) {
+      !parsing.parseTree()) {
     std::cerr << driver.prefix << "could not parse " << path << '\n';
     exitStatus = EXIT_FAILURE;
     return {};

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -222,7 +222,7 @@ std::string CompileFortran(std::string path, Fortran::parser::Options options,
   }
   if ((!parsing.messages().empty() &&
           (driver.warningsAreErrors || parsing.messages().AnyFatalError())) ||
-      !parsing.parseTree().has_value()) {
+      !parsing.parseTree()) {
     std::cerr << driver.prefix << "could not parse " << path << '\n';
     exitStatus = EXIT_FAILURE;
     return {};
@@ -291,7 +291,7 @@ std::string CompileFortran(std::string path, Fortran::parser::Options options,
 
   Fortran::parser::TypedExprAsFortran unparseExpression{
       [](std::ostream &o, const Fortran::evaluate::GenericExprWrapper &x) {
-        if (x.v.has_value()) {
+        if (x.v) {
           o << *x.v;
         } else {
           o << "(bad expression)";


### PR DESCRIPTION
There seems to be a consensus that `if (p != nullptr)` and `if (p.has_value())` would be more readable if they were more simply written `if (p)`.
