### PR TITLE
Detect incorrect use of assumed-type dummy arguments

### DIFF
--- a/lib/semantics/expression.h
+++ b/lib/semantics/expression.h
@@ -348,10 +348,6 @@ private:
 
   std::optional<CalleeAndArguments> AnalyzeProcedureComponentRef(
       const parser::ProcComponentRef &, ActualArguments &&);
-  std::optional<ActualArgument> AnalyzeActualArgument(const parser::Expr &);
-
-  std::optional<ActualArguments> AnalyzeArguments(
-      const parser::Call &, bool isSubroutine);
   std::optional<characteristics::Procedure> CheckCall(
       parser::CharBlock, const ProcedureDesignator &, ActualArguments &);
   using AdjustActuals =

--- a/test/semantics/call13.f90
+++ b/test/semantics/call13.f90
@@ -31,5 +31,12 @@ subroutine s(assumedRank, coarray, class, classStar, typeStar)
   call implicit15(classStar)  ! 15.4.2.2(3)(f)
   !ERROR: Assumed type argument requires an explicit interface
   call implicit16(typeStar)  ! 15.4.2.2(3)(f)
+  !ERROR: TYPE(*) dummy argument may only be used as an actual argument
+  if (typeStar) then
+  endif
+  !ERROR: TYPE(*) dummy argument may only be used as an actual argument
+  classStar = typeStar  ! C710
+  !ERROR: TYPE(*) dummy argument may only be used as an actual argument
+  typeStar = classStar  ! C710
 end subroutine
 


### PR DESCRIPTION
Assumed-type dummy arguments can only be used as actual arguments. If
they are used in other contexts it is an error. Change argument analysis
to handle these differently depending on the context. `allowAssumedType`
is set when the argument can be assumed-type. These expressions now all
get `typedExpr` set to `nullopt`.

Change `AnalyzeSectionSubscripts` to analyze all of the subscripts
even if one has an error. This ensures they all get analyzed expressions
(or `nullopt` in case of error).

Fix a bug analyzing `BoundsRemapping`: the lower bound was analyzed
twice and the upper bound not at all.

These change mean that `typedExpr` is set in all known cases.
Fixes #915.