### PR TITLE
Check for passing DO variables to OUT arguments in a CALL statement

### DIFF
--- a/lib/evaluate/call.h
+++ b/lib/evaluate/call.h
@@ -111,6 +111,11 @@ public:
   void set_isPassedObject(bool yes = true) { isPassedObject_ = yes; }
 
   bool Matches(const characteristics::DummyArgument &) const;
+  common::Intent dummyIntent() const { return dummyIntent_; }
+  ActualArgument &set_dummyIntent(common::Intent intent) {
+    dummyIntent_ = intent;
+    return *this;
+  }
 
   // Wrap this argument in parentheses
   void Parenthesize();
@@ -127,6 +132,7 @@ private:
   std::optional<parser::CharBlock> keyword_;
   bool isAlternateReturn_{false};  // whether expr is a "*label" number
   bool isPassedObject_{false};
+  common::Intent dummyIntent_{common::Intent::Default};
 };
 
 using ActualArguments = std::vector<std::optional<ActualArgument>>;

--- a/lib/semantics/check-call.cc
+++ b/lib/semantics/check-call.cc
@@ -601,6 +601,7 @@ static void CheckExplicitInterfaceArg(evaluate::ActualArgument &arg,
             if (auto *expr{arg.UnwrapExpr()}) {
               if (auto type{characteristics::TypeAndShape::Characterize(
                       *expr, context)}) {
+                arg.set_dummyIntent(object.intent);
                 bool isElemental{object.type.Rank() == 0 && proc.IsElemental()};
                 CheckExplicitDataArg(object, dummyName, *expr, *type,
                     isElemental, IsArrayElement(*expr), context, scope);

--- a/lib/semantics/check-do.h
+++ b/lib/semantics/check-do.h
@@ -14,6 +14,7 @@
 
 namespace Fortran::parser {
 struct AssignmentStmt;
+struct CallStmt;
 struct ConnectSpec;
 struct CycleStmt;
 struct DoConstruct;
@@ -33,6 +34,7 @@ class DoChecker : public virtual BaseChecker {
 public:
   explicit DoChecker(SemanticsContext &context) : context_{context} {}
   void Leave(const parser::AssignmentStmt &);
+  void Leave(const parser::CallStmt &);
   void Leave(const parser::ConnectSpec &);
   void Enter(const parser::CycleStmt &);
   void Enter(const parser::DoConstruct &);

--- a/lib/semantics/check-io.cc
+++ b/lib/semantics/check-io.cc
@@ -509,7 +509,7 @@ static void CheckForDoVariableInNamelist(const Symbol &namelist,
     SemanticsContext &context, parser::CharBlock namelistLocation) {
   const auto &details{namelist.GetUltimate().get<NamelistDetails>()};
   for (const Symbol &object : details.objects()) {
-    context.CheckDoVarRedefine(object, namelistLocation);
+    context.CheckDoVarRedefine(namelistLocation, object);
   }
 }
 

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -152,7 +152,8 @@ public:
 
   // Check to see if a variable being redefined is a DO variable.  If so, emit
   // a message
-  void CheckDoVarRedefine(const Symbol &, const parser::CharBlock &);
+  void WarnDoVarRedefine(const parser::CharBlock &, const Symbol &);
+  void CheckDoVarRedefine(const parser::CharBlock &, const Symbol &);
   void CheckDoVarRedefine(const parser::Variable &);
   void CheckDoVarRedefine(const parser::Name &);
   void ActivateDoVariable(const parser::Name &);
@@ -161,7 +162,8 @@ public:
 
 private:
   parser::CharBlock GetDoVariableLocation(const Symbol &);
-  void SayDoVarRedefine(const parser::CharBlock &, const Symbol &);
+  void CheckDoVarRedefine(
+      const parser::CharBlock &, const Symbol &, parser::MessageFixedText &&);
   const common::IntrinsicTypeDefaultKinds &defaultKinds_;
   const common::LanguageFeatureControl languageFeatures_;
   parser::AllSources &allSources_;

--- a/test/semantics/dosemantics12.f90
+++ b/test/semantics/dosemantics12.f90
@@ -373,3 +373,41 @@ subroutine s11()
   end do
 
 end subroutine s11
+
+subroutine s12()
+
+  Integer :: ivar, jvar
+
+  call intentInSub(jvar, ivar)
+  do ivar = 1,10
+    call intentInSub(jvar, ivar)
+  end do
+
+  call intentOutSub(jvar, ivar)
+  do ivar = 1,10
+!ERROR: Cannot redefine DO variable 'ivar'
+    call intentOutSub(jvar, ivar)
+  end do
+
+  call intentInOutSub(jvar, ivar)
+  do ivar = 1,10
+    call intentInOutSub(jvar, ivar)
+  end do
+
+contains
+  subroutine intentInSub(arg1, arg2)
+    integer, intent(in) :: arg1
+    integer, intent(in) :: arg2
+  end subroutine intentInSub
+
+  subroutine intentOutSub(arg1, arg2)
+    integer, intent(in) :: arg1
+    integer, intent(out) :: arg2
+  end subroutine intentOutSub
+
+  subroutine intentInOutSub(arg1, arg2)
+    integer, intent(in) :: arg1
+    integer, intent(inout) :: arg2
+  end subroutine intentInOutSub
+
+end subroutine s12


### PR DESCRIPTION
I added code to save the INTENT of a dummy argument in the checked expression
of the actual argument.  When processing a CallStmt, I then retrieve the
ProcedureRef, which contains a list of the checked ActualArguments.  I then
traverse this list looking for actual arguments that are active DO variable
that are being passed to dummy arguments whose INTENT is either OUT or INOUT.
For OUT dummies, I put out an error message and warn for INOUT dummies.