### PR TITLE
Fix problems with passed-object arguments...

### DIFF
--- a/lib/evaluate/call.cc
+++ b/lib/evaluate/call.cc
@@ -59,12 +59,11 @@ int ActualArgument::Rank() const {
 }
 
 bool ActualArgument::operator==(const ActualArgument &that) const {
-  return keyword == that.keyword &&
-      isAlternateReturn == that.isAlternateReturn && u_ == that.u_;
+  return keyword_ == that.keyword_ &&
+      isAlternateReturn_ == that.isAlternateReturn_ && u_ == that.u_;
 }
 
 void ActualArgument::Parenthesize() {
-  CHECK(!isAlternateReturn);
   u_ = evaluate::Parenthesize(std::move(DEREF(UnwrapExpr())));
 }
 

--- a/lib/evaluate/characteristics.h
+++ b/lib/evaluate/characteristics.h
@@ -27,6 +27,7 @@
 #include "../common/enum-set.h"
 #include "../common/idioms.h"
 #include "../common/indirection.h"
+#include "../parser/char-block.h"
 #include "../semantics/symbol.h"
 #include <optional>
 #include <ostream>
@@ -260,6 +261,7 @@ struct Procedure {
   bool HasExplicitInterface() const {
     return !attrs.test(Attr::ImplicitInterface);
   }
+  int FindPassIndex(std::optional<parser::CharBlock>) const;
   bool CanBeCalledViaImplicitInterface() const;
   bool CanOverride(const Procedure &, std::optional<int> passIndex) const;
   std::ostream &Dump(std::ostream &) const;

--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -109,10 +109,11 @@ std::ostream &ActualArgument::AssumedType::AsFortran(std::ostream &o) const {
 }
 
 std::ostream &ActualArgument::AsFortran(std::ostream &o) const {
-  if (keyword) {
-    o << keyword->ToString() << '=';
+  CHECK(!IsPassedObject());
+  if (keyword_) {
+    o << keyword_->ToString() << '=';
   }
-  if (isAlternateReturn) {
+  if (isAlternateReturn_) {
     o << '*';
   }
   if (const auto *expr{UnwrapExpr()}) {
@@ -130,7 +131,7 @@ std::ostream &ProcedureRef::AsFortran(std::ostream &o) const {
   proc_.AsFortran(o);
   char separator{'('};
   for (const auto &arg : arguments_) {
-    if (arg) {
+    if (arg && !arg->IsPassedObject()) {
       arg->AsFortran(o << separator);
       separator = ',';
     }

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -990,7 +990,7 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
     if (!arg) {
       ++missingActualArguments;
     } else {
-      if (arg->isAlternateReturn) {
+      if (arg->isAlternateReturn()) {
         messages.Say(
             "alternate return specifier not acceptable on call to intrinsic '%s'"_err_en_US,
             name);
@@ -999,16 +999,16 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
       bool found{false};
       int slot{missingActualArguments};
       for (std::size_t j{0}; j < nonRepeatedDummies && !found; ++j) {
-        if (arg->keyword) {
-          found = *arg->keyword == dummy[j].keyword;
+        if (arg->keyword()) {
+          found = *arg->keyword() == dummy[j].keyword;
           if (found) {
             if (const auto *previous{actualForDummy[j]}) {
-              if (previous->keyword) {
-                messages.Say(*arg->keyword,
+              if (previous->keyword()) {
+                messages.Say(*arg->keyword(),
                     "repeated keyword argument to intrinsic '%s'"_err_en_US,
                     name);
               } else {
-                messages.Say(*arg->keyword,
+                messages.Say(*arg->keyword(),
                     "keyword argument to intrinsic '%s' was supplied "
                     "positionally by an earlier actual argument"_err_en_US,
                     name);
@@ -1024,12 +1024,12 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
         }
       }
       if (!found) {
-        if (repeatLastDummy && !arg->keyword) {
+        if (repeatLastDummy && !arg->keyword()) {
           // MAX/MIN argument after the 2nd
           actualForDummy.push_back(&*arg);
         } else {
-          if (arg->keyword) {
-            messages.Say(*arg->keyword,
+          if (arg->keyword()) {
+            messages.Say(*arg->keyword(),
                 "unknown keyword argument to intrinsic '%s'"_err_en_US, name);
           } else {
             messages.Say(
@@ -1547,10 +1547,10 @@ SpecificCall IntrinsicProcTable::Implementation::HandleNull(
   if (!arguments.empty()) {
     if (arguments.size() > 1) {
       context.messages().Say("Too many arguments to NULL()"_err_en_US);
-    } else if (arguments[0] && arguments[0]->keyword &&
-        arguments[0]->keyword->ToString() != "mold") {
+    } else if (arguments[0] && arguments[0]->keyword() &&
+        arguments[0]->keyword()->ToString() != "mold") {
       context.messages().Say("Unknown argument '%s' to NULL()"_err_en_US,
-          arguments[0]->keyword->ToString());
+          arguments[0]->keyword()->ToString());
     } else {
       if (Expr<SomeType> * mold{arguments[0]->UnwrapExpr()}) {
         if (IsAllocatableOrPointer(*mold)) {

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -669,6 +669,17 @@ Symbol &Symbol::InstantiateComponent(
             Fold(foldingContext, std::move(dim.ubound().GetExplicit())));
       }
     }
+  } else if (!attrs_.test(Attr::NOPASS)) {
+    std::visit(
+        [&result](const auto &x) {
+          using Ty = std::decay_t<decltype(x)>;
+          if constexpr (std::is_base_of_v<WithPassArg, Ty>) {
+            if (auto passName{x.passName()}) {
+              result.get<Ty>().set_passName(*passName);
+            }
+          }
+        },
+        details_);
   }
   return result;
 }

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -182,17 +182,17 @@ private:
 };
 
 // Mixin for details with passed-object dummy argument.
-// passIndex is set based on passName or the PASS attr.
+// If a procedure pointer component or type-bound procedure does not have
+// the NOPASS attribute on its symbol, then PASS is assumed; the name
+// is optional; if it is missing, the first dummy argument of the procedure's
+// interface is the passed-object dummy argument.
 class WithPassArg {
 public:
-  const std::optional<SourceName> &passName() const { return passName_; }
+  std::optional<SourceName> passName() const { return passName_; }
   void set_passName(const SourceName &passName) { passName_ = passName; }
-  std::optional<int> passIndex() const { return passIndex_; }
-  void set_passIndex(int index) { passIndex_ = index; }
 
 private:
   std::optional<SourceName> passName_;
-  std::optional<int> passIndex_;
 };
 
 // A procedure pointer, dummy procedure, or external procedure

--- a/test/evaluate/intrinsics.cc
+++ b/test/evaluate/intrinsics.cc
@@ -93,7 +93,7 @@ struct TestCall {
     std::size_t j{0};
     for (auto &kw : keywords) {
       if (!kw.empty()) {
-        args[j]->keyword = strings(kw);
+        args[j]->set_keyword(strings(kw));
       }
       ++j;
     }

--- a/test/semantics/call11.f90
+++ b/test/semantics/call11.f90
@@ -55,13 +55,13 @@ module m
   subroutine test2
     type(t) :: x
     real :: a(x%tbp_pure(1)) ! ok
-    !ERROR: Invalid specification expression: reference to impure function 'tbp_impure'
+    !ERROR: Invalid specification expression: reference to impure function 'impure'
     real :: b(x%tbp_impure(1))
     forall (j=1:1)
       a(j) = x%tbp_pure(j) ! ok
     end forall
     forall (j=1:1)
-      !ERROR: Impure procedure 'tbp_impure' may not be referenced in a FORALL
+      !ERROR: Impure procedure 'impure' may not be referenced in a FORALL
       a(j) = x%tbp_impure(j) ! C1037
     end forall
     do concurrent (j=1:1, x%tbp_pure(j) /= 0) ! ok

--- a/test/semantics/modfile08.f90
+++ b/test/semantics/modfile08.f90
@@ -45,7 +45,7 @@ end
 !  type::t
 !    procedure(),nopass,pointer::e
 !    procedure(real(4)),nopass,pointer::f
-!    procedure(s),pass(x),pointer,private::g
+!    procedure(s),pointer,private::g
 !  end type
 !contains
 !  subroutine s(x)

--- a/test/semantics/modfile10.f90
+++ b/test/semantics/modfile10.f90
@@ -78,7 +78,7 @@ end module
 !    integer(4)::x
 !  contains
 !    final::c
-!    procedure,pass(x),non_overridable,private::d
+!    procedure,non_overridable,private::d
 !  end type
 !  type,abstract::t2a
 !  contains

--- a/test/semantics/modfile14.f90
+++ b/test/semantics/modfile14.f90
@@ -51,7 +51,7 @@ end
 !  contains
 !    procedure,nopass::s2
 !    procedure,nopass::s3
-!    procedure,pass(dtv)::r
+!    procedure::r
 !    generic::foo=>s2
 !    generic::read(formatted)=>r
 !  end type

--- a/test/semantics/modfile15.f90
+++ b/test/semantics/modfile15.f90
@@ -31,7 +31,7 @@ end module
 !Expect: m.mod
 !module m
 !  type::t
-!    procedure(a),pass(x),pointer::c
+!    procedure(a),pass,pointer::c
 !    procedure(a),pass(x),pointer::d
 !  contains
 !    procedure,pass(y)::a


### PR DESCRIPTION
... by deferring the identification of their indices in the dummy argument list,
simplifying their representation, completing the representation
of their actual arguments, and (while I'm here) resolving
calls to type-bound procedures whose bindings are known at
compilation time.

Button up class ActualArgument by making remaining data
members private and adding accessors & mutators.