### PR TITLE
Check bounds on pointer assignment

### DIFF
--- a/lib/evaluate/characteristics.cc
+++ b/lib/evaluate/characteristics.cc
@@ -155,13 +155,10 @@ bool TypeAndShape::IsCompatibleWith(parser::ContextualMessages &messages,
     bool isElemental) const {
   const auto &len{that.LEN()};
   if (!type_.IsTypeCompatibleWith(that.type_)) {
-    std::stringstream lenstr;
-    if (len) {
-      len->AsFortran(lenstr);
-    }
     messages.Say(
         "%1$s type '%2$s' is not compatible with %3$s type '%4$s'"_err_en_US,
-        thatIs, that.type_.AsFortran(lenstr.str()), thisIs, type_.AsFortran());
+        thatIs, that.type_.AsFortran(len ? len->AsFortran() : ""), thisIs,
+        type_.AsFortran());
     return false;
   }
   return isElemental ||
@@ -213,11 +210,7 @@ void TypeAndShape::AcquireLEN() {
 }
 
 std::ostream &TypeAndShape::Dump(std::ostream &o) const {
-  std::stringstream LENstr;
-  if (LEN_) {
-    LEN_->AsFortran(LENstr);
-  }
-  o << type_.AsFortran(LENstr.str());
+  o << type_.AsFortran(LEN_ ? LEN_->AsFortran() : "");
   attrs_.Dump(o, EnumToString);
   if (!shape_.empty()) {
     o << " dimension(";

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -847,9 +847,10 @@ struct GenericExprWrapper {
 
 // Like GenericExprWrapper but for analyzed assignments
 struct GenericAssignmentWrapper {
+  GenericAssignmentWrapper() {}
   explicit GenericAssignmentWrapper(Assignment &&x) : v{std::move(x)} {}
   ~GenericAssignmentWrapper();
-  Assignment v;
+  std::optional<Assignment> v;  // vacant if error
 };
 
 FOR_EACH_CATEGORY_TYPE(extern template class Expr, )

--- a/lib/evaluate/expression.h
+++ b/lib/evaluate/expression.h
@@ -89,6 +89,7 @@ public:
 
   std::optional<DynamicType> GetType() const;
   int Rank() const;
+  std::string AsFortran() const;
   std::ostream &AsFortran(std::ostream &) const;
   static Derived Rewrite(FoldingContext &, Derived &&);
 };

--- a/lib/evaluate/fold-implementation.h
+++ b/lib/evaluate/fold-implementation.h
@@ -35,7 +35,6 @@
 #include <complex>
 #include <cstdio>
 #include <optional>
-#include <sstream>
 #include <type_traits>
 #include <variant>
 
@@ -185,18 +184,14 @@ std::optional<Expr<T>> Folder<T>::GetNamedConstantValue(const Symbol &symbol0) {
               }
               mutableObject->set_init(std::nullopt);
             } else {
-              std::stringstream ss;
-              unwrapped->AsFortran(ss);
               context_.messages().Say(symbol.name(),
                   "Initialization expression for PARAMETER '%s' (%s) cannot be computed as a constant value"_err_en_US,
-                  symbol.name(), ss.str());
+                  symbol.name(), unwrapped->AsFortran());
             }
           } else {
-            std::stringstream ss;
-            init->AsFortran(ss);
             context_.messages().Say(symbol.name(),
                 "Initialization expression for PARAMETER '%s' (%s) cannot be converted to its type (%s)"_err_en_US,
-                symbol.name(), ss.str(), dyType->AsFortran());
+                symbol.name(), init->AsFortran(), dyType->AsFortran());
           }
         }
       }

