### PR TITLE
Two small fixes

### DIFF
--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -600,6 +600,7 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
         Rank::scalar},
     {"rank", {{"a", AnyData, Rank::anyOrAssumedRank}}, DefaultInt,
         Rank::scalar},
+    {"real", {{"a", SameComplex, Rank::elemental}}, SameReal},  // 16.9.160(4)(ii)
     {"real", {{"a", AnyNumeric, Rank::elementalOrBOZ}, DefaultingKIND},
         KINDReal},
     {"reduce",


### PR DESCRIPTION
As Jean pointed out to me (merci), `REAL(z)` is defined for complex argument `z` to return by default the same kind of real as the argument, not default real.

Also, fix up expression formatting some more.  Sorry about the churn here, it's harder to get right than I thought it would be.  Note that parentheses introduced into the formatted output solely to honor operator precedence rules are distinguished from explicit parentheses by the addition of space characters around the enclosed subexpression.