### PR TITLE
Allow assignment between INTEGER and LOGICAL as extension

### DIFF
--- a/documentation/Extensions.md
+++ b/documentation/Extensions.md
@@ -109,6 +109,8 @@ Extensions, deletions, and legacy features supported by default
 * When a dummy argument is `POINTER` or `ALLOCATABLE` and is `INTENT(IN)`, we
   relax enforcement of some requirements on actual arguments that must otherwise
   hold true for definable arguments.
+* Assignment of `LOGICAL` to `INTEGER` and vice versa (but not other types).
+  The values are normalized.
 
 Extensions supported when enabled by options
 --------------------------------------------
@@ -140,7 +142,7 @@ Extensions and legacy features deliberately not supported
 * Defining an explicit interface for a subprogram within itself (PGI only)
 * USE association of a procedure interface within that same procedure's definition
 * NULL() as a structure constructor expression for an ALLOCATABLE component (PGI).
-* Conversion of LOGICAL to INTEGER.
+* Conversion of LOGICAL to INTEGER in expressions.
 * IF (integer expression) THEN ... END IF  (PGI/Intel)
 * Comparsion of LOGICAL with ==/.EQ. rather than .EQV. (also .NEQV.) (PGI/Intel)
 * Procedure pointers in COMMON blocks (PGI/Intel)

--- a/lib/common/Fortran-features.h
+++ b/lib/common/Fortran-features.h
@@ -33,7 +33,7 @@ ENUM_CLASS(LanguageFeature, BackslashEscapes, OldDebugLines,
     Hollerith, ArithmeticIF, Assign, AssignedGOTO, Pause, OpenMP,
     CruftAfterAmpersand, ClassicCComments, AdditionalFormats, BigIntLiterals,
     RealDoControls, EquivalenceNumericWithCharacter, AdditionalIntrinsics,
-    AnonymousParents, OldLabelDoEndStatements)
+    AnonymousParents, OldLabelDoEndStatements, LogicalIntegerAssignment)
 
 using LanguageFeatures = EnumSet<LanguageFeature, LanguageFeature_enumSize>;
 


### PR DESCRIPTION
GNU Fortran, PGI, and Intel Fortran accept intrinsic assignments of LOGICAL to INTEGER and vice versa.  Extend f18 to also allow these assignments as an extension, with the usual optional warnings and ability to disable with `-Mstandard`.  If the program has defined `ASSIGNMENT(=)` procedures that handle these cases, the extension is overridden.