### PR TITLE
Some fixes

### DIFF
--- a/lib/evaluate/call.h
+++ b/lib/evaluate/call.h
@@ -204,7 +204,7 @@ template<typename A> class FunctionRef : public ProcedureRef {
 public:
   using Result = A;
   CLASS_BOILERPLATE(FunctionRef)
-  FunctionRef(ProcedureRef &&pr) : ProcedureRef{std::move(pr)} {}
+  explicit FunctionRef(ProcedureRef &&pr) : ProcedureRef{std::move(pr)} {}
   FunctionRef(ProcedureDesignator &&p, ActualArguments &&a)
     : ProcedureRef{std::move(p), std::move(a)} {}
 

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -981,8 +981,8 @@ Expr<Type<TypeCategory::Real, KIND>> FoldIntrinsicFunction(
       context.messages().Say(
           "%s(real(kind=%d)) cannot be folded on host"_en_US, name, KIND);
     }
-  }
-  if (name == "atan" || name == "atan2" || name == "hypot" || name == "mod") {
+  } else if (name == "atan" || name == "atan2" || name == "hypot" ||
+      name == "mod") {
     std::string localName{name == "atan2" ? "atan" : name};
     CHECK(args.size() == 2);
     if (auto callable{

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -235,6 +235,19 @@ std::optional<DataRef> ExtractDataRef(const std::optional<A> &x) {
   }
 }
 
+// Predicate: is an expression is an array element reference?
+template<typename T> bool IsArrayElement(const Expr<T> &expr) {
+  if (auto dataRef{ExtractDataRef(expr)}) {
+    const DataRef *ref{&*dataRef};
+    while (const Component * component{std::get_if<Component>(&ref->u)}) {
+      ref = &component->base();
+    }
+    return std::holds_alternative<ArrayRef>(ref->u);
+  } else {
+    return false;
+  }
+}
+
 template<typename A> std::optional<NamedEntity> ExtractNamedEntity(const A &x) {
   if (auto dataRef{ExtractDataRef(x)}) {
     return std::visit(

--- a/lib/parser/preprocessor.cc
+++ b/lib/parser/preprocessor.cc
@@ -980,7 +980,7 @@ bool Preprocessor::IsIfPredicateTrue(const TokenSequence &expr,
         j += 3;
       } else if (j + 1 < expr1.SizeInTokens() &&
           IsLegalIdentifierStart(expr1.TokenAt(j + 1))) {
-        name = expr1.TokenAt(j++);
+        name = expr1.TokenAt(++j);
       }
       if (!name.empty()) {
         char truth{IsNameDefined(name) ? '1' : '0'};

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -233,7 +233,7 @@ public:
   using RawParameter = std::pair<const parser::Keyword *, ParamValue>;
   using RawParameters = std::vector<RawParameter>;
   using ParameterMapType = std::map<SourceName, ParamValue>;
-  explicit DerivedTypeSpec(SourceName, const Symbol &);
+  DerivedTypeSpec(SourceName, const Symbol &);
   DerivedTypeSpec(const DerivedTypeSpec &);
   DerivedTypeSpec(DerivedTypeSpec &&);
 

--- a/test/semantics/call05.f90
+++ b/test/semantics/call05.f90
@@ -84,9 +84,9 @@ module m
     call sup(pp)
     !ERROR: If a POINTER or ALLOCATABLE dummy or actual argument is unlimited polymorphic, both must be so
     call sua(pa)
-    !ERROR: actual argument type 'CLASS(*)' is not compatible with dummy argument type 't'
+    !ERROR: Actual argument type 'CLASS(*)' is not compatible with dummy argument type 't'
     call spp(up)
-    !ERROR: actual argument type 'CLASS(*)' is not compatible with dummy argument type 't'
+    !ERROR: Actual argument type 'CLASS(*)' is not compatible with dummy argument type 't'
     call spa(ua)
     !ERROR: POINTER or ALLOCATABLE dummy and actual arguments must have the same declared type
     call spp(pp2)


### PR DESCRIPTION
More fixes to problems encountered running SPEC CPU codes through f18 with semantics enabled.

The significant bug fixed here is the case of `FOO(x,y,z)` where `FOO` is both the name of a generic interface and the name of a derived type.  The compiler was always treating the reference as a structure constructor, but we need to ensure first that it doesn't match any of the specific procedures in the generic interface.