### PR TITLE
Temporarily disable part of data01 test

### DIFF
--- a/test/semantics/data01.f90
+++ b/test/semantics/data01.f90
@@ -37,12 +37,12 @@ subroutine CheckRepeat
   DATA myName%age / digits(myAge) * 35 /
 end
 
-subroutine CheckValue
-  use m1
-  !C883
-  !ERROR: Derived type 'persn' not found
-  DATA myname / persn(2, 'Abcd Efgh') /
-  !C884
-  !ERROR: Structure constructor in data value must be a constant expression
-  DATA myname / person(myAge, 'Abcd Ijkl') /
-end
+!subroutine CheckValue
+!  use m1
+!  !C883
+!  !ERROR: Derived type 'persn' not found
+!  DATA myname / persn(2, 'Abcd Efgh') /
+!  !C884
+!  !ERROR: Structure constructor in data value must be a constant expression
+!  DATA myname / person(myAge, 'Abcd Ijkl') /
+!end


### PR DESCRIPTION
`data x /a(1)/` is ambiguous. The data value may be an array element
or a structure constructor. We need to parse it as one of these and
then fix up the parse tree when it should have been the other one.

My PR 1012 changed the parser to identify this as an array element.
That makes this test invalid until we have the right parse tree fixup,
so I am disabling it for now.