### PR TITLE
Semantic Checks for critical construct

### DIFF
--- a/lib/semantics/check-coarray.h
+++ b/lib/semantics/check-coarray.h
@@ -33,6 +33,8 @@ public:
   void Leave(const parser::ImageSelectorSpec &);
   void Leave(const parser::FormTeamStmt &);
 
+  void Enter(const parser::CriticalConstruct &);
+
 private:
   SemanticsContext &context_;
 
@@ -40,6 +42,5 @@ private:
   void Say2(const parser::CharBlock &, parser::MessageFixedText &&,
       const parser::CharBlock &, parser::MessageFixedText &&);
 };
-
 }
 #endif  // FORTRAN_SEMANTICS_CHECK_COARRAY_H_

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -194,6 +194,9 @@ set(ERROR_TESTS
   bindings01.f90
   bad-forward-type.f90
   c_f_pointer.f90
+  critical01.f90
+  critical02.f90
+  critical03.f90
 )
 
 # These test files have expected symbols in the source
@@ -279,6 +282,10 @@ set(CANONDO_TESTS
   canondo*.[Ff]90
 )
 
+set(CRITICAL_TESTS
+  critical04.f90
+)
+
 set(GETSYMBOLS_TESTS
   getsymbols01.f90
   getsymbols02-*.f90
@@ -313,7 +320,7 @@ foreach(test ${MODFILE_TESTS})
 endforeach()
 
 foreach(test ${LABEL_TESTS} ${CANONDO_TESTS} ${DOCONCURRENT_TESTS}
-             ${GETSYMBOLS_TESTS} ${GETDEFINITION_TESTS})
+             ${CRITICAL_TESTS} ${GETSYMBOLS_TESTS} ${GETDEFINITION_TESTS})
   add_test(NAME ${test}
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_any.sh ${test} ${F18})
 endforeach()

--- a/test/semantics/critical01.f90
+++ b/test/semantics/critical01.f90
@@ -1,0 +1,23 @@
+!C1117
+
+subroutine test1(a, i)
+  integer i
+  real a(10)
+  one: critical
+    if (a(i) < 0.0) then
+      a(i) = 20.20
+    end if
+  !ERROR: CRITICAL construct name mismatch
+  end critical two
+end subroutine test1
+
+subroutine test2(a, i)
+  integer i
+  real a(10)
+  critical
+    if (a(i) < 0.0) then
+      a(i) = 20.20
+    end if
+  !ERROR: CRITICAL construct name unexpected
+  end critical two
+end subroutine test2