--- a/lib/semantics/assignment.cc
+++ b/lib/semantics/assignment.cc
@@ -158,66 +158,60 @@ void AssignmentContext::Analyze(const parser::AssignmentStmt &stmt) {
 }
 
 void AssignmentContext::Analyze(const parser::PointerAssignmentStmt &stmt) {
+  using PointerAssignment = evaluate::Assignment::PointerAssignment;
   CHECK(!where_);
-  if (const evaluate::Assignment * asst{GetAssignment(stmt)}) {
-    bool hasBounds{false};
-    auto [lhs, rhs]{std::visit(
-        common::visitors{
-            [&](const evaluate::Assignment::IntrinsicAssignment &x) {
-              return std::make_pair(&x.lhs, &x.rhs);
-            },
-            [&](const evaluate::ProcedureRef &x) {
-              return std::make_pair(x.arguments()[0]->UnwrapExpr(),
-                  x.arguments()[1]->UnwrapExpr());
-            },
-            [&](const evaluate::Assignment::PointerAssignment &x) {
-              std::visit(
-                  common::visitors{
-                      [&](const evaluate::Assignment::PointerAssignment::
-                              BoundsSpec &bounds) {
-                        hasBounds = !bounds.empty();
-                        for (const auto &bound : bounds) {
-                          CheckForImpureCall(SomeExpr{bound});
-                        }
-                      },
-                      [&](const evaluate::Assignment::PointerAssignment::
-                              BoundsRemapping &bounds) {
-                        hasBounds = !bounds.empty();
-                        for (const auto &bound : bounds) {
-                          CheckForImpureCall(SomeExpr{bound.first});
-                          CheckForImpureCall(SomeExpr{bound.second});
-                        }
-                      },
-                  },
-                  x.bounds);
-              return std::make_pair(&x.lhs, &x.rhs);
-            },
-        },
-        asst->u)};
-    CheckForImpureCall(lhs);
-    CheckForImpureCall(rhs);
-    if (forall_) {
-      // TODO: Warn if some name in forall_->activeNames or its outer
-      // contexts does not appear on LHS
-    }
-    if (lhs && rhs) {
-      CheckForPureContext(
-          *lhs, *rhs, std::get<parser::Expr>(stmt.t).source, true /* => */);
-      const Symbol *pointer{GetLastSymbol(lhs)};
-      if (pointer && pointer->has<ProcEntityDetails>() &&
-          evaluate::ExtractCoarrayRef(*lhs)) {
-        context_.Say(  // C1027
-            "Procedure pointer may not be a coindexed object"_err_en_US);
-      }
-      if (hasBounds) {
-        // TODO cases with bounds-spec and bounds-remapping
-      } else {
-        auto &foldingContext{context_.foldingContext()};
-        auto restorer{
-            foldingContext.messages().SetLocation(context_.location().value())};
-        CheckPointerAssignment(foldingContext, *pointer, *rhs);
-      }
-    }
+  const evaluate::Assignment *assign{GetAssignment(stmt)};
+  if (!assign) {
+    return;
+  }
+  const auto &ptrAssign{std::get<PointerAssignment>(assign->u)};
+  const SomeExpr &lhs{ptrAssign.lhs};
+  const SomeExpr &rhs{ptrAssign.rhs};
+  std::size_t numBounds{std::visit(
+      common::visitors{
+          [&](const PointerAssignment::BoundsSpec &bounds) {
+            for (const auto &bound : bounds) {
+              CheckForImpureCall(SomeExpr{bound});
+            }
+            return bounds.size();
+          },
+          [&](const PointerAssignment::BoundsRemapping &bounds) {
+            for (const auto &bound : bounds) {
+              CheckForImpureCall(SomeExpr{bound.first});
+              CheckForImpureCall(SomeExpr{bound.second});
+            }
+            return bounds.size();
+          },
+      },
+      ptrAssign.bounds)};
+  const Symbol *pointer{GetLastSymbol(lhs)};
+  if (!pointer) {
+    return;  // error was reported
+  }
+  auto &foldingContext{context_.foldingContext()};
+  auto restorer{
+      foldingContext.messages().SetLocation(context_.location().value())};
+  if (!IsPointer(*pointer)) {
+    evaluate::SayWithDeclaration(foldingContext.messages(), *pointer,
+        "'%s' is not a pointer"_err_en_US, pointer->name());
+    return;
+  }
+  CheckForImpureCall(lhs);
+  CheckForImpureCall(rhs);
+  if (forall_) {
+    // TODO: Warn if some name in forall_->activeNames or its outer
+    // contexts does not appear on LHS
+  }
+  CheckForPureContext(lhs, rhs, std::get<parser::Expr>(stmt.t).source,
+      true /* isPointerAssignment */);
+  if (pointer->has<ProcEntityDetails>() && evaluate::ExtractCoarrayRef(lhs)) {
+    context_.Say(  // C1027
+        "Procedure pointer may not be a coindexed object"_err_en_US);
+  }
+  if (numBounds > 0) {
+    // TODO cases with bounds-spec and bounds-remapping
+  } else {
+    CheckPointerAssignment(foldingContext, *pointer, rhs);
   }
 }
 

--- a/lib/semantics/check-call.cc
+++ b/lib/semantics/check-call.cc
@@ -160,13 +160,10 @@ static void CheckExplicitDataArg(const characteristics::DummyDataObject &dummy,
           "dummy argument", "actual argument");
     }
   } else {
-    std::stringstream lenStr;
-    if (const auto &len{actualType.LEN()}) {
-      len->AsFortran(lenStr);
-    }
+    const auto &len{actualType.LEN()};
     messages.Say(
         "Actual argument type '%s' is not compatible with dummy argument type '%s'"_err_en_US,
-        actualType.type().AsFortran(lenStr.str()),
+        actualType.type().AsFortran(len ? len->AsFortran() : ""),
         dummy.type.type().AsFortran());
   }
 

