### PR TITLE
Disable arm64 gcc builds in CI until they can be fixed

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -43,6 +43,6 @@ def main(ctx):
         clang("amd64"),
         clang("arm64"),
         gcc("amd64"),
-        gcc("arm64"),
+        #gcc("arm64"),
     ]
 


### PR DESCRIPTION
Currently the arm64 gcc builds in CI are getting stuck and I can't work out why.
I think we should disable these to get CI working again until they're fixed, which I'll have a look at on my own branch.