### PR TITLE
Forward references to derived types

### DIFF
--- a/lib/semantics/check-declarations.cc
+++ b/lib/semantics/check-declarations.cc
@@ -370,7 +370,10 @@ void CheckHelper::CheckProcEntity(
 
 void CheckHelper::CheckDerivedType(
     const Symbol &symbol, const DerivedTypeDetails &details) {
-  CHECK(symbol.scope());
+  if (!symbol.scope()) {
+    CHECK(details.isForwardReferenced());
+    return;
+  }
   CHECK(symbol.scope()->symbol() == &symbol);
   CHECK(symbol.scope()->IsDerivedType());
   if (symbol.attrs().test(Attr::ABSTRACT) &&

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -327,4 +327,13 @@ const Scope *Scope::GetDerivedTypeParent() const {
   }
   return nullptr;
 }
+
+void Scope::InstantiateDerivedTypes(SemanticsContext &context) {
+  for (DeclTypeSpec &type : declTypeSpecs_) {
+    if (type.category() == DeclTypeSpec::TypeDerived ||
+        type.category() == DeclTypeSpec::ClassDerived) {
+      type.derivedTypeSpec().Instantiate(*this, context);
+    }
+  }
+}
 }

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -34,6 +34,8 @@ using namespace parser::literals;
 
 using common::ConstantSubscript;
 
+class SemanticsContext;
+
 // An equivalence object is represented by a symbol for the variable name,
 // the indices for an array element, and the lower bound for a substring.
 struct EquivalenceObject {
@@ -214,6 +216,8 @@ public:
     return kind_ == Kind::Module && symbol_ &&
         symbol_->test(Symbol::Flag::ModFile);
   }
+
+  void InstantiateDerivedTypes(SemanticsContext &);
 
 private:
   Scope &parent_;  // this is enclosing scope, not extended derived type base

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -228,10 +228,12 @@ public:
   const std::list<SourceName> &paramNames() const { return paramNames_; }
   const SymbolVector &paramDecls() const { return paramDecls_; }
   bool sequence() const { return sequence_; }
+  bool isForwardReferenced() const { return isForwardReferenced_; }
   void add_paramName(const SourceName &name) { paramNames_.push_back(name); }
   void add_paramDecl(const Symbol &symbol) { paramDecls_.push_back(symbol); }
   void add_component(const Symbol &);
   void set_sequence(bool x = true) { sequence_ = x; }
+  void set_isForwardReferenced() { isForwardReferenced_ = true; }
   const std::list<SourceName> &componentNames() const {
     return componentNames_;
   }
@@ -258,6 +260,7 @@ private:
   // order.  A parent component, if any, appears first in this list.
   std::list<SourceName> componentNames_;
   bool sequence_{false};
+  bool isForwardReferenced_{false};
   friend std::ostream &operator<<(std::ostream &, const DerivedTypeDetails &);
 };
 
@@ -641,6 +644,9 @@ public:
   // The Scope * argument defaults to this->scope_ but should be overridden
   // for a parameterized derived type instantiation with the instance's scope.
   const DerivedTypeSpec *GetParentTypeSpec(const Scope * = nullptr) const;
+
+  // Clones the Symbol into a parameterized derived type instance.
+  Symbol &InstantiateComponent(Scope &, SemanticsContext &) const;
 
 private:
   const Scope *owner_;

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -885,57 +885,6 @@ bool IsPolymorphicAllocatable(const Symbol &symbol) {
   return IsAllocatable(symbol) && IsPolymorphic(symbol);
 }
 
