### PR TITLE
Bump clang-format version and remove some differences from LLVM

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,16 +3,10 @@
 BasedOnStyle: LLVM
 AlignAfterOpenBracket: DontAlign
 AlignEscapedNewlines: DontAlign
-AllowShortCaseLabelsOnASingleLine: true
-AllowShortIfStatementsOnASingleLine: true
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
 AlignOperands: false
 AlignTrailingComments: false
-ConstructorInitializerIndentWidth: 2
-SpaceAfterTemplateKeyword: false
-SpacesBeforeTrailingComments: 2
-FixNamespaceComments: false
 IncludeCategories:
   - Regex:           '^<'
     Priority:        4

--- a/documentation/C++style.md
+++ b/documentation/C++style.md
@@ -88,9 +88,9 @@ well as you do and avoid distracting her by calling out usage of new
 features in comments.
 
 ### Layout
-Always run `clang-format` before committing code.  Other developers should
-be able to run `git pull`, then `clang-format`, and see only their own
-changes. Use `clang-format` from llvm 7.
+Always run `clang-format` on your changes before committing code. LLVM
+has a `git-clang-format` script to facilitate running clang-format only
+on the lines that have changed.
 
 Here's what you can expect to see `clang-format` do:
 1. Indent with two spaces.

--- a/documentation/PullRequestChecklist.md
+++ b/documentation/PullRequestChecklist.md
@@ -31,7 +31,7 @@ can also be used when reviewing pull requests.
 ## Follow the style guide
 The following items are taken from the [C++ style guide](C++style.md).  But
 even though I've read the style guide, they regularly trip me up.
-*  Run clang-format version 7 on all .cpp and .h files.
+*  Run clang-format using the git-clang-format script from LLVM HEAD.
 *  Make sure that all source lines have 80 or fewer characters.  Note that
    clang-format will do this for most code.  But you may need to break up long
    strings.


### PR DESCRIPTION
Hi all,

The purpose of this PR is to start a discussion about whether we can move towards matching the LLVM style by accepting some/all of the formatting changes present here, and whether there are some changes we really cannot accept so that we can start a discussion in the wider community about those.

I changed the F18 clang-format file to match the base LLVM style to see how far from matching we are. The changes are attached in this PR for comparison.

It seems that most of the changes are due to LLVM having spaces after the template keyword, and lining up function arguments differently.

I've also run this with clang-format-9 instead of 7, but the only difference between 7 and 8+ is 8+ has an additional pass related to the indentation of lambdas when used as function arguments.