### PR TITLE
Minor format change to LLVM license lines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#------------------------------------------------------------------------------#
+#===------------------------------------------------------------------------===#
 
 cmake_minimum_required(VERSION 3.9.0)
 

--- a/documentation/OpenMP-4.5-grammar.txt
+++ b/documentation/OpenMP-4.5-grammar.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#------------------------------------------------------------------------------#
+#===------------------------------------------------------------------------===#
 
 # OpenMP 4.5 Specifications
 

--- a/documentation/f2018-grammar.txt
+++ b/documentation/f2018-grammar.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#------------------------------------------------------------------------------#
+#===------------------------------------------------------------------------===#
 
 R0001 digit -> 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
 R0002 letter ->

--- a/documentation/flang-c-style.el
+++ b/documentation/flang-c-style.el
@@ -4,7 +4,7 @@
 ;; See https://llvm.org/LICENSE.txt for license information.
 ;; SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 ;;
-;;----------------------------------------------------------------------------;;
+;;===----------------------------------------------------------------------===;;
 
 ;; Define a cc-mode style for editing C++ codes in Flang.
 ;;

--- a/include/flang/CMakeLists.txt
+++ b/include/flang/CMakeLists.txt
@@ -4,5 +4,5 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#------------------------------------------------------------------------------#
+#===------------------------------------------------------------------------===#
 

--- a/include/flang/Config/config.h.cmake
+++ b/include/flang/Config/config.h.cmake
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#------------------------------------------------------------------------------#
+#===------------------------------------------------------------------------===#
 
 /* This generated file is for internal use. Do not include it from headers. */
 

--- a/include/flang/ISO_Fortran_binding.h
+++ b/include/flang/ISO_Fortran_binding.h
@@ -4,7 +4,7 @@
  * See https://llvm.org/LICENSE.txt for license information.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  *
- * -----------------------------------------------------------------------------
+ * ===-----------------------------------------------------------------------===
  */
 
 #ifndef CFI_ISO_FORTRAN_BINDING_H_

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#------------------------------------------------------------------------------#
+#===------------------------------------------------------------------------===#
 
 add_subdirectory(common)
 add_subdirectory(evaluate)

