### PR TITLE
Add more checks on WHERE and FORALL

### DIFF
--- a/include/flang/semantics/semantics.h
+++ b/include/flang/semantics/semantics.h
@@ -159,10 +159,13 @@ public:
   void CheckIndexVarRedefine(const parser::Name &);
   void ActivateIndexVar(const parser::Name &, IndexVarKind);
   void DeactivateIndexVar(const parser::Name &);
+  SymbolVector GetIndexVars(IndexVarKind);
 
 private:
   void CheckIndexVarRedefine(
       const parser::CharBlock &, const Symbol &, parser::MessageFixedText &&);
+  bool CheckError(bool);
+
   const common::IntrinsicTypeDefaultKinds &defaultKinds_;
   const common::LanguageFeatureControl languageFeatures_;
   parser::AllSources &allSources_;
@@ -176,8 +179,6 @@ private:
   Scope globalScope_;
   parser::Messages messages_;
   evaluate::FoldingContext foldingContext_;
-
-  bool CheckError(bool);
   ConstructStack constructStack_;
   struct IndexVarInfo {
     parser::CharBlock location;

--- a/lib/semantics/assignment.h
+++ b/lib/semantics/assignment.h
@@ -16,9 +16,11 @@
 namespace Fortran::parser {
 class ContextualMessages;
 struct AssignmentStmt;
+struct EndWhereStmt;
+struct MaskedElsewhereStmt;
 struct PointerAssignmentStmt;
+struct WhereConstructStmt;
 struct WhereStmt;
-struct WhereConstruct;
 }
 
 namespace Fortran::semantics {
@@ -41,7 +43,11 @@ public:
   void Enter(const parser::AssignmentStmt &);
   void Enter(const parser::PointerAssignmentStmt &);
   void Enter(const parser::WhereStmt &);
-  void Enter(const parser::WhereConstruct &);
+  void Leave(const parser::WhereStmt &);
+  void Enter(const parser::WhereConstructStmt &);
+  void Leave(const parser::EndWhereStmt &);
+  void Enter(const parser::MaskedElsewhereStmt &);
+  void Leave(const parser::MaskedElsewhereStmt &);
 
 private:
   common::Indirection<AssignmentContext> context_;

--- a/lib/semantics/semantics.cpp
+++ b/lib/semantics/semantics.cpp
@@ -122,7 +122,8 @@ static bool PerformStatementSemantics(
   RewriteParseTree(context, program);
   CheckDeclarations(context);
   StatementSemanticsPass1{context}.Walk(program);
-  return StatementSemanticsPass2{context}.Walk(program);
+  StatementSemanticsPass2{context}.Walk(program);
+  return !context.AnyFatalError();
 }
 
 SemanticsContext::SemanticsContext(
@@ -259,6 +260,16 @@ void SemanticsContext::DeactivateIndexVar(const parser::Name &name) {
       }
     }
   }
+}
+
+SymbolVector SemanticsContext::GetIndexVars(IndexVarKind kind) {
+  SymbolVector result;
+  for (const auto &[symbol, info] : activeIndexVars_) {
+    if (info.kind == kind) {
+      result.push_back(symbol);
+    }
+  }
+  return result;
 }
 
 bool Semantics::Perform() {

--- a/test/semantics/assign01.f90
+++ b/test/semantics/assign01.f90
@@ -1,14 +1,53 @@
-integer :: a1(10), a2(10)
-logical :: m1(10), m2(5,5)
-m1 = .true.
-m2 = .false.
-a1 = [((i),i=1,10)]
-where (m1)
-  a2 = 1
-!ERROR: mask of ELSEWHERE statement is not conformable with the prior mask(s) in its WHERE construct
-elsewhere (m2)
-  a2 = 2
-elsewhere
-  a2 = 3
-end where
+! 10.2.3.1(2) All masks and LHS of assignments in a WHERE must conform
+
+subroutine s1
+  integer :: a1(10), a2(10)
+  logical :: m1(10), m2(5,5)
+  m1 = .true.
+  m2 = .false.
+  a1 = [((i),i=1,10)]
+  where (m1)
+    a2 = 1
+  !ERROR: Must have rank 1 to match prior mask or assignment of WHERE construct
+  elsewhere (m2)
+    a2 = 2
+  elsewhere
+    a2 = 3
+  end where
+end
+
+subroutine s2
+  logical, allocatable :: m1(:), m4(:,:)
+  logical :: m2(2), m3(3)
+  where(m1)
+    where(m2)
+    end where
+    !ERROR: Dimension 1 must have extent 2 to match prior mask or assignment of WHERE construct
+    where(m3)
+    end where
+    !ERROR: Must have rank 1 to match prior mask or assignment of WHERE construct
+    where(m4)
+    end where
+  endwhere
+  where(m1)
+    where(m3)
+    end where
+  !ERROR: Dimension 1 must have extent 3 to match prior mask or assignment of WHERE construct
+  elsewhere(m2)
+  end where
+end
+
+subroutine s3
+  logical, allocatable :: m1(:,:)
+  logical :: m2(4,2)
+  real :: x(4,4), y(4,4)
+  real :: a(4,5), b(4,5)
+  where(m1)
+    x = y
+    !ERROR: Dimension 2 must have extent 4 to match prior mask or assignment of WHERE construct
+    a = b
+    !ERROR: Dimension 2 must have extent 4 to match prior mask or assignment of WHERE construct
+    where(m2)
+    end where
+  end where
 end

--- a/test/semantics/forall01.f90
+++ b/test/semantics/forall01.f90
@@ -16,7 +16,6 @@ subroutine forall1
   end forall
 end
 
-
 subroutine forall2
   integer, pointer :: a(:)
   integer, target :: b(10,10)
@@ -72,4 +71,35 @@ subroutine forall4
   forall(i=1:10:i) a(i) = i
   !ERROR: FORALL step expression may not be zero
   forall(i=1:10:zero) a(i) = i
+end
+
+! Note: this gets warnings but not errors
+subroutine forall5
+  real, target :: x(10), y(10)
+  forall(i=1:10)
+    x(i) = y(i)
+  end forall
+  forall(i=1:10)
+    x = y  ! warning: i not used on LHS
+    forall(j=1:10)
+      x(i) = y(i)  ! warning: j not used on LHS
+      x(j) = y(j)  ! warning: i not used on LHS
+    endforall
+  endforall
+  do concurrent(i=1:10)
+    x = y
+    forall(i=1:10) x = y
+  end do
+end
+
+subroutine forall6
+  type t
+    real, pointer :: p
+  end type
+  type(t) :: a(10)
+  real, target :: b(10)
+  forall(i=1:10)
+    a(i)%p => b(i)
+    a(1)%p => b(i)  ! warning: i not used on LHS
+  end forall
 end


### PR DESCRIPTION
Check that masks and LHS of assignments in WHERE statements and
constructs have consistent shapes. They must all have the same rank and
any extents that are compile-time constants must match.

Emit a warning for assignments in FORALL statements and constructs where
the LHS does not reference each of the index variables.

This makes AssignmentChecker need some Enter/Leave functions that
conflict with those in DoForallChecker so create StatementSemanticsPass3
and move AssignmentChecker there. Future checkers now have the option of
being in that pass.