### PR TITLE
Fix bad deferences in ProgramTree

### DIFF
--- a/lib/semantics/program-tree.cc
+++ b/lib/semantics/program-tree.cc
@@ -62,8 +62,9 @@ ProgramTree ProgramTree::Build(const parser::MainProgram &x) {
       std::get<std::optional<parser::Statement<parser::ProgramStmt>>>(x.t)};
   const auto &end{std::get<parser::Statement<parser::EndProgramStmt>>(x.t)};
   static parser::Name emptyName;
-  const auto &name{stmt ? stmt->statement.v : emptyName};
-  return BuildSubprogramTree(name, x).set_stmt(*stmt).set_endStmt(end);
+  auto result{stmt ? BuildSubprogramTree(stmt->statement.v, x).set_stmt(*stmt)
+                   : BuildSubprogramTree(emptyName, x)};
+  return result.set_endStmt(end);
 }
 
 ProgramTree ProgramTree::Build(const parser::FunctionSubprogram &x) {

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -5916,7 +5916,13 @@ void ResolveNamesVisitor::ResolveSpecificationParts(ProgramTree &node) {
   Scope &scope{currScope()};
   node.set_scope(scope);
   AddSubpNames(node);
-  std::visit([&](const auto *x) { Walk(*x); }, node.stmt());
+  std::visit(
+      [&](const auto *x) {
+        if (x) {
+          Walk(*x);
+        }
+      },
+      node.stmt());
   Walk(node.spec());
   // If this is a function, convert result to an object. This is to prevent the
   // result to be converted later to a function symbol if it is called inside


### PR DESCRIPTION
We weren't handling MainProgram with no ProgramStmt correctly in
ProgramTree. When building it we were dereferencing an empty optional.
And in ResolveSpecificationParts we were dereferencing a null pointer.