--- a/lib/common/CMakeLists.txt
+++ b/lib/common/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#------------------------------------------------------------------------------#
+#===------------------------------------------------------------------------===#
 
 add_library(FortranCommon
   Fortran.cc

--- a/lib/common/Fortran-features.cc
+++ b/lib/common/Fortran-features.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "Fortran-features.h"
 #include "Fortran.h"

--- a/lib/common/Fortran-features.h
+++ b/lib/common/Fortran-features.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_COMMON_FORTRAN_FEATURES_H_
 #define FORTRAN_COMMON_FORTRAN_FEATURES_H_

--- a/lib/common/Fortran.cc
+++ b/lib/common/Fortran.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "Fortran.h"
 

--- a/lib/common/Fortran.h
+++ b/lib/common/Fortran.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_COMMON_FORTRAN_H_
 #define FORTRAN_COMMON_FORTRAN_H_

--- a/lib/common/bit-population-count.h
+++ b/lib/common/bit-population-count.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_COMMON_BIT_POPULATION_COUNT_H_
 #define FORTRAN_COMMON_BIT_POPULATION_COUNT_H_

--- a/lib/common/constexpr-bitset.h
+++ b/lib/common/constexpr-bitset.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_COMMON_CONSTEXPR_BITSET_H_
 #define FORTRAN_COMMON_CONSTEXPR_BITSET_H_

--- a/lib/common/default-kinds.cc
+++ b/lib/common/default-kinds.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "default-kinds.h"
 #include "idioms.h"

--- a/lib/common/default-kinds.h
+++ b/lib/common/default-kinds.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_COMMON_DEFAULT_KINDS_H_
 #define FORTRAN_COMMON_DEFAULT_KINDS_H_

--- a/lib/common/enum-set.h
+++ b/lib/common/enum-set.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_COMMON_ENUM_SET_H_
 #define FORTRAN_COMMON_ENUM_SET_H_

--- a/lib/common/format.h
+++ b/lib/common/format.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_COMMON_FORMAT_H_
 #define FORTRAN_COMMON_FORMAT_H_

--- a/lib/common/idioms.cc
+++ b/lib/common/idioms.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "idioms.h"
 #include <cstdarg>

--- a/lib/common/idioms.h
+++ b/lib/common/idioms.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_COMMON_IDIOMS_H_
 #define FORTRAN_COMMON_IDIOMS_H_

--- a/lib/common/indirection.h
+++ b/lib/common/indirection.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_COMMON_INDIRECTION_H_
 #define FORTRAN_COMMON_INDIRECTION_H_

--- a/lib/common/interval.h
+++ b/lib/common/interval.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_COMMON_INTERVAL_H_
 #define FORTRAN_COMMON_INTERVAL_H_

--- a/lib/common/leading-zero-bit-count.h
+++ b/lib/common/leading-zero-bit-count.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_COMMON_LEADING_ZERO_BIT_COUNT_H_
 #define FORTRAN_COMMON_LEADING_ZERO_BIT_COUNT_H_

--- a/lib/common/reference-counted.h
+++ b/lib/common/reference-counted.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_COMMON_REFERENCE_COUNTED_H_
 #define FORTRAN_COMMON_REFERENCE_COUNTED_H_

--- a/lib/common/reference.h
+++ b/lib/common/reference.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Implements a better std::reference_wrapper<> template class with
 // move semantics, equality testing, and member access.

--- a/lib/common/restorer.h
+++ b/lib/common/restorer.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Utility: before overwriting a variable, capture its value and
 // ensure that it will be restored when the Restorer goes out of scope.

--- a/lib/common/template.h
+++ b/lib/common/template.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_COMMON_TEMPLATE_H_
 #define FORTRAN_COMMON_TEMPLATE_H_

--- a/lib/common/uint128.h
+++ b/lib/common/uint128.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Portable 128-bit unsigned integer arithmetic for use in impoverished
 // C++ implementations lacking __uint128_t.

--- a/lib/common/unsigned-const-division.h
+++ b/lib/common/unsigned-const-division.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_COMMON_UNSIGNED_CONST_DIVISION_H_
 #define FORTRAN_COMMON_UNSIGNED_CONST_DIVISION_H_

--- a/lib/common/unwrap.h
+++ b/lib/common/unwrap.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_COMMON_UNWRAP_H_
 #define FORTRAN_COMMON_UNWRAP_H_

--- a/lib/decimal/CMakeLists.txt
+++ b/lib/decimal/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#------------------------------------------------------------------------------#
+#===------------------------------------------------------------------------===#
 
 add_library(FortranDecimal
   binary-to-decimal.cc

--- a/lib/decimal/big-radix-floating-point.h
+++ b/lib/decimal/big-radix-floating-point.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_DECIMAL_BIG_RADIX_FLOATING_POINT_H_
 #define FORTRAN_DECIMAL_BIG_RADIX_FLOATING_POINT_H_

--- a/lib/decimal/binary-floating-point.h
+++ b/lib/decimal/binary-floating-point.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_DECIMAL_BINARY_FLOATING_POINT_H_
 #define FORTRAN_DECIMAL_BINARY_FLOATING_POINT_H_

--- a/lib/decimal/binary-to-decimal.cc
+++ b/lib/decimal/binary-to-decimal.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "big-radix-floating-point.h"
 #include "../decimal/decimal.h"

--- a/lib/decimal/decimal-to-binary.cc
+++ b/lib/decimal/decimal-to-binary.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "big-radix-floating-point.h"
 #include "binary-floating-point.h"

--- a/lib/decimal/decimal.h
+++ b/lib/decimal/decimal.h
@@ -4,7 +4,7 @@
  * See https://llvm.org/LICENSE.txt for license information.
  * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
  *
- * -----------------------------------------------------------------------------
+ * ===-----------------------------------------------------------------------===
  */
 
 /* C and C++ API for binary-to/from-decimal conversion package. */

--- a/lib/evaluate/CMakeLists.txt
+++ b/lib/evaluate/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#------------------------------------------------------------------------------#
+#===------------------------------------------------------------------------===#
 
 add_library(FortranEvaluate
   call.cc

--- a/lib/evaluate/call.cc
+++ b/lib/evaluate/call.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "call.h"
 #include "characteristics.h"

--- a/lib/evaluate/call.h
+++ b/lib/evaluate/call.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_CALL_H_
 #define FORTRAN_EVALUATE_CALL_H_

--- a/lib/evaluate/character.h
+++ b/lib/evaluate/character.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_CHARACTER_H_
 #define FORTRAN_EVALUATE_CHARACTER_H_

--- a/lib/evaluate/characteristics.cc
+++ b/lib/evaluate/characteristics.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "characteristics.h"
 #include "check-expression.h"

--- a/lib/evaluate/characteristics.h
+++ b/lib/evaluate/characteristics.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Defines data structures to represent "characteristics" of Fortran
 // procedures and other entities as they are specified in section 15.3

--- a/lib/evaluate/check-expression.cc
+++ b/lib/evaluate/check-expression.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "check-expression.h"
 #include "traverse.h"

--- a/lib/evaluate/check-expression.h
+++ b/lib/evaluate/check-expression.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Static expression checking
 

--- a/lib/evaluate/common.cc
+++ b/lib/evaluate/common.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "common.h"
 #include "../common/idioms.h"

--- a/lib/evaluate/common.h
+++ b/lib/evaluate/common.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_COMMON_H_
 #define FORTRAN_EVALUATE_COMMON_H_

--- a/lib/evaluate/complex.cc
+++ b/lib/evaluate/complex.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "complex.h"
 

--- a/lib/evaluate/complex.h
+++ b/lib/evaluate/complex.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_COMPLEX_H_
 #define FORTRAN_EVALUATE_COMPLEX_H_

--- a/lib/evaluate/constant.cc
+++ b/lib/evaluate/constant.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "constant.h"
 #include "expression.h"

--- a/lib/evaluate/constant.h
+++ b/lib/evaluate/constant.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_CONSTANT_H_
 #define FORTRAN_EVALUATE_CONSTANT_H_

--- a/lib/evaluate/expression.cc
+++ b/lib/evaluate/expression.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "expression.h"
 #include "common.h"

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_EXPRESSION_H_
 #define FORTRAN_EVALUATE_EXPRESSION_H_

--- a/lib/evaluate/fold-character.cc
+++ b/lib/evaluate/fold-character.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "fold-implementation.h"
 

--- a/lib/evaluate/fold-complex.cc
+++ b/lib/evaluate/fold-complex.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "fold-implementation.h"
 

--- a/lib/evaluate/fold-implementation.h
+++ b/lib/evaluate/fold-implementation.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_FOLD_IMPLEMENTATION_H_
 #define FORTRAN_EVALUATE_FOLD_IMPLEMENTATION_H_

--- a/lib/evaluate/fold-integer.cc
+++ b/lib/evaluate/fold-integer.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "fold-implementation.h"
 

--- a/lib/evaluate/fold-logical.cc
+++ b/lib/evaluate/fold-logical.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "check-expression.h"
 #include "fold-implementation.h"

--- a/lib/evaluate/fold-real.cc
+++ b/lib/evaluate/fold-real.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "fold-implementation.h"
 

--- a/lib/evaluate/fold.cc
+++ b/lib/evaluate/fold.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "fold.h"
 #include "fold-implementation.h"

--- a/lib/evaluate/fold.h
+++ b/lib/evaluate/fold.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_FOLD_H_
 #define FORTRAN_EVALUATE_FOLD_H_

--- a/lib/evaluate/formatting.cc
+++ b/lib/evaluate/formatting.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "formatting.h"
 #include "call.h"

--- a/lib/evaluate/formatting.h
+++ b/lib/evaluate/formatting.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_FORMATTING_H_
 #define FORTRAN_EVALUATE_FORMATTING_H_

--- a/lib/evaluate/host.cc
+++ b/lib/evaluate/host.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "host.h"
 

--- a/lib/evaluate/host.h
+++ b/lib/evaluate/host.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_HOST_H_
 #define FORTRAN_EVALUATE_HOST_H_

--- a/lib/evaluate/int-power.h
+++ b/lib/evaluate/int-power.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_INT_POWER_H_
 #define FORTRAN_EVALUATE_INT_POWER_H_

--- a/lib/evaluate/integer.cc
+++ b/lib/evaluate/integer.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "integer.h"
 

--- a/lib/evaluate/integer.h
+++ b/lib/evaluate/integer.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_INTEGER_H_
 #define FORTRAN_EVALUATE_INTEGER_H_

--- a/lib/evaluate/intrinsics-library-templates.h
+++ b/lib/evaluate/intrinsics-library-templates.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_INTRINSICS_LIBRARY_TEMPLATES_H_
 #define FORTRAN_EVALUATE_INTRINSICS_LIBRARY_TEMPLATES_H_

--- a/lib/evaluate/intrinsics-library.cc
+++ b/lib/evaluate/intrinsics-library.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // This file defines host runtime functions that can be used for folding
 // intrinsic functions.

--- a/lib/evaluate/intrinsics-library.h
+++ b/lib/evaluate/intrinsics-library.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_INTRINSICS_LIBRARY_H_
 #define FORTRAN_EVALUATE_INTRINSICS_LIBRARY_H_

--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "intrinsics.h"
 #include "common.h"

--- a/lib/evaluate/intrinsics.h
+++ b/lib/evaluate/intrinsics.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_INTRINSICS_H_
 #define FORTRAN_EVALUATE_INTRINSICS_H_

--- a/lib/evaluate/logical.cc
+++ b/lib/evaluate/logical.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "logical.h"
 

--- a/lib/evaluate/logical.h
+++ b/lib/evaluate/logical.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_LOGICAL_H_
 #define FORTRAN_EVALUATE_LOGICAL_H_

--- a/lib/evaluate/real.cc
+++ b/lib/evaluate/real.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "real.h"
 #include "int-power.h"

--- a/lib/evaluate/real.h
+++ b/lib/evaluate/real.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_REAL_H_
 #define FORTRAN_EVALUATE_REAL_H_

--- a/lib/evaluate/rounding-bits.h
+++ b/lib/evaluate/rounding-bits.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_ROUNDING_BITS_H_
 #define FORTRAN_EVALUATE_ROUNDING_BITS_H_

--- a/lib/evaluate/shape.cc
+++ b/lib/evaluate/shape.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "shape.h"
 #include "characteristics.h"

--- a/lib/evaluate/shape.h
+++ b/lib/evaluate/shape.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // GetShape() analyzes an expression and determines its shape, if possible,
 // representing the result as a vector of scalar integer expressions.

--- a/lib/evaluate/static-data.cc
+++ b/lib/evaluate/static-data.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "static-data.h"
 #include "../parser/characters.h"

--- a/lib/evaluate/static-data.h
+++ b/lib/evaluate/static-data.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_STATIC_DATA_H_
 #define FORTRAN_EVALUATE_STATIC_DATA_H_

--- a/lib/evaluate/tools.cc
+++ b/lib/evaluate/tools.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "tools.h"
 #include "characteristics.h"

--- a/lib/evaluate/tools.h
+++ b/lib/evaluate/tools.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_TOOLS_H_
 #define FORTRAN_EVALUATE_TOOLS_H_

--- a/lib/evaluate/traverse.h
+++ b/lib/evaluate/traverse.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_TRAVERSE_H_
 #define FORTRAN_EVALUATE_TRAVERSE_H_

--- a/lib/evaluate/type.cc
+++ b/lib/evaluate/type.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "type.h"
 #include "expression.h"

--- a/lib/evaluate/type.h
+++ b/lib/evaluate/type.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_TYPE_H_
 #define FORTRAN_EVALUATE_TYPE_H_

--- a/lib/evaluate/variable.cc
+++ b/lib/evaluate/variable.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "variable.h"
 #include "fold.h"

--- a/lib/evaluate/variable.h
+++ b/lib/evaluate/variable.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_EVALUATE_VARIABLE_H_
 #define FORTRAN_EVALUATE_VARIABLE_H_

--- a/lib/parser/CMakeLists.txt
+++ b/lib/parser/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#------------------------------------------------------------------------------#
+#===------------------------------------------------------------------------===#
 
 add_library(FortranParser
   Fortran-parsers.cc

--- a/lib/parser/Fortran-parsers.cc
+++ b/lib/parser/Fortran-parsers.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Top-level grammar specification for Fortran.  These parsers drive
 // the tokenization parsers in cooked-tokens.h to consume characters,

--- a/lib/parser/basic-parsers.h
+++ b/lib/parser/basic-parsers.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_BASIC_PARSERS_H_
 #define FORTRAN_PARSER_BASIC_PARSERS_H_

--- a/lib/parser/char-block.h
+++ b/lib/parser/char-block.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_CHAR_BLOCK_H_
 #define FORTRAN_PARSER_CHAR_BLOCK_H_

--- a/lib/parser/char-buffer.cc
+++ b/lib/parser/char-buffer.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "char-buffer.h"
 #include "../common/idioms.h"

--- a/lib/parser/char-buffer.h
+++ b/lib/parser/char-buffer.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_CHAR_BUFFER_H_
 #define FORTRAN_PARSER_CHAR_BUFFER_H_

--- a/lib/parser/char-set.cc
+++ b/lib/parser/char-set.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "char-set.h"
 

--- a/lib/parser/char-set.h
+++ b/lib/parser/char-set.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_CHAR_SET_H_
 #define FORTRAN_PARSER_CHAR_SET_H_

--- a/lib/parser/characters.cc
+++ b/lib/parser/characters.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "characters.h"
 #include "../common/idioms.h"

--- a/lib/parser/characters.h
+++ b/lib/parser/characters.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_CHARACTERS_H_
 #define FORTRAN_PARSER_CHARACTERS_H_

--- a/lib/parser/debug-parser.cc
+++ b/lib/parser/debug-parser.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "debug-parser.h"
 #include "user-state.h"

--- a/lib/parser/debug-parser.h
+++ b/lib/parser/debug-parser.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_DEBUG_PARSER_H_
 #define FORTRAN_PARSER_DEBUG_PARSER_H_

--- a/lib/parser/dump-parse-tree.h
+++ b/lib/parser/dump-parse-tree.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_DUMP_PARSE_TREE_H_
 #define FORTRAN_PARSER_DUMP_PARSE_TREE_H_

--- a/lib/parser/executable-parsers.cc
+++ b/lib/parser/executable-parsers.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Per-type parsers for executable statements
 

--- a/lib/parser/expr-parsers.cc
+++ b/lib/parser/expr-parsers.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Per-type parsers for expressions.
 

--- a/lib/parser/expr-parsers.h
+++ b/lib/parser/expr-parsers.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_EXPR_PARSERS_H_
 #define FORTRAN_PARSER_EXPR_PARSERS_H_

--- a/lib/parser/format-specification.h
+++ b/lib/parser/format-specification.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_FORMAT_SPECIFICATION_H_
 #define FORTRAN_PARSER_FORMAT_SPECIFICATION_H_

--- a/lib/parser/instrumented-parser.cc
+++ b/lib/parser/instrumented-parser.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "instrumented-parser.h"
 #include "message.h"

--- a/lib/parser/instrumented-parser.h
+++ b/lib/parser/instrumented-parser.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_INSTRUMENTED_PARSER_H_
 #define FORTRAN_PARSER_INSTRUMENTED_PARSER_H_

--- a/lib/parser/io-parsers.cc
+++ b/lib/parser/io-parsers.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Per-type parsers for I/O statements and FORMAT
 

--- a/lib/parser/message.cc
+++ b/lib/parser/message.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "message.h"
 #include "char-set.h"

--- a/lib/parser/message.h
+++ b/lib/parser/message.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_MESSAGE_H_
 #define FORTRAN_PARSER_MESSAGE_H_

--- a/lib/parser/misc-parsers.h
+++ b/lib/parser/misc-parsers.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Parser templates and constexpr parsers shared by multiple
 // per-type parser implementation source files.

--- a/lib/parser/openmp-parsers.cc
+++ b/lib/parser/openmp-parsers.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Top-level grammar specification for OpenMP.
 // See OpenMP-4.5-grammar.txt for documentation.

--- a/lib/parser/parse-state.h
+++ b/lib/parser/parse-state.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_PARSE_STATE_H_
 #define FORTRAN_PARSER_PARSE_STATE_H_

--- a/lib/parser/parse-tree-visitor.h
+++ b/lib/parser/parse-tree-visitor.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_PARSE_TREE_VISITOR_H_
 #define FORTRAN_PARSER_PARSE_TREE_VISITOR_H_

--- a/lib/parser/parse-tree.cc
+++ b/lib/parser/parse-tree.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "parse-tree.h"
 #include "user-state.h"

--- a/lib/parser/parse-tree.h
+++ b/lib/parser/parse-tree.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_PARSE_TREE_H_
 #define FORTRAN_PARSER_PARSE_TREE_H_

--- a/lib/parser/parsing.cc
+++ b/lib/parser/parsing.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "parsing.h"
 #include "message.h"

--- a/lib/parser/parsing.h
+++ b/lib/parser/parsing.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_PARSING_H_
 #define FORTRAN_PARSER_PARSING_H_

--- a/lib/parser/preprocessor.cc
+++ b/lib/parser/preprocessor.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "preprocessor.h"
 #include "characters.h"

--- a/lib/parser/preprocessor.h
+++ b/lib/parser/preprocessor.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_PREPROCESSOR_H_
 #define FORTRAN_PARSER_PREPROCESSOR_H_

--- a/lib/parser/prescan.cc
+++ b/lib/parser/prescan.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "prescan.h"
 #include "characters.h"

--- a/lib/parser/prescan.h
+++ b/lib/parser/prescan.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_PRESCAN_H_
 #define FORTRAN_PARSER_PRESCAN_H_

--- a/lib/parser/program-parsers.cc
+++ b/lib/parser/program-parsers.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Per-type parsers for program units
 

--- a/lib/parser/provenance.cc
+++ b/lib/parser/provenance.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "provenance.h"
 #include "../common/idioms.h"

--- a/lib/parser/provenance.h
+++ b/lib/parser/provenance.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_PROVENANCE_H_
 #define FORTRAN_PARSER_PROVENANCE_H_

--- a/lib/parser/source.cc
+++ b/lib/parser/source.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "source.h"
 #include "char-buffer.h"

--- a/lib/parser/source.h
+++ b/lib/parser/source.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_SOURCE_H_
 #define FORTRAN_PARSER_SOURCE_H_

--- a/lib/parser/stmt-parser.h
+++ b/lib/parser/stmt-parser.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_STMT_PARSER_H_
 #define FORTRAN_PARSER_STMT_PARSER_H_

--- a/lib/parser/token-parsers.h
+++ b/lib/parser/token-parsers.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_TOKEN_PARSERS_H_
 #define FORTRAN_PARSER_TOKEN_PARSERS_H_

--- a/lib/parser/token-sequence.cc
+++ b/lib/parser/token-sequence.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "token-sequence.h"
 #include "characters.h"

--- a/lib/parser/token-sequence.h
+++ b/lib/parser/token-sequence.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_TOKEN_SEQUENCE_H_
 #define FORTRAN_PARSER_TOKEN_SEQUENCE_H_

--- a/lib/parser/tools.cc
+++ b/lib/parser/tools.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "tools.h"
 

--- a/lib/parser/tools.h
+++ b/lib/parser/tools.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_TOOLS_H_
 #define FORTRAN_PARSER_TOOLS_H_

--- a/lib/parser/type-parser-implementation.h
+++ b/lib/parser/type-parser-implementation.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Macros for implementing per-type parsers
 

--- a/lib/parser/type-parsers.h
+++ b/lib/parser/type-parsers.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_TYPE_PARSERS_H_
 #define FORTRAN_PARSER_TYPE_PARSERS_H_

--- a/lib/parser/unparse.cc
+++ b/lib/parser/unparse.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Generates Fortran from the content of a parse tree, using the
 // traversal templates in parse-tree-visitor.h.

--- a/lib/parser/unparse.h
+++ b/lib/parser/unparse.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_UNPARSE_H_
 #define FORTRAN_PARSER_UNPARSE_H_

--- a/lib/parser/user-state.cc
+++ b/lib/parser/user-state.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "user-state.h"
 #include "parse-state.h"

--- a/lib/parser/user-state.h
+++ b/lib/parser/user-state.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_PARSER_USER_STATE_H_
 #define FORTRAN_PARSER_USER_STATE_H_

--- a/lib/semantics/CMakeLists.txt
+++ b/lib/semantics/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#------------------------------------------------------------------------------#
+#===------------------------------------------------------------------------===#
 
 add_library(FortranSemantics
   assignment.cc

--- a/lib/semantics/assignment.cc
+++ b/lib/semantics/assignment.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "assignment.h"
 #include "expression.h"

--- a/lib/semantics/assignment.h
+++ b/lib/semantics/assignment.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_ASSIGNMENT_H_
 #define FORTRAN_SEMANTICS_ASSIGNMENT_H_

--- a/lib/semantics/attr.cc
+++ b/lib/semantics/attr.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "attr.h"
 #include "../common/idioms.h"

--- a/lib/semantics/attr.h
+++ b/lib/semantics/attr.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_ATTR_H_
 #define FORTRAN_SEMANTICS_ATTR_H_

--- a/lib/semantics/canonicalize-do.cc
+++ b/lib/semantics/canonicalize-do.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "canonicalize-do.h"
 #include "../parser/parse-tree-visitor.h"

--- a/lib/semantics/canonicalize-do.h
+++ b/lib/semantics/canonicalize-do.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_CANONICALIZE_DO_H_
 #define FORTRAN_SEMANTICS_CANONICALIZE_DO_H_

--- a/lib/semantics/canonicalize-omp.cc
+++ b/lib/semantics/canonicalize-omp.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "canonicalize-omp.h"
 #include "../parser/parse-tree-visitor.h"

--- a/lib/semantics/canonicalize-omp.h
+++ b/lib/semantics/canonicalize-omp.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_CANONICALIZE_OMP_H_
 #define FORTRAN_SEMANTICS_CANONICALIZE_OMP_H_

--- a/lib/semantics/check-allocate.cc
+++ b/lib/semantics/check-allocate.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "check-allocate.h"
 #include "assignment.h"

--- a/lib/semantics/check-allocate.h
+++ b/lib/semantics/check-allocate.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_CHECK_ALLOCATE_H_
 #define FORTRAN_SEMANTICS_CHECK_ALLOCATE_H_

--- a/lib/semantics/check-arithmeticif.cc
+++ b/lib/semantics/check-arithmeticif.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "check-arithmeticif.h"
 #include "tools.h"

--- a/lib/semantics/check-arithmeticif.h
+++ b/lib/semantics/check-arithmeticif.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_CHECK_ARITHMETICIF_STMT_H_
 #define FORTRAN_SEMANTICS_CHECK_ARITHMETICIF_STMT_H_

--- a/lib/semantics/check-call.cc
+++ b/lib/semantics/check-call.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "check-call.h"
 #include "assignment.h"

--- a/lib/semantics/check-call.h
+++ b/lib/semantics/check-call.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Constraint checking for procedure references
 

--- a/lib/semantics/check-coarray.cc
+++ b/lib/semantics/check-coarray.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "check-coarray.h"
 #include "expression.h"

--- a/lib/semantics/check-coarray.h
+++ b/lib/semantics/check-coarray.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_CHECK_COARRAY_H_
 #define FORTRAN_SEMANTICS_CHECK_COARRAY_H_

--- a/lib/semantics/check-deallocate.cc
+++ b/lib/semantics/check-deallocate.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "check-deallocate.h"
 #include "expression.h"

--- a/lib/semantics/check-deallocate.h
+++ b/lib/semantics/check-deallocate.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_CHECK_DEALLOCATE_H_
 #define FORTRAN_SEMANTICS_CHECK_DEALLOCATE_H_

--- a/lib/semantics/check-declarations.cc
+++ b/lib/semantics/check-declarations.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Static declaration checking
 

--- a/lib/semantics/check-declarations.h
+++ b/lib/semantics/check-declarations.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Static declaration checks
 

--- a/lib/semantics/check-do.cc
+++ b/lib/semantics/check-do.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "check-do.h"
 #include "attr.h"

--- a/lib/semantics/check-do.h
+++ b/lib/semantics/check-do.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_CHECK_DO_H_
 #define FORTRAN_SEMANTICS_CHECK_DO_H_

--- a/lib/semantics/check-if-stmt.cc
+++ b/lib/semantics/check-if-stmt.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "check-if-stmt.h"
 #include "tools.h"

--- a/lib/semantics/check-if-stmt.h
+++ b/lib/semantics/check-if-stmt.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_CHECK_IF_STMT_H_
 #define FORTRAN_SEMANTICS_CHECK_IF_STMT_H_

--- a/lib/semantics/check-io.cc
+++ b/lib/semantics/check-io.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "check-io.h"
 #include "expression.h"

--- a/lib/semantics/check-io.h
+++ b/lib/semantics/check-io.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_CHECK_IO_H_
 #define FORTRAN_SEMANTICS_CHECK_IO_H_

--- a/lib/semantics/check-nullify.cc
+++ b/lib/semantics/check-nullify.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "check-nullify.h"
 #include "assignment.h"

--- a/lib/semantics/check-nullify.h
+++ b/lib/semantics/check-nullify.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_CHECK_NULLIFY_H_
 #define FORTRAN_SEMANTICS_CHECK_NULLIFY_H_

--- a/lib/semantics/check-omp-structure.cc
+++ b/lib/semantics/check-omp-structure.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "check-omp-structure.h"
 #include "tools.h"

--- a/lib/semantics/check-omp-structure.h
+++ b/lib/semantics/check-omp-structure.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // OpenMP structure validity check list
 //    1. invalid clauses on directive

--- a/lib/semantics/check-purity.cc
+++ b/lib/semantics/check-purity.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "check-purity.h"
 #include "tools.h"

--- a/lib/semantics/check-purity.h
+++ b/lib/semantics/check-purity.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_CHECK_PURITY_H_
 #define FORTRAN_SEMANTICS_CHECK_PURITY_H_

--- a/lib/semantics/check-return.cc
+++ b/lib/semantics/check-return.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "check-return.h"
 #include "semantics.h"

--- a/lib/semantics/check-return.h
+++ b/lib/semantics/check-return.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_CHECK_RETURN_H_
 #define FORTRAN_SEMANTICS_CHECK_RETURN_H_

--- a/lib/semantics/check-stop.cc
+++ b/lib/semantics/check-stop.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "check-stop.h"
 #include "semantics.h"

--- a/lib/semantics/check-stop.h
+++ b/lib/semantics/check-stop.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_CHECK_STOP_H_
 #define FORTRAN_SEMANTICS_CHECK_STOP_H_

--- a/lib/semantics/expression.cc
+++ b/lib/semantics/expression.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "expression.h"
 #include "assignment.h"

--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_EXPRESSION_H_
 #define FORTRAN_SEMANTICS_EXPRESSION_H_

--- a/lib/semantics/mod-file.cc
+++ b/lib/semantics/mod-file.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "mod-file.h"
 #include "resolve-names.h"

--- a/lib/semantics/mod-file.h
+++ b/lib/semantics/mod-file.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_MOD_FILE_H_
 #define FORTRAN_SEMANTICS_MOD_FILE_H_

--- a/lib/semantics/program-tree.cc
+++ b/lib/semantics/program-tree.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "program-tree.h"
 #include "scope.h"

--- a/lib/semantics/program-tree.h
+++ b/lib/semantics/program-tree.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_PROGRAM_TREE_H_
 #define FORTRAN_SEMANTICS_PROGRAM_TREE_H_

--- a/lib/semantics/resolve-labels.cc
+++ b/lib/semantics/resolve-labels.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "resolve-labels.h"
 #include "semantics.h"

--- a/lib/semantics/resolve-labels.h
+++ b/lib/semantics/resolve-labels.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_RESOLVE_LABELS_H_
 #define FORTRAN_SEMANTICS_RESOLVE_LABELS_H_

--- a/lib/semantics/resolve-names-utils.cc
+++ b/lib/semantics/resolve-names-utils.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "resolve-names-utils.h"
 #include "expression.h"

--- a/lib/semantics/resolve-names-utils.h
+++ b/lib/semantics/resolve-names-utils.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_RESOLVE_NAMES_UTILS_H_
 #define FORTRAN_SEMANTICS_RESOLVE_NAMES_UTILS_H_

--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "resolve-names.h"
 #include "assignment.h"

--- a/lib/semantics/resolve-names.h
+++ b/lib/semantics/resolve-names.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_RESOLVE_NAMES_H_
 #define FORTRAN_SEMANTICS_RESOLVE_NAMES_H_

--- a/lib/semantics/rewrite-parse-tree.cc
+++ b/lib/semantics/rewrite-parse-tree.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "rewrite-parse-tree.h"
 #include "scope.h"

--- a/lib/semantics/rewrite-parse-tree.h
+++ b/lib/semantics/rewrite-parse-tree.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_REWRITE_PARSE_TREE_H_
 #define FORTRAN_SEMANTICS_REWRITE_PARSE_TREE_H_

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "scope.h"
 #include "symbol.h"

--- a/lib/semantics/scope.h
+++ b/lib/semantics/scope.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_SCOPE_H_
 #define FORTRAN_SEMANTICS_SCOPE_H_

--- a/lib/semantics/semantics.cc
+++ b/lib/semantics/semantics.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "semantics.h"
 #include "assignment.h"

--- a/lib/semantics/semantics.h
+++ b/lib/semantics/semantics.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_SEMANTICS_H_
 #define FORTRAN_SEMANTICS_SEMANTICS_H_

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "symbol.h"
 #include "scope.h"

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_SYMBOL_H_
 #define FORTRAN_SEMANTICS_SYMBOL_H_

--- a/lib/semantics/tools.cc
+++ b/lib/semantics/tools.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "tools.h"
 #include "scope.h"

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_TOOLS_H_
 #define FORTRAN_SEMANTICS_TOOLS_H_

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "type.h"
 #include "scope.h"

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_TYPE_H_
 #define FORTRAN_SEMANTICS_TYPE_H_

--- a/lib/semantics/unparse-with-symbols.cc
+++ b/lib/semantics/unparse-with-symbols.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "unparse-with-symbols.h"
 #include "symbol.h"

--- a/lib/semantics/unparse-with-symbols.h
+++ b/lib/semantics/unparse-with-symbols.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_SEMANTICS_UNPARSE_WITH_SYMBOLS_H_
 #define FORTRAN_SEMANTICS_UNPARSE_WITH_SYMBOLS_H_

--- a/module/__fortran_builtins.f90
+++ b/module/__fortran_builtins.f90
@@ -4,7 +4,7 @@
 ! See https://llvm.org/LICENSE.txt for license information.
 ! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 !
-!------------------------------------------------------------------------------!
+!===------------------------------------------------------------------------===!
 
 ! These naming shenanigans prevent names from Fortran intrinsic modules
 ! from being usable on INTRINSIC statements, and force the program

--- a/module/ieee_arithmetic.f90
+++ b/module/ieee_arithmetic.f90
@@ -4,7 +4,7 @@
 ! See https://llvm.org/LICENSE.txt for license information.
 ! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 !
-!------------------------------------------------------------------------------!
+!===------------------------------------------------------------------------===!
 
 ! See Fortran 2018, clause 17.2
 module ieee_arithmetic

--- a/module/ieee_exceptions.f90
+++ b/module/ieee_exceptions.f90
@@ -4,7 +4,7 @@
 ! See https://llvm.org/LICENSE.txt for license information.
 ! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 !
-!------------------------------------------------------------------------------!
+!===------------------------------------------------------------------------===!
 
 ! See Fortran 2018, clause 17
 module ieee_exceptions

--- a/module/ieee_features.f90
+++ b/module/ieee_features.f90
@@ -4,7 +4,7 @@
 ! See https://llvm.org/LICENSE.txt for license information.
 ! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 !
-!------------------------------------------------------------------------------!
+!===------------------------------------------------------------------------===!
 
 ! See Fortran 2018, clause 17.2
 

--- a/module/iso_c_binding.f90
+++ b/module/iso_c_binding.f90
@@ -4,7 +4,7 @@
 ! See https://llvm.org/LICENSE.txt for license information.
 ! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 !
-!------------------------------------------------------------------------------!
+!===------------------------------------------------------------------------===!
 
 ! See Fortran 2018, clause 18.2
 

--- a/module/iso_fortran_env.f90
+++ b/module/iso_fortran_env.f90
@@ -4,7 +4,7 @@
 ! See https://llvm.org/LICENSE.txt for license information.
 ! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 !
-!------------------------------------------------------------------------------!
+!===------------------------------------------------------------------------===!
 
 ! See Fortran 2018, clause 16.10.2
 ! TODO: These are placeholder values so that some tests can be run.

--- a/module/omp_lib.f90
+++ b/module/omp_lib.f90
@@ -4,7 +4,7 @@
 ! See https://llvm.org/LICENSE.txt for license information.
 ! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 !
-!------------------------------------------------------------------------------!
+!===------------------------------------------------------------------------===!
 
 module omp_lib
 

--- a/module/omp_lib.h
+++ b/module/omp_lib.h
@@ -4,7 +4,7 @@
 ! See https://llvm.org/LICENSE.txt for license information.
 ! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 !
-!------------------------------------------------------------------------------!
+!===------------------------------------------------------------------------===!
 
 !dir$ free
 

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#------------------------------------------------------------------------------#
+#===------------------------------------------------------------------------===#
 
 add_library(FortranRuntime
   ISO_Fortran_binding.cc

--- a/runtime/ISO_Fortran_binding.cc
+++ b/runtime/ISO_Fortran_binding.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Implements the required interoperability API from ISO_Fortran_binding.h
 // as specified in section 18.5.5 of Fortran 2018.

--- a/runtime/c-or-cpp.h
+++ b/runtime/c-or-cpp.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_RUNTIME_C_OR_CPP_H_
 #define FORTRAN_RUNTIME_C_OR_CPP_H_

--- a/runtime/derived-type.cc
+++ b/runtime/derived-type.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "derived-type.h"
 #include "descriptor.h"

--- a/runtime/derived-type.h
+++ b/runtime/derived-type.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_RUNTIME_DERIVED_TYPE_H_
 #define FORTRAN_RUNTIME_DERIVED_TYPE_H_

--- a/runtime/descriptor.cc
+++ b/runtime/descriptor.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "descriptor.h"
 #include "../lib/common/idioms.h"

--- a/runtime/descriptor.h
+++ b/runtime/descriptor.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_RUNTIME_DESCRIPTOR_H_
 #define FORTRAN_RUNTIME_DESCRIPTOR_H_

--- a/runtime/entry-names.h
+++ b/runtime/entry-names.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Defines the macro RTNAME(n) which decorates the external name of a runtime
 // library function or object with extra characters so that it

--- a/runtime/io-api.h
+++ b/runtime/io-api.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Defines API between compiled code and I/O runtime library.
 

--- a/runtime/main.cc
+++ b/runtime/main.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "main.h"
 #include "terminator.h"

--- a/runtime/main.h
+++ b/runtime/main.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_RUNTIME_MAIN_H_
 #define FORTRAN_RUNTIME_MAIN_H_

--- a/runtime/stop.cc
+++ b/runtime/stop.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "stop.h"
 #include "terminator.h"

--- a/runtime/stop.h
+++ b/runtime/stop.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_RUNTIME_STOP_H_
 #define FORTRAN_RUNTIME_STOP_H_

--- a/runtime/terminator.cc
+++ b/runtime/terminator.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "terminator.h"
 #include <cstdio>

--- a/runtime/terminator.h
+++ b/runtime/terminator.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Termination of the image
 

--- a/runtime/transformational.cc
+++ b/runtime/transformational.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "transformational.h"
 #include "../lib/common/idioms.h"

--- a/runtime/transformational.h
+++ b/runtime/transformational.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_RUNTIME_TRANSFORMATIONAL_H_
 #define FORTRAN_RUNTIME_TRANSFORMATIONAL_H_

--- a/runtime/type-code.cc
+++ b/runtime/type-code.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #include "type-code.h"
 

--- a/runtime/type-code.h
+++ b/runtime/type-code.h
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 #ifndef FORTRAN_RUNTIME_TYPE_CODE_H_
 #define FORTRAN_RUNTIME_TYPE_CODE_H_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#------------------------------------------------------------------------------#
+#===------------------------------------------------------------------------===#
 
 add_subdirectory(decimal)
 add_subdirectory(evaluate)

--- a/test/decimal/CMakeLists.txt
+++ b/test/decimal/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#------------------------------------------------------------------------------#
+#===------------------------------------------------------------------------===#
 
 add_executable(quick-sanity-test
   quick-sanity-test.cc

--- a/test/evaluate/CMakeLists.txt
+++ b/test/evaluate/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#------------------------------------------------------------------------------#
+#===------------------------------------------------------------------------===#
 
 add_library(FortranEvaluateTesting
   testing.cc

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#------------------------------------------------------------------------------#
+#===------------------------------------------------------------------------===#
 
 # Run tests with test_errors.sh. It compiles the test with f18 and compares
 # actual errors produced with expected ones listed in the source.

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#------------------------------------------------------------------------------#
+#===------------------------------------------------------------------------===#
 
 
 add_subdirectory(f18)

--- a/tools/f18/CMakeLists.txt
+++ b/tools/f18/CMakeLists.txt
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#------------------------------------------------------------------------------#
+#===------------------------------------------------------------------------===#
 
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bin")
 file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include")

--- a/tools/f18/dump.cc
+++ b/tools/f18/dump.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // This file defines Dump routines available for calling from the debugger.
 // Each is based on operator<< for that type. There are overloadings for

--- a/tools/f18/f18-parse-demo.cc
+++ b/tools/f18/f18-parse-demo.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // F18 parsing demonstration.
 //   f18-parse-demo [ -E | -fdump-parse-tree | -funparse-only ]

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // Temporary Fortran front end driver main program for development scaffolding.
 

--- a/tools/f18/flang.sh
+++ b/tools/f18/flang.sh
@@ -5,7 +5,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-#------------------------------------------------------------------------------#
+#===------------------------------------------------------------------------===#
 
 function abspath() {
   pushd . > /dev/null;

--- a/tools/f18/stub-evaluate.cc
+++ b/tools/f18/stub-evaluate.cc
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//----------------------------------------------------------------------------//
+//===----------------------------------------------------------------------===//
 
 // The parse tree has slots in which pointers to the results of semantic
 // analysis may be placed.  When using the parser without the semantics


### PR DESCRIPTION
Replace comment lines containing all dashes with the
proper ===-----....----=== markers.