### PR TITLE
Outline operator<< for CharBlock.

### DIFF
--- a/lib/parser/CMakeLists.txt
+++ b/lib/parser/CMakeLists.txt
@@ -9,6 +9,7 @@
 add_library(FortranParser
   Fortran-parsers.cc
   char-buffer.cc
+  char-block.cc
   char-set.cc
   characters.cc
   debug-parser.cc

--- a/lib/parser/char-block.cc
+++ b/lib/parser/char-block.cc
@@ -1,0 +1,18 @@
+//===-- lib/parser/char-block.cc --------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//----------------------------------------------------------------------------//
+
+#include "char-block.h"
+#include <ostream>
+
+namespace Fortran::parser {
+
+std::ostream &operator<<(std::ostream &os, const CharBlock &x) {
+  return os << x.ToString();
+}
+
+}

--- a/lib/parser/char-block.h
+++ b/lib/parser/char-block.h
@@ -134,9 +134,7 @@ inline bool operator>(const char *left, const CharBlock &right) {
   return right < left;
 }
 
-inline std::ostream &operator<<(std::ostream &os, const CharBlock &x) {
-  return os << x.ToString();
-}
+std::ostream &operator<<(std::ostream &os, const CharBlock &x);
 
 }
 


### PR DESCRIPTION
This fixes an issue where the Dump function definitions in dump.cc
were relying on the forward declaration of operator<< for CharBlock
which was marked inline and only present in char-block.h.

This is not allowed under section 6.2.10 of the C++17 standard, and
caused a compilation failure when building with clang 9 as this was
(validly) inlining every use of the function and therefore not generating 
an outlined definition for linking.