### PR TITLE
Save analyzed ProcedureRef in parse tree node for CALL statement

### DIFF
--- a/lib/evaluate/call.cc
+++ b/lib/evaluate/call.cc
@@ -196,5 +196,8 @@ std::optional<Expr<SubscriptInteger>> ProcedureRef::LEN() const {
   return proc_.LEN();
 }
 
+ProcedureRef::~ProcedureRef() {}
+
 FOR_EACH_SPECIFIC_TYPE(template class FunctionRef, )
 }
+DEFINE_DELETER(Fortran::evaluate::ProcedureRef)

--- a/lib/evaluate/call.h
+++ b/lib/evaluate/call.h
@@ -188,6 +188,7 @@ public:
   CLASS_BOILERPLATE(ProcedureRef)
   ProcedureRef(ProcedureDesignator &&p, ActualArguments &&a)
     : proc_{std::move(p)}, arguments_(std::move(a)) {}
+  ~ProcedureRef();
 
   ProcedureDesignator &proc() { return proc_; }
   const ProcedureDesignator &proc() const { return proc_; }

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -169,13 +169,13 @@ StructureConstructor &StructureConstructor::Add(
   return *this;
 }
 
-GenericExprWrapper::~GenericExprWrapper() = default;
+GenericExprWrapper::~GenericExprWrapper() {}
 
 bool GenericExprWrapper::operator==(const GenericExprWrapper &that) const {
   return v == that.v;
 }
 