-static const DeclTypeSpec &InstantiateIntrinsicType(Scope &scope,
-    const DeclTypeSpec &spec, SemanticsContext &semanticsContext) {
-  const IntrinsicTypeSpec *intrinsic{spec.AsIntrinsic()};
-  CHECK(intrinsic);
-  if (evaluate::ToInt64(intrinsic->kind())) {
-    return spec;  // KIND is already a known constant
-  }
-  // The expression was not originally constant, but now it must be so
-  // in the context of a parameterized derived type instantiation.
-  KindExpr copy{intrinsic->kind()};
-  evaluate::FoldingContext &foldingContext{semanticsContext.foldingContext()};
-  copy = evaluate::Fold(foldingContext, std::move(copy));
-  int kind{semanticsContext.GetDefaultKind(intrinsic->category())};
-  if (auto value{evaluate::ToInt64(copy)}) {
-    if (evaluate::IsValidKindOfIntrinsicType(intrinsic->category(), *value)) {
-      kind = *value;
-    } else {
-      foldingContext.messages().Say(
-          "KIND parameter value (%jd) of intrinsic type %s "
-          "did not resolve to a supported value"_err_en_US,
-          static_cast<std::intmax_t>(*value),
-          parser::ToUpperCaseLetters(
-              common::EnumToString(intrinsic->category())));
-    }
-  }
-  switch (spec.category()) {
-  case DeclTypeSpec::Numeric:
-    return scope.MakeNumericType(intrinsic->category(), KindExpr{kind});
-  case DeclTypeSpec::Logical:  //
-    return scope.MakeLogicalType(KindExpr{kind});
-  case DeclTypeSpec::Character:
-    return scope.MakeCharacterType(
-        ParamValue{spec.characterTypeSpec().length()}, KindExpr{kind});
-  default: CRASH_NO_CASE;
-  }
-}
-
-static const DeclTypeSpec *FindInstantiatedDerivedType(const Scope &scope,
-    const DerivedTypeSpec &spec, DeclTypeSpec::Category category) {
-  DeclTypeSpec type{category, spec};
-  if (const auto *found{scope.FindType(type)}) {
-    return found;
-  } else if (scope.IsGlobal()) {
-    return nullptr;
-  } else {
-    return FindInstantiatedDerivedType(scope.parent(), spec, category);
-  }
-}
-
-static Symbol &InstantiateSymbol(const Symbol &, Scope &, SemanticsContext &);
-
 std::list<SourceName> OrderParameterNames(const Symbol &typeSymbol) {
   std::list<SourceName> result;
   if (const DerivedTypeSpec * spec{typeSymbol.GetParentTypeSpec()}) {
@@ -956,202 +905,20 @@ SymbolVector OrderParameterDeclarations(const Symbol &typeSymbol) {
   return result;
 }
 
-void InstantiateDerivedType(DerivedTypeSpec &spec, Scope &containingScope,
-    SemanticsContext &semanticsContext) {
-  Scope &newScope{containingScope.MakeScope(Scope::Kind::DerivedType)};
-  newScope.set_derivedTypeSpec(spec);
-  spec.ReplaceScope(newScope);
-  const Symbol &typeSymbol{spec.typeSymbol()};
-  const Scope *typeScope{typeSymbol.scope()};
-  CHECK(typeScope);
-  for (const Symbol &symbol : OrderParameterDeclarations(typeSymbol)) {
-    const SourceName &name{symbol.name()};
-    if (typeScope->find(symbol.name()) != typeScope->end()) {
-      // This type parameter belongs to the derived type itself, not to
-      // one of its parents.  Put the type parameter expression value
-      // into the new scope as the initialization value for the parameter.
-      if (ParamValue * paramValue{spec.FindParameter(name)}) {
-        const TypeParamDetails &details{symbol.get<TypeParamDetails>()};
-        paramValue->set_attr(details.attr());
-        if (MaybeIntExpr expr{paramValue->GetExplicit()}) {
-          // Ensure that any kind type parameters with values are
-          // constant by now.
-          if (details.attr() == common::TypeParamAttr::Kind) {
-            // Any errors in rank and type will have already elicited
-            // messages, so don't pile on by complaining further here.
-            if (auto maybeDynamicType{expr->GetType()}) {
-              if (expr->Rank() == 0 &&
-                  maybeDynamicType->category() == TypeCategory::Integer) {
-                if (!evaluate::ToInt64(*expr)) {
-                  std::stringstream fortran;
-                  fortran << *expr;
-                  if (auto *msg{
-                          semanticsContext.foldingContext().messages().Say(
-                              "Value of kind type parameter '%s' (%s) is not "
-                              "a scalar INTEGER constant"_err_en_US,
-                              name, fortran.str())}) {
-                    msg->Attach(name, "declared here"_en_US);
-                  }
-                }
-              }
-            }
-          }
-          TypeParamDetails instanceDetails{details.attr()};
-          if (const DeclTypeSpec * type{details.type()}) {
-            instanceDetails.set_type(*type);
-          }
-          instanceDetails.set_init(std::move(*expr));
-          newScope.try_emplace(name, std::move(instanceDetails));
-        }
-      }
-    }
-  }
-  // Instantiate every non-parameter symbol from the original derived
-  // type's scope into the new instance.
-  auto restorer{semanticsContext.foldingContext().WithPDTInstance(spec)};
-  newScope.AddSourceRange(typeScope->sourceRange());
-  for (const auto &pair : *typeScope) {
-    const Symbol &symbol{*pair.second};
-    InstantiateSymbol(symbol, newScope, semanticsContext);
-  }
-}
-
-void ProcessParameterExpressions(
-    DerivedTypeSpec &spec, evaluate::FoldingContext &foldingContext) {
-  auto paramDecls{OrderParameterDeclarations(spec.typeSymbol())};
-  // Fold the explicit type parameter value expressions first.  Do not
-  // fold them within the scope of the derived type being instantiated;
-  // these expressions cannot use its type parameters.  Convert the values
-  // of the expressions to the declared types of the type parameters.
-  for (const Symbol &symbol : paramDecls) {
-    const SourceName &name{symbol.name()};
-    if (ParamValue * paramValue{spec.FindParameter(name)}) {
-      if (const MaybeIntExpr & expr{paramValue->GetExplicit()}) {
-        if (auto converted{evaluate::ConvertToType(symbol, SomeExpr{*expr})}) {
-          SomeExpr folded{
-              evaluate::Fold(foldingContext, std::move(*converted))};
-          if (auto *intExpr{std::get_if<SomeIntExpr>(&folded.u)}) {
-            paramValue->SetExplicit(std::move(*intExpr));
-            continue;
-          }
-        }
-        std::stringstream fortran;
-        fortran << *expr;
-        if (auto *msg{foldingContext.messages().Say(
-                "Value of type parameter '%s' (%s) is not "
-                "convertible to its type"_err_en_US,
-                name, fortran.str())}) {
-          msg->Attach(name, "declared here"_en_US);
-        }
-      }
-    }
-  }
-  // Type parameter default value expressions are folded in declaration order
-  // within the scope of the derived type so that the values of earlier type
-  // parameters are available for use in the default initialization
-  // expressions of later parameters.
-  auto restorer{foldingContext.WithPDTInstance(spec)};
-  for (const Symbol &symbol : paramDecls) {
-    const SourceName &name{symbol.name()};
-    const TypeParamDetails &details{symbol.get<TypeParamDetails>()};
-    MaybeIntExpr expr;
-    ParamValue *paramValue{spec.FindParameter(name)};
-    if (!paramValue) {
-      expr = evaluate::Fold(foldingContext, common::Clone(details.init()));
-    } else if (paramValue->isExplicit()) {
-      expr = paramValue->GetExplicit();
-    }
-    if (expr) {
-      if (paramValue) {
-        paramValue->SetExplicit(std::move(*expr));
-      } else {
-        spec.AddParamValue(
-            symbol.name(), ParamValue{std::move(*expr), details.attr()});
-      }
-    }
-  }
-}
-
 const DeclTypeSpec &FindOrInstantiateDerivedType(Scope &scope,
     DerivedTypeSpec &&spec, SemanticsContext &semanticsContext,
     DeclTypeSpec::Category category) {
-  ProcessParameterExpressions(spec, semanticsContext.foldingContext());
+  spec.CookParameters(semanticsContext.foldingContext());
+  spec.EvaluateParameters(semanticsContext.foldingContext());
   if (const DeclTypeSpec *
-      type{FindInstantiatedDerivedType(scope, spec, category)}) {
+      type{scope.FindInstantiatedDerivedType(spec, category)}) {
     return *type;
   }
   // Create a new instantiation of this parameterized derived type
   // for this particular distinct set of actual parameter values.
   DeclTypeSpec &type{scope.MakeDerivedType(category, std::move(spec))};
-  InstantiateDerivedType(type.derivedTypeSpec(), scope, semanticsContext);
+  type.derivedTypeSpec().Instantiate(scope, semanticsContext);
   return type;
-}
-
-// Clone a Symbol in the context of a parameterized derived type instance
-static Symbol &InstantiateSymbol(
-    const Symbol &symbol, Scope &scope, SemanticsContext &semanticsContext) {
-  evaluate::FoldingContext foldingContext{semanticsContext.foldingContext()};
-  const DerivedTypeSpec &instanceSpec{DEREF(foldingContext.pdtInstance())};
-  auto pair{scope.try_emplace(symbol.name(), symbol.attrs())};
-  Symbol &result{*pair.first->second};
-  if (!pair.second) {
-    // Symbol was already present in the scope, which can only happen
-    // in the case of type parameters.
-    CHECK(symbol.has<TypeParamDetails>());
-    return result;
-  }
-  result.attrs() = symbol.attrs();
-  result.flags() = symbol.flags();
-  result.set_details(common::Clone(symbol.details()));
-  if (auto *details{result.detailsIf<ObjectEntityDetails>()}) {
-    if (DeclTypeSpec * origType{result.GetType()}) {
-      if (const DerivedTypeSpec * derived{origType->AsDerived()}) {
-        DerivedTypeSpec newSpec{*derived};
-        if (symbol.test(Symbol::Flag::ParentComp)) {
-          // Forward any explicit type parameter values from the
-          // derived type spec under instantiation to its parent
-          // component derived type spec that define type parameters
-          // of the parent component.
-          for (const auto &pair : instanceSpec.parameters()) {
-            if (scope.find(pair.first) == scope.end()) {
-              newSpec.AddParamValue(pair.first, ParamValue{pair.second});
-            }
-          }
-        }
-        details->ReplaceType(FindOrInstantiateDerivedType(
-            scope, std::move(newSpec), semanticsContext, origType->category()));
-      } else if (origType->AsIntrinsic()) {
-        details->ReplaceType(
-            InstantiateIntrinsicType(scope, *origType, semanticsContext));
-      } else if (origType->category() != DeclTypeSpec::ClassStar) {
-        DIE("instantiated component has type that is "
-            "neither intrinsic, derived, nor CLASS(*)");
-      }
-    }
-    details->set_init(
-        evaluate::Fold(foldingContext, std::move(details->init())));
-    for (ShapeSpec &dim : details->shape()) {
-      if (dim.lbound().isExplicit()) {
-        dim.lbound().SetExplicit(
-            Fold(foldingContext, std::move(dim.lbound().GetExplicit())));
-      }
-      if (dim.ubound().isExplicit()) {
-        dim.ubound().SetExplicit(
-            Fold(foldingContext, std::move(dim.ubound().GetExplicit())));
-      }
-    }
-    for (ShapeSpec &dim : details->coshape()) {
-      if (dim.lbound().isExplicit()) {
-        dim.lbound().SetExplicit(
-            Fold(foldingContext, std::move(dim.lbound().GetExplicit())));
-      }
-      if (dim.ubound().isExplicit()) {
-        dim.ubound().SetExplicit(
-            Fold(foldingContext, std::move(dim.ubound().GetExplicit())));
-      }
-    }
-  }
-  return result;
 }
 
 // ComponentIterator implementation

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -188,13 +188,9 @@ SymbolVector OrderParameterDeclarations(const Symbol &);
 // order defined by 7.5.3.2.
 std::list<SourceName> OrderParameterNames(const Symbol &);
 
-// Create a new instantiation of this parameterized derived type
-// for this particular distinct set of actual parameter values.
-void InstantiateDerivedType(DerivedTypeSpec &, Scope &, SemanticsContext &);
 // Return an existing or new derived type instance
 const DeclTypeSpec &FindOrInstantiateDerivedType(Scope &, DerivedTypeSpec &&,
     SemanticsContext &, DeclTypeSpec::Category = DeclTypeSpec::TypeDerived);
-void ProcessParameterExpressions(DerivedTypeSpec &, evaluate::FoldingContext &);
 
 // Determines whether an object might be visible outside a
 // PURE function (C1594); returns a non-null Symbol pointer for

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -195,6 +195,7 @@ set(ERROR_TESTS
   misc-declarations.f90
   separate-module-procs.f90
   bindings01.f90
+  bad-forward-type.f90
 )
 
 # These test files have expected symbols in the source
@@ -214,6 +215,7 @@ set(SYMBOL_TESTS
   symbol14.f90
   symbol15.f90
   symbol16.f90
+  symbol17.f90
   omp-symbol01.f90
   omp-symbol02.f90
   omp-symbol03.f90

--- a/test/semantics/bad-forward-type.f90
+++ b/test/semantics/bad-forward-type.f90
@@ -1,0 +1,83 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Forward references to derived types (error cases)
+
+!ERROR: The derived type 'undef' was forward-referenced but not defined
+type(undef) function f1()
+  call sub(f1)
+end function
+
+!ERROR: The derived type 'undef' was forward-referenced but not defined
+type(undef) function f2() result(r)
+  call sub(r)
+end function
+
+!ERROR: The derived type 'undefpdt' was forward-referenced but not defined
+type(undefpdt(1)) function f3()
+  call sub(f3)
+end function
+
+!ERROR: The derived type 'undefpdt' was forward-referenced but not defined
+type(undefpdt(1)) function f4() result(r)
+  call sub(f4)
+end function
+
+!ERROR: 'bad' is not the name of a parameter for derived type 'pdt'
+type(pdt(bad=1)) function f5()
+  type :: pdt(good)
+    integer, kind :: good = kind(0)
+    integer(kind=good) :: n
+  end type
+end function
+
+subroutine s1(q1)
+  !ERROR: The derived type 'undef' was forward-referenced but not defined
+  implicit type(undef)(q)
+end subroutine
+
+subroutine s2(q1)
+  !ERROR: The derived type 'undefpdt' was forward-referenced but not defined
+  implicit type(undefpdt(1))(q)
+end subroutine
+
+subroutine s3
+  type :: t1
+    !ERROR: Derived type 'undef' not found
+    type(undef) :: x
+  end type
+end subroutine
+
+subroutine s4
+  type :: t1
+    !ERROR: Derived type 'undefpdt' not found
+    type(undefpdt(1)) :: x
+  end type
+end subroutine
+
+subroutine s5(x)
+  !ERROR: Derived type 'undef' not found
+  type(undef) :: x
+end subroutine
+
+subroutine s6(x)
+  !ERROR: Derived type 'undefpdt' not found
+  type(undefpdt(1)) :: x
+end subroutine
+
+subroutine s7(x)
+  !ERROR: Derived type 'undef' not found
+  type, extends(undef) :: t
+  end type
+end subroutine

--- a/test/semantics/symbol17.f90
+++ b/test/semantics/symbol17.f90
@@ -1,0 +1,122 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Forward references to derived types (non-error cases)
+
+!DEF: /main MainProgram
+program main
+ !DEF: /main/t1 DerivedType
+ type :: t1
+  !DEF: /main/t2 DerivedType
+  !DEF: /main/t1/t1a ALLOCATABLE ObjectEntity TYPE(t2)
+  type(t2), allocatable :: t1a
+  !REF: /main/t2
+  !DEF: /main/t1/t1p POINTER ObjectEntity TYPE(t2)
+  type(t2), pointer :: t1p
+ end type
+ !REF: /main/t2
+ type :: t2
+  !REF: /main/t2
+  !DEF: /main/t2/t2a ALLOCATABLE ObjectEntity TYPE(t2)
+  type(t2), allocatable :: t2a
+  !REF: /main/t2
+  !DEF: /main/t2/t2p POINTER ObjectEntity TYPE(t2)
+  type(t2), pointer :: t2p
+ end type
+ !REF: /main/t1
+ !DEF: /main/t1x ObjectEntity TYPE(t1)
+ type(t1) :: t1x
+ !REF: /main/t1x
+ !REF: /main/t1/t1a
+ allocate(t1x%t1a)
+ !REF: /main/t1x
+ !REF: /main/t1/t1p
+ !REF: /main/t1/t1a
+ t1x%t1p => t1x%t1a
+ !REF: /main/t1x
+ !REF: /main/t1/t1a
+ !REF: /main/t2/t2a
+ allocate(t1x%t1a%t2a)
+ !REF: /main/t1x
+ !REF: /main/t1/t1a
+ !REF: /main/t2/t2p
+ !REF: /main/t2/t2a
+ t1x%t1a%t2p => t1x%t1a%t2a
+end program
+!DEF: /f1/fwd DerivedType
+!DEF: /f1 (Function) Subprogram TYPE(fwd)
+!DEF: /f1/n (Implicit) ObjectEntity INTEGER(4)
+type(fwd) function f1(n)
+ !REF: /f1/fwd
+ type :: fwd
+  !DEF: /f1/fwd/n ObjectEntity INTEGER(4)
+  integer :: n
+ end type
+ !DEF: /f1/f1 ObjectEntity TYPE(fwd)
+ !REF: /f1/fwd/n
+ !REF: /f1/n
+ f1%n = n
+end function
+!DEF: /s1 (Subroutine) Subprogram
+!DEF: /s1/q1 (Implicit) ObjectEntity TYPE(fwd)
+subroutine s1 (q1)
+ !DEF: /s1/fwd DerivedType
+ implicit type(fwd)(q)
+ !REF: /s1/fwd
+ type :: fwd
+  !DEF: /s1/fwd/n ObjectEntity INTEGER(4)
+  integer :: n
+ end type
+ !REF: /s1/q1
+ !REF: /s1/fwd/n
+ q1%n = 1
+end subroutine
+!DEF: /f2/fwdpdt DerivedType
+!DEF: /f2/kind INTRINSIC (Function) ProcEntity
+!DEF: /f2 (Function) Subprogram TYPE(fwdpdt(k=4_4))
+!DEF: /f2/n (Implicit) ObjectEntity INTEGER(4)
+type(fwdpdt(kind(0))) function f2(n)
+ !REF: /f2/fwdpdt
+ !DEF: /f2/fwdpdt/k TypeParam INTEGER(4)
+ type :: fwdpdt(k)
+  !REF: /f2/fwdpdt/k
+  integer, kind :: k
+  !REF: /f2/fwdpdt/k
+  !DEF: /f2/fwdpdt/n ObjectEntity INTEGER(int(k,kind=8))
+  integer(kind=k) :: n
+ end type
+ !DEF: /f2/f2 ObjectEntity TYPE(fwdpdt(k=4_4))
+ !DEF: /f2/DerivedType2/n ObjectEntity INTEGER(4)
+ !REF: /f2/n
+ f2%n = n
+end function
+!DEF: /s2 (Subroutine) Subprogram
+!DEF: /s2/q1 (Implicit) ObjectEntity TYPE(fwdpdt(k=4_4))
+subroutine s2 (q1)
+ !DEF: /s2/fwdpdt DerivedType
+ !DEF: /s2/kind INTRINSIC (Function) ProcEntity
+ implicit type(fwdpdt(kind(0)))(q)
+ !REF: /s2/fwdpdt
+ !DEF: /s2/fwdpdt/k TypeParam INTEGER(4)
+ type :: fwdpdt(k)
+  !REF: /s2/fwdpdt/k
+  integer, kind :: k
+  !REF: /s2/fwdpdt/k
+  !DEF: /s2/fwdpdt/n ObjectEntity INTEGER(int(k,kind=8))
+  integer(kind=k) :: n
+ end type
+ !REF: /s2/q1
+ !DEF: /s2/DerivedType2/n ObjectEntity INTEGER(4)
+ q1%n = 1
+end subroutine


### PR DESCRIPTION
Implement forward references to derived types, including parameterized derived types.

Allowing forward references to unparameterized derived types is straightforward (a flag was added to `DerivedTypeDetails` to indicate them, and a state flag in `DeclTypeSpecVisitor` allows them), but enabling forward references to PDTs and getting it right involved some restructuring of existing code so that validation of type parameter lists could be deferred to the time of type instantiation.  So some larger functions were broken up into smaller ones, and many were converted into member functions and relocated into different C++ source files.

Fixes issue #573.