### PR TITLE
Semantic checks for C709, C710, and C711

### DIFF
--- a/include/flang/semantics/type.h
+++ b/include/flang/semantics/type.h
@@ -327,6 +327,9 @@ public:
   bool IsUnlimitedPolymorphic() const {
     return category_ == TypeStar || category_ == ClassStar;
   }
+  bool IsAssumedType() const {
+    return category_ == TypeStar;
+  }
   bool IsNumeric(TypeCategory) const;
   const NumericTypeSpec &numericTypeSpec() const;
   const LogicalTypeSpec &logicalTypeSpec() const;

--- a/lib/semantics/expression.cpp
+++ b/lib/semantics/expression.cpp
@@ -2344,7 +2344,7 @@ MaybeExpr ExpressionAnalyzer::ExprOrVariable(const PARSED &x) {
   if (!x.typedExpr) {
     FixMisparsedFunctionReference(context_, x.u);
     MaybeExpr result;
-    if (AssumedTypeDummy(x)) {
+    if (AssumedTypeDummy(x)) {  // C710
       Say("TYPE(*) dummy argument may only be used as an actual argument"_err_en_US);
     } else {
       if constexpr (std::is_same_v<PARSED, parser::Expr>) {

--- a/module/iso_c_binding.f90
+++ b/module/iso_c_binding.f90
@@ -91,7 +91,7 @@ module iso_c_binding
 
   function c_loc(x)
     type(c_ptr) :: c_loc
-    type(*), intent(in) :: x
+    type(*), dimension(:), intent(in) :: x
     c_loc = c_ptr(loc(x))
   end function c_loc
 

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -102,6 +102,7 @@ set(ERROR_TESTS
   resolve69.f90
   resolve70.f90
   resolve71.f90
+  resolve72.f90
   stop01.f90
   structconst01.f90
   structconst02.f90
@@ -195,6 +196,7 @@ set(ERROR_TESTS
   call12.f90
   call13.f90
   call14.f90
+  call15.f90
   forall01.f90
   misc-declarations.f90
   separate-module-procs.f90

--- a/test/semantics/call15.f90
+++ b/test/semantics/call15.f90
@@ -1,0 +1,17 @@
+! C711 An assumed-type actual argument that corresponds to an assumed-rank 
+! dummy argument shall be assumed-shape or assumed-rank.
+subroutine s(arg1, arg2, arg3)
+  type(*), dimension(..) :: arg1 ! assumed rank
+  type(*), dimension(:) :: arg2 ! assumed shape
+  type(*) :: arg3
+
+  call inner(arg1) ! OK, assumed rank
+  call inner(arg2) ! OK, assumed shape
+  !ERROR: Assumed-type TYPE(*) 'arg3' must be either assumed shape or assumed rank to be associated with TYPE(*) dummy argument 'dummy='
+  call inner(arg3)
+
+    contains
+      subroutine inner(dummy)
+        type(*), dimension(..) :: dummy
+      end subroutine inner
+end subroutine s

--- a/test/semantics/modfile12.f90
+++ b/test/semantics/modfile12.f90
@@ -9,7 +9,6 @@ module m
   end type
   type(t(a+3,:)), allocatable :: z
   class(t(a+4,:)), allocatable :: z2
-  type(*), allocatable :: z3
   class(*), allocatable :: z4
   real*2 :: f
   complex*32 :: g
@@ -24,6 +23,9 @@ contains
   end
   subroutine bar(x)
     real :: x(..)
+  end
+  subroutine baz(x)
+    type(*) :: x
   end
 end
 
@@ -42,7 +44,6 @@ end
 !  end type
 !  type(t(c=4_4,d=:)),allocatable::z
 !  class(t(c=5_4,d=:)),allocatable::z2
-!  type(*),allocatable::z3
 !  class(*),allocatable::z4
 !  real(2)::f
 !  complex(16)::g
@@ -57,5 +58,8 @@ end
 !  end
 !  subroutine bar(x)
 !    real(4)::x(..)
+!  end
+!  subroutine baz(x)
+!    type(*)::x
 !  end
 !end

--- a/test/semantics/resolve72.f90
+++ b/test/semantics/resolve72.f90
@@ -1,0 +1,25 @@
+! C709 An assumed-type entity shall be a dummy data object that does not have 
+! the ALLOCATABLE, CODIMENSION, INTENT (OUT), POINTER, or VALUE attribute and 
+! is not an explicit-shape array.
+subroutine s()
+  !ERROR: Assumed-type entity 'starvar' must be a dummy argument
+  type(*) :: starVar
+
+    contains
+      subroutine inner1(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
+        type(*) :: arg1 ! OK        
+        type(*), dimension(*) :: arg2 ! OK        
+        !ERROR: Assumed-type argument 'arg3' cannot have the ALLOCATABLE attribute
+        type(*), allocatable :: arg3
+        !ERROR: Assumed-type argument 'arg4' cannot be a coarray
+        type(*), codimension[*] :: arg4
+        !ERROR: Assumed-type argument 'arg5' cannot be INTENT(OUT)
+        type(*), intent(out) :: arg5
+        !ERROR: Assumed-type argument 'arg6' cannot have the POINTER attribute
+        type(*), pointer :: arg6
+        !ERROR: Assumed-type argument 'arg7' cannot have the VALUE attribute
+        type(*), value :: arg7
+        !ERROR: Assumed-type argument 'arg8' must be assumed shape or assumed size array
+        type(*), dimension(3) :: arg8
+      end subroutine inner1
+end subroutine s


### PR DESCRIPTION
C709 An assumed-type entity shall be a dummy data object that does not
have the ALLOCATABLE, CODIMENSION, INTENT (OUT), POINTER, or VALUE
attribute and is not an explicit-shape array.

C710 An assumed-type variable name shall not appear in a designator or
expression except as an actual argument corresponding to a dummy
argument that is assumed-type, or as the first argument to the intrinsic
function IS_CONTIGUOUS, LBOUND, PRESENT, RANK, SHAPE, SIZE, or UBOUND,
or the function C_LOC from the intrinsic module ISO_C_BINDING.

C711 An assumed-type actual argument that corresponds to an assumed-rank
dummy argument shall be assumed-shape or assumed-rank.

For C709 I added code to check-declarations.cpp.  In the process, I had
to change several function interfaces from `const Symbol` to `Symbol` so
that I could avoid multiple error messages for the same source line.  I
created the test resolve72.f90 to check it.

C710 was already checked, but I added a notation in the source.

For C711 I added code to check-call.cpp and the test call15.f90.