### PR TITLE
Minor fix in folding of reshape intrinsic

### DIFF
--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -386,8 +386,8 @@ Expr<T> Reshape(FoldingContext &context, FunctionRef<T> &&funcRef) {
               ? source->Reshape(std::move(shape.value()))
               : pad->Reshape(std::move(shape.value()))};
       ConstantSubscripts subscripts{result.lbounds()};
-      auto copied{
-          result.CopyFrom(*source, source->size(), subscripts, dimOrderPtr)};
+      auto copied{result.CopyFrom(*source,
+          std::min(source->size(), resultElements), subscripts, dimOrderPtr)};
       if (copied < resultElements) {
         CHECK(pad);
         copied += result.CopyFrom(

--- a/test/evaluate/folding06.f90
+++ b/test/evaluate/folding06.f90
@@ -31,8 +31,10 @@ module m
   integer(4), parameter :: int_pad(2) = [7, 8]
   integer(4), parameter :: int_expected_result(*, *) = reshape([1, 5, 2, 6, 3, 7, 4, 8], new_shape)
   integer(4), parameter :: int_result(*, *) = reshape(int_source, new_shape, int_pad, order)
+  integer(4), parameter :: int_result_long_source(*, *) = reshape([1, 5, 2, 6, 3, 7, 4, 8, 9], new_shape)
   logical, parameter :: test_reshape_integer_1 = all(int_expected_result == int_result)
   logical, parameter :: test_reshape_integer_2 = all(shape(int_result, 8).EQ.new_shape)
+  logical, parameter :: test_reshape_integer_3 = all(int_expected_result == int_result_long_source)
 
 
   ! Testing characters


### PR DESCRIPTION
The standard permits source to have more elements than the
result (as specified by the SHAPE arg). While copying, ensure
that we do not copy more than the number of elements of the
result.