### PR TITLE
Add initial CODE_OWNERS file

### DIFF
--- a/CODE_OWNERS.TXT
+++ b/CODE_OWNERS.TXT
@@ -9,10 +9,6 @@ beautification by scripts. The fields are: name (N), email (E), web-address
 (S) and (I) IRC handle. Each entry should contain at least the (N), (E) and
 (D) fields.
 
-N: Kiran Chandramohan
-E: kiran.chandramohan@arm.com
-D: OpenMP lowering
-
 N: Tim Keith
 E: tkeith@nvidia.com
 D: Semantic Analysis (lib/semantics)
@@ -20,7 +16,3 @@ D: Semantic Analysis (lib/semantics)
 N: Peter Klausler
 E: pklausler@nvidia.com
 D: Parser (lib/parser)
-
-N: Eric Schweitz
-E: eschweitz@nvidia.com
-D: FIR (lib/fir), Fortran lowering (lib/burnside)

--- a/CODE_OWNERS.TXT
+++ b/CODE_OWNERS.TXT
@@ -1,0 +1,26 @@
+This file is a list of the people responsible for ensuring that patches for a
+particular part of Flang are reviewed, either by themself or by someone else.
+They are also the gatekeepers for their part of Flang, with the final word on
+what goes in or not.
+
+The list is sorted by surname and formatted to allow easy grepping and
+beautification by scripts. The fields are: name (N), email (E), web-address
+(W), PGP key ID and fingerprint (P), description (D), snail-mail address
+(S) and (I) IRC handle. Each entry should contain at least the (N), (E) and
+(D) fields.
+
+N: Kiran Chandramohan
+E: kiran.chandramohan@arm.com
+D: OpenMP lowering
+
+N: Tim Keith
+E: tkeith@nvidia.com
+D: Semantic Analysis (lib/semantics)
+
+N: Peter Klausler
+E: pklausler@nvidia.com
+D: Parser (lib/parser)
+
+N: Eric Schweitz
+E: eschweitz@nvidia.com
+D: FIR (lib/fir), Fortran lowering (lib/burnside)

--- a/CODE_OWNERS.TXT
+++ b/CODE_OWNERS.TXT
@@ -12,7 +12,3 @@ beautification by scripts. The fields are: name (N), email (E), web-address
 N: Tim Keith
 E: tkeith@nvidia.com
 D: Semantic Analysis (lib/semantics)
-
-N: Peter Klausler
-E: pklausler@nvidia.com
-D: Parser (lib/parser)


### PR DESCRIPTION
First cut at adding a CODE_OWNERS file for F18 in preparation for it to land in the LLVM monorepo. It follows the same format as the LLVM equivalent file.

Reminder of code owner duties - https://llvm.org/docs/DeveloperPolicy.html#code-owners

A few comments:
- Are there any large areas that we think need a code owner not listed here?
- Is there a sensible code owner for "anything not covered by anyone else" ? @klausler ?
- I tried to look at who contributed the most commits to each subdirectory when picking a code owner. I know the commits only tell part of the story, so am open to alternative suggestions.