### PR TITLE
Link against zlib when LLVM does.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,10 @@ message(STATUS "Build Type: ${CMAKE_BUILD_TYPE}" )
 
 find_package(LLVM REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION} in ${LLVM_DIR}")
+# If LLVM links to zlib we need the imported targets so we can too.
+if(LLVM_ENABLE_ZLIB)
+  find_package(ZLIB REQUIRED)
+endif()
 
 list(APPEND CMAKE_MODULE_PATH ${LLVM_DIR})
 


### PR DESCRIPTION
If LLVM links against zlib we also need to do the same. Simply using find_package is enough to make the transitive dependencies that the LLVM libraries have on zlib link us against it correctly.

Fixes #1042 