### PR TITLE
Fix bug detecting simply contiguous component

### DIFF
--- a/lib/evaluate/check-expression.cc
+++ b/lib/evaluate/check-expression.cc
@@ -283,7 +283,9 @@ public:
   Result operator()(const CoarrayRef &x) const {
     return CheckSubscripts(x.subscript());
   }
-  Result operator()(const Component &) const { return false; }
+  Result operator()(const Component &x) const {
+    return x.base().Rank() == 0 && (*this)(x.GetLastSymbol());
+  }
   Result operator()(const ComplexPart &) const { return false; }
   Result operator()(const Substring &) const { return false; }
 

--- a/test/semantics/assign03.f90
+++ b/test/semantics/assign03.f90
@@ -134,4 +134,29 @@ contains
     p(1:5,1:5) => y(1:100:2)
   end
 
+  subroutine s10
+    integer, pointer :: p(:)
+    type :: t
+      integer :: a(4, 4)
+      integer :: b
+    end type
+    type(t), target :: x
+    type(t), target :: y(10,10)
+    p(1:16) => x%a
+    p(1:1) => x%b  ! We treat scalars as simply contiguous
+    !ERROR: Pointer bounds remapping target must have rank 1 or be simply contiguous
+    p(1:4) => x%a(::2,::2)
+    !ERROR: Pointer bounds remapping target must have rank 1 or be simply contiguous
+    p(1:100) => y(:,:)%b
+  end
+
+  subroutine s11
+    complex, target :: x(10,10)
+    complex, pointer :: p(:)
+    real, pointer :: q(:)
+    p(1:100) => x(:,:)
+    !ERROR: Pointer bounds remapping target must have rank 1 or be simply contiguous
+    q(1:100) => x(:,:)%re
+  end
+
 end


### PR DESCRIPTION
We were always return false when testing a component for simple
contiguity. Change to check that the component is an array that is
simply continguous.

A pointer with bounds remapping to a complex part is a similar case
so add a test for that too.