### PR TITLE
Make the move constructor default

### DIFF
--- a/lib/Semantics/mod-file.cpp
+++ b/lib/Semantics/mod-file.cpp
@@ -618,7 +618,7 @@ std::ostream &PutLower(std::ostream &os, const std::string &str) {
 
 struct Temp {
   Temp(llvm::sys::fs::file_t fd, std::string path) : fd{fd}, path{path} {}
-  Temp(Temp &&t) : fd{std::exchange(t.fd, -1)}, path{std::move(t.path)} {}
+  Temp(Temp &&t) = default;
   ~Temp() {
     if (fd >= 0) {
       llvm::sys::fs::closeFile(fd);

--- a/lib/Semantics/mod-file.cpp
+++ b/lib/Semantics/mod-file.cpp
@@ -618,7 +618,11 @@ std::ostream &PutLower(std::ostream &os, const std::string &str) {
 
 struct Temp {
   Temp(llvm::sys::fs::file_t fd, std::string path) : fd{fd}, path{path} {}
+#if defined(_WIN32)
   Temp(Temp &&t) = default;
+#else
+  Temp(Temp &&t) : fd{std::exchange(t.fd, -1)}, path{std::move(t.path)} {}
+#endif
   ~Temp() {
     if (fd >= 0) {
       llvm::sys::fs::closeFile(fd);


### PR DESCRIPTION
Avoids the following error,
```
In file included from /projects/66d93023-00f0-4c12-8a25-5d6d4e486740/projects/f18/lib/Semantics/mod-file.cpp:9:
In file included from /projects/66d93023-00f0-4c12-8a25-5d6d4e486740/projects/f18/lib/Semantics/mod-file.h:12:
In file included from /projects/66d93023-00f0-4c12-8a25-5d6d4e486740/projects/f18/include/flang/Semantics/attr.h:12:
In file included from /projects/66d93023-00f0-4c12-8a25-5d6d4e486740/projects/f18/include/flang/Common/enum-set.h:17:
In file included from /projects/66d93023-00f0-4c12-8a25-5d6d4e486740/projects/f18/include/flang/Common/constexpr-bitset.h:19:
In file included from /projects/66d93023-00f0-4c12-8a25-5d6d4e486740/msvc-14.11.25547/include/optional:10:
/projects/66d93023-00f0-4c12-8a25-5d6d4e486740/msvc-14.11.25547/include/utility:645:9: error: assigning to 'void *' from incompatible type 'int'
        _Val = _STD forward<_Other>(_New_val);
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/projects/66d93023-00f0-4c12-8a25-5d6d4e486740/msvc-14.11.25547/include/yvals.h:583:14: note: expanded from macro '_STD'
#define _STD    ::std::
                ^
/projects/66d93023-00f0-4c12-8a25-5d6d4e486740/projects/f18/lib/Semantics/mod-file.cpp:623:28: note: in instantiation of function template specialization 'std::exchange<void *, int>' requested here
  Temp(Temp &&t) : fd{std::exchange(t.fd, -1)}, path{std::move(t.path)} {}
```