### PR TITLE
Fix PURE check on procedure binding

### DIFF
--- a/lib/evaluate/check-expression.cc
+++ b/lib/evaluate/check-expression.cc
@@ -218,7 +218,7 @@ public:
 
   template<typename T> Result operator()(const FunctionRef<T> &x) const {
     if (const auto *symbol{x.proc().GetSymbol()}) {
-      if (!symbol->attrs().test(semantics::Attr::PURE)) {
+      if (!semantics::IsPureProcedure(*symbol)) {
         return "reference to impure function '"s + symbol->name().ToString() +
             "'";
       }

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -242,8 +242,12 @@ bool IsPureProcedure(const Symbol &symbol) {
       // procedure component with a PURE interface
       return IsPureProcedure(*procInterface);
     }
+  } else if (const auto *details{symbol.detailsIf<ProcBindingDetails>()}) {
+    return IsPureProcedure(details->symbol());
+  } else if (!IsProcedure(symbol)) {
+    return false;
   }
-  return symbol.attrs().test(Attr::PURE) && IsProcedure(symbol);
+  return symbol.attrs().test(Attr::PURE);
 }
 
 bool IsPureProcedure(const Scope &scope) {


### PR DESCRIPTION
A symbol that represents a procedure binding is PURE if the procedure
it is bound to is PURE. Fix `IsPureProcedure` to check that.

Make use of `IsPureProcedure` in `CheckSpecificationExprHelper`.