--- a/test/semantics/critical02.f90
+++ b/test/semantics/critical02.f90
@@ -1,0 +1,121 @@
+!C1118
+
+subroutine test1
+  critical
+    !ERROR: RETURN statement is not allowed in a CRITICAL construct
+    return
+  end critical
+end subroutine test1
+
+subroutine test2()
+  implicit none
+  critical
+    !ERROR: An image control statement is not allowed in a CRITICAL construct
+    SYNC ALL
+  end critical
+end subroutine test2
+
+subroutine test3()
+  use iso_fortran_env, only: team_type
+  implicit none
+  type(team_type) :: j
+  critical
+    !ERROR: An image control statement is not allowed in a CRITICAL construct
+    sync team (j)
+  end critical
+end subroutine test3
+
+subroutine test4()
+  integer, allocatable, codimension[:] :: ca
+
+  critical
+    !ERROR: An image control statement is not allowed in a CRITICAL construct
+    allocate(ca[*])
+  end critical
+
+  critical
+    !ERROR: An image control statement is not allowed in a CRITICAL construct
+    deallocate(ca)
+  end critical
+end subroutine test4
+
+subroutine test5()
+  use iso_fortran_env, only: team_type
+  implicit none
+  type(team_type) :: j
+  critical
+    change team (j)
+    !ERROR: An image control statement is not allowed in a CRITICAL construct
+    end team
+  end critical
+end subroutine test5
+
+subroutine test6
+  critical
+    critical
+    !ERROR: An image control statement is not allowed in a CRITICAL construct
+    end critical
+  end critical
+end subroutine test6
+
+subroutine test7()
+  use iso_fortran_env
+  type(event_type) :: x, y
+  critical
+    !ERROR: An image control statement is not allowed in a CRITICAL construct
+    event post (x)
+    !ERROR: An image control statement is not allowed in a CRITICAL construct
+    event wait (y)
+  end critical
+end subroutine test7
+
+subroutine test8()
+  use iso_fortran_env
+  type(team_type) :: t
+
+  critical
+    !ERROR: An image control statement is not allowed in a CRITICAL construct
+    form team(1, t)
+  end critical
+end subroutine test8
+
+subroutine test9()
+  use iso_fortran_env
+  type(lock_type) :: l
+
+  critical
+    !ERROR: An image control statement is not allowed in a CRITICAL construct
+    lock(l)
+    !ERROR: An image control statement is not allowed in a CRITICAL construct
+    unlock(l)
+  end critical
+end subroutine test9
+
+subroutine test10()
+  use iso_fortran_env
+  integer, allocatable, codimension[:] :: ca
+  allocate(ca[*])
+
+  critical
+    block
+      integer, allocatable, codimension[:] :: cb
+      cb = ca
+    !TODO: Deallocation of this coarray is not currently caught
+    end block
+  end critical
+end subroutine test10
+
+subroutine test11()
+  integer, allocatable, codimension[:] :: ca, cb
+  critical
+    !ERROR: An image control statement is not allowed in a CRITICAL construct
+    call move_alloc(cb, ca)
+  end critical
+end subroutine test11
+
+subroutine test12()
+  critical
+    !ERROR: An image control statement is not allowed in a CRITICAL construct
+    stop
+  end critical
+end subroutine test12

--- a/test/semantics/critical03.f90
+++ b/test/semantics/critical03.f90
@@ -1,0 +1,34 @@
+!C1119
+
+subroutine test1(a, i)
+  integer i
+  real a(10)
+  critical
+    if (a(i) < 0.0) then
+      a(i) = 20.20
+      !ERROR: Control flow escapes from CRITICAL
+      goto 20
+    end if
+  end critical
+20 a(i) = -a(i)
+end subroutine test1
+
+subroutine test2(i)
+  integer i
+  critical
+    !ERROR: Control flow escapes from CRITICAL
+    if (i) 10, 10, 20
+    10 i = i + 1
+  end critical
+20 i = i - 1
+end subroutine test2
+
+subroutine test3(i)
+  integer i
+  critical
+    !ERROR: Control flow escapes from CRITICAL
+    goto (10, 10, 20) i
+    10 i = i + 1
+  end critical
+20 i = i - 1
+end subroutine test3

--- a/test/semantics/critical04.f90
+++ b/test/semantics/critical04.f90
@@ -1,0 +1,32 @@
+! RUN: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
+! CHECK-NOT: Control flow escapes from CRITICAL
+
+subroutine test1(a, i)
+  integer i
+  real a(10)
+  critical
+    if (a(i) < 0.0) then
+      a(i) = 20.20
+      goto 20
+    end if
+20 a(i) = -a(i)
+  end critical
+end subroutine test1
+
+subroutine test2(i)
+  integer i
+  critical
+    if (i) 10, 10, 20
+10  i = i + 1
+20  i = i - 1
+  end critical
+end subroutine test2
+
+subroutine test3(i)
+  integer i
+  critical
+    goto (10, 10, 20) i
+10  i = i + 1
+20  i = i - 1
+  end critical
+end subroutine test3


### PR DESCRIPTION
This PR includes checks for the critical construct. Implemented checks include the following,
-> C1119: A branch within a CRITICAL construct shall not have a branch target that is outside the construct. Implemented by refactoring the LabelEnforce class in check-do.cc and putting it in tools.h and using it for CRITICAL construct.
-> C1118: The block of a critical-construct shall not contain a RETURN statement or an image control statement. Implemented directly and using the isimagecontrol function in tools.h.

Handled by existing code
C1117: Matching names for critical and end critical statements

Not implemented (TODO)
11.1.6.5: It is permissible to branch to an end-critical-stmt only from within its CRITICAL construct.

