### PR TITLE
Fix misparsed structure constructor in data stmt

### DIFF
--- a/include/flang/Parser/parse-tree.h
+++ b/include/flang/Parser/parse-tree.h
@@ -1818,6 +1818,8 @@ struct ArrayElement {
   ArrayElement(DataRef &&dr, std::list<SectionSubscript> &&ss)
     : base{std::move(dr)}, subscripts(std::move(ss)) {}
   Substring ConvertToSubstring();
+  StructureConstructor ConvertToStructureConstructor(
+      const semantics::DerivedTypeSpec &);
   DataRef base;
   std::list<SectionSubscript> subscripts;
 };

--- a/include/flang/Parser/tools.h
+++ b/include/flang/Parser/tools.h
@@ -79,6 +79,9 @@ struct UnwrapperHelper {
 template<typename A, typename B> const A *Unwrap(const B &x) {
   return UnwrapperHelper::Unwrap<A>(x);
 }
+template<typename A, typename B> A *Unwrap(B &x) {
+  return const_cast<A *>(Unwrap<A, B>(const_cast<const B &>(x)));
+}
 
 // Get the CoindexedNamedObject if the entity is a coindexed object.
 const CoindexedNamedObject *GetCoindexedNamedObject(const AllocateObject &);

--- a/lib/Parser/parse-tree.cpp
+++ b/lib/Parser/parse-tree.cpp
@@ -9,6 +9,7 @@
 #include "flang/Parser/parse-tree.h"
 #include "flang/Common/idioms.h"
 #include "flang/Common/indirection.h"
+#include "flang/Parser/tools.h"
 #include "flang/Parser/user-state.h"
 #include <algorithm>
 
@@ -180,6 +181,19 @@ StructureConstructor FunctionReference::ConvertToStructureConstructor(
     }
     components.emplace_back(
         std::move(keyword), ComponentDataSource{ActualArgToExpr(arg)});
+  }
+  DerivedTypeSpec spec{std::move(name), std::list<TypeParamSpec>{}};
+  spec.derivedTypeSpec = &derived;
+  return StructureConstructor{std::move(spec), std::move(components)};
+}
+
+StructureConstructor ArrayElement::ConvertToStructureConstructor(
+    const semantics::DerivedTypeSpec &derived) {
+  Name name{std::get<parser::Name>(base.u)};
+  std::list<ComponentSpec> components;
+  for (auto &subscript : subscripts) {
+    components.emplace_back(std::optional<Keyword>{},
+        ComponentDataSource{std::move(*Unwrap<Expr>(subscript))});
   }
   DerivedTypeSpec spec{std::move(name), std::list<TypeParamSpec>{}};
   spec.derivedTypeSpec = &derived;

--- a/test/Semantics/data01.f90
+++ b/test/Semantics/data01.f90
@@ -37,12 +37,25 @@ subroutine CheckRepeat
   DATA myName%age / digits(myAge) * 35 /
 end
 
-!subroutine CheckValue
-!  use m1
-!  !C883
-!  !ERROR: Derived type 'persn' not found
-!  DATA myname / persn(2, 'Abcd Efgh') /
-!  !C884
-!  !ERROR: Structure constructor in data value must be a constant expression
-!  DATA myname / person(myAge, 'Abcd Ijkl') /
-!end
+subroutine CheckValue
+  use m1
+  !OK: constant structure constructor
+  data myname / person(1, 'Abcd Ijkl') /
+  !C883
+  !ERROR: Must have INTEGER type, but is CHARACTER(1)
+  data myname / persn(2, 'Abcd Efgh') /
+  !C884
+  !ERROR: Structure constructor in data value must be a constant expression
+  data myname / person(myAge, 'Abcd Ijkl') /
+  integer, parameter :: a(5) =(/11, 22, 33, 44, 55/)
+  integer :: b(5) =(/11, 22, 33, 44, 55/)
+  integer :: i
+  integer :: x
+  !OK: constant array element
+  data x / a(1) /
+  !C886, C887
+  !ERROR: Must be a constant value
+  data x / a(i) /
+  !ERROR: Must be a constant value
+  data x / b(1) /
+end


### PR DESCRIPTION
In a data statement like `data x / a(1) /`, `a(1)` may be an array
element or a structure constructor. It is parsed as an array element
so if it turns out `a` is a derived type it must be rewritten as a
strucutre constructor.