### PR TITLE
Perform expression analysis on assumed-type dummies

### DIFF
--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -348,10 +348,7 @@ private:
 
   std::optional<CalleeAndArguments> AnalyzeProcedureComponentRef(
       const parser::ProcComponentRef &, ActualArguments &&);
-  std::optional<ActualArgument> AnalyzeActualArgument(const parser::Expr &);
 
-  std::optional<ActualArguments> AnalyzeArguments(
-      const parser::Call &, bool isSubroutine);
   std::optional<characteristics::Procedure> CheckCall(
       parser::CharBlock, const ProcedureDesignator &, ActualArguments &);
   using AdjustActuals =

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -224,8 +224,8 @@ bool ExprTypeKindIsDefault(
 
 struct GetExprHelper {
   const SomeExpr *Get(const parser::Expr::TypedExpr &x) {
-    CHECK(x);
-    return x && x->v ? &*x->v : nullptr;
+    CHECK(x);  // expression analysis must have been done
+    return x->v ? &*x->v : nullptr;
   }
   const SomeExpr *Get(const parser::Expr &x) { return Get(x.typedExpr); }
   const SomeExpr *Get(const parser::Variable &x) { return Get(x.typedExpr); }


### PR DESCRIPTION
When we recognized an expression as an assumed-type dummy argument
we did not otherwise analyze it, so `typedExpr` was not filled in.
When expression check is complete we expect every `typedExpr` data
member to have a value.

The fix is always to analyze the expression and then detect the
assumed-type dummy argument.

Fixes #915.