### PR TITLE
Analyze defined assignments

### DIFF
--- a/lib/evaluate/call.cc
+++ b/lib/evaluate/call.cc
@@ -63,6 +63,11 @@ bool ActualArgument::operator==(const ActualArgument &that) const {
       isAlternateReturn == that.isAlternateReturn && u_ == that.u_;
 }
 
+void ActualArgument::Parenthesize() {
+  CHECK(!isAlternateReturn);
+  u_ = evaluate::Parenthesize(std::move(DEREF(UnwrapExpr())));
+}
+
 SpecificIntrinsic::SpecificIntrinsic(
     IntrinsicProcedure n, characteristics::Procedure &&chars)
   : name{n}, characteristics{new characteristics::Procedure{std::move(chars)}} {

--- a/lib/evaluate/call.h
+++ b/lib/evaluate/call.h
@@ -113,6 +113,9 @@ public:
 
   bool Matches(const characteristics::DummyArgument &) const;
 
+  // Wrap this argument in parentheses
+  void Parenthesize();
+
   // TODO: Mark legacy %VAL and %REF arguments
 
 private:

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -175,6 +175,8 @@ bool GenericExprWrapper::operator==(const GenericExprWrapper &that) const {
   return v == that.v;
 }
 
+GenericAssignmentWrapper::~GenericAssignmentWrapper() = default;
+
 template<TypeCategory CAT> int Expr<SomeKind<CAT>>::GetKind() const {
   return std::visit(
       [](const auto &kx) { return std::decay_t<decltype(kx)>::Result::kind; },
@@ -194,3 +196,4 @@ std::optional<Expr<SubscriptInteger>> Expr<SomeCharacter>::LEN() const {
 INSTANTIATE_EXPRESSION_TEMPLATES
 }
 DEFINE_DELETER(Fortran::evaluate::GenericExprWrapper)
+DEFINE_DELETER(Fortran::evaluate::GenericAssignmentWrapper)

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -854,6 +854,21 @@ public:
   common::CombineVariants<TypelessExpression, CategoryExpression> u;
 };
 
+// An assignment is either intrinsic (with lhs and rhs) or user-defined,
+// represented as a ProcedureRef.
+class Assignment {
+public:
+  explicit Assignment(ProcedureRef &&x) : u{std::move(x)} {}
+  Assignment(Expr<SomeType> &&lhs, Expr<SomeType> &&rhs)
+    : u{IntrinsicAssignment{std::move(lhs), std::move(rhs)}} {}
+  struct IntrinsicAssignment {
+    Expr<SomeType> lhs;
+    Expr<SomeType> rhs;
+  };
+
+  std::variant<IntrinsicAssignment, ProcedureRef> u;
+};
+
 // This wrapper class is used, by means of a forward reference with
 // an owning pointer, to cache analyzed expressions in parse tree nodes.
 // v is nullopt if an error occurred during expression analysis.
@@ -862,6 +877,13 @@ struct GenericExprWrapper {
   ~GenericExprWrapper();
   bool operator==(const GenericExprWrapper &) const;
   std::optional<Expr<SomeType>> v;
+};
+
+// Like GenericExprWrapper but for analyzed assignments
+struct GenericAssignmentWrapper {
+  GenericAssignmentWrapper(std::optional<Assignment> &&x) : v{std::move(x)} {}
+  ~GenericAssignmentWrapper();
+  std::optional<Assignment> v;
 };
 
 FOR_EACH_CATEGORY_TYPE(extern template class Expr, )

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -810,11 +810,11 @@ bool HasVectorSubscript(const Expr<SomeType> &);
 // Utilities for attaching the location of the declaration of a symbol
 // of interest to a message, if both pointers are non-null.  Handles
 // the case of USE association gracefully.
-parser::Message *AttachDeclaration(parser::Message &, const Symbol *);
-parser::Message *AttachDeclaration(parser::Message *, const Symbol *);
+parser::Message *AttachDeclaration(parser::Message &, const Symbol &);
+parser::Message *AttachDeclaration(parser::Message *, const Symbol &);
 template<typename MESSAGES, typename... A>
 parser::Message *SayWithDeclaration(
-    MESSAGES &messages, const Symbol *symbol, A &&... x) {
+    MESSAGES &messages, const Symbol &symbol, A &&... x) {
   return AttachDeclaration(messages.Say(std::forward<A>(x)...), symbol);
 }
 

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -153,6 +153,8 @@ common::IfNoLvalue<Expr<SomeKind<ResultType<A>::category>>, A> AsCategoryExpr(
 
 inline Expr<SomeType> AsGenericExpr(Expr<SomeType> &&x) { return std::move(x); }
 
+Expr<SomeType> Parenthesize(Expr<SomeType> &&);
+
 Expr<SomeReal> GetComplexPart(
     const Expr<SomeComplex> &, bool isImaginary = false);
 

--- a/lib/parser/parse-tree.cc
+++ b/lib/parser/parse-tree.cc
@@ -23,6 +23,9 @@ namespace Fortran::evaluate {
 struct GenericExprWrapper {
   ~GenericExprWrapper();
 };
+struct GenericAssignmentWrapper {
+  ~GenericAssignmentWrapper();
+};
 }
 
 namespace Fortran::parser {
@@ -248,3 +251,4 @@ std::ostream &operator<<(std::ostream &os, const Name &x) {
 }
 
 template class std::unique_ptr<Fortran::evaluate::GenericExprWrapper>;
+template class std::unique_ptr<Fortran::evaluate::GenericAssignmentWrapper>;

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -70,6 +70,7 @@ class DerivedTypeSpec;
 // type-checked generic expression representations by semantic analysis.
 namespace Fortran::evaluate {
 struct GenericExprWrapper;  // forward definition, wraps Expr<SomeType>
+struct GenericAssignmentWrapper;  // forward definition, represent assignment
 }
 
 // Most non-template classes in this file use these default definitions
@@ -1918,6 +1919,9 @@ struct DeallocateStmt {
 // R1032 assignment-stmt -> variable = expr
 struct AssignmentStmt {
   TUPLE_CLASS_BOILERPLATE(AssignmentStmt);
+  using TypedAssignment = std::unique_ptr<evaluate::GenericAssignmentWrapper,
+      common::Deleter<evaluate::GenericAssignmentWrapper>>;
+  mutable TypedAssignment typedAssignment;
   std::tuple<Variable, Expr> t;
 };
 

--- a/lib/semantics/assignment.cc
+++ b/lib/semantics/assignment.cc
@@ -147,7 +147,7 @@ private:
   template<typename... A> parser::Message *Say(A &&... x) {
     auto *msg{messages_.Say(std::forward<A>(x)...)};
     if (pointer_) {
-      return AttachDeclaration(msg, pointer_);
+      return AttachDeclaration(msg, *pointer_);
     } else if (!source_.empty()) {
       msg->Attach(source_, "Declaration of %s"_en_US, description_);
     }
@@ -227,7 +227,7 @@ void CheckPointerAssignment(parser::ContextualMessages &messages,
   // from the RHS.
   if (!IsPointer(lhs)) {
     SayWithDeclaration(
-        messages, &lhs, "'%s' is not a pointer"_err_en_US, lhs.name());
+        messages, lhs, "'%s' is not a pointer"_err_en_US, lhs.name());
   } else {
     auto type{characteristics::TypeAndShape::Characterize(lhs)};
     auto proc{characteristics::Procedure::Characterize(lhs, intrinsics)};
@@ -584,7 +584,7 @@ static const char *WhyBaseObjectIsSuspicious(
 void CheckDefinabilityInPureScope(parser::ContextualMessages &messages,
     const Symbol &lhs, const Scope &scope) {
   if (const char *why{WhyBaseObjectIsSuspicious(lhs, scope)}) {
-    evaluate::SayWithDeclaration(messages, &lhs,
+    evaluate::SayWithDeclaration(messages, lhs,
         "A PURE subprogram may not define '%s' because it is %s"_err_en_US,
         lhs.name(), why);
   }
@@ -611,7 +611,7 @@ void CheckCopyabilityInPureScope(parser::ContextualMessages &messages,
   if (const Symbol * base{GetFirstSymbol(expr)}) {
     if (const char *why{WhyBaseObjectIsSuspicious(*base, scope)}) {
       if (auto pointer{GetPointerComponentDesignatorName(expr)}) {
-        evaluate::SayWithDeclaration(messages, base,
+        evaluate::SayWithDeclaration(messages, *base,
             "A PURE subprogram may not copy the value of '%s' because it is %s and has the POINTER component '%s'"_err_en_US,
             base->name(), why, *pointer);
       }
@@ -634,7 +634,7 @@ void AssignmentContext::CheckForPureContext(const SomeExpr &lhs,
       if (const Symbol * base{GetFirstSymbol(rhs)}) {
         if (const char *why{
                 WhyBaseObjectIsSuspicious(*base, scope)}) {  // C1594(3)
-          evaluate::SayWithDeclaration(messages, base,
+          evaluate::SayWithDeclaration(messages, *base,
               "A PURE subprogram may not use '%s' as the target of pointer assignment because it is %s"_err_en_US,
               base->name(), why);
         }
@@ -652,7 +652,7 @@ void AssignmentContext::CheckForPureContext(const SomeExpr &lhs,
           const DerivedTypeSpec &derived{type->GetDerivedTypeSpec()};
           if (auto bad{FindPolymorphicAllocatableNonCoarrayUltimateComponent(
                   derived)}) {
-            evaluate::SayWithDeclaration(messages, &*bad,
+            evaluate::SayWithDeclaration(messages, *bad,
                 "Deallocation of polymorphic non-coarray component '%s' is not permitted in a PURE subprogram"_err_en_US,
                 bad.BuildResultDesignatorName());
           } else {

--- a/lib/semantics/check-call.cc
+++ b/lib/semantics/check-call.cc
@@ -170,7 +170,7 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
           tbp{FindImmediateComponent(derived, [](const Symbol &symbol) {
             return symbol.has<ProcBindingDetails>();
           })}) {  // 15.5.2.4(2)
-        evaluate::SayWithDeclaration(messages, tbp,
+        evaluate::SayWithDeclaration(messages, *tbp,
             "Actual argument associated with TYPE(*) %s may not have type-bound procedure '%s'"_err_en_US,
             dummyName, tbp->name());
       }
@@ -178,7 +178,7 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
           finalizer{FindImmediateComponent(derived, [](const Symbol &symbol) {
             return symbol.has<FinalProcDetails>();
           })}) {  // 15.5.2.4(2)
-        evaluate::SayWithDeclaration(messages, finalizer,
+        evaluate::SayWithDeclaration(messages, *finalizer,
             "Actual argument associated with TYPE(*) %s may not have FINAL subroutine '%s'"_err_en_US,
             dummyName, finalizer->name());
       }
@@ -187,7 +187,7 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
       if (dummy.intent != common::Intent::In && !dummyIsValue) {
         if (auto bad{
                 FindAllocatableUltimateComponent(derived)}) {  // 15.5.2.4(6)
-          evaluate::SayWithDeclaration(messages, &*bad,
+          evaluate::SayWithDeclaration(messages, *bad,
               "Coindexed actual argument with ALLOCATABLE ultimate component '%s' must be associated with a %s with VALUE or INTENT(IN) attributes"_err_en_US,
               bad.BuildResultDesignatorName(), dummyName);
         }
@@ -197,7 +197,7 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
         if (const DeclTypeSpec * type{coarray.GetType()}) {
           if (const DerivedTypeSpec * derived{type->AsDerived()}) {
             if (auto bad{semantics::FindPointerUltimateComponent(*derived)}) {
-              evaluate::SayWithDeclaration(messages, &coarray,
+              evaluate::SayWithDeclaration(messages, coarray,
                   "Coindexed object '%s' with POINTER ultimate component '%s' cannot be associated with %s"_err_en_US,
                   coarray.name(), bad.BuildResultDesignatorName(), dummyName);
             }
@@ -207,7 +207,7 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
     }
     if (actualIsVolatile != dummyIsVolatile) {  // 15.5.2.4(22)
       if (auto bad{semantics::FindCoarrayUltimateComponent(derived)}) {
-        evaluate::SayWithDeclaration(messages, &*bad,
+        evaluate::SayWithDeclaration(messages, *bad,
             "VOLATILE attribute must match for %s when actual argument has a coarray ultimate component '%s'"_err_en_US,
             dummyName, bad.BuildResultDesignatorName());
       }
@@ -232,8 +232,8 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
           "Scalar actual argument may not be associated with assumed-shape %s"_err_en_US,
           dummyName);
     }
-    if (actualIsAssumedSize) {
-      evaluate::SayWithDeclaration(messages, actualLastSymbol,
+    if (actualIsAssumedSize && actualLastSymbol) {
+      evaluate::SayWithDeclaration(messages, *actualLastSymbol,
           "Assumed-size array may not be associated with assumed-shape %s"_err_en_US,
           dummyName);
     }
@@ -467,7 +467,7 @@ static void CheckProcedureArg(evaluate::ActualArgument &arg,
         } else if (argInterface.attrs.test(
                        characteristics::Procedure::Attr::Elemental)) {
           if (argProcSymbol) {  // C1533
-            evaluate::SayWithDeclaration(messages, argProcSymbol,
+            evaluate::SayWithDeclaration(messages, *argProcSymbol,
                 "Non-intrinsic ELEMENTAL procedure '%s' may not be passed as an actual argument"_err_en_US,
                 argProcSymbol->name());
             return;  // avoid piling on with checks below

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1316,7 +1316,7 @@ MaybeExpr ExpressionAnalyzer::Analyze(
                           "ABSTRACT derived type '%s' may not be used in a "
                           "structure constructor"_err_en_US,
                           typeName),
-        &typeSymbol);
+        typeSymbol);
   }
 
   // This iterator traverses all of the components in the derived type and its
@@ -1478,14 +1478,14 @@ MaybeExpr ExpressionAnalyzer::Analyze(
                     "incompatible with component '%s' of type %s"_err_en_US,
                     valueType->AsFortran(), symbol->name(),
                     symType->AsFortran()),
-                symbol);
+                *symbol);
           } else {
             AttachDeclaration(
                 Say(expr.source,
                     "Value in structure constructor is incompatible with "
                     " component '%s' of type %s"_err_en_US,
                     symbol->name(), symType->AsFortran()),
-                symbol);
+                *symbol);
           }
         }
       }
@@ -1506,7 +1506,7 @@ MaybeExpr ExpressionAnalyzer::Analyze(
                                 "Structure constructor lacks a value for "
                                 "component '%s'"_err_en_US,
                                 symbol.name()),
-              &symbol);
+              symbol);
         }
       }
     }
@@ -1728,7 +1728,7 @@ void ExpressionAnalyzer::CheckForBadRecursion(
             "Assumed-length CHARACTER(*) function '%s' cannot call itself"_err_en_US,
             callSite);
       }
-      AttachDeclaration(msg, &proc);
+      AttachDeclaration(msg, proc);
     }
   }
 }
@@ -2126,7 +2126,7 @@ static void CheckFuncRefToArrayElementRefHasSubscripts(
             "A result variable must be declared with RESULT to allow recursive "
             "function calls"_en_US);
       } else {
-        AttachDeclaration(&msg, name->symbol);
+        AttachDeclaration(&msg, *name->symbol);
       }
     }
   }

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1836,23 +1836,7 @@ MaybeExpr ExpressionAnalyzer::Analyze(const parser::Expr::Parentheses &x) {
         }
       }
     }
-    return std::visit(
-        [&](auto &&x) -> MaybeExpr {
-          using xTy = std::decay_t<decltype(x)>;
-          if constexpr (common::HasMember<xTy, TypelessExpression>) {
-            return operand;  // ignore parentheses around typeless
-          } else if constexpr (std::is_same_v<xTy, Expr<SomeDerived>>) {
-            return operand;  // ignore parentheses around derived type
-          } else {
-            return std::visit(
-                [](auto &&y) -> MaybeExpr {
-                  using Ty = ResultType<decltype(y)>;
-                  return {AsGenericExpr(Parentheses<Ty>{std::move(y)})};
-                },
-                std::move(x.u));
-          }
-        },
-        std::move(operand->u));
+    return Parenthesize(std::move(*operand));
   }
   return std::nullopt;
 }

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -147,8 +147,11 @@ public:
     CHECK(!fatalErrors_);
     return std::move(actuals_);
   }
-  Expr<SomeType> GetAsExpr(std::size_t i) const {
+  const Expr<SomeType> &GetExpr(std::size_t i) const {
     return DEREF(actuals_.at(i).value().UnwrapExpr());
+  }
+  Expr<SomeType> &&MoveExpr(std::size_t i) {
+    return std::move(DEREF(actuals_.at(i).value().UnwrapExpr()));
   }
   void Analyze(const common::Indirection<parser::Expr> &x) {
     Analyze(x.value());
@@ -157,6 +160,7 @@ public:
     actuals_.emplace_back(AnalyzeExpr(x));
     fatalErrors_ |= !actuals_.back();
   }
+  void Analyze(const parser::Variable &);
   void Analyze(const parser::ActualArgSpec &, bool isSubroutine);
 
   bool IsIntrinsicRelational(RelationalOperator) const;
@@ -172,18 +176,21 @@ public:
     return TryDefinedOp(
         context_.context().languageFeatures().GetNames(opr), std::move(msg));
   }
+  // Find and return a user-defined assignment
+  std::optional<ProcedureRef> TryDefinedAssignment();
+  std::optional<ProcedureRef> GetDefinedAssignmentProc();
 
 private:
   MaybeExpr TryDefinedOp(
       std::vector<const char *>, parser::MessageFixedText &&);
   std::optional<ActualArgument> AnalyzeExpr(const parser::Expr &);
   bool AreConformable() const;
-  const Symbol *FindDefinedOp(const char *) const;
+  Symbol *FindDefinedOp(const char *) const;
   std::optional<DynamicType> GetType(std::size_t) const;
   bool IsBOZLiteral(std::size_t i) const {
-    return std::holds_alternative<BOZLiteralConstant>(GetAsExpr(i).u);
+    return std::holds_alternative<BOZLiteralConstant>(GetExpr(i).u);
   }
-  void SayNoMatch(const char *);
+  void SayNoMatch(const std::string &, bool isAssignment = false);
   std::string TypeAsFortran(std::size_t);
   bool AnyUntypedOperand();
 
@@ -1786,6 +1793,18 @@ MaybeExpr ExpressionAnalyzer::AnalyzeCall(
   return std::nullopt;
 }
 
+void ExpressionAnalyzer::Analyze(const parser::AssignmentStmt &x) {
+  ArgumentAnalyzer analyzer{*this};
+  analyzer.Analyze(std::get<parser::Variable>(x.t));
+  analyzer.Analyze(std::get<parser::Expr>(x.t));
+  if (!analyzer.fatalErrors()) {
+    std::optional<ProcedureRef> procRef{analyzer.TryDefinedAssignment()};
+    x.typedAssignment.reset(new GenericAssignmentWrapper{procRef
+            ? Assignment{std::move(*procRef)}
+            : Assignment{analyzer.MoveExpr(0), analyzer.MoveExpr(1)}});
+  }
+}
+
 static bool IsExternalCalledImplicitly(
     parser::CharBlock callSite, const ProcedureDesignator &proc) {
   if (const auto *symbol{proc.GetSymbol()}) {
@@ -1816,8 +1835,8 @@ std::optional<characteristics::Procedure> ExpressionAnalyzer::CheckCall(
           pure{semantics::FindPureProcedureContaining(
               context_.FindScope(callSite))}) {
         Say(callSite,
-            "Procedure referenced in PURE subprogram '%s' must be PURE too"_err_en_US,
-            DEREF(pure->symbol()).name());
+            "Procedure '%s' referenced in PURE subprogram '%s' must be PURE too"_err_en_US,
+            DEREF(proc.GetSymbol()).name(), DEREF(pure->symbol()).name());
       }
     }
   }
@@ -1849,9 +1868,9 @@ static MaybeExpr NumericUnaryHelper(ExpressionAnalyzer &context,
     return std::nullopt;
   } else if (analyzer.IsIntrinsicNumeric(opr)) {
     if (opr == NumericOperator::Add) {
-      return analyzer.GetAsExpr(0);
+      return analyzer.MoveExpr(0);
     } else {
-      return Negation(context.GetContextualMessages(), analyzer.GetAsExpr(0));
+      return Negation(context.GetContextualMessages(), analyzer.MoveExpr(0));
     }
   } else {
     return analyzer.TryDefinedOp(AsFortran(opr),
@@ -1874,7 +1893,7 @@ MaybeExpr ExpressionAnalyzer::Analyze(const parser::Expr::NOT &x) {
     return std::nullopt;
   } else if (analyzer.IsIntrinsicLogical()) {
     return AsGenericExpr(
-        LogicalNegation(std::get<Expr<SomeLogical>>(analyzer.GetAsExpr(0).u)));
+        LogicalNegation(std::get<Expr<SomeLogical>>(analyzer.MoveExpr(0).u)));
   } else {
     return analyzer.TryDefinedOp(LogicalOperator::Not,
         "Operand of %s must be LOGICAL; have %s"_err_en_US);
@@ -1924,7 +1943,7 @@ MaybeExpr NumericBinaryHelper(ExpressionAnalyzer &context, NumericOperator opr,
     return std::nullopt;
   } else if (analyzer.IsIntrinsicNumeric(opr)) {
     return NumericOperation<OPR>(context.GetContextualMessages(),
-        analyzer.GetAsExpr(0), analyzer.GetAsExpr(1),
+        analyzer.MoveExpr(0), analyzer.MoveExpr(1),
         context.GetDefaultKind(TypeCategory::Real));
   } else {
     return analyzer.TryDefinedOp(AsFortran(opr),
@@ -1979,8 +1998,8 @@ MaybeExpr ExpressionAnalyzer::Analyze(const parser::Expr::Concat &x) {
             DIE("different types for intrinsic concat");
           }
         },
-        std::move(std::get<Expr<SomeCharacter>>(analyzer.GetAsExpr(0).u).u),
-        std::move(std::get<Expr<SomeCharacter>>(analyzer.GetAsExpr(1).u).u));
+        std::move(std::get<Expr<SomeCharacter>>(analyzer.MoveExpr(0).u).u),
+        std::move(std::get<Expr<SomeCharacter>>(analyzer.MoveExpr(1).u).u));
   } else {
     return analyzer.TryDefinedOp("//",
         "Operands of %s must be CHARACTER with the same kind; have %s and %s"_err_en_US);
@@ -2010,7 +2029,7 @@ MaybeExpr RelationHelper(ExpressionAnalyzer &context, RelationalOperator opr,
     return std::nullopt;
   } else if (analyzer.IsIntrinsicRelational(opr)) {
     return AsMaybeExpr(Relate(context.GetContextualMessages(), opr,
-        analyzer.GetAsExpr(0), analyzer.GetAsExpr(1)));
+        analyzer.MoveExpr(0), analyzer.MoveExpr(1)));
   } else {
     return analyzer.TryDefinedOp(opr,
         "Operands of %s must have comparable types; have %s and %s"_err_en_US);
@@ -2050,8 +2069,8 @@ MaybeExpr LogicalBinaryHelper(ExpressionAnalyzer &context, LogicalOperator opr,
     return std::nullopt;
   } else if (analyzer.IsIntrinsicLogical()) {
     return AsGenericExpr(BinaryLogicalOperation(opr,
-        std::get<Expr<SomeLogical>>(analyzer.GetAsExpr(0).u),
-        std::get<Expr<SomeLogical>>(analyzer.GetAsExpr(1).u)));
+        std::get<Expr<SomeLogical>>(analyzer.MoveExpr(0).u),
+        std::get<Expr<SomeLogical>>(analyzer.MoveExpr(1).u)));
   } else {
     return analyzer.TryDefinedOp(
         opr, "Operands of %s must be LOGICAL; have %s and %s"_err_en_US);
@@ -2397,6 +2416,15 @@ MaybeExpr ExpressionAnalyzer::MakeFunctionRef(
   }
 }
 
