### PR TITLE
Fix remaining failures in expression semantics

### DIFF
--- a/lib/evaluate/characteristics.h
+++ b/lib/evaluate/characteristics.h
@@ -76,9 +76,12 @@ public:
 
   bool operator==(const TypeAndShape &) const;
   bool operator!=(const TypeAndShape &that) const { return !(*this == that); }
-  static std::optional<TypeAndShape> Characterize(const semantics::Symbol &);
+  static std::optional<TypeAndShape> Characterize(
+      const semantics::Symbol &, FoldingContext &);
   static std::optional<TypeAndShape> Characterize(
       const semantics::ObjectEntityDetails &);
+  static std::optional<TypeAndShape> Characterize(
+      const semantics::AssocEntityDetails &, FoldingContext &);
   static std::optional<TypeAndShape> Characterize(
       const semantics::ProcEntityDetails &);
   static std::optional<TypeAndShape> Characterize(

--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -639,12 +639,17 @@ std::ostream &DescriptorInquiry::AsFortran(std::ostream &o) const {
   case Field::Extent: o << "size("; break;
   case Field::Stride: o << "%STRIDE("; break;
   case Field::Rank: o << "rank("; break;
+  case Field::Len: break;
   }
   base_.AsFortran(o);
-  if (dimension_ >= 0) {
-    o << ",dim=" << (dimension_ + 1);
+  if (field_ == Field::Len) {
+    return o << "%len";
+  } else {
+    if (dimension_ >= 0) {
+      o << ",dim=" << (dimension_ + 1);
+    }
+    return o << ')';
   }
-  return o << ')';
 }
 
 INSTANTIATE_CONSTANT_TEMPLATES

--- a/lib/evaluate/intrinsics.h
+++ b/lib/evaluate/intrinsics.h
@@ -23,13 +23,14 @@
 #include "../parser/message.h"
 #include <optional>
 #include <ostream>
+#include <string>
 
 namespace Fortran::evaluate {
 
 class FoldingContext;
 
 struct CallCharacteristics {
-  parser::CharBlock name;
+  std::string name;
   bool isSubroutineCall{false};
 };
 

--- a/lib/evaluate/type.h
+++ b/lib/evaluate/type.h
@@ -162,6 +162,8 @@ public:
     return DEREF(derived_);
   }
 
+  bool RequiresDescriptor() const;
+
   // 7.3.2.3 & 15.5.2.4 type compatibility.
   // x.IsTypeCompatibleWith(y) is true if "x => y" or passing actual y to
   // dummy argument x would be valid.  Be advised, this is not a reflexive

--- a/lib/evaluate/variable.cc
+++ b/lib/evaluate/variable.cc
@@ -249,14 +249,16 @@ DescriptorInquiry::DescriptorInquiry(
   : base_{base}, field_{field}, dimension_{dim} {
   const Symbol &last{base_.GetLastSymbol()};
   CHECK(IsDescriptor(last));
-  CHECK(dim >= 0 && dim < last.Rank());
+  CHECK((field == Field::Len && dim == 0) ||
+      (field != Field::Len && dim >= 0 && dim < last.Rank()));
 }
 
 DescriptorInquiry::DescriptorInquiry(NamedEntity &&base, Field field, int dim)
   : base_{std::move(base)}, field_{field}, dimension_{dim} {
   const Symbol &last{base_.GetLastSymbol()};
   CHECK(IsDescriptor(last));
-  CHECK(dim >= 0 && dim < last.Rank());
+  CHECK((field == Field::Len && dim == 0) ||
+      (field != Field::Len && dim >= 0 && dim < last.Rank()));
 }
 
 // LEN()
@@ -265,6 +267,9 @@ static std::optional<Expr<SubscriptInteger>> SymbolLEN(const Symbol &sym) {
     if (const semantics::ParamValue * len{dyType->charLength()}) {
       if (auto intExpr{len->GetExplicit()}) {
         return ConvertToType<SubscriptInteger>(*std::move(intExpr));
+      } else {
+        return Expr<SubscriptInteger>{
+            DescriptorInquiry{NamedEntity{sym}, DescriptorInquiry::Field::Len}};
       }
     }
   }

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -139,7 +139,9 @@ private:
 
 // R916 type-param-inquiry
 // N.B. x%LEN for CHARACTER is rewritten in semantics to LEN(x), which is
-// then handled via LEN() member functions in the various classes.
+// then handled via LEN() member functions in the various classes;
+// it becomes a DescriptorInquiry with Field::Len for assumed-length
+// CHARACTER objects.
 // x%KIND for intrinsic types is similarly rewritten in semantics to
 // KIND(x), which is then folded to a constant value.
 // "Bare" type parameter references within a derived type definition do
@@ -441,11 +443,11 @@ template<typename T> struct Variable {
 class DescriptorInquiry {
 public:
   using Result = SubscriptInteger;
-  ENUM_CLASS(Field, LowerBound, Extent, Stride, Rank)
+  ENUM_CLASS(Field, LowerBound, Extent, Stride, Rank, Len)
 
   CLASS_BOILERPLATE(DescriptorInquiry)
-  DescriptorInquiry(const NamedEntity &, Field, int);
-  DescriptorInquiry(NamedEntity &&, Field, int);
+  DescriptorInquiry(const NamedEntity &, Field, int = 0);
+  DescriptorInquiry(NamedEntity &&, Field, int = 0);
 
   NamedEntity &base() { return base_; }
   const NamedEntity &base() const { return base_; }

--- a/lib/semantics/assignment.h
+++ b/lib/semantics/assignment.h
@@ -38,11 +38,10 @@ struct DummyDataObject;
 }
 
 namespace Fortran::evaluate {
-class IntrinsicProcTable;
-void CheckPointerAssignment(parser::ContextualMessages &,
-    const IntrinsicProcTable &, const Symbol &lhs, const Expr<SomeType> &rhs);
-void CheckPointerAssignment(parser::ContextualMessages &,
-    const IntrinsicProcTable &, parser::CharBlock source,
+class FoldingContext;
+void CheckPointerAssignment(
+    FoldingContext &, const Symbol &lhs, const Expr<SomeType> &rhs);
+void CheckPointerAssignment(FoldingContext &, parser::CharBlock source,
     const std::string &description, const characteristics::DummyDataObject &,
     const Expr<SomeType> &rhs);
 }

--- a/lib/semantics/check-call.cc
+++ b/lib/semantics/check-call.cc
@@ -360,8 +360,8 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
     }
     if (!actualIsPointer) {
       if (dummy.intent == common::Intent::In) {
-        CheckPointerAssignment(messages, context.intrinsics(),
-            parser::CharBlock{}, dummyName, dummy, actual);
+        CheckPointerAssignment(
+            context, parser::CharBlock{}, dummyName, dummy, actual);
       } else {
         messages.Say(
             "Actual argument associated with POINTER %s must also be POINTER unless INTENT(IN)"_err_en_US,

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -186,7 +186,7 @@ public:
     return result;
   }
   template<typename A> MaybeExpr Analyze(const parser::Constant<A> &x) {
-    auto save{
+    auto restorer{
         GetFoldingContext().messages().SetLocation(FindSourceLocation(x))};
     auto result{Analyze(x.thing)};
     if (result) {

--- a/lib/semantics/rewrite-parse-tree.cc
+++ b/lib/semantics/rewrite-parse-tree.cc
@@ -140,7 +140,7 @@ void FixMisparsedUntaggedNamelistName(READ_OR_WRITE &x) {
   if (x.iounit && x.format &&
       std::holds_alternative<parser::DefaultCharExpr>(x.format->u)) {
     if (const parser::Name * name{parser::Unwrap<parser::Name>(x.format)}) {
-      if (name->symbol && name->symbol->has<NamelistDetails>()) {
+      if (name->symbol && name->symbol->GetUltimate().has<NamelistDetails>()) {
         x.controls.emplace_front(parser::IoControlSpec{std::move(*name)});
         x.format.reset();
       }

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -78,12 +78,15 @@ public:
   const std::vector<Symbol *> &dummyArgs() const { return dummyArgs_; }
   void add_dummyArg(Symbol &symbol) { dummyArgs_.push_back(&symbol); }
   void add_alternateReturn() { dummyArgs_.push_back(nullptr); }
+  const MaybeExpr &stmtFunction() const { return stmtFunction_; }
+  void set_stmtFunction(SomeExpr &&expr) { stmtFunction_ = std::move(expr); }
 
 private:
   bool isInterface_{false};  // true if this represents an interface-body
   MaybeExpr bindName_;
   std::vector<Symbol *> dummyArgs_;  // nullptr -> alternate return indicator
   Symbol *result_{nullptr};
+  MaybeExpr stmtFunction_;
   friend std::ostream &operator<<(std::ostream &, const SubprogramDetails &);
 };
 

--- a/test/evaluate/intrinsics.cc
+++ b/test/evaluate/intrinsics.cc
@@ -113,7 +113,7 @@ struct TestCall {
       std::cout << '(';
     }
     std::cout << ')' << std::endl;
-    CallCharacteristics call{fName};
+    CallCharacteristics call{fName.ToString()};
     auto messages{strings.Messages(buffer)};
     FoldingContext context{messages, defaults, table};
     std::optional<SpecificCall> si{table.Probe(call, args, context)};


### PR DESCRIPTION
Apply implicit typing to names in COMMON that appear in specification expressions

Extend semantic analysis of expressions to catch missing cases

Fix statement function semantics, add degree trig intrinsics

Add GetUltimate to rewrite of bare namelist

Expression analysis must now succeed (barring previous fatal error) and will emit an internal error message when it fails that includes a dump of the expression's parse tree.
