### PR TITLE
Prevent multiple CI runs on a single architecture

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1,7 +1,8 @@
 def clang(arch):
     return {
         "kind": "pipeline",
-        "name": "%s-clang" % arch,
+        "name": "%s clang" % arch,
+        "concurrency": {"limit": 1},
         "steps": [
             {
                 "name": "test",
@@ -10,7 +11,7 @@ def clang(arch):
                     "apt-get update && apt-get install -y clang-8 cmake ninja-build lld-8 llvm-dev libc++-8-dev libc++abi-8-dev",
                     "mkdir build && cd build",
                     'env CC=clang-8 CXX=clang++-8 CXXFLAGS="-UNDEBUG -stdlib=libc++" LDFLAGS="-fuse-ld=lld" cmake -GNinja -DCMAKE_BUILD_TYPE=Release ..',
-                    "ninja -j8",
+                    "ninja -j16",
                     "ctest --output-on-failure -j24",
                 ],
             },
@@ -21,7 +22,8 @@ def clang(arch):
 def gcc(arch):
     return {
             "kind": "pipeline",
-            "name": "%s-gcc" % arch,
+            "name": "%s gcc" % arch,
+            "concurrency": {"limit": 1},
             "steps": [
                 {
                     "name": "test",
@@ -30,7 +32,7 @@ def gcc(arch):
 			"apt-get update && apt-get install -y cmake ninja-build llvm-dev",
                         "mkdir build && cd build",
                         'env CC=gcc CXX=g++ CXXFLAGS="-UNDEBUG" LDFLAGS="-fuse-ld=gold" cmake -GNinja -DCMAKE_BUILD_TYPE=Release ..',
-                        "ninja -j8",
+                        "ninja -j16",
                         "ctest --output-on-failure -j24",
                     ],
                 },
@@ -45,4 +47,5 @@ def main(ctx):
         gcc("amd64"),
         gcc("arm64"),
     ]
+
 


### PR DESCRIPTION
I believe that the CI failures might be due to Drone running multiple builds on the same machine if you have multiple commits waiting for CI. I've added here a concurrency limit, meaning that new commits will wait for previous commits CI to run before starting.

This would explain why the problem didn't appear in my fork and only manifested in the upstream repo: effectively because the upstream repo has a lot more traffic on it than my own fork.