### PR TITLE
Improve checking of structure constructor keywords

### DIFF
--- a/include/flang/Semantics/tools.h
+++ b/include/flang/Semantics/tools.h
@@ -30,6 +30,7 @@ class DerivedTypeSpec;
 class Scope;
 class Symbol;
 
+const Scope *FindModuleContaining(const Scope &);
 const Symbol *FindCommonBlockContaining(const Symbol &object);
 const Scope *FindProgramUnitContaining(const Scope &);
 const Scope *FindProgramUnitContaining(const Symbol &);
@@ -167,6 +168,9 @@ std::unique_ptr<parser::Message> WhyNotModifiable(SourceName, const SomeExpr &,
 const Symbol *IsExternalInPureContext(const Symbol &, const Scope &);
 bool HasCoarray(const parser::Expr &);
 bool IsPolymorphicAllocatable(const Symbol &);
+// Return an error if component symbol is not accessible from scope (7.5.4.8(2))
+std::optional<parser::MessageFormattedText> CheckAccessibleComponent(
+    const semantics::Scope &, const Symbol &);
 
 // Analysis of image control statements
 bool IsImageControlStmt(const parser::ExecutableConstruct &);

--- a/lib/Semantics/expression.cpp
+++ b/lib/Semantics/expression.cpp
@@ -1402,6 +1402,11 @@ MaybeExpr ExpressionAnalyzer::Analyze(
       }
     }
     if (symbol) {
+      if (const auto *currScope{context_.globalScope().FindScope(source)}) {
+        if (auto msg{CheckAccessibleComponent(*currScope, *symbol)}) {
+          Say(source, *msg);
+        }
+      }
       if (checkConflicts) {
         auto componentIter{
             std::find(components.begin(), components.end(), *symbol)};
@@ -1433,13 +1438,10 @@ MaybeExpr ExpressionAnalyzer::Analyze(
         } else if (symbol->has<semantics::ObjectEntityDetails>()) {
           // C1594(4)
           const auto &innermost{context_.FindScope(expr.source)};
-          if (const auto *pureProc{
-                  semantics::FindPureProcedureContaining(innermost)}) {
-            if (const Symbol *
-                pointer{semantics::FindPointerComponent(*symbol)}) {
+          if (const auto *pureProc{FindPureProcedureContaining(innermost)}) {
+            if (const Symbol * pointer{FindPointerComponent(*symbol)}) {
               if (const Symbol *
-                  object{semantics::FindExternallyVisibleObject(
-                      *value, *pureProc)}) {
+                  object{FindExternallyVisibleObject(*value, *pureProc)}) {
                 if (auto *msg{Say(expr.source,
                         "Externally visible object '%s' may not be "
                         "associated with pointer component '%s' in a "

--- a/lib/Semantics/symbol.cpp
+++ b/lib/Semantics/symbol.cpp
@@ -72,16 +72,7 @@ const Scope *ModuleDetails::parent() const {
   return isSubmodule_ && scope_ ? &scope_->parent() : nullptr;
 }
 const Scope *ModuleDetails::ancestor() const {
-  if (!isSubmodule_ || !scope_) {
-    return nullptr;
-  }
-  for (auto *scope{scope_};;) {
-    auto *parent{&scope->parent()};
-    if (parent->kind() != Scope::Kind::Module) {
-      return scope;
-    }
-    scope = parent;
-  }
+  return isSubmodule_ && scope_ ? FindModuleContaining(*scope_) : nullptr;
 }
 void ModuleDetails::set_scope(const Scope *scope) {
   CHECK(!scope_);

--- a/test/Semantics/resolve10.f90
+++ b/test/Semantics/resolve10.f90
@@ -1,10 +1,42 @@
 module m
   public
+  type t
+    integer, private :: i
+  end type
   !ERROR: The default accessibility of this module has already been declared
-  private
+  private  !C869
 end
 
-subroutine s
+subroutine s1
   !ERROR: PUBLIC statement may only appear in the specification part of a module
-  public
+  public  !C869
+end
+
+subroutine s2
+  !ERROR: PRIVATE attribute may only appear in the specification part of a module
+  integer, private :: i  !C817
+end
+
+subroutine s3
+  type t
+    !ERROR: PUBLIC attribute may only appear in the specification part of a module
+    integer, public :: i  !C817
+  end type
+end
+
+module m4
+  interface
+    module subroutine s()
+    end subroutine
+  end interface
+end
+submodule(m4) sm4
+  !ERROR: PUBLIC statement may only appear in the specification part of a module
+  public  !C869
+  !ERROR: PUBLIC attribute may only appear in the specification part of a module
+  real, public :: x  !C817
+  type :: t
+    !ERROR: PRIVATE attribute may only appear in the specification part of a module
+    real, private :: y  !C817
+  end type
 end

--- a/test/Semantics/resolve34.f90
+++ b/test/Semantics/resolve34.f90
@@ -91,3 +91,43 @@ subroutine s7
   !ERROR: PRIVATE component 't1' is only accessible within module 'm7'
   j = x%t1%i1
 end
+
+! 7.5.4.8(2)
+module m8
+  type  :: t
+    integer :: i1
+    integer, private :: i2
+  end type
+contains
+  subroutine s0
+    type(t) :: x
+    x = t(i1=2, i2=5)  !OK
+  end
+end
+subroutine s8
+  use m8
+  type(t) :: x
+  !ERROR: PRIVATE component 'i2' is only accessible within module 'm8'
+  x = t(2, 5)
+  !ERROR: PRIVATE component 'i2' is only accessible within module 'm8'
+  x = t(i1=2, i2=5)
+end
+
+! 7.5.4.8(2)
+module m9
+  interface
+    module subroutine s()
+    end subroutine
+  end interface
+  type  :: t
+    integer :: i1
+    integer, private :: i2
+  end type
+end
+submodule(m9) sm8
+contains
+  module subroutine s
+    type(t) :: x
+    x = t(i1=2, i2=5)  !OK
+  end
+end


### PR DESCRIPTION
When a misparsed FunctionReference was converted to a StructureConstructor,
the keywords were not checked for accessibility. For example, in `t(i=1)`,
`i` must not be a PRIVATE component of derived type `t`.

The conversion happens in expression analysis so that where the accessibity
must be checked. So move `CheckAccessibleComponent` to `tools.h` so that it
can be shared by `resolve-names.cpp` and `expression.cpp`.

Also check that an access-spec can only appear in a module.