### PR TITLE
Fix forward ref to derived type when symbol exists

### DIFF
--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -708,8 +708,8 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
 // TODO: Non-standard intrinsic functions
 //  AND, OR, XOR, LSHIFT, RSHIFT, SHIFT, ZEXT, IZEXT,
 //  COSD, SIND, TAND, ACOSD, ASIND, ATAND, ATAN2D, COMPL,
-//  DCMPLX, EQV, NEQV, INT8, JINT, JNINT, KNINT,
-//  QCMPLX, DREAL, DFLOAT, QEXT, QFLOAT, QREAL, DNUM,
+//  EQV, NEQV, INT8, JINT, JNINT, KNINT,
+//  QCMPLX, DFLOAT, QEXT, QFLOAT, QREAL, DNUM,
 //  INUM, JNUM, KNUM, QNUM, RNUM, RAN, RANF, ILEN, SIZEOF,
 //  MCLOCK, SECNDS, COTAN, IBCHNG, ISHA, ISHC, ISHL, IXOR
 //  IARG, IARGC, NARGS, NUMARG, BADDRESS, IADDR, CACHESIZE,
@@ -740,7 +740,7 @@ struct SpecificIntrinsicInterface : public IntrinsicInterface {
   //  e.g. IABS(INT(i), INT(j)) not equiv to INT(ABS(i, j)).
   // This is allowed for restricted min/max specific functions because
   // the expected behavior is clear from their definitions. A warning is though
-  // always emitted because other compilers behavior is not ubiquitous here.
+  // always emitted because other compilers' behavior is not ubiquitous here.
   bool useGenericAndForceResultType{false};
 };
 

--- a/test/semantics/symbol17.f90
+++ b/test/semantics/symbol17.f90
@@ -120,3 +120,34 @@ subroutine s2 (q1)
  !DEF: /s2/DerivedType2/n ObjectEntity INTEGER(4)
  q1%n = 1
 end subroutine
+!DEF: /m1 Module
+module m1
+ !DEF: /m1/forward PRIVATE DerivedType
+  private :: forward
+ !DEF: /m1/base PUBLIC DerivedType
+  type :: base
+  !REF: /m1/forward
+  !DEF: /m1/base/p POINTER ObjectEntity CLASS(forward)
+    class(forward), pointer :: p
+  end type
+ !REF: /m1/base
+ !REF: /m1/forward
+  type, extends(base) :: forward
+  !DEF: /m1/forward/n ObjectEntity INTEGER(4)
+    integer :: n
+  end type
+ contains
+ !DEF: /m1/test PUBLIC (Subroutine) Subprogram
+  subroutine test
+  !REF: /m1/forward
+  !DEF: /m1/test/object TARGET ObjectEntity TYPE(forward)
+    type(forward), target :: object
+  !REF: /m1/test/object
+  !REF: /m1/base/p
+    object%p => object
+  !REF: /m1/test/object
+  !REF: /m1/base/p
+  !REF: /m1/forward/n
+    object%p%n = 666
+  end subroutine
+end module


### PR DESCRIPTION
Forward-referenced derived types whose names had previously appeared in the program unit (e.g., in a `PRIVATE` statement) didn't work; now they do.