### PR TITLE
Fix issues with -DBUILD_SHARED_LIBS=On

### DIFF
--- a/tools/f18/CMakeLists.txt
+++ b/tools/f18/CMakeLists.txt
@@ -18,8 +18,8 @@ target_link_libraries(f18
   FortranParser
   FortranEvaluate
   FortranSemantics
-  LLVMSupport
   FortranLower
+  LLVMSupport
 )
 
 add_executable(f18-parse-demo


### PR DESCRIPTION
This re-ordering allows building f18 with shared library using and LLVM build
with static libraries.

This reordering (that also made sens form an alphabetical point of view)
works here to do such "shared+archive" compiling because the current
dependency on LLVM is simple (only one f18 lib + an executable depends on LLVM).
As soon as two f18 libraries will depend on LLVM, one will have to use an LLVM
version built with -DBUILD_SHARED_LIBS=On if one wants to use this option
to compile f18.