### PR TITLE
Revert recent addition of ActualArgument::PassedObject

### DIFF
--- a/lib/evaluate/call.cc
+++ b/lib/evaluate/call.cc
@@ -60,7 +60,8 @@ int ActualArgument::Rank() const {
 
 bool ActualArgument::operator==(const ActualArgument &that) const {
   return keyword_ == that.keyword_ &&
-      isAlternateReturn_ == that.isAlternateReturn_ && u_ == that.u_;
+      isAlternateReturn_ == that.isAlternateReturn_ &&
+      isPassedObject_ == that.isPassedObject_ && u_ == that.u_;
 }
 
 void ActualArgument::Parenthesize() {

--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -109,7 +109,6 @@ std::ostream &ActualArgument::AssumedType::AsFortran(std::ostream &o) const {
 }
 
 std::ostream &ActualArgument::AsFortran(std::ostream &o) const {
-  CHECK(!IsPassedObject());
   if (keyword_) {
     o << keyword_->ToString() << '=';
   }
@@ -128,10 +127,16 @@ std::ostream &SpecificIntrinsic::AsFortran(std::ostream &o) const {
 }
 
 std::ostream &ProcedureRef::AsFortran(std::ostream &o) const {
+  for (const auto &arg : arguments_) {
+    if (arg && arg->isPassedObject()) {
+      arg->AsFortran(o) << '%';
+      break;
+    }
+  }
   proc_.AsFortran(o);
   char separator{'('};
   for (const auto &arg : arguments_) {
-    if (arg && !arg->IsPassedObject()) {
+    if (arg && !arg->isPassedObject()) {
       arg->AsFortran(o << separator);
       separator = ',';
     }

--- a/lib/semantics/check-call.cc
+++ b/lib/semantics/check-call.cc
@@ -565,16 +565,11 @@ static void CheckExplicitInterfaceArg(evaluate::ActualArgument &arg,
                 messages.Say(
                     "Actual argument is not a variable or typed expression"_err_en_US);
               }
-            } else if (const Symbol * assumed{arg.GetAssumedTypeDummy()}) {
-              // An assumed-type dummy is being forwarded.
-              if (!object.type.type().IsAssumedType()) {
-                messages.Say(
-                    "Assumed-type TYPE(*) '%s' may be associated only with an assumed-TYPE(*) %s"_err_en_US,
-                    assumed->name(), dummyName);
-              }
-            } else if (!arg.IsPassedObject()) {
+            } else if (!object.type.type().IsAssumedType()) {
+              const Symbol &assumed{DEREF(arg.GetAssumedTypeDummy())};
               messages.Say(
-                  "Actual argument is not an expression or variable"_err_en_US);
+                  "Assumed-type TYPE(*) '%s' may be associated only with an assumed-TYPE(*) %s"_err_en_US,
+                  assumed.name(), dummyName);
             }
           },
           [&](const characteristics::DummyProcedure &proc) {

--- a/test/semantics/modfile34.f90
+++ b/test/semantics/modfile34.f90
@@ -34,16 +34,33 @@ contains
     type(t) :: x, y
     real :: z(x%add1(y))
   end
+  subroutine test1p(x, y, z)
+    class(t) :: x, y
+    real :: z(x%add1(y))
+  end
   subroutine test2(x, y, z)
     type(t) :: x, y
+    real :: z(x%g(y))
+  end
+  subroutine test2p(x, y, z)
+    class(t) :: x, y
     real :: z(x%g(y))
   end
   subroutine test3(x, y, z)
     type(t) :: x, y
     real :: z(x%g(y, x))
   end
+  subroutine test3p(x, y, z)
+    class(t) :: x, y
+    real :: z(x%g(y, x))
+  end
   subroutine test4(x, y, z)
     type(t) :: x
+    real :: y
+    real :: z(x%g(y))
+  end
+  subroutine test4p(x, y, z)
+    class(t) :: x
     real :: y
     real :: z(x%g(y))
   end
@@ -76,19 +93,39 @@ end
 !  type(t) :: y
 !  real(4) :: z(1_8:add(x, y))
 ! end
+! subroutine test1p(x,y,z)
+!   class(t)::x
+!   class(t)::y
+!   real(4)::z(1_8:x%add1(y))
+! end
 ! subroutine test2(x, y, z)
 !  type(t) :: x
 !  type(t) :: y
+!  real(4)::z(1_8:add(x,y))
+! end
+! subroutine test2p(x,y,z)
+!  class(t)::x
+!  class(t)::y
 !  real(4) :: z(1_8:x%add1(y))
 ! end
 ! subroutine test3(x, y, z)
 !  type(t) :: x
 !  type(t) :: y
+!  real(4)::z(1_8:add(y,x))
+! end
+! subroutine test3p(x,y,z)
+!  class(t)::x
+!  class(t)::y
 !  real(4) :: z(1_8:x%add2(y, x))
 ! end
 ! subroutine test4(x, y, z)
 !  type(t) :: x
 !  real(4) :: y
+!  real(4)::z(1_8:add_real(x,y))
+! end
+! subroutine test4p(x,y,z)
+!  class(t)::x
+!  real(4)::y
 !  real(4) :: z(1_8:x%add_real(y))
 ! end
 !end


### PR DESCRIPTION
This poorly-thought-through invention of mine from last week has broken several legacy correctness tests because it removes the actual passed objects from actual argument lists.  It's a better design to pass the actual passed objects, marking them as such.

This change means that `Component` will appear as a `ProcedureDesignator` only in cases of `NOPASS` bindings and procedure pointer components.