### PR TITLE
Change README to refer to LLVM_BUILD_DIR.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,21 +77,10 @@ the variable `LLVM_DIR` to find the installed components.
 To get the correct LLVM libraries included in your f18 build,
 define LLVM_DIR on the cmake command line.
 ```
-LLVM=<LLVM_INSTALLATION_DIR>/lib/cmake/llvm cmake -DLLVM_DIR=$LLVM ...
+LLVM=<LLVM_BUILD_DIR>/lib/cmake/llvm cmake -DLLVM_DIR=$LLVM ...
 ```
-where `LLVM_INSTALLATION_DIR` is
-the top-level directory
-where llvm is installed.
-
-### LLVM dependency for lit Regression tests
-
-F18 has tests that use the lit framework, these tests rely on the
-presence of llvm tools as llvm-lit, FileCheck, and others.
-These tools are installed when LLVM build set:
-```
-LLVM_INSTALL_UTILS=On
-```
-to run the regression tests on f18.
+where `LLVM_BUILD_DIR` is
+the top-level directory where LLVM was built.
 
 ### Building f18 with GCC
 

--- a/test-lit/CMakeLists.txt
+++ b/test-lit/CMakeLists.txt
@@ -14,17 +14,12 @@ set(FLANG_TEST_PARAMS
   flang_site_config=${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py)
 
 set(FLANG_TEST_DEPENDS
-  flang
   f18
-  llvm-lit
-  FileCheck
-  count
-  not
 )
 add_lit_testsuite(check-all "Running the Flang regression tests"
   ${CMAKE_CURRENT_BINARY_DIR}
   PARAMS ${FLANG_TEST_PARAMS}
-  DEPENDS ${FLANG_TEST_DEPENS}
+  DEPENDS ${FLANG_TEST_DEPENDS}
   )
 set_target_properties(check-all PROPERTIES FOLDER "Tests")
 


### PR DESCRIPTION
LLVM_INSTALL_TOOLS doesn't seem to install llvm-lit anymore. However
pointing to the cmake file in the build directory works fine, and lit
and FileCheck will be picked up correctly this way.