### PR TITLE
RFC: example implementation of combined constructs

### DIFF
--- a/test/semantics/omp-device-constructs.f90
+++ b/test/semantics/omp-device-constructs.f90
@@ -97,6 +97,12 @@ program main
   enddo
   !$omp end teams
 
+  !$omp target teams num_teams(2) defaultmap(tofrom:scalar)
+  do i = 1, N
+      a = 3.14
+  enddo
+  !$omp end target teams
+
   !$omp target map(tofrom:a)
   do i = 1, N
      a = 3.14


### PR DESCRIPTION
This is a possible way of implementing combined constructs without repetition, by outlining the set of accepted clauses for each construct as a static constexpr variable that can be reused.
If other people think this is an acceptable way to move forward then I will implement all the constructs this way and push that as one PR with comments explaining what this does, so don't merge this PR.

PS. ignore the char-block changes, those are in a separate PR but I need them to be able to build on my system.