-GenericAssignmentWrapper::~GenericAssignmentWrapper() = default;
+GenericAssignmentWrapper::~GenericAssignmentWrapper() {}
 
 template<TypeCategory CAT> int Expr<SomeKind<CAT>>::GetKind() const {
   return std::visit(

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -171,10 +171,6 @@ StructureConstructor &StructureConstructor::Add(
 
 GenericExprWrapper::~GenericExprWrapper() {}
 
-bool GenericExprWrapper::operator==(const GenericExprWrapper &that) const {
-  return v == that.v;
-}
-
 GenericAssignmentWrapper::~GenericAssignmentWrapper() {}
 
 template<TypeCategory CAT> int Expr<SomeKind<CAT>>::GetKind() const {

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -872,19 +872,19 @@ public:
 
 // This wrapper class is used, by means of a forward reference with
 // an owning pointer, to cache analyzed expressions in parse tree nodes.
-// v is nullopt if an error occurred during expression analysis.
 struct GenericExprWrapper {
-  GenericExprWrapper(std::optional<Expr<SomeType>> &&x) : v{std::move(x)} {}
+  GenericExprWrapper() {}
+  explicit GenericExprWrapper(std::optional<Expr<SomeType>> &&x)
+    : v{std::move(x)} {}
   ~GenericExprWrapper();
-  bool operator==(const GenericExprWrapper &) const;
-  std::optional<Expr<SomeType>> v;
+  std::optional<Expr<SomeType>> v;  // vacant if error
 };
 
 // Like GenericExprWrapper but for analyzed assignments
 struct GenericAssignmentWrapper {
-  GenericAssignmentWrapper(std::optional<Assignment> &&x) : v{std::move(x)} {}
+  explicit GenericAssignmentWrapper(Assignment &&x) : v{std::move(x)} {}
   ~GenericAssignmentWrapper();
-  std::optional<Assignment> v;
+  Assignment v;
 };
 
 FOR_EACH_CATEGORY_TYPE(extern template class Expr, )

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -71,6 +71,7 @@ class DerivedTypeSpec;
 namespace Fortran::evaluate {
 struct GenericExprWrapper;  // forward definition, wraps Expr<SomeType>
 struct GenericAssignmentWrapper;  // forward definition, represent assignment
+class ProcedureRef;  // forward definition, represents a CALL statement
 }
 
 // Most non-template classes in this file use these default definitions
@@ -3136,7 +3137,12 @@ struct FunctionReference {
 };
 
 // R1521 call-stmt -> CALL procedure-designator [( [actual-arg-spec-list] )]
-WRAPPER_CLASS(CallStmt, Call);
+struct CallStmt {
+  WRAPPER_CLASS_BOILERPLATE(CallStmt, Call);
+  mutable std::unique_ptr<evaluate::ProcedureRef,
+      common::Deleter<evaluate::ProcedureRef>>
+      typedCall;  // filled by semantics
+};
 
 // R1529 function-subprogram ->
 //         function-stmt [specification-part] [execution-part]

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -803,7 +803,7 @@ public:
 
   // R1001 - R1022
   bool Pre(const Expr &x) {
-    if (asFortran_ && x.typedExpr.get()) {
+    if (asFortran_ && x.typedExpr) {
       // Format the expression representation from semantics
       asFortran_->expr(out_, *x.typedExpr);
       return false;

--- a/lib/parser/unparse.h
+++ b/lib/parser/unparse.h
@@ -22,6 +22,8 @@
 
 namespace Fortran::evaluate {
 struct GenericExprWrapper;
+struct GenericAssignmentWrapper;
+class ProcedureRef;
 }
 
 namespace Fortran::parser {
@@ -32,16 +34,22 @@ struct Program;
 using preStatementType =
     std::function<void(const CharBlock &, std::ostream &, int)>;
 
-// A function to handle unparsing of evaluate::GenericExprWrapper
-// rather than original expression parse trees.
-using TypedExprAsFortran =
-    std::function<void(std::ostream &, const evaluate::GenericExprWrapper &)>;
+// Functions to handle unparsing of analyzed expressions and related
+// objects rather than their original parse trees.
+struct AnalyzedObjectsAsFortran {
+  std::function<void(std::ostream &, const evaluate::GenericExprWrapper &)>
+      expr;
+  std::function<void(
+      std::ostream &, const evaluate::GenericAssignmentWrapper &)>
+      assignment;
+  std::function<void(std::ostream &, const evaluate::ProcedureRef &)> call;
+};
 
 // Converts parsed program to out as Fortran.
 void Unparse(std::ostream &out, const Program &program,
     Encoding encoding = Encoding::UTF_8, bool capitalizeKeywords = true,
     bool backslashEscapes = true, preStatementType *preStatement = nullptr,
-    TypedExprAsFortran *expr = nullptr);
+    AnalyzedObjectsAsFortran * = nullptr);
 }
 
 #endif

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1822,8 +1822,11 @@ MaybeExpr ExpressionAnalyzer::Analyze(
   return AnalyzeCall(funcRef.v, false);
 }
 
-void ExpressionAnalyzer::Analyze(const parser::CallStmt &call) {
-  AnalyzeCall(call.v, true);
+void ExpressionAnalyzer::Analyze(const parser::CallStmt &callStmt) {
+  auto expr{AnalyzeCall(callStmt.v, true)};
+  if (auto *procRef{UnwrapExpr<ProcedureRef>(expr)}) {
+    callStmt.typedCall.reset(new ProcedureRef{*procRef});
+  }
 }
 
 MaybeExpr ExpressionAnalyzer::AnalyzeCall(

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -2260,7 +2260,7 @@ static void FixMisparsedFunctionReference(
 // Common handling of parser::Expr and parser::Variable
 template<typename PARSED>
 MaybeExpr ExpressionAnalyzer::ExprOrVariable(const PARSED &x) {
-  if (!x.typedExpr) {  // not yet analyzed
+  if (!x.typedExpr) {
     FixMisparsedFunctionReference(context_, x.u);
     MaybeExpr result;
     if constexpr (std::is_same_v<PARSED, parser::Expr>) {

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -393,7 +393,7 @@ bool ExprTypeKindIsDefault(
 
 const evaluate::Assignment *GetAssignment(const parser::AssignmentStmt &x) {
   const auto &typed{x.typedAssignment};
-  return typed && typed->v ? &*typed->v : nullptr;
+  return typed ? &typed->v : nullptr;
 }
 
 const Symbol *FindInterface(const Symbol &symbol) {

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -233,7 +233,7 @@ bool ExprTypeKindIsDefault(
 struct GetExprHelper {
   const SomeExpr *Get(const parser::Expr::TypedExpr &x) {
     CHECK(x);
-    return x->v ? &*x->v : nullptr;
+    return x && x->v ? &*x->v : nullptr;
   }
   const SomeExpr *Get(const parser::Expr &x) { return Get(x.typedExpr); }
   const SomeExpr *Get(const parser::Variable &x) { return Get(x.typedExpr); }

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -292,26 +292,22 @@ std::string CompileFortran(std::string path, Fortran::parser::Options options,
   Fortran::parser::AnalyzedObjectsAsFortran asFortran{
       [](std::ostream &o, const Fortran::evaluate::GenericExprWrapper &x) {
         if (x.v) {
-          o << *x.v;
+          x.v->AsFortran(o);
         } else {
           o << "(bad expression)";
         }
       },
       [](std::ostream &o,
           const Fortran::evaluate::GenericAssignmentWrapper &x) {
-        if (x.v) {
-          std::visit(
-              Fortran::common::visitors{
-                  [&](const Fortran::evaluate::Assignment::IntrinsicAssignment
-                          &y) { y.rhs.AsFortran(y.lhs.AsFortran(o) << '='); },
-                  [&](const Fortran::evaluate::ProcedureRef &y) {
-                    y.AsFortran(o << "CALL ");
-                  },
-              },
-              x.v->u);
-        } else {
-          o << "(bad assignment)";
-        }
+        std::visit(
+            Fortran::common::visitors{
+                [&](const Fortran::evaluate::Assignment::IntrinsicAssignment
+                        &y) { y.rhs.AsFortran(y.lhs.AsFortran(o) << '='); },
+                [&](const Fortran::evaluate::ProcedureRef &y) {
+                  y.AsFortran(o << "CALL ");
+                },
+            },
+            x.v.u);
       },
       [](std::ostream &o, const Fortran::evaluate::ProcedureRef &x) {
         x.AsFortran(o << "CALL ");

--- a/tools/f18/stub-evaluate.cc
+++ b/tools/f18/stub-evaluate.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The parse tree has slots in which pointers to typed expressions may be
-// placed.  When using the parser without the expression library, as here,
-// we need to stub out the dependence on the external destructor, which
-// will never actually be called.
+// The parse tree has slots in which pointers to the results of semantic
+// analysis may be placed.  When using the parser without the semantics
+// libraries, as here, we need to stub out the dependences on the external
+// destructors, which will never actually be called.
 
 #include "../../lib/common/indirection.h"
 
@@ -23,12 +23,17 @@ namespace Fortran::evaluate {
 struct GenericExprWrapper {
   ~GenericExprWrapper();
 };
-GenericExprWrapper::~GenericExprWrapper() = default;
+GenericExprWrapper::~GenericExprWrapper() {}
 struct GenericAssignmentWrapper {
   ~GenericAssignmentWrapper();
 };
-GenericAssignmentWrapper::~GenericAssignmentWrapper() = default;
+GenericAssignmentWrapper::~GenericAssignmentWrapper() {}
+struct ProcedureRef {
+  ~ProcedureRef();
+};
+ProcedureRef::~ProcedureRef() {}
 }
 
 DEFINE_DELETER(Fortran::evaluate::GenericExprWrapper)
 DEFINE_DELETER(Fortran::evaluate::GenericAssignmentWrapper)
+DEFINE_DELETER(Fortran::evaluate::ProcedureRef)


### PR DESCRIPTION
For @psteinfeld .  Saves the results of semantic analysis of a subroutine `CALL` statement in the parse tree.  Also enables unparsing of these saved calls (and saved assignment statements, too).