### PR TITLE
Save CallStmt::typedCall

### DIFF
--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -1822,8 +1822,9 @@ MaybeExpr ExpressionAnalyzer::Analyze(
 }
 
 void ExpressionAnalyzer::Analyze(const parser::CallStmt &callStmt) {
-  if (auto expr{AnalyzeCall(callStmt.v, true)}) {
-    callStmt.typedCall.reset(new ProcedureRef{*UnwrapExpr<ProcedureRef>(expr)});
+  MaybeExpr expr{AnalyzeCall(callStmt.v, true)};
+  if (const auto *proc{UnwrapExpr<ProcedureRef>(expr)}) {
+    callStmt.typedCall.reset(new ProcedureRef{*proc});
   }
 }
 


### PR DESCRIPTION
When `ExpressionAnalyzer::AnalyzeCall` processed a subroutine it was
always returning std::nullopt. Change it to return a `ProcedureRef`
wrapped in an `Expr` so that it can be saved in `CallStmt::typedCall`.