### PR TITLE
Move checks for valid array-spec to check-declarations.cc

### DIFF
--- a/test/semantics/resolve58.f90
+++ b/test/semantics/resolve58.f90
@@ -48,3 +48,10 @@ function f()
   !ERROR: Array 'f' without ALLOCATABLE or POINTER attribute must have explicit shape
   real, dimension(:) :: f  ! C832
 end
+
+subroutine s5()
+  !ERROR: Allocatable array 'a' must have deferred shape or assumed rank
+  integer :: a(10), b(:)
+  allocatable :: a
+  allocatable :: b
+end subroutine

--- a/test/semantics/resolve61.f90
+++ b/test/semantics/resolve61.f90
@@ -44,8 +44,8 @@ program p7
 contains
   subroutine s(x, y)
     real :: x(*)  ! assumed size
-    real :: y(:)  ! assumed shape
     !ERROR: Cray pointee 'y' must have must have explicit shape or assumed size
+    real :: y(:)  ! assumed shape
     pointer(w, y)
   end
 end


### PR DESCRIPTION
At the time we finish processing an array-spec in `resolve-names.cc`,
we don't know if the entity is going to be declared ALLOCATABLE later
so we can't check for validity there. In the new test in `resolve58.f90`
(based on issue #930) we were reporting an error on `b` and not on `a`
when it should be the reverse.

The fix is to move array-spec checking to `check-declarations.cc`,
after name resolution is complete.

Fixes #930.