### PR TITLE
12HHELLO, WORLD

### DIFF
--- a/include/flang/ISO_Fortran_binding.h
+++ b/include/flang/ISO_Fortran_binding.h
@@ -30,8 +30,9 @@ inline namespace Fortran_2018 {
 #define CFI_MAX_RANK 15
 typedef unsigned char CFI_rank_t;
 
-// This type is probably larger than a default Fortran INTEGER
-// and should be used for all array indexing and loop bound calculations.
+/* This type is probably larger than a default Fortran INTEGER
+ * and should be used for all array indexing and loop bound calculations.
+ */
 typedef ptrdiff_t CFI_index_t;
 
 typedef unsigned char CFI_attribute_t;

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -11,7 +11,11 @@ add_library(FortranRuntime
   derived-type.cc
   descriptor.cc
   format.cc
+  io-api.cc
+  io-error.cc
+  io-stmt.cc
   main.cc
+  memory.cc
   stop.cc
   terminator.cc
   transformational.cc
@@ -19,5 +23,6 @@ add_library(FortranRuntime
 )
 
 target_link_libraries(FortranRuntime
-  FortranEvaluate
+  FortranCommon
+  FortranDecimal
 )

--- a/runtime/entry-names.h
+++ b/runtime/entry-names.h
@@ -16,7 +16,7 @@
 // runtime library must change in some way that breaks backward compatibility.
 
 #ifndef RTNAME
-#define PREFIX _Fortran
-#define REVISION A
-#define RTNAME(name) PREFIX##REVISION##name
+#define NAME_WITH_PREFIX_AND_REVISION(prefix, revision, name) \
+  prefix##revision##name
+#define RTNAME(name) NAME_WITH_PREFIX_AND_REVISION(_Fortran, A, name)
 #endif

--- a/runtime/io-api.cc
+++ b/runtime/io-api.cc
@@ -1,0 +1,31 @@
+//===-- runtime/io.cc -------------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "io-api.h"
+#include "format.h"
+#include "io-stmt.h"
+#include "memory.h"
+#include "terminator.h"
+#include <cstdlib>
+#include <memory>
+
+namespace Fortran::runtime::io {
+
+Cookie IONAME(BeginInternalFormattedOutput)(char *internal,
+    std::size_t internalLength, const char *format, std::size_t formatLength,
+    void ** /*scratchArea*/, std::size_t /*scratchBytes*/,
+    const char *sourceFile, int sourceLine) {
+  Terminator oom{sourceFile, sourceLine};
+  return &New<InternalFormattedIoStatementState<false>>{}(oom, internal,
+      internalLength, format, formatLength, sourceFile, sourceLine);
+}
+
+enum Iostat IONAME(EndIoStatement)(Cookie io) {
+  return static_cast<enum Iostat>(io->EndIoStatement());
+}
+}

--- a/runtime/io-api.h
+++ b/runtime/io-api.h
@@ -19,7 +19,7 @@
 namespace Fortran::runtime {
 class Descriptor;
 class NamelistGroup;
-};
+}
 
 namespace Fortran::runtime::io {
 
@@ -60,30 +60,32 @@ Cookie IONAME(BeginInternalArrayListInput)(const Descriptor &,
     void **scratchArea = nullptr, std::size_t scratchBytes = 0,
     const char *sourceFile = nullptr, int sourceLine = 0);
 Cookie IONAME(BeginInternalArrayFormattedOutput)(const Descriptor &,
-    const char *format, std::size_t formatBytes, void **scratchArea = nullptr,
+    const char *format, std::size_t formatLength, void **scratchArea = nullptr,
     std::size_t scratchBytes = 0, const char *sourceFile = nullptr,
     int sourceLine = 0);
 Cookie IONAME(BeginInternalArrayFormattedInput)(const Descriptor &,
-    const char *format, std::size_t formatBytes, void **scratchArea = nullptr,
+    const char *format, std::size_t formatLength, void **scratchArea = nullptr,
     std::size_t scratchBytes = 0, const char *sourceFile = nullptr,
     int sourceLine = 0);
 
 // Internal I/O to/from a default-kind character scalar can avoid a
 // descriptor.
-Cookie IONAME(BeginInternalListOutput)(char *internal, std::size_t bytes,
-    void **scratchArea = nullptr, std::size_t scratchBytes = 0,
-    const char *sourceFile = nullptr, int sourceLine = 0);
-Cookie IONAME(BeginInternalListInput)(char *internal, std::size_t bytes,
-    void **scratchArea = nullptr, std::size_t scratchBytes = 0,
-    const char *sourceFile = nullptr, int sourceLine = 0);
-Cookie IONAME(BeginInternalFormattedOutput)(char *internal, std::size_t bytes,
-    const char *format, std::size_t formatBytes, void **scratchArea = nullptr,
+Cookie IONAME(BeginInternalListOutput)(char *internal,
+    std::size_t internalLength, void **scratchArea = nullptr,
     std::size_t scratchBytes = 0, const char *sourceFile = nullptr,
     int sourceLine = 0);
-Cookie IONAME(BeginInternalFormattedInput)(char *internal, std::size_t bytes,
-    const char *format, std::size_t formatBytes, void **scratchArea = nullptr,
+Cookie IONAME(BeginInternalListInput)(char *internal,
+    std::size_t internalLength, void **scratchArea = nullptr,
     std::size_t scratchBytes = 0, const char *sourceFile = nullptr,
     int sourceLine = 0);
+Cookie IONAME(BeginInternalFormattedOutput)(char *internal,
+    std::size_t internalLength, const char *format, std::size_t formatLength,
+    void **scratchArea = nullptr, std::size_t scratchBytes = 0,
+    const char *sourceFile = nullptr, int sourceLine = 0);
+Cookie IONAME(BeginInternalFormattedInput)(char *internal,
+    std::size_t internalLength, const char *format, std::size_t formatLength,
+    void **scratchArea = nullptr, std::size_t scratchBytes = 0,
+    const char *sourceFile = nullptr, int sourceLine = 0);
 
 // Internal namelist I/O
 Cookie IONAME(BeginInternalNamelistOutput)(const Descriptor &,
@@ -110,10 +112,10 @@ Cookie IONAME(BeginUnformattedOutput)(ExternalUnit = DefaultUnit,
     const char *sourceFile = nullptr, int sourceLine = 0);
 Cookie IONAME(BeginUnformattedInput)(ExternalUnit = DefaultUnit,
     const char *sourceFile = nullptr, int sourceLine = 0);
-Cookie IONAME(BeginNamelistOutput)(const NamelistGroup &,
+Cookie IONAME(BeginExternalNamelistOutput)(const NamelistGroup &,
     ExternalUnit = DefaultUnit, const char *sourceFile = nullptr,
     int sourceLine = 0);
-Cookie IONAME(BeginNamelistInput)(const NamelistGroup &,
+Cookie IONAME(BeginExternalNamelistInput)(const NamelistGroup &,
     ExternalUnit = DefaultUnit, const char *sourceFile = nullptr,
     int sourceLine = 0);
 
@@ -150,7 +152,8 @@ Cookie IONAME(BeginInquireUnit)(
     ExternalUnit, const char *sourceFile = nullptr, int sourceLine = 0);
 Cookie IONAME(BeginInquireFile)(const char *, std::size_t, int kind = 1,
     const char *sourceFile = nullptr, int sourceLine = 0);
-Cookie IONAME(BeginInquireIoLength(const char *sourceFile = nullptr, int sourceLine = 0);
+Cookie IONAME(BeginInquireIoLength)(
+    const char *sourceFile = nullptr, int sourceLine = 0);
 
 // If an I/O statement has any IOSTAT=, ERR=, END=, or EOR= specifiers,
 // call EnableHandlers() immediately after the Begin...() call.
@@ -228,28 +231,28 @@ bool IONAME(InputLogical)(Cookie, bool &);
 // SetDelim(), GetIoMsg(), SetPad(), SetRound(), & SetSign()
 // are also acceptable for OPEN.
 // ACCESS=SEQUENTIAL, DIRECT, STREAM
-bool IONAME(SetAccess, Cookie, const char *, std::size_t);
+bool IONAME(SetAccess)(Cookie, const char *, std::size_t);
 // ACTION=READ, WRITE, or READWRITE
-bool IONAME(SetAction, Cookie, const char *, std::size_t);
+bool IONAME(SetAction)(Cookie, const char *, std::size_t);
 // ASYNCHRONOUS=YES, NO
-bool IONAME(SetAsynchronous, Cookie, const char *, std::size_t);
+bool IONAME(SetAsynchronous)(Cookie, const char *, std::size_t);
 // ENCODING=UTF-8, DEFAULT
-bool IONAME(SetEncoding, Cookie, const char *, std::size_t);
+bool IONAME(SetEncoding)(Cookie, const char *, std::size_t);
 // FORM=FORMATTED, UNFORMATTED
-bool IONAME(SetForm, Cookie, const char *, std::size_t);
+bool IONAME(SetForm)(Cookie, const char *, std::size_t);
 // POSITION=ASIS, REWIND, APPEND
-bool IONAME(SetPosition, Cookie, const char *, std::size_t);
-bool IONAME(SetRecl, Cookie, std::size_t);  // RECL=
+bool IONAME(SetPosition)(Cookie, const char *, std::size_t);
+bool IONAME(SetRecl)(Cookie, std::size_t);  // RECL=
 
 // STATUS can be set during an OPEN or CLOSE statement.
 // For OPEN: STATUS=OLD, NEW, SCRATCH, REPLACE, UNKNOWN
 // For CLOSE: STATUS=KEEP, DELETE
-bool IONAME(SetStatus, Cookie, const char *, std::size_t);
+bool IONAME(SetStatus)(Cookie, const char *, std::size_t);
 
 // SetFile() may pass a CHARACTER argument of non-default kind,
 // and such filenames are converted to UTF-8 before being
 // presented to the filesystem.
-bool IONAME(SetFile, Cookie, const char *, std::size_t, int kind = 1);
+bool IONAME(SetFile)(Cookie, const char *, std::size_t, int kind = 1);
 
 // GetNewUnit() must not be called until after all Set...()
 // connection list specifiers have been called after
@@ -271,13 +274,15 @@ void IONAME(GetIoMsg)(Cookie, char *, std::size_t);  // IOMSG=
 // ACCESS, ACTION, ASYNCHRONOUS, BLANK, DECIMAL, DELIM, DIRECT, ENCODING,
 // FORM, FORMATTED, NAME, PAD, POSITION, READ, READWRITE, ROUND,
 // SEQUENTIAL, SIGN, STREAM, UNFORMATTED, WRITE:
-bool IONAME(InquireCharacter)(Cookie, const char *specifier, char *, std::size_t);
+bool IONAME(InquireCharacter)(
+    Cookie, const char *specifier, char *, std::size_t);
 // EXIST, NAMED, OPENED, and PENDING (without ID):
 bool IONAME(InquireLogical)(Cookie, const char *specifier, bool &);
 // PENDING with ID
 bool IONAME(InquirePendingId)(Cookie, std::int64_t, bool &);
 // NEXTREC, NUMBER, POS, RECL, SIZE
-bool IONAME(InquireInteger64)(Cookie, const char *specifier, std::int64_t &, int kind = 8);
+bool IONAME(InquireInteger64)(
+    Cookie, const char *specifier, std::int64_t &, int kind = 8);
 
 // The value of IOSTAT= is zero when no error, end-of-record,
 // or end-of-file condition has arisen; errors are positive values.
@@ -307,6 +312,6 @@ enum Iostat {
 // rather than by terminating the image.
 enum Iostat IONAME(EndIoStatement)(Cookie);
 
-};  // extern "C"
+}  // extern "C"
 }
 #endif

--- a/runtime/io-error.cc
+++ b/runtime/io-error.cc
@@ -1,0 +1,67 @@
+//===-- runtime/io-error.cc -------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "io-error.h"
+#include "magic-numbers.h"
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+
+namespace Fortran::runtime::io {
+
+void IoErrorHandler::Begin(const char *sourceFileName, int sourceLine) {
+  flags_ = 0;
+  ioStat_ = 0;
+  hitEnd_ = false;
+  hitEor_ = false;
+  SetLocation(sourceFileName, sourceLine);
+}
+
+void IoErrorHandler::SignalError(int iostatOrErrno) {
+  if (iostatOrErrno != 0) {
+    if (flags_ & hasIoStat) {
+      if (!ioStat_) {
+        ioStat_ = iostatOrErrno;
+      }
+    } else if (iostatOrErrno == FORTRAN_RUNTIME_IOSTAT_INQUIRE_INTERNAL_UNIT) {
+      Crash("INQUIRE on internal unit");
+    } else {
+      Crash("I/O error %d: %s", iostatOrErrno, std::strerror(iostatOrErrno));
+    }
+  }
+}
+
+void IoErrorHandler::SignalEnd() {
+  if (flags_ & hasEnd) {
+    hitEnd_ = true;
+  } else {
+    Crash("End of file");
+  }
+}
+
+void IoErrorHandler::SignalEor() {
+  if (flags_ & hasEor) {
+    hitEor_ = true;
+  } else {
+    Crash("End of record");
+  }
+}
+
+int IoErrorHandler::GetIoStat() const {
+  if (ioStat_) {
+    return ioStat_;
+  } else if (hitEnd_) {
+    return FORTRAN_RUNTIME_IOSTAT_END;
+  } else if (hitEor_) {
+    return FORTRAN_RUNTIME_IOSTAT_EOR;
+  } else {
+    return 0;
+  }
+}
+
+}

--- a/runtime/io-error.h
+++ b/runtime/io-error.h
@@ -1,0 +1,50 @@
+//===-- runtime/io-error.h --------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Distinguishes I/O error conditions; fatal ones lead to termination,
+// and those that the user program has chosen to handle are recorded
+// so that the highest-priority one can be returned as IOSTAT=.
+
+#ifndef FORTRAN_RUNTIME_IO_ERROR_H_
+#define FORTRAN_RUNTIME_IO_ERROR_H_
+
+#include "terminator.h"
+#include <cinttypes>
+
+namespace Fortran::runtime::io {
+
+class IoErrorHandler : virtual public Terminator {
+public:
+  using Terminator::Terminator;
+  void Begin(const char *sourceFileName, int sourceLine);
+  void HasIoStat() { flags_ |= hasIoStat; }
+  void HasErrLabel() { flags_ |= hasErr; }
+  void HasEndLabel() { flags_ |= hasEnd; }
+  void HasEorLabel() { flags_ |= hasEor; }
+
+  void SignalError(int iostatOrErrno);
+  void SignalEnd();
+  void SignalEor();
+
+  int GetIoStat() const;
+
+private:
+  enum Flag : std::uint8_t {
+    hasIoStat = 1,  // IOSTAT=
+    hasErr = 2,  // ERR=
+    hasEnd = 4,  // END=
+    hasEor = 8,  // EOR=
+  };
+  std::uint8_t flags_{0};
+  bool hitEnd_{false};
+  bool hitEor_{false};
+  int ioStat_{0};
+};
+
+}
+#endif  // FORTRAN_RUNTIME_IO_ERROR_H_

--- a/runtime/io-stmt.cc
+++ b/runtime/io-stmt.cc
@@ -1,0 +1,88 @@
+//===-- runtime/io-stmt.cc --------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "io-stmt.h"
+#include "memory.h"
+#include <algorithm>
+#include <cstring>
+
+namespace Fortran::runtime::io {
+
+int IoStatementState::EndIoStatement() { return GetIoStat(); }
+
+int InternalIoStatementState::EndIoStatement() {
+  auto result{GetIoStat()};
+  if (free_) {
+    FreeMemory(this);
+  }
+  return result;
+}
+
+InternalIoStatementState::InternalIoStatementState(
+    const char *sourceFile, int sourceLine)
+  : IoStatementState(sourceFile, sourceLine) {}
+
+template<bool isInput, typename CHAR>
+InternalFormattedIoStatementState<isInput,
+    CHAR>::InternalFormattedIoStatementState(Buffer internal,
+    std::size_t internalLength, const CHAR *format, std::size_t formatLength,
+    const char *sourceFile, int sourceLine)
+  : InternalIoStatementState{sourceFile, sourceLine}, FormatContext{},
+    internal_{internal}, internalLength_{internalLength}, format_{*this, format,
+                                                              formatLength} {
+  std::fill_n(internal_, internalLength_, static_cast<CHAR>(' '));
+}
+
+template<bool isInput, typename CHAR>
+void InternalFormattedIoStatementState<isInput, CHAR>::Emit(
+    const CHAR *data, std::size_t chars) {
+  if constexpr (isInput) {
+    FormatContext::Emit(data, chars);  // default Crash()
+  } else if (at_ + chars > internalLength_) {
+    SignalEor();
+  } else {
+    std::memcpy(internal_ + at_, data, chars * sizeof(CHAR));
+    at_ += chars;
+  }
+}
+
+template<bool isInput, typename CHAR>
+void InternalFormattedIoStatementState<isInput, CHAR>::HandleAbsolutePosition(
+    int n) {
+  if (n < 0 || static_cast<std::size_t>(n) >= internalLength_) {
+    Crash("T%d control edit descriptor is out of range", n);
+  } else {
+    at_ = n;
+  }
+}
+
+template<bool isInput, typename CHAR>
+void InternalFormattedIoStatementState<isInput, CHAR>::HandleRelativePosition(
+    int n) {
+  if (n < 0) {
+    at_ -= std::min(at_, -static_cast<std::size_t>(n));
+  } else {
+    at_ += n;
+    if (at_ > internalLength_) {
+      Crash("TR%d control edit descriptor is out of range", n);
+    }
+  }
+}
+
+template<bool isInput, typename CHAR>
+int InternalFormattedIoStatementState<isInput, CHAR>::EndIoStatement() {
+  format_.FinishOutput(*this);
+  auto result{GetIoStat()};
+  if (free_) {
+    FreeMemory(this);
+  }
+  return result;
+}
+
+template class InternalFormattedIoStatementState<false>;
+}

--- a/runtime/io-stmt.h
+++ b/runtime/io-stmt.h
@@ -1,0 +1,64 @@
+//===-- runtime/io-stmt.h ---------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Represents state of an I/O statement in progress
+
+#ifndef FORTRAN_RUNTIME_IO_STMT_H_
+#define FORTRAN_RUNTIME_IO_STMT_H_
+
+#include "descriptor.h"
+#include "format.h"
+#include "io-error.h"
+#include <type_traits>
+
+namespace Fortran::runtime::io {
+
+class IoStatementState : public IoErrorHandler {
+public:
+  using IoErrorHandler::IoErrorHandler;
+  virtual int EndIoStatement();
+
+protected:
+};
+
+class InternalIoStatementState : public IoStatementState {
+public:
+  InternalIoStatementState(const char *sourceFile, int sourceLine);
+  virtual int EndIoStatement();
+
+protected:
+  bool free_{true};
+};
+
+template<bool IsInput, typename CHAR = char>
+class InternalFormattedIoStatementState : public InternalIoStatementState,
+                                          private FormatContext {
+private:
+  using Buffer = std::conditional_t<IsInput, const CHAR *, CHAR *>;
+
+public:
+  InternalFormattedIoStatementState(Buffer internal, std::size_t internalLength,
+      const CHAR *format, std::size_t formatLength,
+      const char *sourceFile = nullptr, int sourceLine = 0);
+  void Emit(const CHAR *, std::size_t chars);
+  // TODO pmk: void HandleSlash(int);
+  void HandleRelativePosition(int);
+  void HandleAbsolutePosition(int);
+  int EndIoStatement();
+
+private:
+  Buffer internal_;
+  std::size_t internalLength_;
+  std::size_t at_{0};
+  FormatControl<CHAR> format_;  // must be last, may be partial
+};
+
+extern template class InternalFormattedIoStatementState<false>;
+
+}
+#endif  // FORTRAN_RUNTIME_IO_STMT_H_

--- a/runtime/magic-numbers.h
+++ b/runtime/magic-numbers.h
@@ -17,6 +17,8 @@ These include:
    to an IOSTAT= or STAT= specifier on a Fortran I/O statement
    or coindexed data reference (see Fortran 2018 12.11.5,
    16.10.2, and 16.10.2.33)
+Codes from <errno.h>, e.g. ENOENT, are assumed to be positive
+and are used "raw" as IOSTAT values.
 #endif
 #ifndef FORTRAN_RUNTIME_MAGIC_NUMBERS_H_
 #define FORTRAN_RUNTIME_MAGIC_NUMBERS_H_
@@ -24,7 +26,7 @@ These include:
 #define FORTRAN_RUNTIME_IOSTAT_END (-1)
 #define FORTRAN_RUNTIME_IOSTAT_EOR (-2)
 #define FORTRAN_RUNTIME_IOSTAT_FLUSH (-3)
-#define FORTRAN_RUNTIME_IOSTAT_INQUIRE_INTERNAL_UNIT 1
+#define FORTRAN_RUNTIME_IOSTAT_INQUIRE_INTERNAL_UNIT 255
 
 #define FORTRAN_RUNTIME_STAT_FAILED_IMAGE 10
 #define FORTRAN_RUNTIME_STAT_LOCKED 11

--- a/runtime/main.h
+++ b/runtime/main.h
@@ -1,4 +1,4 @@
-//===-- runtime/main.cc -----------------------------------------*- C++ -*-===//
+//===-- runtime/main.h ------------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -12,9 +12,15 @@
 #include "entry-names.h"
 
 namespace Fortran::runtime {
-extern int argc;
-extern const char **argv;
-extern const char **envp;
+struct ExecutionEnvironment {
+  void Configure(int argc, const char *argv[], const char *envp[]);
+
+  int argc;
+  const char **argv;
+  const char **envp;
+  int listDirectedOutputLineLengthLimit;
+};
+extern ExecutionEnvironment executionEnvironment;
 }
 
 extern "C" {

--- a/runtime/memory.cc
+++ b/runtime/memory.cc
@@ -1,0 +1,33 @@
+//===-- runtime/memory.cc ---------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "memory.h"
+#include "terminator.h"
+#include <cstdlib>
+
+namespace Fortran::runtime {
+
+void *AllocateMemoryOrCrash(Terminator &terminator, std::size_t bytes) {
+  if (void *p{std::malloc(bytes)}) {
+    return p;
+  }
+  if (bytes > 0) {
+    terminator.Crash(
+        "Fortran runtime internal error: out of memory, needed %zd bytes",
+        bytes);
+  }
+  return nullptr;
+}
+
+void FreeMemory(void *p) { std::free(p); }
+
+void FreeMemoryAndNullify(void *&p) {
+  std::free(p);
+  p = nullptr;
+}
+}

--- a/runtime/memory.h
+++ b/runtime/memory.h
@@ -1,0 +1,43 @@
+//===-- runtime/memory.h ----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Thin wrapper around malloc()/free() to isolate the dependency,
+// ease porting, and provide an owning pointer.
+
+#ifndef FORTRAN_RUNTIME_MEMORY_H_
+#define FORTRAN_RUNTIME_MEMORY_H_
+
+#include <memory>
+
+namespace Fortran::runtime {
+
+class Terminator;
+
+void *AllocateMemoryOrCrash(Terminator &, std::size_t bytes);
+template<typename A> A &AllocateOrCrash(Terminator &t) {
+  return *reinterpret_cast<A *>(AllocateMemoryOrCrash(t, sizeof(A)));
+}
+void FreeMemory(void *);
+void FreeMemoryAndNullify(void *&);
+
+template<typename A> struct New {
+  template<typename... X> A &operator()(Terminator &terminator, X&&... x) {
+    return *new (AllocateMemoryOrCrash(terminator, sizeof(A))) A{std::forward<X>(x)...};
+  }
+};
+
+namespace {
+template<typename A> class OwningPtrDeleter {
+  void operator()(A *p) { FreeMemory(p); }
+};
+}
+
+template<typename A> using OwningPtr = std::unique_ptr<A, OwningPtrDeleter<A>>;
+}
+
+#endif  // FORTRAN_RUNTIME_MEMORY_H_

--- a/runtime/terminator.cc
+++ b/runtime/terminator.cc
@@ -35,6 +35,12 @@ namespace Fortran::runtime {
   std::abort();
 }
 
+[[noreturn]] void Terminator::CheckFailed(
+    const char *predicate, const char *file, int line) {
+  Crash("Internal error: RUNTIME_CHECK(%s) failed at %s(%d)", predicate, file,
+      line);
+}
+
 void NotifyOtherImagesOfNormalEnd() {
   // TODO
 }

--- a/runtime/terminator.h
+++ b/runtime/terminator.h
@@ -29,11 +29,19 @@ public:
   }
   [[noreturn]] void Crash(const char *message, ...);
   [[noreturn]] void CrashArgs(const char *message, va_list &);
+  [[noreturn]] void CheckFailed(
+      const char *predicate, const char *file, int line);
 
 private:
   const char *sourceFileName_{nullptr};
   int sourceLine_{0};
 };
+
+#define RUNTIME_CHECK(terminator, pred) \
+  if (pred) \
+    ; \
+  else \
+    (terminator).CheckFailed(#pred, __FILE__, __LINE__)
 
 void NotifyOtherImagesOfNormalEnd();
 void NotifyOtherImagesOfFailImageStatement();

--- a/runtime/transformational.cc
+++ b/runtime/transformational.cc
@@ -8,7 +8,6 @@
 
 #include "transformational.h"
 #include "../lib/common/idioms.h"
-#include "../lib/evaluate/integer.h"
 #include <algorithm>
 #include <bitset>
 #include <cinttypes>
@@ -16,18 +15,12 @@
 
 namespace Fortran::runtime {
 
-template<int BITS> inline std::int64_t LoadInt64(const char *p) {
-  using Int = const evaluate::value::Integer<BITS>;
-  Int *ip{reinterpret_cast<Int *>(p)};
-  return ip->ToInt64();
-}
-
 static inline std::int64_t GetInt64(const char *p, std::size_t bytes) {
   switch (bytes) {
-  case 1: return LoadInt64<8>(p);
-  case 2: return LoadInt64<16>(p);
-  case 4: return LoadInt64<32>(p);
-  case 8: return LoadInt64<64>(p);
+  case 1: return *reinterpret_cast<const std::int8_t *>(p);
+  case 2: return *reinterpret_cast<const std::int16_t *>(p);
+  case 4: return *reinterpret_cast<const std::int32_t *>(p);
+  case 8: return *reinterpret_cast<const std::int64_t *>(p);
   default: CRASH_NO_CASE;
   }
 }

--- a/test/runtime/CMakeLists.txt
+++ b/test/runtime/CMakeLists.txt
@@ -19,3 +19,13 @@ target_link_libraries(format-test
 )
 
 add_test(Format format-test)
+
+add_executable(hello-world
+  hello.cc
+)
+
+target_link_libraries(hello-world
+  FortranRuntime
+)
+
+add_test(HelloWorld hello-world)

--- a/test/runtime/hello.cc
+++ b/test/runtime/hello.cc
@@ -1,0 +1,33 @@
+// Basic tests of I/O API
+
+#include "../../runtime/io-api.h"
+#include <cstring>
+#include <iostream>
+
+using namespace Fortran::runtime::io;
+
+static int failures{0};
+
+int main() {
+  char buffer[32];
+  const char *format1{"(12HHELLO, WORLD)"};
+  auto cookie{IONAME(BeginInternalFormattedOutput)(buffer, sizeof buffer, format1, std::strlen(format1))};
+  if (auto status{IONAME(EndIoStatement)(cookie)}) {
+    std::cerr << "format1 failed, status " << static_cast<int>(status) << '\n';
+    ++failures;
+  }
+  std::string got1{buffer, sizeof buffer};
+  std::string expect1{"HELLO, WORLD"};
+  expect1.resize(got1.length(), ' ');
+  if (got1 != expect1) {
+    std::cerr << "format1 failed, got '" << got1 << "', expected '" << expect1 << "'\n";
+    ++failures;
+  }
+
+  if (failures == 0) {
+    std::cout << "PASS\n";
+  } else {
+    std::cout << "FAIL " << failures << " tests\n";
+  }
+  return failures > 0;
+}


### PR DESCRIPTION
Drill down to a working implementation of the APIs for an internal formatted WRITE with no data list items.

- Improve argument names in io-api.h
- Bump up error number to not conflict with errno values
- Use Fortran::runtime::io namespace
- Add wrapper around malloc/free, allow use of unique_ptr with wrapper
- Define IoErrorHandler
- Revamp FormatContext, use virtual member functions
- Update comment syntax, allow for old C
- Demonstrate 12HHELLO, WORLD
- Remove files not yet ready for review
- Use std::forward
- Fix GCC build warnings in io-api.h
