### PR TITLE
Expression analysis on DataStmtConstant

### DIFF
--- a/include/flang/Semantics/expression.h
+++ b/include/flang/Semantics/expression.h
@@ -230,6 +230,10 @@ public:
     return Analyze<parser::DataRef>(dr);
   }
   MaybeExpr Analyze(const parser::StructureComponent &);
+  MaybeExpr Analyze(const parser::SignedIntLiteralConstant &);
+  MaybeExpr Analyze(const parser::SignedRealLiteralConstant &);
+  MaybeExpr Analyze(const parser::SignedComplexLiteralConstant &);
+  MaybeExpr Analyze(const parser::StructureConstructor &);
 
   void Analyze(const parser::CallStmt &);
   const Assignment *Analyze(const parser::AssignmentStmt &);
@@ -240,9 +244,7 @@ protected:
 
 private:
   MaybeExpr Analyze(const parser::IntLiteralConstant &);
-  MaybeExpr Analyze(const parser::SignedIntLiteralConstant &);
   MaybeExpr Analyze(const parser::RealLiteralConstant &);
-  MaybeExpr Analyze(const parser::SignedRealLiteralConstant &);
   MaybeExpr Analyze(const parser::ComplexPart &);
   MaybeExpr Analyze(const parser::ComplexLiteralConstant &);
   MaybeExpr Analyze(const parser::LogicalLiteralConstant &);
@@ -255,7 +257,6 @@ private:
   MaybeExpr Analyze(const parser::CoindexedNamedObject &);
   MaybeExpr Analyze(const parser::CharLiteralConstantSubstring &);
   MaybeExpr Analyze(const parser::ArrayConstructor &);
-  MaybeExpr Analyze(const parser::StructureConstructor &);
   MaybeExpr Analyze(const parser::FunctionReference &,
       std::optional<parser::StructureConstructor> * = nullptr);
   MaybeExpr Analyze(const parser::Expr::Parentheses &);
@@ -448,6 +449,7 @@ public:
     AnalyzePointerAssignmentStmt(context_, x);
     return false;
   }
+  bool Pre(const parser::DataStmtConstant &);
 
   template<typename A> bool Pre(const parser::Scalar<A> &x) {
     AnalyzeExpr(context_, x);

--- a/test/Semantics/CMakeLists.txt
+++ b/test/Semantics/CMakeLists.txt
@@ -213,6 +213,7 @@ set(ERROR_TESTS
   block-data01.f90
   complex01.f90
   data01.f90
+  data02.f90
   namelist01.f90
 )
 

--- a/test/Semantics/data02.f90
+++ b/test/Semantics/data02.f90
@@ -1,0 +1,31 @@
+! Check that expressions are analyzed in data statements
+
+subroutine s1
+  type :: t
+    character(1) :: c
+  end type
+  type(t) :: x
+  !ERROR: Value in structure constructor of type INTEGER(4) is incompatible with component 'c' of type CHARACTER(KIND=1,LEN=1_4)
+  data x /t(1)/
+end
+
+subroutine s2
+  real :: x1, x2
+  integer :: i1, i2
+  !ERROR: Unsupported REAL(KIND=99)
+  data x1 /1.0_99/
+  !ERROR: Unsupported REAL(KIND=99)
+  data x2 /-1.0_99/
+  !ERROR: INTEGER(KIND=99) is not a supported type
+  data i1 /1_99/
+  !ERROR: INTEGER(KIND=99) is not a supported type
+  data i2 /-1_99/
+end
+
+subroutine s3
+  complex :: z1, z2
+  !ERROR: Unsupported REAL(KIND=99)
+  data z1 /(1.0, 2.0_99)/
+  !ERROR: Unsupported REAL(KIND=99)
+  data z2 /-(1.0, 2.0_99)/
+end


### PR DESCRIPTION
Data statements contains expressions but they are not wrapped in one of
the kinds of parse tree nodes that are analyzed, like `parser::Expr`.
So potential errors were not discovered.

Change `ExprChecker` to handle `DataStmtConstant` and analyze any
expressions that are contained in it. Note that the analyzed form of
the expression is not yet saved in the parse tree.