### PR TITLE
Dodge build problem in some Power environments

### DIFF
--- a/runtime/main.cc
+++ b/runtime/main.cc
@@ -22,11 +22,22 @@ extern "C" {
 void __FortranProgram();  // PROGRAM statement
 
 int main(int argc, const char *argv[], const char *envp[]) {
+
   Fortran::runtime::argc = argc;
   Fortran::runtime::argv = argv;
   Fortran::runtime::envp = envp;
+
+#ifdef feclearexcept  // a macro in some environments; omit std::
+  feclearexcept(FE_ALL_EXCEPT);
+#else
   std::feclearexcept(FE_ALL_EXCEPT);
+#endif
+#ifdef fesetround
+  fesetround(FE_TONEAREST);
+#else
   std::fesetround(FE_TONEAREST);
+#endif
+
   std::atexit(Fortran::runtime::NotifyOtherImagesOfNormalEnd);
   // TODO: Runtime configuration settings from environment
   __FortranProgram();

--- a/runtime/stop.cc
+++ b/runtime/stop.cc
@@ -15,7 +15,12 @@
 extern "C" {
 
 static void DescribeIEEESignaledExceptions() {
-  if (auto excepts{std::fetestexcept(FE_ALL_EXCEPT)}) {
+#ifdef fetestexcept  // a macro in some environments; omit std::
+  auto excepts{fetestexcept(FE_ALL_EXCEPT)};
+#else
+  auto excepts{std::fetestexcept(FE_ALL_EXCEPT)};
+#endif
+  if (excepts) {
     std::fputs("IEEE arithmetic exceptions signaled:", stderr);
     if (excepts & FE_DIVBYZERO) {
       std::fputs(" DIVBYZERO", stderr);


### PR DESCRIPTION
Looks like some APIs from `#include <cfenv>` are macros, not `std::` entry points, in some Power build environments, so make their usage conditional in some new code that I merged earlier today.