### PR TITLE
Fix another bug checking simple contiguity

### DIFF
--- a/lib/evaluate/check-expression.cc
+++ b/lib/evaluate/check-expression.cc
@@ -277,8 +277,7 @@ public:
   }
 
   Result operator()(const ArrayRef &x) const {
-    return (x.base().IsSymbol() || x.base().Rank() == 0) &&
-        CheckSubscripts(x.subscript()) && (*this)(x.base());
+    return CheckSubscripts(x.subscript()) && (*this)(x.base());
   }
   Result operator()(const CoarrayRef &x) const {
     return CheckSubscripts(x.subscript());

--- a/test/semantics/assign03.f90
+++ b/test/semantics/assign03.f90
@@ -144,6 +144,7 @@ contains
     type(t), target :: y(10,10)
     p(1:16) => x%a
     p(1:1) => x%b  ! We treat scalars as simply contiguous
+    p(1:8) => x%a(:,3:4)
     !ERROR: Pointer bounds remapping target must have rank 1 or be simply contiguous
     p(1:4) => x%a(::2,::2)
     !ERROR: Pointer bounds remapping target must have rank 1 or be simply contiguous


### PR DESCRIPTION
My last change was not complete: when the RHS of a pointer bounds
remapping was an array section rather than a whole array we weren't
correctly determine if it was simply contiguous.