### PR TITLE
Complex expression dump fixes

### DIFF
--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -257,7 +257,8 @@ struct ComplexComponent
   ComplexComponent(bool isImaginary, Expr<Operand> &&x)
     : Base{std::move(x)}, isImaginaryPart{isImaginary} {}
 
-  const char *Suffix() const { return isImaginaryPart ? "%IM" : "%RE"; }
+  const char *Prefix() const { return isImaginaryPart ? "IMAG(" : "REAL("; }
+  const char *Suffix() const { return ")"; }
 
   bool isImaginaryPart{true};
 };

--- a/lib/evaluate/real.cc
+++ b/lib/evaluate/real.cc
@@ -470,10 +470,6 @@ std::ostream &Real<W, P, IM>::AsFortran(
       o << "(1._" << kind << "/0.)";
     }
   } else {
-    bool parenthesize{IsNegative()};
-    if (parenthesize) {
-      o << "(";
-    }
     using B = decimal::BinaryFloatingPointNumber<P>;
     const auto *value{reinterpret_cast<const B *>(this)};
     char buffer[24000];  // accommodate real*16
@@ -496,9 +492,6 @@ std::ostream &Real<W, P, IM>::AsFortran(
       o << 'e' << expo;
     }
     o << '_' << kind;
-    if (parenthesize) {
-      o << ')';
-    }
   }
   return o;
 }

--- a/test/semantics/modfile20.f90
+++ b/test/semantics/modfile20.f90
@@ -22,6 +22,7 @@ module m
   character(10, kind=k1) :: c = k1_"asdf"
   character(10), parameter :: c2 = k1_"qwer"
   complex*16, parameter :: z = (1.0_k8, 2.0_k8)
+  complex*16, parameter :: zn = (-1.0_k8, 2.0_k8)
   type t
     integer :: a = 123
     type(t), pointer :: b => null()
@@ -40,6 +41,7 @@ end
 !  character(10_4,1)::c
 !  character(10_4,1),parameter::c2=1_"qwer      "
 !  complex(8),parameter::z=(1._8,2._8)
+!  complex(8),parameter::zn=(-1._8,2._8)
 !  type::t
 !    integer(4)::a=123_4
 !    type(t),pointer::b=>NULL()


### PR DESCRIPTION
1. Dump negative parts in complex constants without parentheses

After expression analysis, `(-1., 0.)` was dumped as `((-1.), 0.)` .
The latter format is only valid with the complex constructor extension that is not supported by all compilers.
It turns out the parenthesis added by `Real::AsFortran` are not required because operation dumping is
already taking care of this at: https://github.com/flang-compiler/f18/blob/fdb351ca2afb0d71028785da4687113343e11f54/lib/evaluate/formatting.cc#L250
`Integer::AsFortran` is actually already not inserting its own parentheses.

2. Dump evaluate::ComplexComponent with REAL/IMAG instead of %RE/%IM
f18 was failing to re-parse its own dump in some cases involving complex expressions like `-z**i`. See for instance:
```
function foo(z)
  complex :: foo, z
  integer :: i
  foo = -z**i
end function
```
The reason was %RE and %IM were used to dump `ComplexComponents`. %RE and %IM can only be used on designator but `ComplexComponent` can contain arbitrary complex expressions.
This commit replace them with call to intrinsic function `REAL`/`IMAG`.

**Note that this may unfortunately be unsafe if the user shadowed REAL or IMAG but I do not see an easy way to solve this... f18 still fails to re-parse its own unparsed code for**:
```
module m
interface
  function real(c)
    real :: real
    character :: c
  end function
end interface
contains
  function foo(z, i)
    complex :: foo, z
    foo = -z**i
  end function
end module
```