### PR TITLE
Fix bug #931: spurious error reported on CSHIFT

### DIFF
--- a/lib/evaluate/intrinsics.cc
+++ b/lib/evaluate/intrinsics.cc
@@ -1246,11 +1246,7 @@ std::optional<SpecificCall> IntrinsicInterface::Match(
         break;
       case Rank::dimRemoved:
         CHECK(arrayArg);
-        if (hasDimArg) {
-          argOk = rank == 0 || rank + 1 == arrayArg->Rank();
-        } else {
-          argOk = rank == 0;
-        }
+        argOk = rank == 0 || rank + 1 == arrayArg->Rank();
         break;
       case Rank::reduceOperation:
         // TODO: Confirm that the argument is a pure function


### PR DESCRIPTION
The `SHIFT` argument to the `CSHIFT` intrinsic function (and some related arguments to other intrinsics) is allowed to be an array in the absence of the optional `DIM=` argument; I was incorrectly emitting an error message in this case if it were not scalar.