### PR TITLE
Fix clang-format issues identified during relicensing

### DIFF
--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -594,7 +594,8 @@ static const IntrinsicInterface genericIntrinsicFunction[]{
         Rank::scalar},
     {"rank", {{"a", AnyData, Rank::anyOrAssumedRank}}, DefaultInt,
         Rank::scalar},
-    {"real", {{"a", SameComplex, Rank::elemental}}, SameReal},  // 16.9.160(4)(ii)
+    {"real", {{"a", SameComplex, Rank::elemental}},
+        SameReal},  // 16.9.160(4)(ii)
     {"real", {{"a", AnyNumeric, Rank::elementalOrBOZ}, DefaultingKIND},
         KINDReal},
     {"reduce",

--- a/lib/parser/type-parser-implementation.h
+++ b/lib/parser/type-parser-implementation.h
@@ -33,4 +33,3 @@
   TYPE_PARSER(CONTEXT_PARSER((contextText), (pexpr)))
 
 #endif
-

--- a/test/evaluate/fp-testing.cc
+++ b/test/evaluate/fp-testing.cc
@@ -11,7 +11,7 @@ ScopedHostFloatingPointEnvironment::ScopedHostFloatingPointEnvironment(
 #else
     bool, bool
 #endif
-    ) {
+) {
   errno = 0;
   if (feholdexcept(&originalFenv_) != 0) {
     std::fprintf(stderr, "feholdexcept() failed: %s\n", std::strerror(errno));


### PR DESCRIPTION
While running clang-format during the relicensing, there were
a few files that showed minor format issues that could be cleaned
up. These changes address them.