### PR TITLE
For call11.f90: more checks on PURE subprograms and TBP bindings

### DIFF
--- a/lib/evaluate/characteristics.h
+++ b/lib/evaluate/characteristics.h
@@ -261,6 +261,7 @@ struct Procedure {
     return !attrs.test(Attr::ImplicitInterface);
   }
   bool CanBeCalledViaImplicitInterface() const;
+  bool CanOverride(const Procedure &, std::optional<int> passIndex) const;
   std::ostream &Dump(std::ostream &) const;
 
   std::optional<FunctionResult> functionResult;

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -817,5 +817,10 @@ parser::Message *SayWithDeclaration(
     MESSAGES &messages, const Symbol *symbol, A &&... x) {
   return AttachDeclaration(messages.Say(std::forward<A>(x)...), symbol);
 }
+
+// Check for references to impure procedures; returns the name
+// of one to complain about, if any exist.
+std::optional<std::string> FindImpureCall(
+    const IntrinsicProcTable &, const Expr<SomeType> &);
 }
 #endif  // FORTRAN_EVALUATE_TOOLS_H_

--- a/lib/evaluate/variable.cc
+++ b/lib/evaluate/variable.cc
@@ -606,10 +606,10 @@ bool Component::operator==(const Component &that) const {
   return base_ == that.base_ && &*symbol_ == &*that.symbol_;
 }
 bool NamedEntity::operator==(const NamedEntity &that) const {
-  if (&GetLastSymbol() != &that.GetLastSymbol()) {
-    return false;
+  if (IsSymbol()) {
+    return that.IsSymbol() && GetLastSymbol() == that.GetLastSymbol();
   } else {
-    return UnwrapComponent() == that.UnwrapComponent();
+    return !that.IsSymbol() && GetComponent() == that.GetComponent();
   }
 }
 template<int KIND>

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -85,6 +85,18 @@ Symbol *Scope::FindSymbol(const SourceName &name) const {
   }
 }
 
+Symbol *Scope::FindComponent(SourceName name) const {
+  CHECK(IsDerivedType());
+  auto found{find(name)};
+  if (found != end()) {
+    return &*found->second;
+  } else if (const Scope * parent{GetDerivedTypeParent()}) {
+    return parent->FindComponent(name);
+  } else {
+    return nullptr;
+  }
+}
+
 const std::list<EquivalenceSet> &Scope::equivalenceSets() const {
   return equivalenceSets_;
 }

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -123,6 +123,10 @@ public:
   // Look for symbol by name in this scope and host (depending on imports).
   Symbol *FindSymbol(const SourceName &) const;
 
+  // Look for component symbol by name in a derived type's scope and
+  // parents'.
+  Symbol *FindComponent(SourceName) const;
+
   /// Make a Symbol with unknown details.
   std::pair<iterator, bool> try_emplace(
       const SourceName &name, Attrs attrs = Attrs()) {

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -556,7 +556,7 @@ const Symbol *Symbol::GetParentComponent(const Scope *scope) const {
       CHECK(scope_);
       scope = scope_;
     }
-    return dtDetails->GetParentComponent(*scope);
+    return dtDetails->GetParentComponent(DEREF(scope));
   } else {
     return nullptr;
   }

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -582,8 +582,23 @@ public:
         details_);
   }
 
-  bool operator==(const Symbol &that) const { return this == &that; }
-  bool operator!=(const Symbol &that) const { return this != &that; }
+  // For the purposes of comparing type parameter expressions while
+  // testing the compatibility of procedure characteristics, two
+  // object dummy arguments with the same name are considered equal.
+  bool operator==(const Symbol &that) const {
+    if (this == &that) {
+      return true;
+    } else if (name() != that.name()) {
+      return false;
+    } else if (const auto *object{detailsIf<ObjectEntityDetails>()}) {
+      if (const auto *thatObject{that.detailsIf<ObjectEntityDetails>()}) {
+        return object->isDummy() && thatObject->isDummy();
+      }
+    }
+    return false;
+  }
+  bool operator!=(const Symbol &that) const { return !(*this == that); }
+
   bool operator<(const Symbol &that) const {
     // For sets of symbols: collate them by source location
     return name_.begin() < that.name_.begin();

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -46,6 +46,12 @@ const Symbol *FindPointerComponent(const Symbol &);
 const Symbol *FindInterface(const Symbol &);
 const Symbol *FindSubprogram(const Symbol &);
 const Symbol *FindFunctionResult(const Symbol &);
+const Symbol *FindOverriddenBinding(const Symbol &);
+
+const DeclTypeSpec *FindParentTypeSpec(const DerivedTypeSpec &);
+const DeclTypeSpec *FindParentTypeSpec(const DeclTypeSpec &);
+const DeclTypeSpec *FindParentTypeSpec(const Scope &);
+const DeclTypeSpec *FindParentTypeSpec(const Symbol &);
 
 // Return the Symbol of the variable of a construct association, if it exists
 const Symbol *GetAssociationRoot(const Symbol &);
@@ -443,6 +449,8 @@ UltimateComponentIterator::const_iterator FindAllocatableUltimateComponent(
     const DerivedTypeSpec &);
 UltimateComponentIterator::const_iterator
 FindPolymorphicAllocatableUltimateComponent(const DerivedTypeSpec &);
+UltimateComponentIterator::const_iterator
+FindPolymorphicAllocatableNonCoarrayUltimateComponent(const DerivedTypeSpec &);
 
 }
 #endif  // FORTRAN_SEMANTICS_TOOLS_H_

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -184,10 +184,12 @@ set(ERROR_TESTS
   call08.f90
   call09.f90
   call10.f90
+  call11.f90
   call13.f90
   call14.f90
   misc-declarations.f90
   separate-module-procs.f90
+  bindings01.f90
 )
 
 # These test files have expected symbols in the source