+void ArgumentAnalyzer::Analyze(const parser::Variable &x) {
+  source_.ExtendToCover(x.GetSource());
+  if (MaybeExpr expr{context_.Analyze(x)}) {
+    actuals_.emplace_back(std::move(*expr));
+  } else {
+    fatalErrors_ = true;
+  }
+}
+
 void ArgumentAnalyzer::Analyze(
     const parser::ActualArgSpec &arg, bool isSubroutine) {
   // TODO: C1002: Allow a whole assumed-size array to appear if the dummy
@@ -2492,7 +2520,7 @@ bool ArgumentAnalyzer::IsIntrinsicConcat() const {
 
 MaybeExpr ArgumentAnalyzer::TryDefinedOp(
     const char *opr, parser::MessageFixedText &&error) {
-  const Symbol *symbol{AnyUntypedOperand() ? nullptr : FindDefinedOp(opr)};
+  Symbol *symbol{AnyUntypedOperand() ? nullptr : FindDefinedOp(opr)};
   if (!symbol) {
     if (actuals_.size() == 1 || AreConformable()) {
       context_.Say(std::move(error), ToUpperCase(opr), TypeAsFortran(0),
@@ -2505,11 +2533,11 @@ MaybeExpr ArgumentAnalyzer::TryDefinedOp(
     return std::nullopt;
   }
   parser::Messages messages;
-  parser::Name name{source_, const_cast<Symbol *>(symbol)};
+  parser::Name name{source_, symbol};
   if (auto result{context_.AnalyzeDefinedOp(messages, name, GetActuals())}) {
     return result;
   } else {
-    SayNoMatch(opr);
+    SayNoMatch("OPERATOR(" + ToUpperCase(opr) + ')');
     return std::nullopt;
   }
 }
@@ -2522,6 +2550,43 @@ MaybeExpr ArgumentAnalyzer::TryDefinedOp(
     }
   }
   return TryDefinedOp(oprs[0], std::move(error));
+}
+
+std::optional<ProcedureRef> ArgumentAnalyzer::TryDefinedAssignment() {
+  using semantics::Tristate;
+  const Expr<SomeType> &lhs{GetExpr(0)};
+  const Expr<SomeType> &rhs{GetExpr(1)};
+  Tristate isDefined{semantics::IsDefinedAssignment(
+      lhs.GetType(), lhs.Rank(), rhs.GetType(), rhs.Rank())};
+  if (isDefined == Tristate::No) {
+    return std::nullopt;  // user-defined assignment not allowed for these args
+  }
+  auto restorer{context_.GetContextualMessages().SetLocation(source_)};
+  auto procRef{GetDefinedAssignmentProc()};
+  if (!procRef) {
+    if (isDefined == Tristate::Yes) {
+      SayNoMatch("ASSIGNMENT(=)", true);
+    }
+    return std::nullopt;
+  }
+  context_.CheckCall(source_, procRef->proc(), procRef->arguments());
+  return std::move(*procRef);
+}
+
+std::optional<ProcedureRef> ArgumentAnalyzer::GetDefinedAssignmentProc() {
+  parser::Messages tmpMessages;
+  auto restorer{context_.GetContextualMessages().SetMessages(tmpMessages)};
+  const auto &scope{context_.context().FindScope(source_)};
+  if (const Symbol *
+      symbol{scope.FindSymbol(parser::CharBlock{"assignment(=)"s})}) {
+    const Symbol *specific{context_.ResolveGeneric(*symbol, actuals_)};
+    if (specific) {
+      ProcedureDesignator designator{*specific};
+      actuals_[1]->Parenthesize();
+      return ProcedureRef{std::move(designator), std::move(actuals_)};
+    }
+  }
+  return std::nullopt;
 }
 
 std::optional<ActualArgument> ArgumentAnalyzer::AnalyzeExpr(
@@ -2542,7 +2607,7 @@ bool ArgumentAnalyzer::AreConformable() const {
   return evaluate::AreConformable(*actuals_[0], *actuals_[1]);
 }
 
-const Symbol *ArgumentAnalyzer::FindDefinedOp(const char *opr) const {
+Symbol *ArgumentAnalyzer::FindDefinedOp(const char *opr) const {
   const auto &scope{context_.context().FindScope(source_)};
   return scope.FindSymbol(parser::CharBlock{"operator("s + opr + ')'});
 }
@@ -2552,28 +2617,40 @@ std::optional<DynamicType> ArgumentAnalyzer::GetType(std::size_t i) const {
 }
 
 // Report error resolving opr when there is a user-defined one available
-void ArgumentAnalyzer::SayNoMatch(const char *opr) {
+void ArgumentAnalyzer::SayNoMatch(const std::string &opr, bool isAssignment) {
+  std::string type0{TypeAsFortran(0)};
   auto rank0{actuals_[0]->Rank()};
   if (actuals_.size() == 1) {
     if (rank0 > 0) {
-      context_.Say("No user-defined or intrinsic %s operator matches "
+      context_.Say("No intrinsic or user-defined %s matches "
                    "rank %d array of %s"_err_en_US,
-          ToUpperCase(opr), rank0, TypeAsFortran(0));
+          opr, rank0, type0);
     } else {
-      context_.Say("No user-defined or intrinsic %s operator matches "
+      context_.Say("No intrinsic or user-defined %s matches "
                    "operand type %s"_err_en_US,
-          ToUpperCase(opr), TypeAsFortran(0));
+          opr, type0);
     }
   } else {
+    std::string type1{TypeAsFortran(1)};
     auto rank1{actuals_[1]->Rank()};
     if (rank0 > 0 && rank1 > 0 && rank0 != rank1) {
-      context_.Say("No user-defined or intrinsic %s operator matches "
+      context_.Say("No intrinsic or user-defined %s matches "
                    "rank %d array of %s and rank %d array of %s"_err_en_US,
-          ToUpperCase(opr), rank0, TypeAsFortran(0), rank1, TypeAsFortran(1));
+          opr, rank0, type0, rank1, type1);
+    } else if (isAssignment && rank0 != rank1) {
+      if (rank0 == 0) {
+        context_.Say("No intrinsic or user-defined %s matches "
+                     "scalar %s and rank %d array of %s"_err_en_US,
+            opr, type0, rank1, type1);
+      } else {
+        context_.Say("No intrinsic or user-defined %s matches "
+                     "rank %d array of %s and scalar %s"_err_en_US,
+            opr, rank0, type0, type1);
+      }
     } else {
-      context_.Say("No user-defined or intrinsic %s operator matches "
+      context_.Say("No intrinsic or user-defined %s matches "
                    "operand types %s and %s"_err_en_US,
-          ToUpperCase(opr), TypeAsFortran(0), TypeAsFortran(1));
+          opr, type0, type1);
     }
   }
 }
@@ -2613,6 +2690,11 @@ evaluate::Expr<evaluate::SubscriptInteger> AnalyzeKindSelector(
 
 void AnalyzeCallStmt(SemanticsContext &context, const parser::CallStmt &call) {
   evaluate::ExpressionAnalyzer{context}.Analyze(call);
+}
+
+void AnalyzeAssignmentStmt(
+    SemanticsContext &context, const parser::AssignmentStmt &stmt) {
+  evaluate::ExpressionAnalyzer{context}.Analyze(stmt);
 }
 
 ExprChecker::ExprChecker(SemanticsContext &context) : context_{context} {}

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -237,6 +237,7 @@ public:
   MaybeExpr Analyze(const parser::StructureComponent &);
 
   void Analyze(const parser::CallStmt &);
+  void Analyze(const parser::AssignmentStmt &);
 
 protected:
   int IntegerTypeSpecKind(const parser::IntegerTypeSpec &);
@@ -383,6 +384,7 @@ evaluate::Expr<evaluate::SubscriptInteger> AnalyzeKindSelector(
     const std::optional<parser::KindSelector> &);
 
 void AnalyzeCallStmt(SemanticsContext &, const parser::CallStmt &);
+void AnalyzeAssignmentStmt(SemanticsContext &, const parser::AssignmentStmt &);
 
 // Semantic analysis of all expressions in a parse tree, which becomes
 // decorated with typed representations for top-level expressions.
@@ -404,6 +406,10 @@ public:
   }
   bool Pre(const parser::CallStmt &x) {
     AnalyzeCallStmt(context_, x);
+    return false;
+  }
+  bool Pre(const parser::AssignmentStmt &x) {
+    AnalyzeAssignmentStmt(context_, x);
     return false;
   }
 

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -200,12 +200,20 @@ void ModFileWriter::PutSymbol(
           [&](const DerivedTypeDetails &) { PutDerivedType(symbol); },
           [&](const SubprogramDetails &) { PutSubprogram(symbol); },
           [&](const GenericDetails &x) {
-            PutGeneric(symbol);
-            if (x.specific()) {
-              PutSymbol(typeBindings, *x.specific());
-            }
-            if (x.derivedType()) {
-              PutSymbol(typeBindings, *x.derivedType());
+            if (symbol.owner().IsDerivedType()) {
+              // generic binding
+              for (const Symbol &proc : x.specificProcs()) {
+                typeBindings << "generic::" << symbol.name() << "=>"
+                             << proc.name() << '\n';
+              }
+            } else {
+              PutGeneric(symbol);
+              if (x.specific()) {
+                PutSymbol(typeBindings, *x.specific());
+              }
+              if (x.derivedType()) {
+                PutSymbol(typeBindings, *x.derivedType());
+              }
             }
           },
           [&](const UseDetails &) { PutUse(symbol); },
@@ -227,12 +235,6 @@ void ModFileWriter::PutSymbol(
               typeBindings << "=>" << x.symbol().name();
             }
             typeBindings << '\n';
-          },
-          [&](const GenericBindingDetails &x) {
-            for (const Symbol &proc : x.specificProcs()) {
-              typeBindings << "generic::" << symbol.name() << "=>"
-                           << proc.name() << '\n';
-            }
           },
           [&](const NamelistDetails &x) {
             decls_ << "namelist/" << symbol.name();

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -358,8 +358,7 @@ void ModFileWriter::PutSubprogram(const Symbol &symbol) {
 
 static bool IsIntrinsicOp(const Symbol &symbol) {
   if (const auto *details{symbol.GetUltimate().detailsIf<GenericDetails>()}) {
-    GenericKind kind{details->kind()};
-    return kind >= GenericKind::OpPower && kind <= GenericKind::OpNEQV;
+    return details->kind().IsIntrinsicOperator();
   } else {
     return false;
   }

--- a/lib/semantics/resolve-names-utils.cc
+++ b/lib/semantics/resolve-names-utils.cc
@@ -120,8 +120,6 @@ void GenericSpecInfo::Resolve(Symbol *symbol) const {
   if (symbol) {
     if (auto *details{symbol->detailsIf<GenericDetails>()}) {
       details->set_kind(kind_);
-    } else if (auto *details{symbol->detailsIf<GenericBindingDetails>()}) {
-      details->set_kind(kind_);
     }
     if (parseName_) {
       semantics::Resolve(*parseName_, symbol);

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -143,7 +143,7 @@ public:
   void SayWithDecl(const Symbol &symbol, const parser::CharBlock &at,
       parser::MessageFixedText &&msg, A &&... args) {
     auto &message{Say(at, std::move(msg), args...)};
-    evaluate::AttachDeclaration(&message, &symbol);
+    evaluate::AttachDeclaration(&message, symbol);
   }
 
   const Scope &FindScope(parser::CharBlock) const;

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -150,6 +150,11 @@ UseErrorDetails &UseErrorDetails::add_occurrence(
 GenericDetails::GenericDetails(const SymbolVector &specificProcs)
   : specificProcs_{specificProcs} {}
 
+void GenericDetails::AddSpecificProc(
+    const Symbol &proc, SourceName bindingName) {
+  specificProcs_.push_back(proc);
+  bindingNames_.push_back(bindingName);
+}
 void GenericDetails::set_specific(Symbol &specific) {
   CHECK(!specific_);
   CHECK(!derivedType_);
@@ -214,7 +219,6 @@ std::string DetailsToString(const Details &details) {
           [](const HostAssocDetails &) { return "HostAssoc"; },
           [](const GenericDetails &) { return "Generic"; },
           [](const ProcBindingDetails &) { return "ProcBinding"; },
-          [](const GenericBindingDetails &) { return "GenericBinding"; },
           [](const NamelistDetails &) { return "Namelist"; },
           [](const CommonBlockDetails &) { return "CommonBlockDetails"; },
           [](const FinalProcDetails &) { return "FinalProc"; },
@@ -436,10 +440,6 @@ std::ostream &operator<<(std::ostream &os, const Details &details) {
           [&](const ProcBindingDetails &x) {
             os << " => " << x.symbol().name();
             DumpOptional(os, "passName", x.passName());
-          },
-          [&](const GenericBindingDetails &x) {
-            os << " =>";
-            DumpSymbolVector(os, x.specificProcs());
           },
           [&](const NamelistDetails &x) {
             os << ':';

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -84,7 +84,7 @@ const Scope *FindPureProcedureContaining(const Scope &start) {
 
 bool IsGenericDefinedOp(const Symbol &symbol) {
   const auto *details{symbol.GetUltimate().detailsIf<GenericDetails>()};
-  return details && details->kind() == GenericKind::DefinedOp;
+  return details && details->kind().IsDefinedOperator();
 }
 
 bool IsCommonBlockContaining(const Symbol &block, const Symbol &object) {

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -315,6 +315,11 @@ bool ExprTypeKindIsDefault(
       dynamicType->kind() == context.GetDefaultKind(dynamicType->category());
 }
 
+const evaluate::Assignment *GetAssignment(const parser::AssignmentStmt &x) {
+  const auto &typed{x.typedAssignment};
+  return typed && typed->v ? &*typed->v : nullptr;
+}
+
 const Symbol *FindInterface(const Symbol &symbol) {
   return std::visit(
       common::visitors{

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -23,6 +23,7 @@
 #include "semantics.h"
 #include "../common/Fortran.h"
 #include "../evaluate/expression.h"
+#include "../evaluate/type.h"
 #include "../evaluate/variable.h"
 #include "../parser/message.h"
 #include "../parser/parse-tree.h"
@@ -57,6 +58,14 @@ const DeclTypeSpec *FindParentTypeSpec(const Symbol &);
 // Return the Symbol of the variable of a construct association, if it exists
 const Symbol *GetAssociationRoot(const Symbol &);
 
+enum class Tristate { No, Yes, Maybe };
+inline Tristate ToTristate(bool x) { return x ? Tristate::Yes : Tristate::No; }
+
+// Is this a user-defined assignment? If both sides are the same derived type
+// (and the ranks are okay) the answer is Maybe.
+Tristate IsDefinedAssignment(
+    const std::optional<evaluate::DynamicType> &lhsType, int lhsRank,
+    const std::optional<evaluate::DynamicType> &rhsType, int rhsRank);
 bool IsGenericDefinedOp(const Symbol &);
 bool IsCommonBlockContaining(const Symbol &block, const Symbol &object);
 bool DoesScopeContain(const Scope *maybeAncestor, const Scope &maybeDescendent);

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -241,6 +241,8 @@ template<typename T> const SomeExpr *GetExpr(const T &x) {
   return GetExprHelper{}.Get(x);
 }
 
+const evaluate::Assignment *GetAssignment(const parser::AssignmentStmt &);
+
 template<typename T> std::optional<std::int64_t> GetIntValue(const T &x) {
   if (const auto *expr{GetExpr(x)}) {
     return evaluate::ToInt64(*expr);

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -102,6 +102,7 @@ set(ERROR_TESTS
   resolve63.f90
   resolve64.f90
   resolve65.f90
+  resolve66.f90
   stop01.f90
   structconst01.f90
   structconst02.f90

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -101,6 +101,7 @@ set(ERROR_TESTS
   resolve62.f90
   resolve63.f90
   resolve64.f90
+  resolve65.f90
   stop01.f90
   structconst01.f90
   structconst02.f90

--- a/test/semantics/call10.f90
+++ b/test/semantics/call10.f90
@@ -146,7 +146,7 @@ module m
   ! C1594 is tested in call12.f90.
   pure subroutine s10 ! C1595
     integer :: n
-    !ERROR: Procedure referenced in PURE subprogram 's10' must be PURE too
+    !ERROR: Procedure 'notpure' referenced in PURE subprogram 's10' must be PURE too
     n = notpure(1)
   end subroutine
   pure subroutine s11(to) ! C1596

--- a/test/semantics/resolve15.f90
+++ b/test/semantics/resolve15.f90
@@ -1,4 +1,4 @@
-! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+! Copyright (c) 2018-2019, NVIDIA CORPORATION.  All rights reserved.
 !
 ! Licensed under the Apache License, Version 2.0 (the "License");
 ! you may not use this file except in compliance with the License.
@@ -41,6 +41,8 @@ subroutine s
     module procedure :: sub
   end interface
 contains
-  subroutine sub
+  subroutine sub(x, y)
+    real, intent(out) :: x
+    logical, intent(in) :: y
   end
 end

--- a/test/semantics/resolve53.f90
+++ b/test/semantics/resolve53.f90
@@ -445,32 +445,8 @@ contains
   end
 end
 
-! C1512 - rules for assignment
-! s1 and s2 are not distinguishable for a generic name but they are
-! for assignment
-module m19
-  interface assignment(=)
-    module procedure s1
-    module procedure s2
-  end interface
-  !ERROR: Generic 'g' may not have specific procedures 's1' and 's2' as their interfaces are not distinguishable
-  interface g
-    module procedure s1
-    module procedure s2
-  end interface
-contains
-  subroutine s1(d, p)
-    real, intent(out) :: d
-    integer, intent(in) :: p
-  end subroutine
-  subroutine s2(p, d)
-    integer, intent(out) :: p
-    real, intent(in) :: d
-  end subroutine
-end module
-
 ! C1511 - rules for operators
-module m20
+module m19
   interface operator(.foo.)
     module procedure f1
     module procedure f2

--- a/test/semantics/resolve62.f90
+++ b/test/semantics/resolve62.f90
@@ -40,7 +40,8 @@ subroutine s2
   real :: x, y(10), z
   logical :: a
   a = f(1.0)
-  a = f(y)  !TODO: this should resolve to f2 -- should get error here
+  !ERROR: No intrinsic or user-defined ASSIGNMENT(=) matches operand types LOGICAL(4) and REAL(4)
+  a = f(y)
 end
 
 ! Resolve named operator

--- a/test/semantics/resolve63.f90
+++ b/test/semantics/resolve63.f90
@@ -61,36 +61,36 @@ contains
   subroutine test_relational()
     l = x == y  !OK
     l = x .eq. y  !OK
-    !ERROR: No user-defined or intrinsic == operator matches operand types TYPE(t) and REAL(4)
+    !ERROR: No intrinsic or user-defined OPERATOR(==) matches operand types TYPE(t) and REAL(4)
     l = x == r
   end
   subroutine test_numeric()
     l = x + r  !OK
-    !ERROR: No user-defined or intrinsic + operator matches operand types REAL(4) and TYPE(t)
+    !ERROR: No intrinsic or user-defined OPERATOR(+) matches operand types REAL(4) and TYPE(t)
     l = r + x
   end
   subroutine test_logical()
     l = x .and. r  !OK
-    !ERROR: No user-defined or intrinsic .AND. operator matches operand types REAL(4) and TYPE(t)
+    !ERROR: No intrinsic or user-defined OPERATOR(.AND.) matches operand types REAL(4) and TYPE(t)
     l = r .and. x
   end
   subroutine test_unary()
     l = +x  !OK
-    !ERROR: No user-defined or intrinsic + operator matches operand type LOGICAL(4)
+    !ERROR: No intrinsic or user-defined OPERATOR(+) matches operand type LOGICAL(4)
     l = +l
     l = .not. r  !OK
-    !ERROR: No user-defined or intrinsic .NOT. operator matches operand type TYPE(t)
+    !ERROR: No intrinsic or user-defined OPERATOR(.NOT.) matches operand type TYPE(t)
     l = .not. x
   end
   subroutine test_concat()
     l = x // y  !OK
-    !ERROR: No user-defined or intrinsic // operator matches operand types TYPE(t) and REAL(4)
+    !ERROR: No intrinsic or user-defined OPERATOR(//) matches operand types TYPE(t) and REAL(4)
     l = x // r
   end
   subroutine test_conformability(x, y)
     real :: x(10), y(10,10)
     l = x + y  !OK
-    !ERROR: No user-defined or intrinsic + operator matches rank 2 array of REAL(4) and rank 1 array of REAL(4)
+    !ERROR: No intrinsic or user-defined OPERATOR(+) matches rank 2 array of REAL(4) and rank 1 array of REAL(4)
     l = y + x
   end
 end
@@ -201,7 +201,7 @@ contains
   subroutine s1(x, y, z)
     logical :: x
     complex :: y, z
-    !ERROR: No user-defined or intrinsic .AND. operator matches operand types COMPLEX(4) and COMPLEX(4)
+    !ERROR: No intrinsic or user-defined OPERATOR(.AND.) matches operand types COMPLEX(4) and COMPLEX(4)
     x = y .and. z
     !ERROR: No specific procedure of generic operator '.a.' matches the actual arguments
     x = y .a. z

--- a/test/semantics/resolve64.f90
+++ b/test/semantics/resolve64.f90
@@ -51,9 +51,9 @@ contains
   subroutine s1(x, y, z)
     logical :: x
     complex :: y, z
-    !ERROR: No user-defined or intrinsic .A. operator matches operand types COMPLEX(4) and COMPLEX(4)
+    !ERROR: No intrinsic or user-defined OPERATOR(.A.) matches operand types COMPLEX(4) and COMPLEX(4)
     x = y .and. z
-    !ERROR: No user-defined or intrinsic .A. operator matches operand types COMPLEX(4) and COMPLEX(4)
+    !ERROR: No intrinsic or user-defined OPERATOR(.A.) matches operand types COMPLEX(4) and COMPLEX(4)
     x = y .a. z
   end
 end

--- a/test/semantics/resolve65.f90
+++ b/test/semantics/resolve65.f90
@@ -1,0 +1,120 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test restrictions on what subprograms can be used for defined assignment.
+
+module m1
+  implicit none
+  type :: t
+  contains
+    !ERROR: Defined assignment procedure 'binding' must be a subroutine
+    generic :: assignment(=) => binding
+    procedure :: binding => assign_t1
+    procedure :: assign_t
+    procedure :: assign_t2
+    procedure :: assign_t3
+    !ERROR: Defined assignment subroutine 'assign_t2' must have two dummy arguments
+    !ERROR: In defined assignment subroutine 'assign_t3', second dummy argument 'y' must have INTENT(IN) or VALUE attribute
+    !ERROR: In defined assignment subroutine 'assign_t4', first dummy argument 'x' must have INTENT(OUT) or INTENT(INOUT)
+    generic :: assignment(=) => assign_t, assign_t2, assign_t3, assign_t4
+    procedure :: assign_t4
+  end type
+contains
+  subroutine assign_t(x, y)
+    class(t), intent(out) :: x
+    type(t), intent(in) :: y
+  end
+  logical function assign_t1(x, y)
+    class(t), intent(out) :: x
+    type(t), intent(in) :: y
+  end
+  subroutine assign_t2(x)
+    class(t), intent(out) :: x
+  end
+  subroutine assign_t3(x, y)
+    class(t), intent(out) :: x
+    real :: y
+  end
+  subroutine assign_t4(x, y)
+    class(t) :: x
+      integer, intent(in) :: y
+  end
+end
+
+module m2
+  type :: t
+  end type
+  interface assignment(=)
+    !ERROR: In defined assignment subroutine 's1', dummy argument 'y' may not be OPTIONAL
+    subroutine s1(x, y)
+      import t
+      type(t), intent(out) :: x
+      real, optional, intent(in) :: y
+    end
+    !ERROR: In defined assignment subroutine 's2', dummy argument 'y' must be a data object
+    subroutine s2(x, y)
+      import t
+      type(t), intent(out) :: x
+      intent(in) :: y
+      interface
+        subroutine y()
+        end
+      end interface
+    end
+  end interface
+end
+
+! Detect defined assignment that conflicts with intrinsic assignment
+module m5
+  type :: t
+  end type
+  interface assignment(=)
+    ! OK - lhs is derived type
+    subroutine assign_tt(x, y)
+      import t
+      type(t), intent(out) :: x
+      type(t), intent(in) :: y
+    end
+    !OK - incompatible types
+    subroutine assign_il(x, y)
+      integer, intent(out) :: x
+      logical, intent(in) :: y
+    end
+    !OK - different ranks
+    subroutine assign_23(x, y)
+      integer, intent(out) :: x(:,:)
+      integer, intent(in) :: y(:,:,:)
+    end
+    !OK - scalar = array
+    subroutine assign_01(x, y)
+      integer, intent(out) :: x
+      integer, intent(in) :: y(:)
+    end
+    !ERROR: Defined assignment subroutine 'assign_10' conflicts with intrinsic assignment
+    subroutine assign_10(x, y)
+      integer, intent(out) :: x(:)
+      integer, intent(in) :: y
+    end
+    !ERROR: Defined assignment subroutine 'assign_ir' conflicts with intrinsic assignment
+    subroutine assign_ir(x, y)
+      integer, intent(out) :: x
+      real, intent(in) :: y
+    end
+    !ERROR: Defined assignment subroutine 'assign_ii' conflicts with intrinsic assignment
+    subroutine assign_ii(x, y)
+      integer(2), intent(out) :: x
+      integer(1), intent(in) :: y
+    end
+  end interface
+end

--- a/test/semantics/resolve66.f90
+++ b/test/semantics/resolve66.f90
@@ -1,0 +1,119 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test that user-defined assignment is used in the right places
+
+module m1
+  type t1
+  end type
+  type t2
+  end type
+  interface assignment(=)
+    subroutine assign_il(x, y)
+      integer, intent(out) :: x
+      logical, intent(in) :: y
+    end
+    subroutine assign_li(x, y)
+      logical, intent(out) :: x
+      integer, intent(in) :: y
+    end
+    subroutine assign_tt(x, y)
+      import t1
+      type(t1), intent(out) :: x
+      type(t1), intent(in) :: y
+    end
+    subroutine assign_tz(x, y)
+      import t1
+      type(t1), intent(out) :: x
+      complex, intent(in) :: y
+    end
+    subroutine assign_01(x, y)
+      real, intent(out) :: x
+      real, intent(in) :: y(:)
+    end
+  end interface
+contains
+  ! These are all intrinsic assignments
+  pure subroutine test1()
+    type(t2) :: a, b, b5(5)
+    logical :: l
+    integer :: i, i5(5)
+    a = b
+    b5 = a
+    l = .true.
+    i = z'1234'
+    i5 = 1.0
+  end
+
+  ! These have invalid type combinations
+  subroutine test2()
+    type(t1) :: a
+    type(t2) :: b
+    logical :: l, l5(5)
+    complex :: z, z5(5), z55(5,5)
+    !ERROR: No intrinsic or user-defined ASSIGNMENT(=) matches operand types TYPE(t1) and TYPE(t2)
+    a = b
+    !ERROR: No intrinsic or user-defined ASSIGNMENT(=) matches operand types REAL(4) and LOGICAL(4)
+    r = l
+    !ERROR: No intrinsic or user-defined ASSIGNMENT(=) matches operand types LOGICAL(4) and REAL(4)
+    l = r
+    !ERROR: No intrinsic or user-defined ASSIGNMENT(=) matches operand types TYPE(t1) and REAL(4)
+    a = r
+    !ERROR: No intrinsic or user-defined ASSIGNMENT(=) matches operand types TYPE(t2) and COMPLEX(4)
+    b = z
+    !ERROR: No intrinsic or user-defined ASSIGNMENT(=) matches scalar COMPLEX(4) and rank 1 array of COMPLEX(4)
+    z = z5
+    !ERROR: No intrinsic or user-defined ASSIGNMENT(=) matches rank 1 array of LOGICAL(4) and scalar COMPLEX(4)
+    l5 = z
+    !ERROR: No intrinsic or user-defined ASSIGNMENT(=) matches rank 1 array of COMPLEX(4) and rank 2 array of COMPLEX(4)
+    z5 = z55
+  end
+
+  ! These should all be defined assignments. Because the subroutines
+  ! implementing them are not pure, they should all produce errors
+  pure subroutine test3()
+    type(t1) :: a, b
+    integer :: i
+    logical :: l
+    complex :: z
+    real :: r, r5(5)
+    !ERROR: Procedure 'assign_tt' referenced in PURE subprogram 'test3' must be PURE too
+    a = b
+    !ERROR: Procedure 'assign_il' referenced in PURE subprogram 'test3' must be PURE too
+    i = l
+    !ERROR: Procedure 'assign_li' referenced in PURE subprogram 'test3' must be PURE too
+    l = i
+    !ERROR: Procedure 'assign_il' referenced in PURE subprogram 'test3' must be PURE too
+    i = .true.
+    !ERROR: Procedure 'assign_tz' referenced in PURE subprogram 'test3' must be PURE too
+    a = z
+    !ERROR: Procedure 'assign_01' referenced in PURE subprogram 'test3' must be PURE too
+    r = r5
+  end
+
+  ! Like test3 but not in a pure subroutine so no errors.
+  subroutine test4()
+    type(t1) :: a, b
+    integer :: i
+    logical :: l
+    complex :: z
+    real :: r, r5(5)
+    a = b
+    i = l
+    l = i
+    i = .true.
+    a = z
+    r = r5
+  end
+end

--- a/tools/f18/stub-evaluate.cc
+++ b/tools/f18/stub-evaluate.cc
@@ -24,6 +24,11 @@ struct GenericExprWrapper {
   ~GenericExprWrapper();
 };
 GenericExprWrapper::~GenericExprWrapper() = default;
+struct GenericAssignmentWrapper {
+  ~GenericAssignmentWrapper();
+};
+GenericAssignmentWrapper::~GenericAssignmentWrapper() = default;
 }
 
 DEFINE_DELETER(Fortran::evaluate::GenericExprWrapper)
+DEFINE_DELETER(Fortran::evaluate::GenericAssignmentWrapper)


### PR DESCRIPTION
Commits 1-4 and 6 are refactorings and should not result in functional changes.
The rest perform checks on defined assignments and when successful insert an analyzed form of the assignment into the parse tree.

Note: For lowering to FIR the analyzed form (retrieved by `GetAssignment` in `semantics/tools.h`) should be used.