### PR TITLE
Semantic checks for deallocating entities with IMPURE FINAL procedures

### DIFF
--- a/include/flang/semantics/tools.h
+++ b/include/flang/semantics/tools.h
@@ -48,7 +48,7 @@ const DeclTypeSpec *FindParentTypeSpec(const DerivedTypeSpec &);
 const DeclTypeSpec *FindParentTypeSpec(const DeclTypeSpec &);
 const DeclTypeSpec *FindParentTypeSpec(const Scope &);
 const DeclTypeSpec *FindParentTypeSpec(const Symbol &);
-
+ 
 // Return the Symbol of the variable of a construct association, if it exists
 const Symbol *GetAssociationRoot(const Symbol &);
 

--- a/lib/semantics/tools.cpp
+++ b/lib/semantics/tools.cpp
@@ -508,7 +508,7 @@ const DeclTypeSpec *FindParentTypeSpec(const Symbol &symbol) {
   return nullptr;
 }
 
-// When an construct association maps to a variable, and that variable
+// When a construct association maps to a variable, and that variable
 // is not an array with a vector-valued subscript, return the base
 // Symbol of that variable, else nullptr.  Descends into other construct
 // associations when one associations maps to another.
@@ -665,6 +665,8 @@ bool IsFinalizable(const DerivedTypeSpec &derived) {
       components.end();
 }
 
+// TODO The following function returns true for all types with FINAL procedures
+// This is because we don't yet fill in the data for FinalProcDetails
 bool HasImpureFinal(const DerivedTypeSpec &derived) {
   ScopeComponentIterator components{derived};
   return std::find_if(


### PR DESCRIPTION
You cannot call an IMPURE procedure in a DO CONCURRENT construct.  One
way that can happen is if an entity with an IMPURE FINAL procedure gets
deallocated.  Similar to the checks for deallocating coarrays, there are
three ways that an entity can get deallocated that are applicable to DO
CONCURRENT constructs -- an actual DEALLOCATE statement, block exit, and
assignment.

This change depends on the utility function `HasImpureFinal()` in tools.h to
determine if an entity has a derived type with an IMPURE FINAL
procedure.  In the course of testing this change, I realized that this
check is incorrect, but the code specific to DO CONCURRENT is
independent of the check, so I might as well implement it.