### PR TITLE
Resolve calls to type-bound generic names

### DIFF
--- a/lib/semantics/check-call.cc
+++ b/lib/semantics/check-call.cc
@@ -572,7 +572,7 @@ static void CheckExplicitInterfaceArg(evaluate::ActualArgument &arg,
                     "Assumed-type TYPE(*) '%s' may be associated only with an assumed-TYPE(*) %s"_err_en_US,
                     assumed->name(), dummyName);
               }
-            } else {
+            } else if (!arg.IsPassedObject()) {
               messages.Say(
                   "Actual argument is not an expression or variable"_err_en_US);
             }

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -328,7 +328,8 @@ private:
       const parser::Call &, bool isSubroutine);
   std::optional<characteristics::Procedure> CheckCall(
       parser::CharBlock, const ProcedureDesignator &, ActualArguments &);
-  const Symbol *ResolveGeneric(const Symbol &, ActualArguments &);
+  const Symbol *ResolveGeneric(const Symbol &, const ActualArguments &,
+      const std::optional<Expr<SomeDerived>> & = std::nullopt);
   std::optional<CalleeAndArguments> GetCalleeAndArguments(
       const parser::Name &, ActualArguments &&, bool isSubroutine = false);
   std::optional<CalleeAndArguments> GetCalleeAndArguments(

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -104,6 +104,7 @@ set(ERROR_TESTS
   resolve65.f90
   resolve66.f90
   resolve67.f90
+  resolve68.f90
   stop01.f90
   structconst01.f90
   structconst02.f90
@@ -262,6 +263,7 @@ set(MODFILE_TESTS
   modfile31.f90
   modfile32.f90
   modfile33.f90
+  modfile34.f90
 )
 
 set(LABEL_TESTS

--- a/test/semantics/modfile34.f90
+++ b/test/semantics/modfile34.f90
@@ -1,0 +1,94 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test resolution of type-bound generics.
+
+module m1
+  type :: t
+  contains
+    procedure, pass(x) :: add1 => add
+    procedure, nopass :: add2 => add
+    procedure :: add_real
+    generic :: g => add1, add2, add_real
+  end type
+contains
+  integer(8) pure function add(x, y)
+    class(t), intent(in) :: x, y
+  end
+  integer(8) pure function add_real(x, y)
+    class(t), intent(in) :: x
+    real, intent(in) :: y
+  end
+  subroutine test1(x, y, z)
+    type(t) :: x, y
+    real :: z(x%add1(y))
+  end
+  subroutine test2(x, y, z)
+    type(t) :: x, y
+    real :: z(x%g(y))
+  end
+  subroutine test3(x, y, z)
+    type(t) :: x, y
+    real :: z(x%g(y, x))
+  end
+  subroutine test4(x, y, z)
+    type(t) :: x
+    real :: y
+    real :: z(x%g(y))
+  end
+end
+
+!Expect: m1.mod
+!module m1
+! type :: t
+! contains
+!  procedure, pass(x) :: add1 => add
+!  procedure, nopass :: add2 => add
+!  procedure :: add_real
+!  generic :: g => add1
+!  generic :: g => add2
+!  generic :: g => add_real
+! end type
+!contains
+! pure function add(x, y)
+!  class(t), intent(in) :: x
+!  class(t), intent(in) :: y
+!  integer(8) :: add
+! end
+! pure function add_real(x, y)
+!  class(t), intent(in) :: x
+!  real(4), intent(in) :: y
+!  integer(8) :: add_real
+! end
+! subroutine test1(x, y, z)
+!  type(t) :: x
+!  type(t) :: y
+!  real(4) :: z(1_8:add(x, y))
+! end
+! subroutine test2(x, y, z)
+!  type(t) :: x
+!  type(t) :: y
+!  real(4) :: z(1_8:x%add1(y))
+! end
+! subroutine test3(x, y, z)
+!  type(t) :: x
+!  type(t) :: y
+!  real(4) :: z(1_8:x%add2(y, x))
+! end
+! subroutine test4(x, y, z)
+!  type(t) :: x
+!  real(4) :: y
+!  real(4) :: z(1_8:x%add_real(y))
+! end
+!end

--- a/test/semantics/resolve68.f90
+++ b/test/semantics/resolve68.f90
@@ -1,0 +1,47 @@
+! Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+! Test resolution of type-bound generics.
+
+module m1
+  type :: t
+  contains
+    procedure, pass(x) :: add1 => add
+    procedure, nopass :: add2 => add
+    procedure :: add_real
+    generic :: g => add1, add2, add_real
+  end type
+contains
+  integer function add(x, y)
+    class(t), intent(in) :: x, y
+  end
+  integer function add_real(x, y)
+    class(t), intent(in) :: x
+    real, intent(in) :: y
+  end
+  subroutine test1(x, y, z)
+    type(t) :: x
+    integer :: y
+    integer :: z
+    !ERROR: No specific procedure of generic 'g' matches the actual arguments
+    z = x%g(y)
+  end
+  subroutine test2(x, y, z)
+    type(t) :: x
+    real :: y
+    integer :: z
+    !ERROR: No specific procedure of generic 'g' matches the actual arguments
+    z = x%g(x, y)
+  end
+end


### PR DESCRIPTION
Extend `ResolveGeneric` to handle calls to procedure components by
passing in the data-ref that is used as the passed-object argument.

`AddPassArg` takes care of adding a placeholder for the passed object.
This is shared by the generic and non-generic cases of calls to
procedure components.