### PR TITLE
Fix issues comming from clang-10 warnings

### DIFF
--- a/include/flang/semantics/symbol.h
+++ b/include/flang/semantics/symbol.h
@@ -52,10 +52,6 @@ private:
 
 class SubprogramDetails {
 public:
-  SubprogramDetails() {}
-  SubprogramDetails(const SubprogramDetails &that)
-    : dummyArgs_{that.dummyArgs_}, result_{that.result_} {}
-
   bool isFunction() const { return result_ != nullptr; }
   bool isInterface() const { return isInterface_; }
   void set_isInterface(bool value = true) { isInterface_ = value; }

--- a/lib/semantics/mod-file.cpp
+++ b/lib/semantics/mod-file.cpp
@@ -915,10 +915,10 @@ void SubprogramSymbolCollector::DoType(const DeclTypeSpec *type) {
       if (const DerivedTypeSpec * extends{typeSymbol.GetParentTypeSpec()}) {
         DoSymbol(extends->name(), extends->typeSymbol());
       }
-      for (const auto pair : derived->parameters()) {
+      for (const auto &pair : derived->parameters()) {
         DoParamValue(pair.second);
       }
-      for (const auto pair : *typeSymbol.scope()) {
+      for (const auto &pair : *typeSymbol.scope()) {
         const Symbol &comp{*pair.second};
         DoSymbol(comp);
       }

--- a/lib/semantics/resolve-labels.cpp
+++ b/lib/semantics/resolve-labels.cpp
@@ -824,7 +824,7 @@ void CheckBranchesIntoDoBody(const SourceStmtList &branches,
     if (HasScope(branchTarget.proxyForScope)) {
       const auto &fromPosition{branch.parserCharBlock};
       const auto &toPosition{branchTarget.parserCharBlock};
-      for (const auto body : loopBodies) {
+      for (const auto &body : loopBodies) {
         if (!InBody(fromPosition, body) && InBody(toPosition, body)) {
           context.Say(fromPosition, "branch into loop body from outside"_en_US)
               .Attach(body.first, "the loop branched into"_en_US);

--- a/lib/semantics/resolve-names.cpp
+++ b/lib/semantics/resolve-names.cpp
@@ -4099,7 +4099,7 @@ void DeclarationVisitor::SetSaveAttr(Symbol &symbol) {
 // Check types of common block objects, now that they are known.
 void DeclarationVisitor::CheckCommonBlocks() {
   // check for empty common blocks
-  for (const auto pair : currScope().commonBlocks()) {
+  for (const auto &pair : currScope().commonBlocks()) {
     const auto &symbol{*pair.second};
     if (symbol.get<CommonBlockDetails>().objects().empty() &&
         symbol.attrs().test(Attr::BIND_C)) {

--- a/lib/semantics/semantics.cpp
+++ b/lib/semantics/semantics.cpp
@@ -294,7 +294,7 @@ void Semantics::DumpSymbols(std::ostream &os) {
 void Semantics::DumpSymbolsSources(std::ostream &os) const {
   NameToSymbolMap symbols;
   GetSymbolNames(context_.globalScope(), symbols);
-  for (const auto pair : symbols) {
+  for (const auto &pair : symbols) {
     const Symbol &symbol{pair.second};
     if (auto sourceInfo{cooked_.GetSourcePositionRange(symbol.name())}) {
       os << symbol.name().ToString() << ": " << sourceInfo->first.file.path()

--- a/runtime/buffer.h
+++ b/runtime/buffer.h
@@ -66,7 +66,6 @@ public:
         } else {
           // [cde........ab] -> [abcde........]
           auto n{start_ + length_ - size_};  // 3 for cde
-          auto gap{size_ - length_};  // 13 - 5 = 8
           RUNTIME_CHECK(handler, length_ >= n);
           std::memmove(buffer_ + n, buffer_ + start_, length_ - n);  // cdeab
           LeftShiftBufferCircularly(buffer_, length_, n);  // abcde


### PR DESCRIPTION
Fix 3 warning from clang-10:

> error: unused variable 'gap' [-Werror,-Wunused-variable]

@klausler, I could not find what `gap` was intended for, so I've deleted it, but I am suspecting it's wrong and you had it there for a reason.

>error: definition of implicit copy assignment operator for 'SubprogramDetails' is deprecated because it has a user-declared copy constructor [-Werror, -Wdeprecated-copy]

@tskeith , it's a complaint about the rule of three/five not being respected. I don't get why `SubprogramDetails(const SubprogramDetails &that)` was made explicit but it is not copying some of the members, so I did not remove it. Is it really normal that some of the fields like `isInterface_` or `stmtFunction_` are not copied ?

>error: loop variable 'pair' of type [...] creates a copy from type [...] [-Werror,-Wrange-loop-construct]

The `auto` instead of `auto&` was creating copies in `for (const auto pair : symbols)` and such. That seems a legit complaint to me so I have added a `&`.