### PR TITLE
Add analyzed form of pointer assignment

### DIFF
--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -165,6 +165,49 @@ StructureConstructor &StructureConstructor::Add(
 
 GenericExprWrapper::~GenericExprWrapper() {}
 
+std::ostream &Assignment::AsFortran(std::ostream &o) const {
+  std::visit(
+      common::visitors{
+          [&](const evaluate::Assignment::IntrinsicAssignment &x) {
+            x.rhs.AsFortran(x.lhs.AsFortran(o) << '=');
+          },
+          [&](const evaluate::ProcedureRef &x) { x.AsFortran(o << "CALL "); },
+          [&](const evaluate::Assignment::PointerAssignment &x) {
+            x.lhs.AsFortran(o);
+            std::visit(
+                common::visitors{
+                    [&](const evaluate::Assignment::PointerAssignment::
+                            BoundsSpec &bounds) {
+                      if (!bounds.empty()) {
+                        char sep{'('};
+                        for (const auto &bound : bounds) {
+                          bound.AsFortran(o << sep) << ':';
+                          sep = ',';
+                        }
+                        o << ')';
+                      }
+                    },
+                    [&](const evaluate::Assignment::PointerAssignment::
+                            BoundsRemapping &bounds) {
+                      if (!bounds.empty()) {
+                        char sep{'('};
+                        for (const auto &bound : bounds) {
+                          bound.first.AsFortran(o << sep) << ':';
+                          bound.second.AsFortran(o);
+                          sep = ',';
+                        }
+                        o << ')';
+                      }
+                    },
+                },
+                x.bounds);
+            x.rhs.AsFortran(o << " => ");
+          },
+      },
+      u);
+  return o;
+}
+
 GenericAssignmentWrapper::~GenericAssignmentWrapper() {}
 
 template<TypeCategory CAT> int Expr<SomeKind<CAT>>::GetKind() const {

--- a/lib/parser/dump-parse-tree.h
+++ b/lib/parser/dump-parse-tree.h
@@ -766,7 +766,8 @@ protected:
       if (asFortran_ && x.typedExpr) {
         asFortran_->expr(ss, *x.typedExpr);
       }
-    } else if constexpr (std::is_same_v<T, AssignmentStmt>) {
+    } else if constexpr (std::is_same_v<T, AssignmentStmt> ||
+        std::is_same_v<T, PointerAssignmentStmt>) {
       if (asFortran_ && x.typedAssignment) {
         asFortran_->assignment(ss, *x.typedAssignment);
       }

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -1942,6 +1942,7 @@ struct PointerAssignmentStmt {
     std::variant<std::list<BoundsRemapping>, std::list<BoundsSpec>> u;
   };
   TUPLE_CLASS_BOILERPLATE(PointerAssignmentStmt);
+  mutable AssignmentStmt::TypedAssignment typedAssignment;
   std::tuple<DataRef, Bounds, Expr> t;
 };
 

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -849,16 +849,22 @@ public:
     }
   }
   void Unparse(const PointerAssignmentStmt &x) {  // R1033, R1034, R1038
-    Walk(std::get<DataRef>(x.t));
-    std::visit(
-        common::visitors{
-            [&](const std::list<BoundsRemapping> &y) {
-              Put('('), Walk(y), Put(')');
-            },
-            [&](const std::list<BoundsSpec> &y) { Walk("(", y, ", ", ")"); },
-        },
-        std::get<PointerAssignmentStmt::Bounds>(x.t).u);
-    Put(" => "), Walk(std::get<Expr>(x.t));
+    if (asFortran_ && x.typedAssignment.get()) {
+      Put(' ');
+      asFortran_->assignment(out_, *x.typedAssignment);
+      Put('\n');
+    } else {
+      Walk(std::get<DataRef>(x.t));
+      std::visit(
+          common::visitors{
+              [&](const std::list<BoundsRemapping> &y) {
+                Put('('), Walk(y), Put(')');
+              },
+              [&](const std::list<BoundsSpec> &y) { Walk("(", y, ", ", ")"); },
+          },
+          std::get<PointerAssignmentStmt::Bounds>(x.t).u);
+      Put(" => "), Walk(std::get<Expr>(x.t));
+    }
   }
   void Post(const BoundsSpec &) {  // R1035
     Put(':');

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -399,6 +399,11 @@ const evaluate::Assignment *GetAssignment(const parser::AssignmentStmt &x) {
   const auto &typed{x.typedAssignment};
   return typed ? &typed->v : nullptr;
 }
+const evaluate::Assignment *GetAssignment(
+    const parser::PointerAssignmentStmt &x) {
+  const auto &typed{x.typedAssignment};
+  return typed ? &typed->v : nullptr;
+}
 
 const Symbol *FindInterface(const Symbol &symbol) {
   return std::visit(

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -251,6 +251,8 @@ template<typename T> const SomeExpr *GetExpr(const T &x) {
 }
 
 const evaluate::Assignment *GetAssignment(const parser::AssignmentStmt &);
+const evaluate::Assignment *GetAssignment(
+    const parser::PointerAssignmentStmt &);
 
 template<typename T> std::optional<std::int64_t> GetIntValue(const T &x) {
   if (const auto *expr{GetExpr(x)}) {

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -188,6 +188,7 @@ set(ERROR_TESTS
   call12.f90
   call13.f90
   call14.f90
+  forall01.f90
   misc-declarations.f90
   separate-module-procs.f90
   bindings01.f90
@@ -278,10 +279,6 @@ set(CANONDO_TESTS
   canondo*.[Ff]90
 )
 
-set(FORALL_TESTS
-  forall*.[Ff]90
-)
-
 set(GETSYMBOLS_TESTS
   getsymbols01.f90
   getsymbols02-*.f90
@@ -316,7 +313,7 @@ foreach(test ${MODFILE_TESTS})
 endforeach()
 
 foreach(test ${LABEL_TESTS} ${CANONDO_TESTS} ${DOCONCURRENT_TESTS}
-             ${FORALL_TESTS} ${GETSYMBOLS_TESTS} ${GETDEFINITION_TESTS})
+             ${GETSYMBOLS_TESTS} ${GETDEFINITION_TESTS})
   add_test(NAME ${test}
     COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_any.sh ${test} ${F18})
 endforeach()

--- a/test/semantics/forall01.f90
+++ b/test/semantics/forall01.f90
@@ -1,10 +1,23 @@
-subroutine forall
+subroutine forall1
   real :: a(9)
   !ERROR: 'i' is already declared in this scoping unit
   forall (i=1:8, i=1:9)  a(i) = i
   forall (j=1:8)
-  !ERROR: 'j' is already declared in this scoping unit
+    !ERROR: 'j' is already declared in this scoping unit
     forall (j=1:9)
     end forall
   end forall
-end subroutine forall
+end
+
+subroutine forall2
+  integer, pointer :: a(:)
+  integer, target :: b(10,10)
+  forall (i=1:10)
+    !ERROR: Impure procedure 'f_impure' may not be referenced in a FORALL
+    a(f_impure(i):) => b(i,:)
+  end forall
+contains
+  impure integer function f_impure(i)
+    f_impure = i
+  end
+end

--- a/test/semantics/forall01.f90
+++ b/test/semantics/forall01.f90
@@ -1,13 +1,9 @@
-! RUN: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
-! CHECK: Previous declaration of 'i'
-! CHECK: Previous declaration of 'j'
-
 subroutine forall
   real :: a(9)
-! ERROR: 'i' is already declared in this scoping unit
+  !ERROR: 'i' is already declared in this scoping unit
   forall (i=1:8, i=1:9)  a(i) = i
   forall (j=1:8)
-! ERROR: 'j' is already declared in this scoping unit
+  !ERROR: 'j' is already declared in this scoping unit
     forall (j=1:9)
     end forall
   end forall

--- a/test/semantics/resolve35.f90
+++ b/test/semantics/resolve35.f90
@@ -69,6 +69,16 @@ contains
   end
 end
 
+subroutine s6b
+  integer, parameter :: k = 4
+  integer :: l = 4
+  forall(integer(k) :: i = 1:10)
+  end forall
+  !ERROR: Must be a constant value
+  forall(integer(l) :: i = 1:10)
+  end forall
+end
+
 subroutine s7
   !ERROR: 'i' is already declared in this scoping unit
   do concurrent(integer::i=1:5) local(j, i) &

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -172,16 +172,7 @@ static Fortran::parser::AnalyzedObjectsAsFortran asFortran{
       }
     },
     [](std::ostream &o, const Fortran::evaluate::GenericAssignmentWrapper &x) {
-      std::visit(
-          Fortran::common::visitors{
-              [&](const Fortran::evaluate::Assignment::IntrinsicAssignment &y) {
-                y.rhs.AsFortran(y.lhs.AsFortran(o) << '=');
-              },
-              [&](const Fortran::evaluate::ProcedureRef &y) {
-                y.AsFortran(o << "CALL ");
-              },
-          },
-          x.v.u);
+      x.v.AsFortran(o);
     },
     [](std::ostream &o, const Fortran::evaluate::ProcedureRef &x) {
       x.AsFortran(o << "CALL ");


### PR DESCRIPTION
Add `typedAssignment` to `PointerAssignmentStmt` parse tree node and
extend `evaluate::Assignment` to include pointer assignment, including
analyzed bounds. Analyze pointer assignments and fill those in.
Emit them in unparsed output and parse tree dump when present.

Change assignment checking to use analyzed expressions and assignments
rather than calling AnalyzeExpr. Check bounds in pointer assignments
for impure function calls in FORALL context.

Add `Fold` convenience function to `ExpressionAnalyzer`.

Fix type resolution in `ConcurrentHeader`.