### PR TITLE
Dodge GCC 7.2 bug

### DIFF
--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -708,10 +708,22 @@ bool GenericKind::IsOperator() const {
 
 std::string GenericKind::ToString() const {
   return std::visit(
-      common::visitors{
-          [](const OtherKind &x) { return EnumToString(x); },
-          [](const DefinedIo &x) { return EnumToString(x); },
-          [](const auto &x) { return common::EnumToString(x); },
+      common::visitors {
+        [](const OtherKind &x) { return EnumToString(x); },
+            [](const DefinedIo &x) { return EnumToString(x); },
+#if !__clang__ && __GNUC__ == 7 && __GNUC_MINOR__ == 2
+            [](const common::NumericOperator &x) {
+              return common::EnumToString(x);
+            },
+            [](const common::LogicalOperator &x) {
+              return common::EnumToString(x);
+            },
+            [](const common::RelationalOperator &x) {
+              return common::EnumToString(x);
+            },
+#else
+            [](const auto &x) { return common::EnumToString(x); },
+#endif
       },
       u);
 }


### PR DESCRIPTION
GCC 7.2 has a bug that I've had to work around elsewhere in the f18 codebase -- in `visitors` lists with `auto` catch-alls, the `auto` case is sometimes incorrectly selected rather than an explicit match.