### PR TITLE
Fix template step limit issue with clang

### DIFF
--- a/include/flang/common/template.h
+++ b/include/flang/common/template.h
@@ -153,15 +153,12 @@ template<typename... Ts> struct VariantToTupleHelper<std::variant<Ts...>> {
 template<typename VARIANT>
 using VariantToTuple = typename VariantToTupleHelper<VARIANT>::type;
 
-template<typename A, typename B, typename... REST>
-struct AreTypesDistinctHelper {
+template<typename A, typename... REST> struct AreTypesDistinctHelper {
   static constexpr bool value() {
-    if constexpr (std::is_same_v<A, B>) {
-      return false;
-    }
     if constexpr (sizeof...(REST) > 0) {
-      return AreTypesDistinctHelper<A, REST...>::value() &&
-          AreTypesDistinctHelper<B, REST...>::value();
+      // extra () for clang-format
+      return ((... && !std::is_same_v<A, REST>)) &&
+          AreTypesDistinctHelper<REST...>::value();
     }
     return true;
   }


### PR DESCRIPTION
While working on PR #959, I instantiated a `common::TupleToVariant`
with ~50+ types inside the tuple. Clang would then crash after
1hr compilation with message:
"constexpr evaluation hit maximum step limit; possible infinite loop"
After investigating, it turned out clang handles very badly the way
`common::AreTypesDistinctHelper` was implemented.
Its "number of steps" was exponential with the number of types.
This fix makes this number quadratic which solves the issue.

For more information about clang constexpr step, see: https://stackoverflow.com/questions/24591466/constexpr-depth-limit-with-clang-fconstexpr-depth-doesnt-seem-to-work

I did not measure the impact on compile-time/memory.