--- a/lib/semantics/pointer-assignment.cc
+++ b/lib/semantics/pointer-assignment.cc
@@ -326,19 +326,15 @@ void CheckPointerAssignment(
     evaluate::FoldingContext &context, const Symbol &lhs, const SomeExpr &rhs) {
   // TODO: Acquire values of deferred type parameters &/or array bounds
   // from the RHS.
-  if (!IsPointer(lhs)) {
-    evaluate::SayWithDeclaration(
-        context.messages(), lhs, "'%s' is not a pointer"_err_en_US, lhs.name());
-  } else {
-    std::string description{"pointer '"s + lhs.name().ToString() + '\''};
-    PointerAssignmentChecker{lhs.name(), description, context}
-        .set_lhsType(TypeAndShape::Characterize(lhs, context))
-        .set_procedure(Procedure::Characterize(lhs, context.intrinsics()))
-        .set_lhs(lhs)
-        .set_isContiguous(lhs.attrs().test(Attr::CONTIGUOUS))
-        .set_isVolatile(lhs.attrs().test(Attr::VOLATILE))
-        .Check(rhs);
-  }
+  CHECK(IsPointer(lhs));
+  std::string description{"pointer '"s + lhs.name().ToString() + '\''};
+  PointerAssignmentChecker{lhs.name(), description, context}
+      .set_lhsType(TypeAndShape::Characterize(lhs, context))
+      .set_procedure(Procedure::Characterize(lhs, context.intrinsics()))
+      .set_lhs(lhs)
+      .set_isContiguous(lhs.attrs().test(Attr::CONTIGUOUS))
+      .set_isVolatile(lhs.attrs().test(Attr::VOLATILE))
+      .Check(rhs);
 }
 
 void CheckPointerAssignment(evaluate::FoldingContext &context,

--- a/lib/semantics/pointer-assignment.cc
+++ b/lib/semantics/pointer-assignment.cc
@@ -33,21 +33,31 @@ using evaluate::characteristics::DummyDataObject;
 using evaluate::characteristics::FunctionResult;
 using evaluate::characteristics::Procedure;
 using evaluate::characteristics::TypeAndShape;
+using parser::MessageFixedText;
+using parser::MessageFormattedText;
+using PointerAssignment = evaluate::Assignment::PointerAssignment;
 
 class PointerAssignmentChecker {
 public:
-  PointerAssignmentChecker(parser::CharBlock source,
-      const std::string &description, evaluate::FoldingContext &context)
-    : source_{source}, description_{description}, context_{context} {}
-  PointerAssignmentChecker &set_lhs(const Symbol &);
+  PointerAssignmentChecker(evaluate::FoldingContext &context,
+      parser::CharBlock source, const std::string &description)
+    : context_{context}, source_{source}, description_{description} {}
+  PointerAssignmentChecker(evaluate::FoldingContext &context, const Symbol &lhs)
+    : context_{context}, source_{lhs.name()},
+      description_{"pointer '"s + lhs.name().ToString() + '\''}, lhs_{&lhs},
+      procedure_{Procedure::Characterize(lhs, context.intrinsics())} {
+    set_lhsType(TypeAndShape::Characterize(lhs, context));
+    set_isContiguous(lhs.attrs().test(Attr::CONTIGUOUS));
+    set_isVolatile(lhs.attrs().test(Attr::VOLATILE));
+  }
   PointerAssignmentChecker &set_lhsType(std::optional<TypeAndShape> &&);
-  PointerAssignmentChecker &set_procedure(std::optional<Procedure> &&);
   PointerAssignmentChecker &set_isContiguous(bool);
   PointerAssignmentChecker &set_isVolatile(bool);
+  PointerAssignmentChecker &set_isBoundsRemapping(bool);
   void Check(const SomeExpr &);
 
 private:
-  template<typename A> void Check(const A &);
+  template<typename T> void Check(const T &);
   template<typename T> void Check(const evaluate::Expr<T> &);
   template<typename T> void Check(const evaluate::FunctionRef<T> &);
   template<typename T> void Check(const evaluate::Designator<T> &);
@@ -60,30 +70,20 @@ private:
   bool LhsOkForUnlimitedPoly() const;
   template<typename... A> parser::Message *Say(A &&...);
 
-  const parser::CharBlock source_;
-  const std::string &description_;
   evaluate::FoldingContext &context_;
+  const parser::CharBlock source_;
+  const std::string description_;
   const Symbol *lhs_{nullptr};
   std::optional<TypeAndShape> lhsType_;
   std::optional<Procedure> procedure_;
   bool isContiguous_{false};
   bool isVolatile_{false};
+  bool isBoundsRemapping_{false};
 };
-
-PointerAssignmentChecker &PointerAssignmentChecker::set_lhs(const Symbol &lhs) {
-  lhs_ = &lhs;
-  return *this;
-}
 
 PointerAssignmentChecker &PointerAssignmentChecker::set_lhsType(
     std::optional<TypeAndShape> &&lhsType) {
   lhsType_ = std::move(lhsType);
-  return *this;
-}
-
-PointerAssignmentChecker &PointerAssignmentChecker::set_procedure(
-    std::optional<Procedure> &&procedure) {
-  procedure_ = std::move(procedure);
   return *this;
 }
 
@@ -99,7 +99,13 @@ PointerAssignmentChecker &PointerAssignmentChecker::set_isVolatile(
   return *this;
 }
 
-template<typename A> void PointerAssignmentChecker::Check(const A &) {
+PointerAssignmentChecker &PointerAssignmentChecker::set_isBoundsRemapping(
+    bool isBoundsRemapping) {
+  isBoundsRemapping_ = isBoundsRemapping;
+  return *this;
+}
+
+template<typename T> void PointerAssignmentChecker::Check(const T &) {
   // Catch-all case for really bad target expression
   Say("Target associated with %s must be a designator or a call to a"
       " pointer-valued function"_err_en_US,
@@ -138,7 +144,7 @@ void PointerAssignmentChecker::Check(const evaluate::FunctionRef<T> &f) {
   if (!proc) {
     return;
   }
-  std::optional<parser::MessageFixedText> msg;
+  std::optional<MessageFixedText> msg;
   const auto &funcResult{proc->functionResult};  // C1025
   if (!funcResult) {
     msg = "%s is associated with the non-existent result of reference to"
@@ -180,7 +186,7 @@ void PointerAssignmentChecker::Check(const evaluate::Designator<T> &d) {
     context_.messages().Say("Pointer target is not a named entity"_err_en_US);
     return;
   }
-  std::optional<parser::MessageFixedText> msg;
+  std::optional<std::variant<MessageFixedText, MessageFormattedText>> msg;
   if (procedure_) {
     // Shouldn't be here in this function unless lhs is an object pointer.
     msg = "In assignment to procedure %s, the target is not a procedure or"
@@ -208,14 +214,31 @@ void PointerAssignmentChecker::Check(const evaluate::Designator<T> &d) {
               " derived type when target is unlimited polymorphic"_err_en_US;
       }
     } else {
-      lhsType_->IsCompatibleWith(context_.messages(), *rhsType);
+      if (!lhsType_->type().IsTypeCompatibleWith(rhsType->type())) {
+        msg = MessageFormattedText{
+            "Target type %s is not compatible with pointer type %s"_err_en_US,
+            rhsType->type().AsFortran(), lhsType_->type().AsFortran()};
+
+      } else if (!isBoundsRemapping_) {
+        std::size_t lhsRank{lhsType_->shape().size()};
+        std::size_t rhsRank{rhsType->shape().size()};
+        if (lhsRank != rhsRank) {
+          msg = MessageFormattedText{
+              "Pointer has rank %d but target has rank %d"_err_en_US, lhsRank,
+              rhsRank};
+        }
+      }
     }
   }
   if (msg) {
-    std::ostringstream ss;
-    d.AsFortran(ss);
     auto restorer{common::ScopedSet(lhs_, last)};
-    Say(*msg, description_, ss.str());
+    if (auto *m{std::get_if<MessageFixedText>(&*msg)}) {
+      std::ostringstream ss;
+      d.AsFortran(ss);
+      Say(*m, description_, ss.str());
+    } else {
+      Say(std::get<MessageFormattedText>(*msg));
+    }
   }
 }
 
@@ -235,7 +258,7 @@ static bool CharacteristicsMatch(const Procedure &lhs, const Procedure &rhs) {
 // Common handling for procedure pointer right-hand sides
 void PointerAssignmentChecker::Check(
     parser::CharBlock rhsName, bool isCall, const Procedure *rhsProcedure) {
-  std::optional<parser::MessageFixedText> msg;
+  std::optional<MessageFixedText> msg;
   if (!procedure_) {
     msg = "In assignment to object %s, the target '%s' is a procedure"
           " designator"_err_en_US;
@@ -322,25 +345,95 @@ parser::Message *PointerAssignmentChecker::Say(A &&... x) {
   return msg;
 }
 
+// Verify that any bounds on the LHS of a pointer assignment are valid.
+// Return true if it is a bound-remapping so we can perform further checks.
+static bool CheckPointerBounds(
+    evaluate::FoldingContext &context, const PointerAssignment &assignment) {
+  auto &messages{context.messages()};
+  const SomeExpr &lhs{assignment.lhs};
+  const SomeExpr &rhs{assignment.rhs};
+  bool isBoundsRemapping{false};
+  std::size_t numBounds{std::visit(
+      common::visitors{
+          [&](const PointerAssignment::BoundsSpec &bounds) {
+            return bounds.size();
+          },
+          [&](const PointerAssignment::BoundsRemapping &bounds) {
+            isBoundsRemapping = true;
+            evaluate::ExtentExpr lhsSizeExpr{1};
+            for (const auto &bound : bounds) {
+              lhsSizeExpr = std::move(lhsSizeExpr) *
+                  (common::Clone(bound.second) - common::Clone(bound.first) +
+                      evaluate::ExtentExpr{1});
+            }
+            if (std::optional<std::int64_t> lhsSize{evaluate::ToInt64(
+                    evaluate::Fold(context, std::move(lhsSizeExpr)))}) {
+              if (auto shape{evaluate::GetShape(context, rhs)}) {
+                if (std::optional<std::int64_t> rhsSize{
+                        evaluate::ToInt64(evaluate::Fold(
+                            context, evaluate::GetSize(std::move(*shape))))}) {
+                  if (*lhsSize > *rhsSize) {
+                    messages.Say(
+                        "Pointer bounds require %d elements but target has"
+                        " only %d"_err_en_US,
+                        *lhsSize, *rhsSize);  // 10.2.2.3(9)
+                  }
+                }
+              }
+            }
+            return bounds.size();
+          },
+      },
+      assignment.bounds)};
+  if (numBounds > 0) {
+    if (lhs.Rank() != static_cast<int>(numBounds)) {
+      messages.Say("Pointer '%s' has rank %d but the number of bounds specified"
+                   " is %d"_err_en_US,
+          lhs.AsFortran(), lhs.Rank(), numBounds);  // C1018
+    }
+  }
+  if (isBoundsRemapping && rhs.Rank() != 1 &&
+      !evaluate::IsSimplyContiguous(rhs, context.intrinsics())) {
+    messages.Say("Pointer bounds remapping target must have rank 1 or be"
+                 " simply contiguous"_err_en_US);  // 10.2.2.3(9)
+  }
+  return isBoundsRemapping;
+}
+
+void CheckPointerAssignment(
+    evaluate::FoldingContext &context, const PointerAssignment &assignment) {
+  const SomeExpr &lhs{assignment.lhs};
+  const SomeExpr &rhs{assignment.rhs};
+  const Symbol *pointer{GetLastSymbol(lhs)};
+  if (!pointer) {
+    return;  // error was reported
+  }
+  if (!IsPointer(*pointer)) {
+    evaluate::SayWithDeclaration(context.messages(), *pointer,
+        "'%s' is not a pointer"_err_en_US, pointer->name());
+    return;
+  }
+  if (pointer->has<ProcEntityDetails>() && evaluate::ExtractCoarrayRef(lhs)) {
+    context.messages().Say(  // C1027
+        "Procedure pointer may not be a coindexed object"_err_en_US);
+    return;
+  }
+  bool isBoundsRemapping{CheckPointerBounds(context, assignment)};
+  PointerAssignmentChecker{context, *pointer}
+      .set_isBoundsRemapping(isBoundsRemapping)
+      .Check(rhs);
+}
+
 void CheckPointerAssignment(
     evaluate::FoldingContext &context, const Symbol &lhs, const SomeExpr &rhs) {
-  // TODO: Acquire values of deferred type parameters &/or array bounds
-  // from the RHS.
   CHECK(IsPointer(lhs));
-  std::string description{"pointer '"s + lhs.name().ToString() + '\''};
-  PointerAssignmentChecker{lhs.name(), description, context}
-      .set_lhsType(TypeAndShape::Characterize(lhs, context))
-      .set_procedure(Procedure::Characterize(lhs, context.intrinsics()))
-      .set_lhs(lhs)
-      .set_isContiguous(lhs.attrs().test(Attr::CONTIGUOUS))
-      .set_isVolatile(lhs.attrs().test(Attr::VOLATILE))
-      .Check(rhs);
+  PointerAssignmentChecker{context, lhs}.Check(rhs);
 }
 
 void CheckPointerAssignment(evaluate::FoldingContext &context,
     parser::CharBlock source, const std::string &description,
     const DummyDataObject &lhs, const SomeExpr &rhs) {
-  PointerAssignmentChecker{source, description, context}
+  PointerAssignmentChecker{context, source, description}
       .set_lhsType(common::Clone(lhs.type))
       .set_isContiguous(lhs.attrs.test(DummyDataObject::Attr::Contiguous))
       .set_isVolatile(lhs.attrs.test(DummyDataObject::Attr::Volatile))

--- a/lib/semantics/pointer-assignment.h
+++ b/lib/semantics/pointer-assignment.h
@@ -10,6 +10,7 @@
 #define FORTRAN_SEMANTICS_POINTER_ASSIGNMENT_H_
 
 #include "type.h"
+#include "../evaluate/expression.h"
 #include "../parser/char-block.h"
 #include <string>
 
@@ -25,6 +26,8 @@ namespace Fortran::semantics {
 
 class Symbol;
 
+void CheckPointerAssignment(evaluate::FoldingContext &,
+    const evaluate::Assignment::PointerAssignment &);
 void CheckPointerAssignment(
     evaluate::FoldingContext &, const Symbol &lhs, const SomeExpr &rhs);
 void CheckPointerAssignment(evaluate::FoldingContext &,

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -11,6 +11,7 @@
 #include "semantics.h"
 #include "tools.h"
 #include "../common/idioms.h"
+#include "../evaluate/expression.h"
 #include <ostream>
 #include <string>
 
@@ -20,6 +21,13 @@ template<typename T>
 static void DumpOptional(std::ostream &os, const char *label, const T &x) {
   if (x) {
     os << ' ' << label << ':' << *x;
+  }
+}
+template<typename T>
+static void DumpExpr(std::ostream &os, const char *label,
+    const std::optional<evaluate::Expr<T>> &x) {
+  if (x) {
+    x->AsFortran(os << ' ' << label << ':');
   }
 }
 
@@ -84,7 +92,7 @@ void ModuleDetails::set_scope(const Scope *scope) {
 
 std::ostream &operator<<(std::ostream &os, const SubprogramDetails &x) {
   DumpBool(os, "isInterface", x.isInterface_);
-  DumpOptional(os, "bindName", x.bindName_);
+  DumpExpr(os, "bindName", x.bindName_);
   if (x.result_) {
     os << " result:" << x.result_->name();
     if (!x.result_->attrs().empty()) {
@@ -336,7 +344,7 @@ std::ostream &operator<<(std::ostream &os, const EntityDetails &x) {
   if (x.type()) {
     os << " type: " << *x.type();
   }
-  DumpOptional(os, "bindName", x.bindName_);
+  DumpExpr(os, "bindName", x.bindName_);
   return os;
 }
 
@@ -344,13 +352,13 @@ std::ostream &operator<<(std::ostream &os, const ObjectEntityDetails &x) {
   os << *static_cast<const EntityDetails *>(&x);
   DumpList(os, "shape", x.shape());
   DumpList(os, "coshape", x.coshape());
-  DumpOptional(os, "init", x.init_);
+  DumpExpr(os, "init", x.init_);
   return os;
 }
 
 std::ostream &operator<<(std::ostream &os, const AssocEntityDetails &x) {
   os << *static_cast<const EntityDetails *>(&x);
-  DumpOptional(os, "expr", x.expr());
+  DumpExpr(os, "expr", x.expr());
   return os;
 }
 
@@ -360,7 +368,7 @@ std::ostream &operator<<(std::ostream &os, const ProcEntityDetails &x) {
   } else {
     DumpType(os, x.interface_.type());
   }
-  DumpOptional(os, "bindName", x.bindName());
+  DumpExpr(os, "bindName", x.bindName());
   DumpOptional(os, "passName", x.passName());
   if (x.init()) {
     if (const Symbol * target{*x.init()}) {
@@ -409,7 +417,7 @@ std::ostream &operator<<(std::ostream &os, const Details &details) {
               os << dummy->name();
             }
             os << ')';
-            DumpOptional(os, "bindName", x.bindName());
+            DumpExpr(os, "bindName", x.bindName());
             if (x.isFunction()) {
               os << " result(";
               DumpType(os, x.result());
@@ -455,7 +463,7 @@ std::ostream &operator<<(std::ostream &os, const Details &details) {
           [&](const TypeParamDetails &x) {
             DumpOptional(os, "type", x.type());
             os << ' ' << common::EnumToString(x.attr());
-            DumpOptional(os, "init", x.init());
+            DumpExpr(os, "init", x.init());
           },
           [&](const MiscDetails &x) {
             os << ' ' << MiscDetails::EnumToString(x.kind());

--- a/lib/semantics/tools.h
+++ b/lib/semantics/tools.h
@@ -226,12 +226,8 @@ bool ExprTypeKindIsDefault(
     const SomeExpr &expr, const SemanticsContext &context);
 
 struct GetExprHelper {
-  const SomeExpr *Get(const parser::Expr::TypedExpr &x) {
-    CHECK(x);
-    return x && x->v ? &*x->v : nullptr;
-  }
-  const SomeExpr *Get(const parser::Expr &x) { return Get(x.typedExpr); }
-  const SomeExpr *Get(const parser::Variable &x) { return Get(x.typedExpr); }
+  const SomeExpr *Get(const parser::Expr &);
+  const SomeExpr *Get(const parser::Variable &);
   template<typename T> const SomeExpr *Get(const common::Indirection<T> &x) {
     return Get(x.value());
   }

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -122,11 +122,9 @@ void DerivedTypeSpec::EvaluateParameters(
             continue;
           }
         }
-        std::stringstream fortran;
-        expr->AsFortran(fortran);
         evaluate::SayWithDeclaration(messages, symbol,
             "Value of type parameter '%s' (%s) is not convertible to its type"_err_en_US,
-            name, fortran.str());
+            name, expr->AsFortran());
       }
     }
   }
@@ -243,12 +241,10 @@ void DerivedTypeSpec::Instantiate(
               if (expr->Rank() == 0 &&
                   maybeDynamicType->category() == TypeCategory::Integer) {
                 if (!evaluate::ToInt64(*expr)) {
-                  std::stringstream fortran;
-                  fortran << *expr;
                   if (auto *msg{foldingContext.messages().Say(
                           "Value of kind type parameter '%s' (%s) is not "
                           "a scalar INTEGER constant"_err_en_US,
-                          name, fortran.str())}) {
+                          name, expr->AsFortran())}) {
                     msg->Attach(name, "declared here"_en_US);
                   }
                 }
@@ -322,7 +318,7 @@ std::ostream &operator<<(std::ostream &o, const Bound &x) {
   } else if (x.isDeferred()) {
     o << ':';
   } else if (x.expr_) {
-    o << x.expr_;
+    x.expr_->AsFortran(o);
   } else {
     o << "<no-expr>";
   }

--- a/test/evaluate/expression.cc
+++ b/test/evaluate/expression.cc
@@ -6,37 +6,30 @@
 #include "../../lib/parser/message.h"
 #include <cstdio>
 #include <cstdlib>
-#include <sstream>
 #include <string>
 
 using namespace Fortran::evaluate;
 
-template<typename A> std::string AsFortran(const A &x) {
-  std::stringstream ss;
-  ss << x;
-  return ss.str();
-}
-
 int main() {
   using DefaultIntegerExpr = Expr<Type<TypeCategory::Integer, 4>>;
   TEST(DefaultIntegerExpr::Result::AsFortran() == "INTEGER(4)");
-  MATCH("666_4", AsFortran(DefaultIntegerExpr{666}));
-  MATCH("-1_4", AsFortran(-DefaultIntegerExpr{1}));
+  MATCH("666_4", DefaultIntegerExpr{666}.AsFortran());
+  MATCH("-1_4", (-DefaultIntegerExpr{1}).AsFortran());
   auto ex1{
       DefaultIntegerExpr{2} + DefaultIntegerExpr{3} * -DefaultIntegerExpr{4}};
-  MATCH("2_4+3_4*(-4_4)", AsFortran(ex1));
+  MATCH("2_4+3_4*(-4_4)", ex1.AsFortran());
   Fortran::common::IntrinsicTypeDefaultKinds defaults;
   auto intrinsics{Fortran::evaluate::IntrinsicProcTable::Configure(defaults)};
   FoldingContext context{
       Fortran::parser::ContextualMessages{nullptr}, defaults, intrinsics};
   ex1 = Fold(context, std::move(ex1));
-  MATCH("-10_4", AsFortran(ex1));
-  MATCH("1_4/2_4", AsFortran(DefaultIntegerExpr{1} / DefaultIntegerExpr{2}));
+  MATCH("-10_4", ex1.AsFortran());
+  MATCH("1_4/2_4", (DefaultIntegerExpr{1} / DefaultIntegerExpr{2}).AsFortran());
   DefaultIntegerExpr a{1};
   DefaultIntegerExpr b{2};
-  MATCH("1_4", AsFortran(a));
+  MATCH("1_4", a.AsFortran());
   a = b;
-  MATCH("2_4", AsFortran(a));
-  MATCH("2_4", AsFortran(b));
+  MATCH("2_4", a.AsFortran());
+  MATCH("2_4", b.AsFortran());
   return testing::Complete();
 }

--- a/test/semantics/assign02.f90
+++ b/test/semantics/assign02.f90
@@ -30,18 +30,18 @@ contains
     logical, target :: l
     real, pointer :: p
     p => r
-    !ERROR: TARGET type 'REAL(8)' is not compatible with POINTER type 'REAL(4)'
+    !ERROR: Target type REAL(8) is not compatible with pointer type REAL(4)
     p => r8
-    !ERROR: TARGET type 'LOGICAL(4)' is not compatible with POINTER type 'REAL(4)'
+    !ERROR: Target type LOGICAL(4) is not compatible with pointer type REAL(4)
     p => l
   end
 
-  ! C1015
+  ! C1019
   subroutine s2
     real, target :: r1(4), r2(4,4)
     real, pointer :: p(:)
     p => r1
-    !ERROR: Rank of POINTER is 1, but TARGET has rank 2
+    !ERROR: Pointer has rank 1 but target has rank 2
     p => r2
   end
 
@@ -51,7 +51,7 @@ contains
     type(t(2)), target :: x2
     type(t(1)), pointer :: p
     p => x1
-    !ERROR: TARGET type 't(k=2_4)' is not compatible with POINTER type 't(k=1_4)'
+    !ERROR: Target type t(k=2_4) is not compatible with pointer type t(k=1_4)
     p => x2
   end
 

--- a/test/semantics/assign03.f90
+++ b/test/semantics/assign03.f90
@@ -108,4 +108,30 @@ contains
     p_f => s_external
   end
 
+  ! C1017: bounds-spec
+  subroutine s8
+    real, target :: x(10, 10)
+    real, pointer :: p(:, :)
+    p(2:,3:) => x
+    !ERROR: Pointer 'p' has rank 2 but the number of bounds specified is 1
+    p(2:) => x
+  end
+
+  ! bounds-remapping
+  subroutine s9
+    real, target :: x(10, 10), y(100)
+    real, pointer :: p(:, :)
+    ! C1018
+    !ERROR: Pointer 'p' has rank 2 but the number of bounds specified is 1
+    p(1:100) => x
+    ! 10.2.2.3(9)
+    !ERROR: Pointer bounds remapping target must have rank 1 or be simply contiguous
+    p(1:5,1:5) => x(1:10,::2)
+    ! 10.2.2.3(9)
+    !ERROR: Pointer bounds require 25 elements but target has only 20
+    p(1:5,1:5) => x(:,1:2)
+    !OK - rhs has rank 1 and enough elements
+    p(1:5,1:5) => y(1:100:2)
+  end
+
 end

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -172,7 +172,11 @@ static Fortran::parser::AnalyzedObjectsAsFortran asFortran{
       }
     },
     [](std::ostream &o, const Fortran::evaluate::GenericAssignmentWrapper &x) {
-      x.v.AsFortran(o);
+      if (x.v) {
+        x.v->AsFortran(o);
+      } else {
+        o << "(bad assignment)";
+      }
     },
     [](std::ostream &o, const Fortran::evaluate::ProcedureRef &x) {
       x.AsFortran(o << "CALL ");


### PR DESCRIPTION
Perform checks on bounds-spec and bounds-remapping in a pointer
assignment statement:
- check that the rank of the bounds specified matches the rank of the
  pointer
- for bounds-spec, check that the pointer rank matches the target rank
- for bounds-remapping:
  - check that the target is rank 1 or simply contiguous
  - check that there are sufficient elements on the RHS for the bounds
    specified, when it can be determined at compile time

Move more of the pointer-specific checking from `assignment.cc`
to `pointer-assignment.cc`.

With this PR pointer assignment checks should be complete.
