### PR TITLE
Add .mod file dependencies

### DIFF
--- a/module/iso_c_binding.f90
+++ b/module/iso_c_binding.f90
@@ -8,8 +8,6 @@
 
 ! See Fortran 2018, clause 18.2
 
-include '__fortran_builtins.f90' ! avoid inter-module dependence
-
 module iso_c_binding
 
   use __Fortran_builtins, only: &

--- a/module/iso_fortran_env.f90
+++ b/module/iso_fortran_env.f90
@@ -10,7 +10,6 @@
 ! TODO: These are placeholder values so that some tests can be run.
 
 include '../runtime/magic-numbers.h' ! for IOSTAT= error/end code values
-include '__fortran_builtins.f90' ! avoid inter-module dependence
 
 module iso_fortran_env
 

--- a/test/semantics/canondo16.f90
+++ b/test/semantics/canondo16.f90
@@ -4,7 +4,7 @@
 ! By default, this is not an error and label do are rewritten to non-label do.
 ! A warning is generated with -Mstandard
 
-! RUN: ${F18} -funparse-with-symbols -Mstandard %s 2>&1 | ${FileCheck} %s
+! RUN: ${F18} -funparse-with-symbols -Mstandard -I../../tools/f18/include %s 2>&1 | ${FileCheck} %s
 
 ! CHECK: end do
 
@@ -15,10 +15,8 @@
 
 ! CHECK: A DO loop should terminate with an END DO or CONTINUE
 
-include '../../module/iso_c_binding.f90'
-
 subroutine foo8()
-  use :: __fortran_builtins, only : team_type => __builtin_team_type
+  use iso_fortran_env, only : team_type
   type(team_type) :: odd_even
   do 01 k=1,10
     change team (odd_even)

--- a/tools/f18/CMakeLists.txt
+++ b/tools/f18/CMakeLists.txt
@@ -35,31 +35,38 @@ set_target_properties(f18 f18-parse-demo
 )
 
 set(MODULES
-  "__fortran_builtins" # must be first
   "ieee_arithmetic"
   "ieee_exceptions"
   "ieee_features"
   "iso_c_binding"
   "iso_fortran_env"
   "omp_lib"
+  "__fortran_builtins"
 )
+
+set(include ${CMAKE_CURRENT_BINARY_DIR}/include)
 
 # Create module files directly from the top-level module source directory
 foreach(filename ${MODULES})
-  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.mod
-    COMMAND f18 -fparse-only -fdebug-semantics -I{${CMAKE_CURRENT_BINARY_DIR}/include} ${PROJECT_SOURCE_DIR}/module/${filename}.f90
-    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include"
-    DEPENDS f18 ${PROJECT_SOURCE_DIR}/module/${filename}.f90
+  if(${filename} MATCHES "__fortran_builtins")
+    set(depends "")
+  else()
+    set(depends ${include}/__fortran_builtins.mod)
+  endif()
+  add_custom_command(OUTPUT ${include}/${filename}.mod
+    COMMAND f18 -fparse-only -fdebug-semantics -I${include}
+      ${PROJECT_SOURCE_DIR}/module/${filename}.f90
+    WORKING_DIRECTORY ${include}
+    DEPENDS f18 ${PROJECT_SOURCE_DIR}/module/${filename}.f90 ${depends}
   )
-  add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.f18.mod
-    COMMAND f18 -fparse-only -fdebug-semantics -module-suffix .f18.mod -I{${CMAKE_CURRENT_BINARY_DIR}/include} ${PROJECT_SOURCE_DIR}/module/${filename}.f90
-    WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include"
-    DEPENDS f18 ${PROJECT_SOURCE_DIR}/module/${filename}.f90
-  )
-  list(APPEND MODULE_FILES "${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.mod")
-  list(APPEND MODULE_FILES "${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.f18.mod")
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.mod DESTINATION include)
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/${filename}.f18.mod DESTINATION include)
+  add_custom_command(OUTPUT ${include}/${filename}.f18.mod
+    DEPENDS ${include}/${filename}.mod
+    COMMAND ${CMAKE_COMMAND} -E
+      copy ${include}/${filename}.mod ${include}/${filename}.f18.mod)
+  list(APPEND MODULE_FILES ${include}/${filename}.mod)
+  list(APPEND MODULE_FILES ${include}/${filename}.f18.mod)
+  install(FILES ${include}/${filename}.mod DESTINATION include)
+  install(FILES ${include}/${filename}.f18.mod DESTINATION include)
 endforeach()
 
 add_custom_target(module_files ALL DEPENDS ${MODULE_FILES})


### PR DESCRIPTION
Make compilation of other predefined module files depend on
__fortran_builtins.mod. Currently only iso_c_binding.f90 and
iso_fortran_env.f90 depend on it but others could in the future.

Create the .f18.mod files by copying from the .mod files so that
we don't have to worry about dependencies for those.