### PR TITLE
Fix type-bound user-defined operators

### DIFF
--- a/lib/parser/message.cc
+++ b/lib/parser/message.cc
@@ -126,7 +126,7 @@ bool Message::SortBefore(const Message &that) const {
   // Messages from prescanning have ProvenanceRange values for their locations,
   // while messages from later phases have CharBlock values, since the
   // conversion of cooked source stream locations to provenances is not
-  // free and needs to be deferred, since many messages created during parsing
+  // free and needs to be deferred, and many messages created during parsing
   // are speculative.  Messages with ProvenanceRange locations are ordered
   // before others for sorting.
   return std::visit(

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -5794,7 +5794,8 @@ bool ResolveNamesVisitor::Pre(const parser::DefinedOpName &x) {
     Say(name,
         "Logical constant '%s' may not be used as a defined operator"_err_en_US);
   } else {
-    Say(name, "Defined operator '%s' not found"_err_en_US);
+    // Resolved later in expression semantics
+    MakePlaceholder(name, MiscDetails::Kind::TypeBoundDefinedOp);
   }
   return false;
 }

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -194,7 +194,7 @@ Scope &SemanticsContext::FindScope(parser::CharBlock source) {
   if (auto *scope{globalScope_.FindScope(source)}) {
     return *scope;
   } else {
-    common::die("invalid source location");
+    common::die("SemanticsContext::FindScope(): invalid source location");
   }
 }
 

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -299,8 +299,8 @@ class FinalProcDetails {};  // TODO
 class MiscDetails {
 public:
   ENUM_CLASS(Kind, None, ConstructName, ScopeName, PassName, ComplexPartRe,
-      ComplexPartIm, KindParamInquiry, LenParamInquiry,
-      SelectTypeAssociateName);
+      ComplexPartIm, KindParamInquiry, LenParamInquiry, SelectTypeAssociateName,
+      TypeBoundDefinedOp);
   MiscDetails(Kind kind) : kind_{kind} {}
   Kind kind() const { return kind_; }
 

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -149,8 +149,14 @@ bool IsIntrinsicConcat(const evaluate::DynamicType &type0, int rank0,
 }
 
 bool IsGenericDefinedOp(const Symbol &symbol) {
-  const auto *details{symbol.GetUltimate().detailsIf<GenericDetails>()};
-  return details && details->kind().IsDefinedOperator();
+  const Symbol &ultimate{symbol.GetUltimate()};
+  if (const auto *generic{ultimate.detailsIf<GenericDetails>()}) {
+    return generic->kind().IsDefinedOperator();
+  } else if (const auto *misc{ultimate.detailsIf<MiscDetails>()}) {
+    return misc->kind() == MiscDetails::Kind::TypeBoundDefinedOp;
+  } else {
+    return false;
+  }
 }
 
 bool IsCommonBlockContaining(const Symbol &block, const Symbol &object) {

--- a/test/semantics/modfile35.f90
+++ b/test/semantics/modfile35.f90
@@ -149,3 +149,102 @@ end
 !  real(4) :: a(1_8:y%p2(x))
 ! end
 !end
+
+module m3
+  type :: t1
+  contains
+    procedure, pass(x) :: p1 => f1
+    procedure :: p3 => f3
+    generic :: operator(.binary.) => p1
+    generic :: operator(.unary.) => p3
+  end type
+  type, extends(t1) :: t2
+  contains
+    procedure, pass(y) :: p2 => f2
+    generic :: operator(.binary.) => p2
+  end type
+contains
+  integer(8) pure function f1(x, y)
+    class(t1), intent(in) :: x
+    integer, intent(in) :: y
+  end
+  integer(8) pure function f2(x, y)
+    class(t1), intent(in) :: x
+    class(t2), intent(in) :: y
+  end
+  integer(8) pure function f3(x)
+    class(t1), intent(in) :: x
+  end
+  subroutine test1(x, y, a)
+    class(t1) :: x
+    integer :: y
+    real :: a(x .binary. y)
+  end
+  ! Resolve to operator in parent class
+  subroutine test2(x, y, a)
+    class(t2) :: x
+    integer :: y
+    real :: a(x .binary. y)
+  end
+  ! 2nd arg is passed object
+  subroutine test3(x, y, a)
+    class(t1) :: x
+    class(t2) :: y
+    real :: a(x .binary. y)
+  end
+  subroutine test4(x, y, a)
+    class(t1) :: x
+    class(t2) :: y
+    real :: a(.unary. x + .unary. y)
+  end
+end
+!Expect: m3.mod
+!module m3
+!  type::t1
+!  contains
+!    procedure,pass(x)::p1=>f1
+!    procedure::p3=>f3
+!    generic::.binary.=>p1
+!    generic::.unary.=>p3
+!  end type
+!  type,extends(t1)::t2
+!  contains
+!    procedure,pass(y)::p2=>f2
+!    generic::.binary.=>p2
+!  end type
+!contains
+!  pure function f1(x,y)
+!    class(t1),intent(in)::x
+!    integer(4),intent(in)::y
+!    integer(8)::f1
+!  end
+!  pure function f2(x,y)
+!    class(t1),intent(in)::x
+!    class(t2),intent(in)::y
+!    integer(8)::f2
+!  end
+!  pure function f3(x)
+!    class(t1),intent(in)::x
+!    integer(8)::f3
+!  end
+!  subroutine test1(x,y,a)
+!    class(t1)::x
+!    integer(4)::y
+!    real(4)::a(1_8:x%p1(y))
+!  end
+!  subroutine test2(x,y,a)
+!    class(t2)::x
+!    integer(4)::y
+!    real(4)::a(1_8:x%p1(y))
+!  end
+!  subroutine test3(x,y,a)
+!    class(t1)::x
+!    class(t2)::y
+!    real(4)::a(1_8:y%p2(x))
+!  end
+!  subroutine test4(x,y,a)
+!    class(t1)::x
+!    class(t2)::y
+!    real(4)::a(1_8:x%p3()+y%p3())
+!  end
+!end

--- a/test/semantics/resolve62.f90
+++ b/test/semantics/resolve62.f90
@@ -43,7 +43,7 @@ subroutine s3
   logical :: a, b, c
   x = y .foo. z  ! OK: f_real
   i = j .foo. k  ! OK: f_integer
-  !ERROR: No specific procedure of generic operator '.foo.' matches the actual arguments
+  !ERROR: No intrinsic or user-defined .FOO. matches operand types LOGICAL(4) and LOGICAL(4)
   a = b .foo. c
 end
 

--- a/test/semantics/resolve63.f90
+++ b/test/semantics/resolve63.f90
@@ -157,15 +157,15 @@ contains
   subroutine s1(x, y, z)
     logical :: x
     real :: y, z
-    !ERROR: Defined operator '.a.' not found
+    !ERROR: No operator .A. defined for REAL(4) and REAL(4)
     x = y .a. z
-    !ERROR: Defined operator '.o.' not found
+    !ERROR: No operator .O. defined for REAL(4) and REAL(4)
     x = y .o. z
-    !ERROR: Defined operator '.n.' not found
+    !ERROR: No operator .N. defined for REAL(4)
     x = .n. y
-    !ERROR: Defined operator '.xor.' not found
+    !ERROR: No operator .XOR. defined for REAL(4) and REAL(4)
     x = y .xor. z
-    !ERROR: Defined operator '.x.' not found
+    !ERROR: No operator .X. defined for REAL(4)
     x = .x. y
   end
 end
@@ -189,7 +189,7 @@ contains
     complex :: y, z
     !ERROR: No intrinsic or user-defined OPERATOR(.AND.) matches operand types COMPLEX(4) and COMPLEX(4)
     x = y .and. z
-    !ERROR: No specific procedure of generic operator '.a.' matches the actual arguments
+    !ERROR: No intrinsic or user-defined .A. matches operand types COMPLEX(4) and COMPLEX(4)
     x = y .a. z
   end
 end


### PR DESCRIPTION
Type-bound generics of intrinsic operators (e.g., `operator(+)`) work, and non-type-bound generic user-defined operators (e.g., `operator(.foo.)`) work, but type-bound generic user-defined operators didn't.  This PR pulls the pieces together in `semantics/expression.cc` and gets a few more correctness tests to pass.