### PR TITLE
Remove `default` case for OmpSectionsDirective (only two enum values)

### DIFF
--- a/lib/semantics/resolve-names.cpp
+++ b/lib/semantics/resolve-names.cpp
@@ -5980,7 +5980,6 @@ bool OmpAttributeVisitor::Pre(const parser::OpenMPSectionsConstruct &x) {
   case parser::OmpSectionsDirective::Directive::Sections:
     PushContext(beginDir.source, OmpDirective::SECTIONS);
     break;
-  default: break;
   }
   ClearDataSharingAttributeObjects();
   return true;


### PR DESCRIPTION
clang 7 fails to compile with this case.