### PR TITLE
Another attempt to fix bug #877

### DIFF
--- a/lib/parser/characters.cc
+++ b/lib/parser/characters.cc
@@ -15,6 +15,8 @@
 
 namespace Fortran::parser {
 
+bool useHexadecimalEscapeSequences{false};
+
 int UTF_8CharacterBytes(const char *p) {
   if ((*p & 0x80) == 0) {
     return 1;

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -615,8 +615,13 @@ int main(int argc, char *const argv[]) {
       driver.pgf90Args.push_back(
           "-Mbackslash");  // yes, this *disables* them in pgf90
     }
+    Fortran::parser::useHexadecimalEscapeSequences = false;
   } else {
-    // TODO: equivalents for other Fortran compilers
+    if (options.features.IsEnabled(
+            Fortran::common::LanguageFeature::BackslashEscapes)) {
+      driver.pgf90Args.push_back("-fbackslash");
+    }
+    Fortran::parser::useHexadecimalEscapeSequences = true;
   }
 
   if (!anyFiles) {


### PR DESCRIPTION
Use hexadecimal escape sequences rather than octal if the underlying Fortran compiler is not PGF90.

Avoid using escape sequences for bytes of quoted characters unless explicitly enabled or the character is a newline.