### PR TITLE
Patch build problem

### DIFF
--- a/module/iso_c_binding.f90
+++ b/module/iso_c_binding.f90
@@ -8,6 +8,8 @@
 
 ! See Fortran 2018, clause 18.2
 
+include '__fortran_builtins.f90' ! avoid inter-module dependence
+
 module iso_c_binding
 
   use __Fortran_builtins, only: &

--- a/module/iso_fortran_env.f90
+++ b/module/iso_fortran_env.f90
@@ -10,6 +10,7 @@
 ! TODO: These are placeholder values so that some tests can be run.
 
 include '../runtime/magic-numbers.h' ! for IOSTAT= error/end code values
+include '__fortran_builtins.f90' ! avoid inter-module dependence
 
 module iso_fortran_env
 

--- a/test/semantics/canondo16.f90
+++ b/test/semantics/canondo16.f90
@@ -15,7 +15,6 @@
 
 ! CHECK: A DO loop should terminate with an END DO or CONTINUE
 
-include '../../module/__fortran_builtins.f90'
 include '../../module/iso_c_binding.f90'
 
 subroutine foo8()


### PR DESCRIPTION
Until I can figure out the cmake magic to properly declare a dependence between our intrinsic modules and `__fortran_builtins`, use `INCLUDE` to ensure that its contents are available in the two modules that need it.