### PR TITLE
Misc fixes from SPEC

### DIFF
--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -226,6 +226,10 @@ template<typename T> static Precedence ToPrecedence(const Constant<T> &x) {
 template<typename T> constexpr Precedence ToPrecedence(const Parentheses<T> &) {
   return Precedence::Parenthesize;
 }
+template<int KIND>
+constexpr Precedence ToPrecedence(const ComplexConstructor<KIND> &) {
+  return Precedence::Parenthesize;
+}
 
 template<typename T> static Precedence ToPrecedence(const Expr<T> &expr) {
   return std::visit([](const auto &x) { return ToPrecedence(x); }, expr.u);
@@ -260,7 +264,25 @@ constexpr OperatorSpelling SpellOperator(const Negate<A> &) {
 }
 template<int KIND>
 static OperatorSpelling SpellOperator(const ComplexComponent<KIND> &x) {
-  return OperatorSpelling{x.isImaginaryPart ? "AIMAG(" : "REAL(", "", ")"};
+  if (x.isImaginaryPart) {
+    return {"aimag(", "", ")"};
+  } else if constexpr (KIND == 2) {
+    return {"real(", "", ",kind=2)"};
+  } else if constexpr (KIND == 3) {
+    return {"real(", "", ",kind=3)"};
+  } else if constexpr (KIND == 4) {
+    return {"real(", "", ",kind=4)"};
+  } else if constexpr (KIND == 8) {
+    return {"real(", "", ",kind=8)"};
+  } else if constexpr (KIND == 10) {
+    return {"real(", "", ",kind=10)"};
+  } else if constexpr (KIND == 16) {
+    return {"real(", "", ",kind=16)"};
+  } else {
+    static_assert(KIND == 2 || KIND == 3 || KIND == 4 || KIND == 8 ||
+            KIND == 10 || KIND == 16,
+        "bad KIND");
+  }
 }
 template<int KIND> constexpr OperatorSpelling SpellOperator(const Not<KIND> &) {
   return OperatorSpelling{".NOT.", "", ""};
@@ -299,7 +321,7 @@ constexpr OperatorSpelling SpellOperator(const RealToIntPower<A> &) {
 template<typename A>
 static OperatorSpelling SpellOperator(const Extremum<A> &x) {
   return OperatorSpelling{
-      x.ordering == Ordering::Less ? "MIN(" : "MAX(", ",", ")"};
+      x.ordering == Ordering::Less ? "min(" : "max(", ",", ")"};
 }
 template<int KIND>
 constexpr OperatorSpelling SpellOperator(const Concat<KIND> &) {

--- a/lib/semantics/assignment.h
+++ b/lib/semantics/assignment.h
@@ -55,8 +55,8 @@ extern template class Fortran::common::Indirection<
 
 namespace Fortran::semantics {
 // Applies checks from C1594(1-2) on definitions in PURE subprograms
-void CheckDefinabilityInPureScope(
-    parser::ContextualMessages &, const Symbol &, const Scope &);
+void CheckDefinabilityInPureScope(parser::ContextualMessages &, const Symbol &,
+    const Scope &context, const Scope &pure);
 // Applies checks from C1594(5-6) on copying pointers in PURE subprograms
 void CheckCopyabilityInPureScope(parser::ContextualMessages &,
     const evaluate::Expr<evaluate::SomeType> &, const Scope &);

--- a/lib/semantics/check-io.cc
+++ b/lib/semantics/check-io.cc
@@ -425,35 +425,39 @@ void IoChecker::Enter(const parser::StatusExpr &spec) {
 }
 
 void IoChecker::Enter(const parser::StatVariable &) {
-  SetSpecifier(IoSpecKind::Iostat);
+  if (stmt_ == IoStmtKind::None) {
+    // ALLOCATE & DEALLOCATE
+  } else {
+    SetSpecifier(IoSpecKind::Iostat);
+  }
 }
 
 void IoChecker::Leave(const parser::BackspaceStmt &) {
   CheckForPureSubprogram();
   CheckForRequiredSpecifier(
       flags_.test(Flag::NumberUnit), "UNIT number");  // C1240
-  stmt_ = IoStmtKind::None;
+  Done();
 }
 
 void IoChecker::Leave(const parser::CloseStmt &) {
   CheckForPureSubprogram();
   CheckForRequiredSpecifier(
       flags_.test(Flag::NumberUnit), "UNIT number");  // C1208
-  stmt_ = IoStmtKind::None;
+  Done();
 }
 
 void IoChecker::Leave(const parser::EndfileStmt &) {
   CheckForPureSubprogram();
   CheckForRequiredSpecifier(
       flags_.test(Flag::NumberUnit), "UNIT number");  // C1240
-  stmt_ = IoStmtKind::None;
+  Done();
 }
 
 void IoChecker::Leave(const parser::FlushStmt &) {
   CheckForPureSubprogram();
   CheckForRequiredSpecifier(
       flags_.test(Flag::NumberUnit), "UNIT number");  // C1243
-  stmt_ = IoStmtKind::None;
+  Done();
 }
 
 void IoChecker::Leave(const parser::InquireStmt &stmt) {
@@ -466,7 +470,7 @@ void IoChecker::Leave(const parser::InquireStmt &stmt) {
     CheckForProhibitedSpecifier(IoSpecKind::File, IoSpecKind::Unit);  // C1246
     CheckForRequiredSpecifier(IoSpecKind::Id, IoSpecKind::Pending);  // C1248
   }
-  stmt_ = IoStmtKind::None;
+  Done();
 }
 
 void IoChecker::Leave(const parser::OpenStmt &) {
@@ -499,12 +503,12 @@ void IoChecker::Leave(const parser::OpenStmt &) {
     CheckForProhibitedSpecifier(flags_.test(Flag::AccessStream),
         "STATUS='STREAM'", IoSpecKind::Recl);  // 12.5.6.15
   }
-  stmt_ = IoStmtKind::None;
+  Done();
 }
 
 void IoChecker::Leave(const parser::PrintStmt &) {
   CheckForPureSubprogram();
-  stmt_ = IoStmtKind::None;
+  Done();
 }
 
 void IoChecker::Leave(const parser::ReadStmt &) {
@@ -512,6 +516,7 @@ void IoChecker::Leave(const parser::ReadStmt &) {
     CheckForPureSubprogram();
   }
   if (!flags_.test(Flag::IoControlList)) {
+    Done();
     return;
   }
   LeaveReadWrite();
@@ -525,21 +530,21 @@ void IoChecker::Leave(const parser::ReadStmt &) {
       "FMT or NML");  // C1227
   CheckForRequiredSpecifier(
       IoSpecKind::Pad, flags_.test(Flag::FmtOrNml), "FMT or NML");  // C1227
-  stmt_ = IoStmtKind::None;
+  Done();
 }
 
 void IoChecker::Leave(const parser::RewindStmt &) {
   CheckForRequiredSpecifier(
       flags_.test(Flag::NumberUnit), "UNIT number");  // C1240
   CheckForPureSubprogram();
-  stmt_ = IoStmtKind::None;
+  Done();
 }
 
 void IoChecker::Leave(const parser::WaitStmt &) {
   CheckForRequiredSpecifier(
       flags_.test(Flag::NumberUnit), "UNIT number");  // C1237
   CheckForPureSubprogram();
-  stmt_ = IoStmtKind::None;
+  Done();
 }
 
 void IoChecker::Leave(const parser::WriteStmt &) {
@@ -557,7 +562,7 @@ void IoChecker::Leave(const parser::WriteStmt &) {
   CheckForRequiredSpecifier(IoSpecKind::Delim,
       flags_.test(Flag::StarFmt) || specifierSet_.test(IoSpecKind::Nml),
       "FMT=* or NML");  // C1228
-  stmt_ = IoStmtKind::None;
+  Done();
 }
 
 void IoChecker::LeaveReadWrite() const {

--- a/lib/semantics/check-io.h
+++ b/lib/semantics/check-io.h
@@ -134,10 +134,12 @@ private:
     flags_.reset();
   }
 
+  void Done() { stmt_ = IoStmtKind::None; }
+
   void CheckForPureSubprogram() const;
 
   SemanticsContext &context_;
-  IoStmtKind stmt_ = IoStmtKind::None;
+  IoStmtKind stmt_{IoStmtKind::None};
   common::EnumSet<IoSpecKind, common::IoSpecKind_enumSize> specifierSet_;
   common::EnumSet<Flag, Flag_enumSize> flags_;
 };

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -101,8 +101,8 @@ struct SetExprHelper {
   template<typename T> void Set(const T &x) {
     if constexpr (ConstraintTrait<T>) {
       Set(x.thing);
-    } else {
-      static_assert("bad type");
+    } else if constexpr (WrapperTrait<T>) {
+      Set(x.v);
     }
   }
 

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -5916,7 +5916,7 @@ bool ResolveNamesVisitor::BeginScope(const ProgramTree &node) {
 }
 
 // Some analyses and checks, such as the processing of initializers of
-// pointers, is deferred until all of the pertinent specification parts
+// pointers, are deferred until all of the pertinent specification parts
 // have been visited.  This deferred processing enables the use of forward
 // references in these circumstances.
 class DeferredCheckVisitor {
@@ -6020,7 +6020,8 @@ void ResolveNamesVisitor::FinishSpecificationParts(const ProgramTree &node) {
 // type parameter values of a particular instantiation.
 void ResolveNamesVisitor::FinishDerivedTypeInstantiation(Scope &scope) {
   CHECK(scope.IsDerivedType() && !scope.symbol());
-  if (const DerivedTypeSpec * spec{scope.derivedTypeSpec()}) {
+  if (DerivedTypeSpec * spec{scope.derivedTypeSpec()}) {
+    spec->Instantiate(currScope(), context());
     const Symbol &origTypeSymbol{spec->typeSymbol()};
     if (const Scope * origTypeScope{origTypeSymbol.scope()}) {
       CHECK(origTypeScope->IsDerivedType() &&

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -197,9 +197,8 @@ public:
   void add_importName(const SourceName &);
 
   const DerivedTypeSpec *derivedTypeSpec() const { return derivedTypeSpec_; }
-  void set_derivedTypeSpec(const DerivedTypeSpec &spec) {
-    derivedTypeSpec_ = &spec;
-  }
+  DerivedTypeSpec *derivedTypeSpec() { return derivedTypeSpec_; }
+  void set_derivedTypeSpec(DerivedTypeSpec &spec) { derivedTypeSpec_ = &spec; }
 
   // The range of the source of this and nested scopes.
   const parser::CharBlock &sourceRange() const { return sourceRange_; }
@@ -234,7 +233,7 @@ private:
   std::string chars_;
   std::optional<ImportKind> importKind_;
   std::set<SourceName> importNames_;
-  const DerivedTypeSpec *derivedTypeSpec_{nullptr};  // dTS->scope() == this
+  DerivedTypeSpec *derivedTypeSpec_{nullptr};  // dTS->scope() == this
   // When additional data members are added to Scope, remember to
   // copy them, if appropriate, in InstantiateDerivedType().
 

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -204,8 +204,11 @@ void DerivedTypeSpec::Instantiate(
       const Symbol &symbol{*pair.second};
       if (const DeclTypeSpec * type{symbol.GetType()}) {
         if (const DerivedTypeSpec * derived{type->AsDerived()}) {
-          auto &instantiatable{*const_cast<DerivedTypeSpec *>(derived)};
-          instantiatable.Instantiate(containingScope, context);
+          if (!(derived->IsForwardReferenced() &&
+                  IsAllocatableOrPointer(symbol))) {
+            auto &instantiatable{*const_cast<DerivedTypeSpec *>(derived)};
+            instantiatable.Instantiate(containingScope, context);
+          }
         }
       }
     }

--- a/test/semantics/call12.f90
+++ b/test/semantics/call12.f90
@@ -42,21 +42,21 @@ module m
     type(hasCoarray), pointer :: hcp
     integer :: n
     common /block/ y
-    !ERROR: A PURE subprogram may not define 'x' because it is host-associated
+    !ERROR: PURE subprogram 'test' may not define 'x' because it is host-associated
     x%a = 0.
-    !ERROR: A PURE subprogram may not define 'y' because it is in a COMMON block
+    !ERROR: PURE subprogram 'test' may not define 'y' because it is in a COMMON block
     y%a = 0. ! C1594(1)
-    !ERROR: A PURE subprogram may not define 'useassociated' because it is USE-associated
+    !ERROR: PURE subprogram 'test' may not define 'useassociated' because it is USE-associated
     useassociated = 0.  ! C1594(1)
-    !ERROR: A PURE subprogram may not define 'ptr' because it is a POINTER dummy argument of a PURE function
+    !ERROR: PURE subprogram 'test' may not define 'ptr' because it is a POINTER dummy argument of a PURE function
     ptr%a = 0. ! C1594(1)
-    !ERROR: A PURE subprogram may not define 'in' because it is an INTENT(IN) dummy argument
+    !ERROR: PURE subprogram 'test' may not define 'in' because it is an INTENT(IN) dummy argument
     in%a = 0. ! C1594(1)
     !ERROR: A PURE subprogram may not define a coindexed object
     hcp%co[1] = 0. ! C1594(1)
-    !ERROR: A PURE subprogram may not define 'ptr' because it is a POINTER dummy argument of a PURE function
+    !ERROR: PURE subprogram 'test' may not define 'ptr' because it is a POINTER dummy argument of a PURE function
     ptr => z ! C1594(2)
-    !ERROR: A PURE subprogram may not define 'ptr' because it is a POINTER dummy argument of a PURE function
+    !ERROR: PURE subprogram 'test' may not define 'ptr' because it is a POINTER dummy argument of a PURE function
     nullify(ptr) ! C1594(2), 19.6.8
     !ERROR: A PURE subprogram may not use 'ptr' as the target of pointer assignment because it is a POINTER dummy argument of a PURE function
     ptr2 => ptr ! C1594(3)
@@ -79,7 +79,7 @@ module m
    contains
     pure subroutine internal
       type(hasPtr) :: localhp
-      !ERROR: A PURE subprogram may not define 'z' because it is host-associated
+      !ERROR: PURE subprogram 'internal' may not define 'z' because it is host-associated
       z%a = 0.
       !ERROR: Externally visible object 'z' may not be associated with pointer component 'p' in a PURE procedure
       localhp = hasPtr(z%a)


### PR DESCRIPTION
This PR rolls up some small patches that help build SPEC CPU 2008 with semantics enabled and fixed-point unparsed output.  There's more to come, but some of the codes are now clean.