--- a/test/semantics/bindings01.f90
+++ b/test/semantics/bindings01.f90
@@ -1,0 +1,127 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Confirm enforcement of constraints and restrictions in 7.5.7.3
+! and C779-C785.
+
+module m
+  !ERROR: An ABSTRACT derived type must be extensible
+  type, abstract, bind(c) :: badAbstract1
+  end type
+  !ERROR: An ABSTRACT derived type must be extensible
+  type, abstract :: badAbstract2
+    sequence
+  end type
+  type, abstract :: abstract
+   contains
+    !ERROR: DEFERRED is required when an interface-name is provided
+    procedure(s1), pass :: ab1
+    !ERROR: Type-bound procedure 'ab3' may not be both DEFERRED and NON_OVERRIDABLE
+    procedure(s1), deferred, non_overridable :: ab3
+    !ERROR: DEFERRED is only allowed when an interface-name is provided
+    procedure, deferred, non_overridable :: ab4 => s1
+  end type
+  type :: nonoverride
+   contains
+    procedure, non_overridable, nopass :: no1 => s1
+  end type
+  type, extends(nonoverride) :: nonoverride2
+  end type
+  type, extends(nonoverride2) :: nonoverride3
+   contains
+    !ERROR: Override of NON_OVERRIDABLE 'no1' is not permitted
+    procedure, nopass :: no1 => s1
+  end type
+  type, abstract :: missing
+   contains
+    procedure(s4), deferred :: am1
+  end type
+  !ERROR: Non-ABSTRACT extension of ABSTRACT derived type 'missing' lacks a binding for DEFERRED procedure 'am1'
+  type, extends(missing) :: concrete
+  end type
+  type, extends(missing) :: intermediate
+   contains
+    procedure :: am1 => s7
+  end type
+  type, extends(intermediate) :: concrete2  ! ensure no false missing binding error
+  end type
+  type, bind(c) :: inextensible1
+  end type
+  !ERROR: The parent type is not extensible
+  type, extends(inextensible1) :: badExtends1
+  end type
+  type :: inextensible2
+    sequence
+  end type
+  !ERROR: The parent type is not extensible
+  type, extends(inextensible2) :: badExtends2
+  end type
+  !ERROR: Derived type 'real' not found
+  type, extends(real) :: badExtends3
+  end type
+  type :: base
+    real :: component
+   contains
+    !ERROR: Procedure bound to non-ABSTRACT derived type 'base' may not be DEFERRED
+    procedure(s2), deferred :: bb1
+    !ERROR: DEFERRED is only allowed when an interface-name is provided
+    procedure, deferred :: bb2 => s2
+  end type
+  type, extends(base) :: extension
+   contains
+     !ERROR: A type-bound procedure binding may not have the same name as a parent component
+     procedure :: component => s3
+  end type
+  type :: nopassBase
+   contains
+    procedure, nopass :: tbp => s1
+  end type
+  type, extends(nopassBase) :: passExtends
+   contains
+    !ERROR: A passed-argument type-bound procedure may not override a NOPASS procedure
+    procedure :: tbp => s5
+  end type
+  type :: passBase
+   contains
+    procedure :: tbp => s6
+  end type
+  type, extends(passBase) :: nopassExtends
+   contains
+    !ERROR: A NOPASS type-bound procedure may not override a passed-argument procedure
+    procedure, nopass :: tbp => s1
+  end type
+ contains
+  subroutine s1(x)
+    class(abstract), intent(in) :: x
+  end subroutine s1
+  subroutine s2(x)
+    class(base), intent(in) :: x
+  end subroutine s2
+  subroutine s3(x)
+    class(extension), intent(in) :: x
+  end subroutine s3
+  subroutine s4(x)
+    class(missing), intent(in) :: x
+  end subroutine s4
+  subroutine s5(x)
+    class(passExtends), intent(in) :: x
+  end subroutine s5
+  subroutine s6(x)
+    class(passBase), intent(in) :: x
+  end subroutine s6
+  subroutine s7(x)
+    class(intermediate), intent(in) :: x
+  end subroutine s7
+end module
+

