### PR TITLE
Allow for access-stmt before namelist-stmt

### DIFF
--- a/lib/Semantics/resolve-names.cpp
+++ b/lib/Semantics/resolve-names.cpp
@@ -2957,7 +2957,7 @@ void DeclarationVisitor::Post(const parser::EntityDecl &x) {
     if (ConvertToObjectEntity(symbol)) {
       Initialization(name, *init, false);
     }
-  } else if (attrs.test(Attr::PARAMETER)) { // C882, C883
+  } else if (attrs.test(Attr::PARAMETER)) {  // C882, C883
     Say(name, "Missing initialization for parameter '%s'"_err_en_US);
   }
 }
@@ -3925,13 +3925,11 @@ bool DeclarationVisitor::Pre(const parser::NamelistStmt::Group &x) {
 
   const auto &groupName{std::get<parser::Name>(x.t)};
   auto *groupSymbol{FindInScope(currScope(), groupName)};
-  if (!groupSymbol) {
+  if (!groupSymbol || !groupSymbol->has<NamelistDetails>()) {
     groupSymbol = &MakeSymbol(groupName, std::move(details));
-  } else if (groupSymbol->has<NamelistDetails>()) {
-    groupSymbol->get<NamelistDetails>().add_objects(details.objects());
-  } else {
-    SayAlreadyDeclared(groupName, *groupSymbol);
+    groupSymbol->ReplaceName(groupName.source);
   }
+  groupSymbol->get<NamelistDetails>().add_objects(details.objects());
   return false;
 }
 
@@ -4408,7 +4406,7 @@ std::optional<DerivedTypeSpec> DeclarationVisitor::ResolveDerivedType(
       DerivedTypeDetails details;
       details.set_isForwardReferenced();
       symbol->set_details(std::move(details));
-    } else { // C883
+    } else {  // C883
       Say(name, "Derived type '%s' not found"_err_en_US);
       return std::nullopt;
     }

--- a/test/Semantics/resolve40.f90
+++ b/test/Semantics/resolve40.f90
@@ -72,3 +72,19 @@ subroutine s9
   !ERROR: 'i' is already declared in this scoping unit
   data ((x(i,i),i=1,2),i=1,2)/4*0.0/
 end
+
+module m10
+  integer :: x
+  public :: nl
+  namelist /nl/ x
+end
+
+subroutine s11
+  integer :: nl2
+  !ERROR: 'nl2' is already declared in this scoping unit
+  namelist /nl2/x
+  namelist /nl3/x
+  !ERROR: 'nl3' is already declared in this scoping unit
+  integer :: nl3
+  nl2 = 1
+end


### PR DESCRIPTION
You can declare a name in an access statement and then declare it as
a namelist group name. We weren't allowing that because we didn't
convert a symbol with UnknownDetails to one with NamelistDetails.

Fixes #1022.