### PR TITLE
Convert INTEGER scalar actual argument expressions to the kinds of dummies

### DIFF
--- a/documentation/Extensions.md
+++ b/documentation/Extensions.md
@@ -23,6 +23,13 @@ Intentional violations of the standard
   `SIZE`, `LBOUND`, `UBOUND`, `SHAPE`, and the location reductions
   `FINDLOC`, `MAXLOC`, and `MINLOC`.  We return `INTEGER(KIND=8)` by
   default in these cases.
+* Scalar `INTEGER` actual argument expressions (not variables!)
+  are converted to the kinds of scalar `INTEGER` dummy arguments
+  when the interface is explicit and the kinds differ.
+  This conversion allows the results of the intrinsics like
+  `SIZE` that (as mentioned above) no longer return default
+  `INTEGER` results by default to be passed.  A warning is
+  emitted when truncation is possible.
 
 Extensions, deletions, and legacy features supported by default
 ===============================================================

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -1646,7 +1646,9 @@ public:
   }
   void Unparse(const CallStmt &x) {  // R1521
     if (asFortran_ && x.typedCall.get()) {
+      Put(' ');
       asFortran_->call(out_, *x.typedCall);
+      Put('\n');
     } else {
       const auto &pd{std::get<ProcedureDesignator>(x.v.t)};
       const auto &args{std::get<std::list<ActualArgSpec>>(x.v.t)};


### PR DESCRIPTION
When passing the result of `SIZE()` to a dummy argument that is default `INTEGER`, automatically convert the value from the larger kind of `INTEGER` that we use in order to support large arrays.

(This PR implements a more general actual argument expression conversion, and it emits a warning when truncation may occur.  It does not apply to actual arguments that are variables, nor does it apply to arrays.)