--- a/test/semantics/call10.f90
+++ b/test/semantics/call10.f90
@@ -154,7 +154,7 @@ module m
     !ERROR: Deallocation of polymorphic object 'auto%a' is not permitted in a PURE subprogram
     type(polyAlloc) :: auto
     type(polyAlloc), intent(in out) :: to
-    !ERROR: Deallocation of polymorphic component '%a' is not permitted in a PURE subprogram
+    !ERROR: Deallocation of polymorphic non-coarray component '%a' is not permitted in a PURE subprogram
     to = auto
   end subroutine
   pure subroutine s12

--- a/test/semantics/call11.f90
+++ b/test/semantics/call11.f90
@@ -39,15 +39,15 @@ module m
 
   subroutine test
     real :: a(pure(1)) ! ok
-    !ERROR: A function referenced in a specification expression must be PURE
+    !ERROR: Invalid specification expression: reference to impure function 'impure'
     real :: b(impure(1)) ! 10.1.11(4)
     forall (j=1:1)
-      !ERROR: A procedure referenced in a FORALL body must be PURE
+      !ERROR: Impure procedure 'impure' may not be referenced in a FORALL
       a(j) = impure(j) ! C1037
     end forall
-    !ERROR: concurrent-header mask expression cannot reference an impure procedure
+    !ERROR: Concurrent-header mask expression cannot reference an impure procedure
     do concurrent (j=1:1, impure(j) /= 0) ! C1121
-      !ERROR: call to impure procedure in DO CONCURRENT not allowed
+      !ERROR: Call to an impure procedure is not allowed in DO CONCURRENT
       a(j) = impure(j) ! C1139
     end do
   end subroutine

--- a/test/semantics/modfile10.f90
+++ b/test/semantics/modfile10.f90
@@ -32,6 +32,9 @@ module m
     private
     final :: c
     procedure, non_overridable :: d
+  end type
+  type, abstract :: t2a
+  contains
     procedure(a), deferred, public, nopass :: e
   end type
   type t3
@@ -76,6 +79,9 @@ end module
 !  contains
 !    final::c
 !    procedure,pass(x),non_overridable,private::d
+!  end type
+!  type,abstract::t2a
+!  contains
 !    procedure(a),deferred,nopass::e
 !  end type
 !  type::t3

--- a/test/semantics/resolve31.f90
+++ b/test/semantics/resolve31.f90
@@ -55,8 +55,10 @@ module m4
     sequence
     private  ! not a fatal error
   end type
+  type :: t1a
+  end type
   !ERROR: A sequence type may not have the EXTENDS attribute
-  type, extends(t1) :: t2
+  type, extends(t1a) :: t2
     sequence
     integer i
   end type

--- a/test/semantics/resolve32.f90
+++ b/test/semantics/resolve32.f90
@@ -53,12 +53,15 @@ module m
     procedure, nopass :: i
     !ERROR: Type parameter, component, or procedure binding 'b' already defined in this type
     procedure, nopass :: b => s4
+    !ERROR: DEFERRED is required when an interface-name is provided
+    procedure(foo), nopass :: g
+  end type
+  type, abstract :: t1a ! DEFERRED valid only in ABSTRACT derived type
+  contains
     procedure(foo), nopass, deferred :: e
     procedure(s), nopass, deferred :: f
     !ERROR: Type parameter, component, or procedure binding 'f' already defined in this type
     procedure(foo), nopass, deferred :: f
-    !ERROR: DEFERRED is required when an interface-name is provided
-    procedure(foo), nopass :: g
     !ERROR: 'bar' must be an abstract interface or a procedure with an explicit interface
     procedure(bar), nopass, deferred :: h
   end type

--- a/test/semantics/resolve52.f90
+++ b/test/semantics/resolve52.f90
@@ -123,7 +123,7 @@ end
 module m7
   type :: t
     sequence  ! t is not extensible
-    !ERROR: Passed-object dummy argument 'x' of procedure 'a' must not be polymorphic because 't' is not extensible
+    !ERROR: Passed-object dummy argument 'x' of procedure 'a' may not be polymorphic because 't' is not extensible
     procedure(s), pointer :: a
   end type
 contains
@@ -135,7 +135,7 @@ end
 module m8
   type :: t
   contains
-    !ERROR: Passed-object dummy argument 'x' of procedure 's' must polymorphic because 't' is extensible
+    !ERROR: Passed-object dummy argument 'x' of procedure 's' must be polymorphic because 't' is extensible
     procedure :: s
   end type
 contains


### PR DESCRIPTION
Extend, enable, and pass the test cases in call11.f90.  Add and pass new bindings01.f90 test for other constraints and restrictions on type-bound procedures and their overrides.