### PR TITLE
[LLVMify F18] Replace the use std::ostream with LLVM streams llvm::ostream

### DIFF
--- a/documentation/ParserCombinators.md
+++ b/documentation/ParserCombinators.md
@@ -160,5 +160,5 @@ is built.  All of the following parsers consume characters acquired from
 
 ### Debugging Parser
 Last, a string literal `"..."_debug` denotes a parser that emits the string to
-`std::cerr` and succeeds.  It is useful for tracing while debugging a parser but should
+`llvm::errs` and succeeds.  It is useful for tracing while debugging a parser but should
 obviously not be committed for production code.

--- a/include/flang/Common/enum-set.h
+++ b/include/flang/Common/enum-set.h
@@ -16,11 +16,11 @@
 
 #include "constexpr-bitset.h"
 #include "idioms.h"
+#include "llvm/Support/raw_ostream.h"
 #include <bitset>
 #include <cstddef>
 #include <initializer_list>
 #include <optional>
-#include <ostream>
 #include <string>
 #include <type_traits>
 
@@ -199,8 +199,8 @@ public:
     }
   }
 
-  std::ostream &Dump(
-      std::ostream &o, std::string EnumToString(enumerationType)) const {
+  llvm::raw_ostream &Dump(
+      llvm::raw_ostream &o, std::string EnumToString(enumerationType)) const {
     char sep{'{'};
     IterateOverMembers([&](auto e) {
       o << sep << EnumToString(e);

--- a/include/flang/Evaluate/call.h
+++ b/include/flang/Evaluate/call.h
@@ -18,8 +18,11 @@
 #include "flang/Parser/char-block.h"
 #include "flang/Semantics/attr.h"
 #include <optional>
-#include <ostream>
 #include <vector>
+
+namespace llvm {
+class raw_ostream;
+}
 
 namespace Fortran::semantics {
 class Symbol;
@@ -60,7 +63,7 @@ public:
     bool operator==(const AssumedType &that) const {
       return &*symbol_ == &*that.symbol_;
     }
-    std::ostream &AsFortran(std::ostream &) const;
+    llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
   private:
     SymbolRef symbol_;
@@ -101,7 +104,7 @@ public:
   std::optional<DynamicType> GetType() const;
   int Rank() const;
   bool operator==(const ActualArgument &) const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
   std::optional<parser::CharBlock> keyword() const { return keyword_; }
   void set_keyword(parser::CharBlock x) { keyword_ = x; }
@@ -146,7 +149,7 @@ struct SpecificIntrinsic {
   DECLARE_CONSTRUCTORS_AND_ASSIGNMENTS(SpecificIntrinsic)
   ~SpecificIntrinsic();
   bool operator==(const SpecificIntrinsic &) const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
   IntrinsicProcedure name;
   bool isRestrictedSpecific{false};  // if true, can only call it, not pass it
@@ -177,7 +180,7 @@ struct ProcedureDesignator {
   int Rank() const;
   bool IsElemental() const;
   std::optional<Expr<SubscriptInteger>> LEN() const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
   std::variant<SpecificIntrinsic, SymbolRef,
       common::CopyableIndirection<Component>>
@@ -200,7 +203,7 @@ public:
   int Rank() const;
   bool IsElemental() const { return proc_.IsElemental(); }
   bool operator==(const ProcedureRef &) const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
 protected:
   ProcedureDesignator proc_;

--- a/include/flang/Evaluate/characteristics.h
+++ b/include/flang/Evaluate/characteristics.h
@@ -24,10 +24,13 @@
 #include "flang/Parser/char-block.h"
 #include "flang/Semantics/symbol.h"
 #include <optional>
-#include <ostream>
 #include <string>
 #include <variant>
 #include <vector>
+
+namespace llvm {
+class raw_ostream;
+}
 
 namespace Fortran::evaluate {
 class IntrinsicProcTable;
@@ -131,7 +134,7 @@ public:
       const char *thisIs = "POINTER", const char *thatIs = "TARGET",
       bool isElemental = false) const;
 
-  std::ostream &Dump(std::ostream &) const;
+  llvm::raw_ostream &Dump(llvm::raw_ostream &) const;
 
 private:
   void AcquireShape(const semantics::ObjectEntityDetails &);
@@ -160,7 +163,7 @@ struct DummyDataObject {
   }
   static std::optional<DummyDataObject> Characterize(const semantics::Symbol &);
   bool CanBePassedViaImplicitInterface() const;
-  std::ostream &Dump(std::ostream &) const;
+  llvm::raw_ostream &Dump(llvm::raw_ostream &) const;
   TypeAndShape type;
   std::vector<Expr<SubscriptInteger>> coshape;
   common::Intent intent{common::Intent::Default};
@@ -177,7 +180,7 @@ struct DummyProcedure {
   bool operator!=(const DummyProcedure &that) const { return !(*this == that); }
   static std::optional<DummyProcedure> Characterize(
       const semantics::Symbol &, const IntrinsicProcTable &);
-  std::ostream &Dump(std::ostream &) const;
+  llvm::raw_ostream &Dump(llvm::raw_ostream &) const;
   CopyableIndirection<Procedure> procedure;
   common::Intent intent{common::Intent::Default};
   Attrs attrs;
@@ -187,7 +190,7 @@ struct DummyProcedure {
 struct AlternateReturn {
   bool operator==(const AlternateReturn &) const { return true; }
   bool operator!=(const AlternateReturn &) const { return false; }
-  std::ostream &Dump(std::ostream &) const;
+  llvm::raw_ostream &Dump(llvm::raw_ostream &) const;
 };
 
 // 15.3.2.1
@@ -208,7 +211,7 @@ struct DummyArgument {
   bool IsOptional() const;
   void SetOptional(bool = true);
   bool CanBePassedViaImplicitInterface() const;
-  std::ostream &Dump(std::ostream &) const;
+  llvm::raw_ostream &Dump(llvm::raw_ostream &) const;
   // name and pass are not characteristics and so does not participate in
   // operator== but are needed to determine if procedures are distinguishable
   std::string name;
@@ -247,7 +250,7 @@ struct FunctionResult {
   void SetType(DynamicType t) { std::get<TypeAndShape>(u).set_type(t); }
   bool CanBeReturnedViaImplicitInterface() const;
 
-  std::ostream &Dump(std::ostream &) const;
+  llvm::raw_ostream &Dump(llvm::raw_ostream &) const;
 
   Attrs attrs;
   std::variant<TypeAndShape, CopyableIndirection<Procedure>> u;
@@ -288,7 +291,7 @@ struct Procedure {
   int FindPassIndex(std::optional<parser::CharBlock>) const;
   bool CanBeCalledViaImplicitInterface() const;
   bool CanOverride(const Procedure &, std::optional<int> passIndex) const;
-  std::ostream &Dump(std::ostream &) const;
+  llvm::raw_ostream &Dump(llvm::raw_ostream &) const;
 
   std::optional<FunctionResult> functionResult;
   DummyArguments dummyArguments;

--- a/include/flang/Evaluate/complex.h
+++ b/include/flang/Evaluate/complex.h
@@ -13,6 +13,10 @@
 #include "real.h"
 #include <string>
 
+namespace llvm {
+class raw_ostream;
+}
+
 namespace Fortran::evaluate::value {
 
 template<typename REAL_TYPE> class Complex {
@@ -82,7 +86,7 @@ public:
   }
 
   std::string DumpHexadecimal() const;
-  std::ostream &AsFortran(std::ostream &, int kind) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &, int kind) const;
 
   // TODO: (C)ABS once Real::HYPOT is done
   // TODO: unit testing

--- a/include/flang/Evaluate/constant.h
+++ b/include/flang/Evaluate/constant.h
@@ -14,8 +14,11 @@
 #include "flang/Common/default-kinds.h"
 #include "flang/Common/reference.h"
 #include <map>
-#include <ostream>
 #include <vector>
+
+namespace llvm {
+class raw_ostream;
+}
 
 namespace Fortran::semantics {
 class Symbol;
@@ -110,7 +113,7 @@ public:
   constexpr Result result() const { return result_; }
 
   constexpr DynamicType GetType() const { return result_.GetType(); }
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
 protected:
   std::vector<Element> Reshape(const ConstantSubscripts &) const;
@@ -178,7 +181,7 @@ public:
   Scalar<Result> At(const ConstantSubscripts &) const;
 
   Constant Reshape(ConstantSubscripts &&) const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
   static constexpr DynamicType GetType() {
     return {TypeCategory::Character, KIND};
   }

--- a/include/flang/Evaluate/expression.h
+++ b/include/flang/Evaluate/expression.h
@@ -28,10 +28,13 @@
 #include "flang/Parser/char-block.h"
 #include <algorithm>
 #include <list>
-#include <ostream>
 #include <tuple>
 #include <type_traits>
 #include <variant>
+
+namespace llvm {
+class raw_ostream;
+}
 
 namespace Fortran::evaluate {
 
@@ -90,7 +93,7 @@ public:
   std::optional<DynamicType> GetType() const;
   int Rank() const;
   std::string AsFortran() const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
   static Derived Rewrite(FoldingContext &, Derived &&);
 };
 
@@ -185,7 +188,7 @@ public:
     return operand_ == that.operand_;
   }
 
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
 private:
   Container operand_;
@@ -212,7 +215,7 @@ struct Convert : public Operation<Convert<TO, FROMCAT>, TO, SomeKind<FROMCAT>> {
   using Operand = SomeKind<FROMCAT>;
   using Base = Operation<Convert, Result, Operand>;
   using Base::Base;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 };
 
 template<typename A>
@@ -446,7 +449,7 @@ public:
   template<typename T> explicit ArrayConstructor(const Expr<T> &) {}
   static constexpr Result result() { return Result{}; }
   static constexpr DynamicType GetType() { return Result::GetType(); }
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 };
 
 template<int KIND>
@@ -464,7 +467,7 @@ public:
   bool operator==(const ArrayConstructor &) const;
   static constexpr Result result() { return Result{}; }
   static constexpr DynamicType GetType() { return Result::GetType(); }
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
   const Expr<SubscriptInteger> &LEN() const { return length_.value(); }
 
 private:
@@ -488,7 +491,7 @@ public:
   bool operator==(const ArrayConstructor &) const;
   constexpr Result result() const { return result_; }
   constexpr DynamicType GetType() const { return result_.GetType(); }
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
 private:
   Result result_;
@@ -629,7 +632,7 @@ public:
   int Rank() const {
     return std::visit([](const auto &x) { return x.Rank(); }, u);
   }
-  std::ostream &AsFortran(std::ostream &o) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &o) const;
   common::MapTemplate<Relational, DirectlyComparableTypes> u;
 };
 
@@ -715,7 +718,7 @@ public:
   StructureConstructor &Add(const semantics::Symbol &, Expr<SomeType> &&);
   int Rank() const { return 0; }
   DynamicType GetType() const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
 private:
   Result result_;
@@ -823,7 +826,7 @@ public:
   using BoundsSpec = std::vector<Expr<SubscriptInteger>>;
   using BoundsRemapping =
       std::vector<std::pair<Expr<SubscriptInteger>, Expr<SubscriptInteger>>>;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
   Expr<SomeType> lhs;
   Expr<SomeType> rhs;

--- a/include/flang/Evaluate/formatting.h
+++ b/include/flang/Evaluate/formatting.h
@@ -9,10 +9,10 @@
 #ifndef FORTRAN_EVALUATE_FORMATTING_H_
 #define FORTRAN_EVALUATE_FORMATTING_H_
 
-// It is inconvenient in C++ to have std::ostream::operator<<() as a direct
+// It is inconvenient in C++ to have llvm::raw_ostream::operator<<() as a direct
 // friend function of a class template with many instantiations, so the
 // various representational class templates in lib/Evaluate format themselves
-// via AsFortran(std::ostream &) member functions, which the operator<<()
+// via AsFortran(llvm::raw_ostream &) member functions, which the operator<<()
 // overload below will call.  Others have AsFortran() member functions that
 // return strings.
 //
@@ -20,31 +20,31 @@
 // representational class templates that need it, not by external clients.
 
 #include "flang/Common/indirection.h"
+#include "llvm/Support/raw_ostream.h"
 #include <optional>
-#include <ostream>
 #include <type_traits>
 
 namespace Fortran::evaluate {
 
 template<typename A>
-auto operator<<(std::ostream &o, const A &x) -> decltype(x.AsFortran(o)) {
+auto operator<<(llvm::raw_ostream &o, const A &x) -> decltype(x.AsFortran(o)) {
   return x.AsFortran(o);
 }
 
 template<typename A>
-auto operator<<(std::ostream &o, const A &x) -> decltype(o << x.AsFortran()) {
+auto operator<<(llvm::raw_ostream &o, const A &x) -> decltype(o << x.AsFortran()) {
   return o << x.AsFortran();
 }
 
 template<typename A, bool COPYABLE>
 auto operator<<(
-    std::ostream &o, const Fortran::common::Indirection<A, COPYABLE> &x)
+    llvm::raw_ostream &o, const Fortran::common::Indirection<A, COPYABLE> &x)
     -> decltype(o << x.value()) {
   return o << x.value();
 }
 
 template<typename A>
-auto operator<<(std::ostream &o, const std::optional<A> &x)
+auto operator<<(llvm::raw_ostream &o, const std::optional<A> &x)
     -> decltype(o << *x) {
   if (x) {
     o << *x;

--- a/include/flang/Evaluate/intrinsics.h
+++ b/include/flang/Evaluate/intrinsics.h
@@ -16,8 +16,11 @@
 #include "flang/Parser/char-block.h"
 #include "flang/Parser/message.h"
 #include <optional>
-#include <ostream>
 #include <string>
+
+namespace llvm {
+class raw_ostream;
+}
 
 namespace Fortran::evaluate {
 
@@ -76,7 +79,7 @@ public:
   std::optional<SpecificIntrinsicFunctionInterface> IsSpecificIntrinsicFunction(
       const std::string &) const;
 
-  std::ostream &Dump(std::ostream &) const;
+  llvm::raw_ostream &Dump(llvm::raw_ostream &) const;
 
 private:
   Implementation *impl_{nullptr};  // owning pointer

--- a/include/flang/Evaluate/real.h
+++ b/include/flang/Evaluate/real.h
@@ -16,13 +16,15 @@
 #include "flang/Evaluate/common.h"
 #include <cinttypes>
 #include <limits>
-#include <ostream>
 #include <string>
 
 // Some environments, viz. clang on Darwin, allow the macro HUGE
 // to leak out of <math.h> even when it is never directly included.
 #undef HUGE
 
+namespace llvm {
+class raw_ostream;
+}
 namespace Fortran::evaluate::value {
 
 // LOG10(2.)*1E12
@@ -310,7 +312,7 @@ public:
 
   // Emits a character representation for an equivalent Fortran constant
   // or parenthesized constant expression that produces this value.
-  std::ostream &AsFortran(std::ostream &, int kind, bool minimal = false) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &, int kind, bool minimal = false) const;
 
 private:
   using Significand = Integer<significandBits>;  // no implicit bit

--- a/include/flang/Evaluate/static-data.h
+++ b/include/flang/Evaluate/static-data.h
@@ -17,9 +17,12 @@
 #include <cinttypes>
 #include <memory>
 #include <optional>
-#include <ostream>
 #include <string>
 #include <vector>
+
+namespace llvm {
+class raw_ostream;
+}
 
 namespace Fortran::evaluate {
 
@@ -63,7 +66,7 @@ public:
   std::optional<std::string> AsString() const;
   std::optional<std::u16string> AsU16String() const;
   std::optional<std::u32string> AsU32String() const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
   static bool bigEndian;
 

--- a/include/flang/Evaluate/variable.h
+++ b/include/flang/Evaluate/variable.h
@@ -25,9 +25,12 @@
 #include "flang/Common/template.h"
 #include "flang/Parser/char-block.h"
 #include <optional>
-#include <ostream>
 #include <variant>
 #include <vector>
+
+namespace llvm {
+class raw_ostream;
+}
 
 namespace Fortran::semantics {
 class Symbol;
@@ -49,7 +52,7 @@ struct BaseObject {
   EVALUATE_UNION_CLASS_BOILERPLATE(BaseObject)
   int Rank() const;
   std::optional<Expr<SubscriptInteger>> LEN() const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
   const Symbol *symbol() const {
     if (const auto *result{std::get_if<SymbolRef>(&u)}) {
       return &result->get();
@@ -82,7 +85,7 @@ public:
   const Symbol &GetLastSymbol() const { return symbol_; }
   std::optional<Expr<SubscriptInteger>> LEN() const;
   bool operator==(const Component &) const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
 private:
   common::CopyableIndirection<DataRef> base_;
@@ -110,7 +113,7 @@ public:
   int Rank() const;
   std::optional<Expr<SubscriptInteger>> LEN() const;
   bool operator==(const NamedEntity &) const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
 private:
   std::variant<SymbolRef, Component> u_;
@@ -140,7 +143,7 @@ public:
 
   static constexpr int Rank() { return 0; }  // always scalar
   bool operator==(const TypeParamInquiry &) const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
 private:
   std::optional<NamedEntity> base_;
@@ -168,7 +171,7 @@ public:
 
   bool operator==(const Triplet &) const;
   bool IsStrideOne() const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
 private:
   std::optional<IndirectSubscriptIntegerExpr> lower_, upper_;
@@ -181,7 +184,7 @@ struct Subscript {
   explicit Subscript(Expr<SubscriptInteger> &&s)
     : u{IndirectSubscriptIntegerExpr::Make(std::move(s))} {}
   int Rank() const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
   std::variant<IndirectSubscriptIntegerExpr, Triplet> u;
 };
 
@@ -217,7 +220,7 @@ public:
   const Symbol &GetLastSymbol() const;
   std::optional<Expr<SubscriptInteger>> LEN() const;
   bool operator==(const ArrayRef &) const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
 private:
   NamedEntity base_;
@@ -265,7 +268,7 @@ public:
   NamedEntity GetBase() const;
   std::optional<Expr<SubscriptInteger>> LEN() const;
   bool operator==(const CoarrayRef &) const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
 private:
   SymbolVector base_;
@@ -286,7 +289,7 @@ struct DataRef {
   const Symbol &GetFirstSymbol() const;
   const Symbol &GetLastSymbol() const;
   std::optional<Expr<SubscriptInteger>> LEN() const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
   std::variant<SymbolRef, Component, ArrayRef, CoarrayRef> u;
 };
@@ -327,7 +330,7 @@ public:
   const Symbol *GetLastSymbol() const;
   std::optional<Expr<SubscriptInteger>> LEN() const;
   bool operator==(const Substring &) const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
   std::optional<Expr<SomeCharacter>> Fold(FoldingContext &);
 
@@ -352,7 +355,7 @@ public:
   const Symbol &GetFirstSymbol() const { return complex_.GetFirstSymbol(); }
   const Symbol &GetLastSymbol() const { return complex_.GetLastSymbol(); }
   bool operator==(const ComplexPart &) const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
 private:
   DataRef complex_;
@@ -387,7 +390,7 @@ public:
   BaseObject GetBaseObject() const;
   const Symbol *GetLastSymbol() const;
   std::optional<Expr<SubscriptInteger>> LEN() const;
-  std::ostream &AsFortran(std::ostream &o) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &o) const;
 
   Variant u;
 };
@@ -405,7 +408,7 @@ template<typename T> struct Variable {
   int Rank() const {
     return std::visit([](const auto &x) { return x.Rank(); }, u);
   }
-  std::ostream &AsFortran(std::ostream &o) const {
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &o) const {
     std::visit([&](const auto &x) { x.AsFortran(o); }, u);
     return o;
   }
@@ -428,7 +431,7 @@ public:
 
   static constexpr int Rank() { return 0; }  // always scalar
   bool operator==(const DescriptorInquiry &) const;
-  std::ostream &AsFortran(std::ostream &) const;
+  llvm::raw_ostream &AsFortran(llvm::raw_ostream &) const;
 
 private:
   NamedEntity base_;

--- a/include/flang/Lower/PFTBuilder.h
+++ b/include/flang/Lower/PFTBuilder.h
@@ -11,7 +11,6 @@
 
 #include "flang/Common/template.h"
 #include "flang/Parser/parse-tree.h"
-#include "llvm/Support/raw_ostream.h"
 #include <memory>
 
 /// Build a light-weight tree over the parse-tree to help with lowering to FIR.
@@ -25,6 +24,10 @@
 /// units.  Function like units will contain lists of evaluations.  Evaluations
 /// are either statements or constructs, where a construct contains a list of
 /// evaluations. The resulting PFT structure can then be used to create FIR.
+
+namespace llvm {
+class raw_ostream;
+}
 
 namespace Fortran::lower {
 namespace pft {

--- a/include/flang/Parser/char-block.h
+++ b/include/flang/Parser/char-block.h
@@ -19,6 +19,10 @@
 #include <string>
 #include <utility>
 
+namespace llvm {
+class raw_ostream;
+}
+
 namespace Fortran::parser {
 
 class CharBlock {
@@ -134,7 +138,7 @@ inline bool operator>(const char *left, const CharBlock &right) {
   return right < left;
 }
 
-std::ostream &operator<<(std::ostream &os, const CharBlock &x);
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const CharBlock &x);
 
 }
 

--- a/include/flang/Parser/instrumented-parser.h
+++ b/include/flang/Parser/instrumented-parser.h
@@ -15,7 +15,10 @@
 #include "flang/Parser/provenance.h"
 #include <cstddef>
 #include <map>
-#include <ostream>
+
+namespace llvm {
+class raw_ostream;
+}
 
 namespace Fortran::parser {
 
@@ -28,7 +31,7 @@ public:
   bool Fails(const char *at, const MessageFixedText &tag, ParseState &);
   void Note(const char *at, const MessageFixedText &tag, bool pass,
       const ParseState &);
-  void Dump(std::ostream &, const CookedSource &) const;
+  void Dump(llvm::raw_ostream &, const CookedSource &) const;
 
 private:
   struct LogForPosition {

--- a/include/flang/Parser/message.h
+++ b/include/flang/Parser/message.h
@@ -22,7 +22,6 @@
 #include <cstring>
 #include <forward_list>
 #include <optional>
-#include <ostream>
 #include <string>
 #include <utility>
 #include <variant>
@@ -187,7 +186,7 @@ public:
   std::string ToString() const;
   std::optional<ProvenanceRange> GetProvenanceRange(const CookedSource &) const;
   void Emit(
-      std::ostream &, const CookedSource &, bool echoSourceLine = true) const;
+      llvm::raw_ostream &, const CookedSource &, bool echoSourceLine = true) const;
 
   // If this Message or any of its attachments locates itself via a CharBlock
   // within a particular CookedSource, replace its location with the
@@ -255,7 +254,7 @@ public:
   void Merge(Messages &&);
   void Copy(const Messages &);
   void ResolveProvenances(const CookedSource &);
-  void Emit(std::ostream &, const CookedSource &cooked,
+  void Emit(llvm::raw_ostream &, const CookedSource &cooked,
       bool echoSourceLines = true) const;
   void AttachTo(Message &);
   bool AnyFatalError() const;

--- a/include/flang/Parser/parsing.h
+++ b/include/flang/Parser/parsing.h
@@ -15,8 +15,8 @@
 #include "parse-tree.h"
 #include "provenance.h"
 #include "flang/Common/Fortran-features.h"
+#include "llvm/Support/raw_ostream.h"
 #include <optional>
-#include <ostream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -50,19 +50,19 @@ public:
   std::optional<Program> &parseTree() { return parseTree_; }
 
   const SourceFile *Prescan(const std::string &path, Options);
-  void DumpCookedChars(std::ostream &) const;
-  void DumpProvenance(std::ostream &) const;
-  void DumpParsingLog(std::ostream &) const;
-  void Parse(std::ostream *debugOutput = nullptr);
+  void DumpCookedChars(llvm::raw_ostream &) const;
+  void DumpProvenance(llvm::raw_ostream &) const;
+  void DumpParsingLog(llvm::raw_ostream &) const;
+  void Parse(llvm::raw_ostream &debugOutput);
   void ClearLog();
 
-  void EmitMessage(std::ostream &o, const char *at, const std::string &message,
+  void EmitMessage(llvm::raw_ostream &o, const char *at, const std::string &message,
       bool echoSourceLine = false) const {
     cooked_.allSources().EmitMessage(
         o, cooked_.GetProvenanceRange(CharBlock(at)), message, echoSourceLine);
   }
 
-  bool ForTesting(std::string path, std::ostream &);
+  bool ForTesting(std::string path, llvm::raw_ostream &);
 
 private:
   Options options_;

--- a/include/flang/Parser/provenance.h
+++ b/include/flang/Parser/provenance.h
@@ -15,12 +15,11 @@
 #include "source.h"
 #include "flang/Common/idioms.h"
 #include "flang/Common/interval.h"
+#include "llvm/Support/raw_ostream.h"
 #include <cstddef>
 #include <map>
 #include <memory>
 #include <optional>
-#include <ostream>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <variant>
@@ -91,7 +90,7 @@ public:
   bool empty() const { return map_.empty(); }
   void Put(ProvenanceRange, std::size_t offset);
   std::optional<std::size_t> Map(ProvenanceRange) const;
-  std::ostream &Dump(std::ostream &) const;
+  llvm::raw_ostream &Dump(llvm::raw_ostream &) const;
 
 private:
   // A comparison function object for use in std::multimap<Compare=>.
@@ -120,7 +119,7 @@ public:
   ProvenanceRange Map(std::size_t at) const;
   void RemoveLastBytes(std::size_t);
   ProvenanceRangeToOffsetMappings Invert(const AllSources &) const;
-  std::ostream &Dump(std::ostream &) const;
+  llvm::raw_ostream &Dump(llvm::raw_ostream &) const;
 
 private:
   struct ContiguousProvenanceMapping {
@@ -150,8 +149,8 @@ public:
 
   void PushSearchPathDirectory(std::string);
   std::string PopSearchPathDirectory();
-  const SourceFile *Open(std::string path, std::stringstream *error);
-  const SourceFile *ReadStandardInput(std::stringstream *error);
+  const SourceFile *Open(std::string path, llvm::raw_ostream &error);
+  const SourceFile *ReadStandardInput(llvm::raw_ostream &error);
 
   ProvenanceRange AddIncludedFile(
       const SourceFile &, ProvenanceRange, bool isModule = false);
@@ -163,7 +162,7 @@ public:
   bool IsValid(ProvenanceRange range) const {
     return range.size() > 0 && range_.Contains(range);
   }
-  void EmitMessage(std::ostream &, const std::optional<ProvenanceRange> &,
+  void EmitMessage(llvm::raw_ostream &, const std::optional<ProvenanceRange> &,
       const std::string &message, bool echoSourceLine = false) const;
   const SourceFile *GetSourceFile(
       Provenance, std::size_t *offset = nullptr) const;
@@ -174,7 +173,7 @@ public:
   Provenance CompilerInsertionProvenance(char ch);
   Provenance CompilerInsertionProvenance(const char *, std::size_t);
   ProvenanceRange IntersectionWithSourceFiles(ProvenanceRange) const;
-  std::ostream &Dump(std::ostream &) const;
+  llvm::raw_ostream &Dump(llvm::raw_ostream &) const;
 
 private:
   struct Inclusion {
@@ -260,7 +259,7 @@ public:
   void Marshal();  // marshals text into one contiguous block
   void CompileProvenanceRangeToOffsetMappings();
   std::string AcquireData() { return std::move(data_); }
-  std::ostream &Dump(std::ostream &) const;
+  llvm::raw_ostream &Dump(llvm::raw_ostream &) const;
 
 private:
   AllSources &allSources_;

--- a/include/flang/Parser/source.h
+++ b/include/flang/Parser/source.h
@@ -16,10 +16,13 @@
 
 #include "characters.h"
 #include <cstddef>
-#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
+
+namespace llvm {
+class raw_ostream;
+}
 
 namespace Fortran::parser {
 
@@ -44,8 +47,8 @@ public:
   std::size_t lines() const { return lineStart_.size(); }
   Encoding encoding() const { return encoding_; }
 
-  bool Open(std::string path, std::stringstream *error);
-  bool ReadStandardInput(std::stringstream *error);
+  bool Open(std::string path, llvm::raw_ostream &error);
+  bool ReadStandardInput(llvm::raw_ostream &error);
   void Close();
   SourcePosition FindOffsetLineAndColumn(std::size_t) const;
   std::size_t GetLineStartOffset(int lineNumber) const {
@@ -53,7 +56,7 @@ public:
   }
 
 private:
-  bool ReadFile(std::string errorPath, std::stringstream *error);
+  bool ReadFile(std::string errorPath, llvm::raw_ostream &error);
   void IdentifyPayload();
   void RecordLineStarts();
 

--- a/include/flang/Parser/unparse.h
+++ b/include/flang/Parser/unparse.h
@@ -14,6 +14,10 @@
 #include <functional>
 #include <iosfwd>
 
+namespace llvm {
+class raw_ostream;
+}
+
 namespace Fortran::evaluate {
 struct GenericExprWrapper;
 struct GenericAssignmentWrapper;
@@ -26,21 +30,21 @@ struct Program;
 
 // A function called before each Statement is unparsed.
 using preStatementType =
-    std::function<void(const CharBlock &, std::ostream &, int)>;
+    std::function<void(const CharBlock &, llvm::raw_ostream &, int)>;
 
 // Functions to handle unparsing of analyzed expressions and related
 // objects rather than their original parse trees.
 struct AnalyzedObjectsAsFortran {
-  std::function<void(std::ostream &, const evaluate::GenericExprWrapper &)>
+  std::function<void(llvm::raw_ostream &, const evaluate::GenericExprWrapper &)>
       expr;
   std::function<void(
-      std::ostream &, const evaluate::GenericAssignmentWrapper &)>
+      llvm::raw_ostream &, const evaluate::GenericAssignmentWrapper &)>
       assignment;
-  std::function<void(std::ostream &, const evaluate::ProcedureRef &)> call;
+  std::function<void(llvm::raw_ostream &, const evaluate::ProcedureRef &)> call;
 };
 
 // Converts parsed program to out as Fortran.
-void Unparse(std::ostream &out, const Program &program,
+void Unparse(llvm::raw_ostream &out, const Program &program,
     Encoding encoding = Encoding::UTF_8, bool capitalizeKeywords = true,
     bool backslashEscapes = true, preStatementType *preStatement = nullptr,
     AnalyzedObjectsAsFortran * = nullptr);

--- a/include/flang/Parser/user-state.h
+++ b/include/flang/Parser/user-state.h
@@ -18,9 +18,9 @@
 #include "flang/Common/idioms.h"
 #include "flang/Parser/char-block.h"
 #include "flang/Parser/parse-tree.h"
+#include "llvm/Support/raw_ostream.h"
 #include <cinttypes>
 #include <optional>
-#include <ostream>
 #include <set>
 #include <unordered_map>
 
@@ -40,9 +40,9 @@ public:
   const CookedSource &cooked() const { return cooked_; }
   const common::LanguageFeatureControl &features() const { return features_; }
 
-  std::ostream *debugOutput() const { return debugOutput_; }
-  UserState &set_debugOutput(std::ostream *out) {
-    debugOutput_ = out;
+  llvm::raw_ostream *debugOutput() const { return debugOutput_; }
+  UserState &set_debugOutput(llvm::raw_ostream &out) {
+    debugOutput_ = &out;
     return *this;
   }
 
@@ -91,7 +91,7 @@ public:
 private:
   const CookedSource &cooked_;
 
-  std::ostream *debugOutput_{nullptr};
+  llvm::raw_ostream *debugOutput_{nullptr};
 
   ParsingLog *log_{nullptr};
   bool instrumentedParse_{false};

--- a/include/flang/Semantics/attr.h
+++ b/include/flang/Semantics/attr.h
@@ -14,6 +14,10 @@
 #include <cinttypes>
 #include <string>
 
+namespace llvm {
+class raw_ostream;
+}
+
 namespace Fortran::semantics {
 
 // All available attributes.
@@ -38,13 +42,13 @@ public:
   void CheckValid(const Attrs &allowed) const;
 
 private:
-  friend std::ostream &operator<<(std::ostream &, const Attrs &);
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const Attrs &);
 };
 
 // Return string representation of attr that matches Fortran source.
 std::string AttrToString(Attr attr);
 
-std::ostream &operator<<(std::ostream &o, Attr attr);
-std::ostream &operator<<(std::ostream &o, const Attrs &attrs);
+llvm::raw_ostream &operator<<(llvm::raw_ostream &o, Attr attr);
+llvm::raw_ostream &operator<<(llvm::raw_ostream &o, const Attrs &attrs);
 }
 #endif  // FORTRAN_SEMANTICS_ATTR_H_

--- a/include/flang/Semantics/scope.h
+++ b/include/flang/Semantics/scope.h
@@ -22,6 +22,10 @@
 #include <set>
 #include <string>
 
+namespace llvm {
+class raw_ostream;
+}
+
 namespace Fortran::semantics {
 
 using namespace parser::literals;
@@ -234,7 +238,7 @@ private:
   bool CanImport(const SourceName &) const;
   const DeclTypeSpec &MakeLengthlessType(DeclTypeSpec &&);
 
-  friend std::ostream &operator<<(std::ostream &, const Scope &);
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const Scope &);
 };
 }
 #endif  // FORTRAN_SEMANTICS_SCOPE_H_

--- a/include/flang/Semantics/semantics.h
+++ b/include/flang/Semantics/semantics.h
@@ -19,6 +19,10 @@
 #include <string>
 #include <vector>
 
+namespace llvm {
+class raw_ostream;
+}
+
 namespace Fortran::common {
 class IntrinsicTypeDefaultKinds;
 }
@@ -209,9 +213,9 @@ public:
     return context_.FindScope(where);
   }
   bool AnyFatalError() const { return context_.AnyFatalError(); }
-  void EmitMessages(std::ostream &) const;
-  void DumpSymbols(std::ostream &);
-  void DumpSymbolsSources(std::ostream &) const;
+  void EmitMessages(llvm::raw_ostream &) const;
+  void DumpSymbols(llvm::raw_ostream &);
+  void DumpSymbolsSources(llvm::raw_ostream &) const;
 
 private:
   SemanticsContext &context_;

--- a/include/flang/Semantics/symbol.h
+++ b/include/flang/Semantics/symbol.h
@@ -19,6 +19,10 @@
 #include <set>
 #include <vector>
 
+namespace llvm {
+class raw_ostream;
+}
+
 namespace Fortran::semantics {
 
 /// A Symbol consists of common information (name, owner, and attributes)
@@ -79,7 +83,7 @@ private:
   std::vector<Symbol *> dummyArgs_;  // nullptr -> alternate return indicator
   Symbol *result_{nullptr};
   MaybeExpr stmtFunction_;
-  friend std::ostream &operator<<(std::ostream &, const SubprogramDetails &);
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const SubprogramDetails &);
 };
 
 // For SubprogramNameDetails, the kind indicates whether it is the name
@@ -121,7 +125,7 @@ private:
   bool isFuncResult_{false};
   const DeclTypeSpec *type_{nullptr};
   MaybeExpr bindName_;
-  friend std::ostream &operator<<(std::ostream &, const EntityDetails &);
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const EntityDetails &);
 };
 
 // Symbol is associated with a name or expression in a SELECT TYPE or ASSOCIATE.
@@ -176,7 +180,7 @@ private:
   ArraySpec shape_;
   ArraySpec coshape_;
   const Symbol *commonBlock_{nullptr};  // common block this object is in
-  friend std::ostream &operator<<(std::ostream &, const ObjectEntityDetails &);
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const ObjectEntityDetails &);
 };
 
 // Mixin for details with passed-object dummy argument.
@@ -213,7 +217,7 @@ public:
 private:
   ProcInterface interface_;
   std::optional<const Symbol *> init_;
-  friend std::ostream &operator<<(std::ostream &, const ProcEntityDetails &);
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const ProcEntityDetails &);
 };
 
 // These derived type details represent the characteristics of a derived
@@ -259,7 +263,7 @@ private:
   std::list<SourceName> componentNames_;
   bool sequence_{false};
   bool isForwardReferenced_{false};
-  friend std::ostream &operator<<(std::ostream &, const DerivedTypeDetails &);
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const DerivedTypeDetails &);
 };
 
 class ProcBindingDetails : public WithPassArg {
@@ -443,7 +447,7 @@ using Details = std::variant<UnknownDetails, MainProgramDetails, ModuleDetails,
     DerivedTypeDetails, UseDetails, UseErrorDetails, HostAssocDetails,
     GenericDetails, ProcBindingDetails, NamelistDetails, CommonBlockDetails,
     FinalProcDetails, TypeParamDetails, MiscDetails>;
-std::ostream &operator<<(std::ostream &, const Details &);
+llvm::raw_ostream &operator<<(llvm::raw_ostream &, const Details &);
 std::string DetailsToString(const Details &);
 
 class Symbol {
@@ -657,8 +661,8 @@ private:
 
   Symbol() {}  // only created in class Symbols
   const std::string GetDetailsName() const;
-  friend std::ostream &operator<<(std::ostream &, const Symbol &);
-  friend std::ostream &DumpForUnparse(std::ostream &, const Symbol &, bool);
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const Symbol &);
+  friend llvm::raw_ostream &DumpForUnparse(llvm::raw_ostream &, const Symbol &, bool);
 
   // If a derived type's symbol refers to an extended derived type,
   // return the parent component's symbol.  The scope of the derived type
@@ -669,7 +673,7 @@ private:
   template<class, std::size_t> friend struct std::array;
 };
 
-std::ostream &operator<<(std::ostream &, Symbol::Flag);
+llvm::raw_ostream &operator<<(llvm::raw_ostream &, Symbol::Flag);
 
 // Manage memory for all symbols. BLOCK_SIZE symbols at a time are allocated.
 // Make() returns a reference to the next available one. They are never

--- a/include/flang/Semantics/type.h
+++ b/include/flang/Semantics/type.h
@@ -21,6 +21,10 @@
 #include <variant>
 #include <vector>
 
+namespace llvm {
+class raw_ostream;
+}
+
 namespace Fortran::parser {
 struct Keyword;
 }
@@ -71,7 +75,7 @@ private:
     : category_{category}, expr_{std::move(expr)} {}
   Category category_{Category::Explicit};
   MaybeSubscriptIntExpr expr_;
-  friend std::ostream &operator<<(std::ostream &, const Bound &);
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const Bound &);
 };
 
 // A type parameter value: integer expression or assumed or deferred.
@@ -107,7 +111,7 @@ private:
   Category category_{Category::Explicit};
   common::TypeParamAttr attr_{common::TypeParamAttr::Kind};
   MaybeIntExpr expr_;
-  friend std::ostream &operator<<(std::ostream &, const ParamValue &);
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const ParamValue &);
 };
 
 class IntrinsicTypeSpec {
@@ -126,7 +130,7 @@ protected:
 private:
   TypeCategory category_;
   KindExpr kind_;
-  friend std::ostream &operator<<(std::ostream &os, const IntrinsicTypeSpec &x);
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const IntrinsicTypeSpec &x);
 };
 
 class NumericTypeSpec : public IntrinsicTypeSpec {
@@ -153,7 +157,7 @@ public:
 
 private:
   ParamValue length_;
-  friend std::ostream &operator<<(std::ostream &os, const CharacterTypeSpec &x);
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const CharacterTypeSpec &x);
 };
 
 class ShapeSpec {
@@ -205,7 +209,7 @@ private:
   ShapeSpec(Bound &&lb, Bound &&ub) : lb_{std::move(lb)}, ub_{std::move(ub)} {}
   Bound lb_;
   Bound ub_;
-  friend std::ostream &operator<<(std::ostream &, const ShapeSpec &);
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const ShapeSpec &);
 };
 
 struct ArraySpec : public std::vector<ShapeSpec> {
@@ -224,7 +228,7 @@ private:
     return !empty() && std::all_of(begin(), end(), predicate);
   }
 };
-std::ostream &operator<<(std::ostream &, const ArraySpec &);
+llvm::raw_ostream &operator<<(llvm::raw_ostream &, const ArraySpec &);
 
 // Each DerivedTypeSpec has a typeSymbol that has DerivedTypeDetails.
 // The name may not match the symbol's name in case of a USE rename.
@@ -289,7 +293,7 @@ private:
   bool instantiated_{false};
   RawParameters rawParameters_;
   ParameterMapType parameters_;
-  friend std::ostream &operator<<(std::ostream &, const DerivedTypeSpec &);
+  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const DerivedTypeSpec &);
 };
 
 class DeclTypeSpec {
@@ -370,7 +374,7 @@ private:
       CharacterTypeSpec, DerivedTypeSpec>
       typeSpec_;
 };
-std::ostream &operator<<(std::ostream &, const DeclTypeSpec &);
+llvm::raw_ostream &operator<<(llvm::raw_ostream &, const DeclTypeSpec &);
 
 // This represents a proc-interface in the declaration of a procedure or
 // procedure component. It comprises a symbol that represents the specific

--- a/include/flang/Semantics/unparse-with-symbols.h
+++ b/include/flang/Semantics/unparse-with-symbols.h
@@ -12,12 +12,16 @@
 #include "flang/Parser/characters.h"
 #include <iosfwd>
 
+namespace llvm {
+class raw_ostream;
+}
+
 namespace Fortran::parser {
 struct Program;
 }
 
 namespace Fortran::semantics {
-void UnparseWithSymbols(std::ostream &, const parser::Program &,
+void UnparseWithSymbols(llvm::raw_ostream &, const parser::Program &,
     parser::Encoding encoding = parser::Encoding::UTF_8);
 }
 

--- a/lib/Evaluate/characteristics.cpp
+++ b/lib/Evaluate/characteristics.cpp
@@ -16,8 +16,8 @@
 #include "flang/Parser/message.h"
 #include "flang/Semantics/scope.h"
 #include "flang/Semantics/symbol.h"
+#include "llvm/Support/raw_ostream.h"
 #include <initializer_list>
-#include <ostream>
 
 using namespace Fortran::parser::literals;
 
@@ -179,7 +179,7 @@ void TypeAndShape::AcquireLEN() {
   }
 }
 
-std::ostream &TypeAndShape::Dump(std::ostream &o) const {
+llvm::raw_ostream &TypeAndShape::Dump(llvm::raw_ostream &o) const {
   o << type_.AsFortran(LEN_ ? LEN_->AsFortran() : "");
   attrs_.Dump(o, EnumToString);
   if (!shape_.empty()) {
@@ -261,7 +261,7 @@ bool DummyDataObject::CanBePassedViaImplicitInterface() const {
   }
 }
 
-std::ostream &DummyDataObject::Dump(std::ostream &o) const {
+llvm::raw_ostream &DummyDataObject::Dump(llvm::raw_ostream &o) const {
   attrs.Dump(o, EnumToString);
   if (intent != common::Intent::Default) {
     o << "INTENT(" << common::EnumToString(intent) << ')';
@@ -306,7 +306,7 @@ std::optional<DummyProcedure> DummyProcedure::Characterize(
   }
 }
 
-std::ostream &DummyProcedure::Dump(std::ostream &o) const {
+llvm::raw_ostream &DummyProcedure::Dump(llvm::raw_ostream &o) const {
   attrs.Dump(o, EnumToString);
   if (intent != common::Intent::Default) {
     o << "INTENT(" << common::EnumToString(intent) << ')';
@@ -315,7 +315,9 @@ std::ostream &DummyProcedure::Dump(std::ostream &o) const {
   return o;
 }
 
-std::ostream &AlternateReturn::Dump(std::ostream &o) const { return o << '*'; }
+llvm::raw_ostream &AlternateReturn::Dump(llvm::raw_ostream &o) const {
+  return o << '*';
+}
 
 DummyArgument::~DummyArgument() {}
 
@@ -417,7 +419,7 @@ bool DummyArgument::CanBePassedViaImplicitInterface() const {
   }
 }
 
-std::ostream &DummyArgument::Dump(std::ostream &o) const {
+llvm::raw_ostream &DummyArgument::Dump(llvm::raw_ostream &o) const {
   if (!name.empty()) {
     o << name << '=';
   }
@@ -503,7 +505,7 @@ bool FunctionResult::CanBeReturnedViaImplicitInterface() const {
   }
 }
 
-std::ostream &FunctionResult::Dump(std::ostream &o) const {
+llvm::raw_ostream &FunctionResult::Dump(llvm::raw_ostream &o) const {
   attrs.Dump(o, EnumToString);
   std::visit(
       common::visitors{
@@ -698,7 +700,7 @@ bool Procedure::CanBeCalledViaImplicitInterface() const {
   }
 }
 
-std::ostream &Procedure::Dump(std::ostream &o) const {
+llvm::raw_ostream &Procedure::Dump(llvm::raw_ostream &o) const {
   attrs.Dump(o, EnumToString);
   if (functionResult) {
     functionResult->Dump(o << "TYPE(") << ") FUNCTION";

--- a/lib/Evaluate/complex.cpp
+++ b/lib/Evaluate/complex.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "flang/Evaluate/complex.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace Fortran::evaluate::value {
 
@@ -90,7 +91,7 @@ template<typename R> std::string Complex<R>::DumpHexadecimal() const {
 }
 
 template<typename R>
-std::ostream &Complex<R>::AsFortran(std::ostream &o, int kind) const {
+llvm::raw_ostream &Complex<R>::AsFortran(llvm::raw_ostream &o, int kind) const {
   re_.AsFortran(o << '(', kind);
   im_.AsFortran(o << ',', kind);
   return o << ')';

--- a/lib/Evaluate/expression.cpp
+++ b/lib/Evaluate/expression.cpp
@@ -13,6 +13,7 @@
 #include "flang/Evaluate/tools.h"
 #include "flang/Evaluate/variable.h"
 #include "flang/Parser/message.h"
+#include "llvm/Support/raw_ostream.h"
 #include <string>
 #include <type_traits>
 

--- a/lib/Evaluate/host.cpp
+++ b/lib/Evaluate/host.cpp
@@ -9,7 +9,7 @@
 #include "host.h"
 
 #include "flang/Common/idioms.h"
-#include <cerrno>
+#include "llvm/Support/Errno.h"
 #include <cfenv>
 
 namespace Fortran::evaluate::host {
@@ -20,12 +20,12 @@ void HostFloatingPointEnvironment::SetUpHostFloatingPointEnvironment(
   errno = 0;
   if (feholdexcept(&originalFenv_) != 0) {
     common::die("Folding with host runtime: feholdexcept() failed: %s",
-        std::strerror(errno));
+        llvm::sys::StrError(errno).c_str());
     return;
   }
   if (fegetenv(&currentFenv_) != 0) {
     common::die("Folding with host runtime: fegetenv() failed: %s",
-        std::strerror(errno));
+        llvm::sys::StrError(errno).c_str());
     return;
   }
 #if __x86_64__
@@ -72,7 +72,7 @@ void HostFloatingPointEnvironment::SetUpHostFloatingPointEnvironment(
   errno = 0;
   if (fesetenv(&currentFenv_) != 0) {
     common::die("Folding with host runtime: fesetenv() failed: %s",
-        std::strerror(errno));
+        llvm::sys::StrError(errno).c_str());
     return;
   }
   switch (context.rounding().mode) {
@@ -127,10 +127,11 @@ void HostFloatingPointEnvironment::CheckAndRestoreFloatingPointEnvironment(
   }
   errno = 0;
   if (fesetenv(&originalFenv_) != 0) {
-    std::fprintf(stderr, "fesetenv() failed: %s\n", std::strerror(errno));
+    std::fprintf(
+        stderr, "fesetenv() failed: %s\n", llvm::sys::StrError(errno).c_str());
     common::die(
         "Folding with host runtime: fesetenv() failed while restoring fenv: %s",
-        std::strerror(errno));
+        llvm::sys::StrError(errno).c_str());
   }
   errno = 0;
 }

--- a/lib/Evaluate/intrinsics.cpp
+++ b/lib/Evaluate/intrinsics.cpp
@@ -16,10 +16,9 @@
 #include "flang/Evaluate/shape.h"
 #include "flang/Evaluate/tools.h"
 #include "flang/Evaluate/type.h"
+#include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <map>
-#include <ostream>
-#include <sstream>
 #include <string>
 #include <utility>
 
@@ -90,7 +89,7 @@ ENUM_CLASS(KindCode, none, defaultIntegerKind,
 struct TypePattern {
   CategorySet categorySet;
   KindCode kindCode{KindCode::none};
-  std::ostream &Dump(std::ostream &) const;
+  llvm::raw_ostream &Dump(llvm::raw_ostream &) const;
 };
 
 // Abbreviations for argument and result patterns in the intrinsic prototypes:
@@ -195,7 +194,7 @@ struct IntrinsicDummyArgument {
   TypePattern typePattern;
   Rank rank{Rank::elemental};
   Optionality optionality{Optionality::required};
-  std::ostream &Dump(std::ostream &) const;
+  llvm::raw_ostream &Dump(llvm::raw_ostream &) const;
 };
 
 // constexpr abbreviations for popular arguments:
@@ -234,7 +233,7 @@ struct IntrinsicInterface {
       const common::IntrinsicTypeDefaultKinds &, ActualArguments &,
       FoldingContext &context) const;
   int CountArguments() const;
-  std::ostream &Dump(std::ostream &) const;
+  llvm::raw_ostream &Dump(llvm::raw_ostream &) const;
 };
 
 int IntrinsicInterface::CountArguments() const {
@@ -1517,7 +1516,7 @@ public:
   std::optional<SpecificIntrinsicFunctionInterface> IsSpecificIntrinsicFunction(
       const std::string &) const;
 
-  std::ostream &Dump(std::ostream &) const;
+  llvm::raw_ostream &Dump(llvm::raw_ostream &) const;
 
 private:
   DynamicType GetSpecificType(const TypePattern &) const;
@@ -2000,7 +1999,7 @@ IntrinsicProcTable::IsSpecificIntrinsicFunction(const std::string &name) const {
   return DEREF(impl_).IsSpecificIntrinsicFunction(name);
 }
 
-std::ostream &TypePattern::Dump(std::ostream &o) const {
+llvm::raw_ostream &TypePattern::Dump(llvm::raw_ostream &o) const {
   if (categorySet == AnyType) {
     o << "any type";
   } else {
@@ -2016,7 +2015,7 @@ std::ostream &TypePattern::Dump(std::ostream &o) const {
   return o;
 }
 
-std::ostream &IntrinsicDummyArgument::Dump(std::ostream &o) const {
+llvm::raw_ostream &IntrinsicDummyArgument::Dump(llvm::raw_ostream &o) const {
   if (keyword) {
     o << keyword << '=';
   }
@@ -2024,7 +2023,7 @@ std::ostream &IntrinsicDummyArgument::Dump(std::ostream &o) const {
       << ' ' << EnumToString(rank) << ' ' << EnumToString(optionality);
 }
 
-std::ostream &IntrinsicInterface::Dump(std::ostream &o) const {
+llvm::raw_ostream &IntrinsicInterface::Dump(llvm::raw_ostream &o) const {
   o << name;
   char sep{'('};
   for (const auto &d : dummy) {
@@ -2040,7 +2039,8 @@ std::ostream &IntrinsicInterface::Dump(std::ostream &o) const {
   return result.Dump(o << " -> ") << ' ' << EnumToString(rank);
 }
 
-std::ostream &IntrinsicProcTable::Implementation::Dump(std::ostream &o) const {
+llvm::raw_ostream &IntrinsicProcTable::Implementation::Dump(
+    llvm::raw_ostream &o) const {
   o << "generic intrinsic functions:\n";
   for (const auto &iter : genericFuncs_) {
     iter.second->Dump(o << iter.first << ": ") << '\n';
@@ -2060,7 +2060,7 @@ std::ostream &IntrinsicProcTable::Implementation::Dump(std::ostream &o) const {
   return o;
 }
 
-std::ostream &IntrinsicProcTable::Dump(std::ostream &o) const {
+llvm::raw_ostream &IntrinsicProcTable::Dump(llvm::raw_ostream &o) const {
   return impl_->Dump(o);
 }
 }

--- a/lib/Evaluate/real.cpp
+++ b/lib/Evaluate/real.cpp
@@ -11,6 +11,7 @@
 #include "flang/Common/idioms.h"
 #include "flang/Decimal/decimal.h"
 #include "flang/Parser/characters.h"
+#include "llvm/Support/raw_ostream.h"
 #include <limits>
 
 namespace Fortran::evaluate::value {
@@ -478,8 +479,8 @@ template<typename W, int P> std::string Real<W, P>::DumpHexadecimal() const {
 }
 
 template<typename W, int P>
-std::ostream &Real<W, P>::AsFortran(
-    std::ostream &o, int kind, bool minimal) const {
+llvm::raw_ostream &Real<W, P>::AsFortran(
+    llvm::raw_ostream &o, int kind, bool minimal) const {
   if (IsNotANumber()) {
     o << "(0._" << kind << "/0.)";
   } else if (IsInfinite()) {

--- a/lib/Evaluate/static-data.cpp
+++ b/lib/Evaluate/static-data.cpp
@@ -13,7 +13,7 @@ namespace Fortran::evaluate {
 
 bool StaticDataObject::bigEndian{false};
 
-std::ostream &StaticDataObject::AsFortran(std::ostream &o) const {
+llvm::raw_ostream &StaticDataObject::AsFortran(llvm::raw_ostream &o) const {
   if (auto string{AsString()}) {
     o << parser::QuoteCharacterLiteral(*string);
   } else if (auto string{AsU16String()}) {

--- a/lib/Evaluate/type.cpp
+++ b/lib/Evaluate/type.cpp
@@ -18,7 +18,6 @@
 #include "flang/Semantics/type.h"
 #include <algorithm>
 #include <optional>
-#include <sstream>
 #include <string>
 
 // IsDescriptor() predicate

--- a/lib/Evaluate/variable.cpp
+++ b/lib/Evaluate/variable.cpp
@@ -14,7 +14,6 @@
 #include "flang/Parser/characters.h"
 #include "flang/Parser/message.h"
 #include "flang/Semantics/symbol.h"
-#include <ostream>
 #include <type_traits>
 
 using namespace Fortran::parser::literals;

--- a/lib/Parser/CMakeLists.txt
+++ b/lib/Parser/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(FortranParser
 
 target_link_libraries(FortranParser
   FortranCommon
+  LLVMSupport
 )
 
 install (TARGETS FortranParser

--- a/lib/Parser/char-block.cpp
+++ b/lib/Parser/char-block.cpp
@@ -7,11 +7,11 @@
 //----------------------------------------------------------------------------//
 
 #include "flang/Parser/char-block.h"
-#include <ostream>
+#include "llvm/Support/raw_ostream.h"
 
 namespace Fortran::parser {
 
-std::ostream &operator<<(std::ostream &os, const CharBlock &x) {
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const CharBlock &x) {
   return os << x.ToString();
 }
 

--- a/lib/Parser/debug-parser.cpp
+++ b/lib/Parser/debug-parser.cpp
@@ -8,7 +8,6 @@
 
 #include "debug-parser.h"
 #include "flang/Parser/user-state.h"
-#include <ostream>
 #include <string>
 
 namespace Fortran::parser {

--- a/lib/Parser/instrumented-parser.cpp
+++ b/lib/Parser/instrumented-parser.cpp
@@ -9,8 +9,8 @@
 #include "flang/Parser/instrumented-parser.h"
 #include "flang/Parser/message.h"
 #include "flang/Parser/provenance.h"
+#include "llvm/Support/raw_ostream.h"
 #include <map>
-#include <ostream>
 
 namespace Fortran::parser {
 
@@ -63,7 +63,7 @@ void ParsingLog::Note(const char *at, const MessageFixedText &tag, bool pass,
   }
 }
 
-void ParsingLog::Dump(std::ostream &o, const CookedSource &cooked) const {
+void ParsingLog::Dump(llvm::raw_ostream &o, const CookedSource &cooked) const {
   for (const auto &posLog : perPos_) {
     const char *at{reinterpret_cast<const char *>(posLog.first)};
     for (const auto &tagLog : posLog.second.perTag) {

--- a/lib/Parser/message.cpp
+++ b/lib/Parser/message.cpp
@@ -9,6 +9,7 @@
 #include "flang/Parser/message.h"
 #include "flang/Common/idioms.h"
 #include "flang/Parser/char-set.h"
+#include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <cstdarg>
 #include <cstddef>
@@ -19,7 +20,7 @@
 
 namespace Fortran::parser {
 
-std::ostream &operator<<(std::ostream &o, const MessageFixedText &t) {
+llvm::raw_ostream &operator<<(llvm::raw_ostream &o, const MessageFixedText &t) {
   std::size_t n{t.text().size()};
   for (std::size_t j{0}; j < n; ++j) {
     o << t.text()[j];
@@ -187,8 +188,8 @@ std::optional<ProvenanceRange> Message::GetProvenanceRange(
       location_);
 }
 
-void Message::Emit(
-    std::ostream &o, const CookedSource &cooked, bool echoSourceLine) const {
+void Message::Emit(llvm::raw_ostream &o, const CookedSource &cooked,
+    bool echoSourceLine) const {
   std::optional<ProvenanceRange> provenanceRange{GetProvenanceRange(cooked)};
   std::string text;
   if (IsFatal()) {
@@ -306,8 +307,8 @@ void Messages::ResolveProvenances(const CookedSource &cooked) {
   }
 }
 
-void Messages::Emit(
-    std::ostream &o, const CookedSource &cooked, bool echoSourceLines) const {
+void Messages::Emit(llvm::raw_ostream &o, const CookedSource &cooked,
+    bool echoSourceLines) const {
   std::vector<const Message *> sorted;
   for (const auto &msg : messages_) {
     sorted.push_back(&msg);

--- a/lib/Parser/parse-tree.cpp
+++ b/lib/Parser/parse-tree.cpp
@@ -11,6 +11,7 @@
 #include "flang/Common/indirection.h"
 #include "flang/Parser/tools.h"
 #include "flang/Parser/user-state.h"
+#include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 
 // So "delete Expr;" calls an external destructor for its typedExpr.
@@ -252,7 +253,7 @@ CharBlock Variable::GetSource() const {
       u);
 }
 
-std::ostream &operator<<(std::ostream &os, const Name &x) {
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Name &x) {
   return os << x.ToString();
 }
 

--- a/lib/Parser/preprocessor.cpp
+++ b/lib/Parser/preprocessor.cpp
@@ -11,6 +11,7 @@
 #include "flang/Common/idioms.h"
 #include "flang/Parser/characters.h"
 #include "flang/Parser/message.h"
+#include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <cinttypes>
 #include <cstddef>
@@ -19,7 +20,6 @@
 #include <memory>
 #include <optional>
 #include <set>
-#include <sstream>
 #include <utility>
 
 namespace Fortran::parser {
@@ -257,7 +257,8 @@ std::optional<TokenSequence> Preprocessor::MacroReplacement(
           repl = "\""s +
               allSources_.GetPath(prescanner.GetCurrentProvenance()) + '"';
         } else if (name == "__LINE__") {
-          std::stringstream ss;
+          std::string buf;
+          llvm::raw_string_ostream ss{buf};
           ss << allSources_.GetLineNumber(prescanner.GetCurrentProvenance());
           repl = ss.str();
         }
@@ -574,8 +575,9 @@ void Preprocessor::Directive(const TokenSequence &dir, Prescanner *prescanner) {
           "#include: empty include file name"_err_en_US);
       return;
     }
-    std::stringstream error;
-    const SourceFile *included{allSources_.Open(include, &error)};
+    std::string buf;
+    llvm::raw_string_ostream error{buf};
+    const SourceFile *included{allSources_.Open(include, error)};
     if (!included) {
       prescanner->Say(dir.GetTokenProvenanceRange(dirOffset),
           "#include: %s"_err_en_US, error.str());

--- a/lib/Parser/prescan.cpp
+++ b/lib/Parser/prescan.cpp
@@ -13,9 +13,9 @@
 #include "flang/Parser/characters.h"
 #include "flang/Parser/message.h"
 #include "flang/Parser/source.h"
+#include "llvm/Support/raw_ostream.h"
 #include <cstddef>
 #include <cstring>
-#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -736,14 +736,15 @@ void Prescanner::FortranInclude(const char *firstQuote) {
     Say(GetProvenanceRange(garbage, p),
         "excess characters after path name"_en_US);
   }
-  std::stringstream error;
+  std::string buf;
+  llvm::raw_string_ostream error{buf};
   Provenance provenance{GetProvenance(nextLine_)};
   AllSources &allSources{cooked_.allSources()};
   const SourceFile *currentFile{allSources.GetSourceFile(provenance)};
   if (currentFile) {
     allSources.PushSearchPathDirectory(DirectoryName(currentFile->path()));
   }
-  const SourceFile *included{allSources.Open(path, &error)};
+  const SourceFile *included{allSources.Open(path, error)};
   if (currentFile) {
     allSources.PopSearchPathDirectory();
   }

--- a/lib/Parser/token-sequence.cpp
+++ b/lib/Parser/token-sequence.cpp
@@ -8,6 +8,7 @@
 
 #include "token-sequence.h"
 #include "flang/Parser/characters.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace Fortran::parser {
 
@@ -123,7 +124,7 @@ void TokenSequence::Put(const std::string &s, Provenance provenance) {
   Put(s.data(), s.size(), provenance);
 }
 
-void TokenSequence::Put(const std::stringstream &ss, Provenance provenance) {
+void TokenSequence::Put(llvm::raw_string_ostream &ss, Provenance provenance) {
   Put(ss.str(), provenance);
 }
 
@@ -248,7 +249,7 @@ void TokenSequence::Emit(CookedSource &cooked) const {
   cooked.PutProvenanceMappings(provenances_);
 }
 
-void TokenSequence::Dump(std::ostream &o) const {
+void TokenSequence::Dump(llvm::raw_ostream &o) const {
   o << "TokenSequence has " << char_.size() << " chars; nextStart_ "
     << nextStart_ << '\n';
   for (std::size_t j{0}; j < start_.size(); ++j) {

--- a/lib/Parser/token-sequence.h
+++ b/lib/Parser/token-sequence.h
@@ -17,10 +17,13 @@
 #include "flang/Parser/provenance.h"
 #include <cstddef>
 #include <cstring>
-#include <ostream>
 #include <string>
 #include <utility>
 #include <vector>
+
+namespace llvm {
+class raw_ostream;
+}
 
 namespace Fortran::parser {
 
@@ -91,7 +94,7 @@ public:
   void Put(const char *, std::size_t, Provenance);
   void Put(const CharBlock &, Provenance);
   void Put(const std::string &, Provenance);
-  void Put(const std::stringstream &, Provenance);
+  void Put(llvm::raw_string_ostream &, Provenance);
 
   Provenance GetTokenProvenance(
       std::size_t token, std::size_t offset = 0) const;
@@ -109,7 +112,7 @@ public:
   TokenSequence &RemoveRedundantBlanks(std::size_t firstChar = 0);
   TokenSequence &ClipComment(bool skipFirst = false);
   void Emit(CookedSource &) const;
-  void Dump(std::ostream &) const;
+  void Dump(llvm::raw_ostream &) const;
 
 private:
   std::size_t TokenBytes(std::size_t token) const {

--- a/lib/Parser/unparse.cpp
+++ b/lib/Parser/unparse.cpp
@@ -16,6 +16,7 @@
 #include "flang/Parser/characters.h"
 #include "flang/Parser/parse-tree-visitor.h"
 #include "flang/Parser/parse-tree.h"
+#include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <cinttypes>
 #include <cstddef>
@@ -25,9 +26,9 @@ namespace Fortran::parser {
 
 class UnparseVisitor {
 public:
-  UnparseVisitor(std::ostream &out, int indentationAmount, Encoding encoding,
-      bool capitalize, bool backslashEscapes, preStatementType *preStatement,
-      AnalyzedObjectsAsFortran *asFortran)
+  UnparseVisitor(llvm::raw_ostream &out, int indentationAmount,
+      Encoding encoding, bool capitalize, bool backslashEscapes,
+      preStatementType *preStatement, AnalyzedObjectsAsFortran *asFortran)
     : out_{out}, indentationAmount_{indentationAmount}, encoding_{encoding},
       capitalizeKeywords_{capitalize}, backslashEscapes_{backslashEscapes},
       preStatement_{preStatement}, asFortran_{asFortran} {}
@@ -2511,7 +2512,7 @@ private:
     structureComponents_.clear();
   }
 
-  std::ostream &out_;
+  llvm::raw_ostream &out_;
   int indent_{0};
   const int indentationAmount_{1};
   int column_{1};
@@ -2593,7 +2594,7 @@ void UnparseVisitor::Word(const char *str) {
 
 void UnparseVisitor::Word(const std::string &str) { Word(str.c_str()); }
 
-void Unparse(std::ostream &out, const Program &program, Encoding encoding,
+void Unparse(llvm::raw_ostream &out, const Program &program, Encoding encoding,
     bool capitalizeKeywords, bool backslashEscapes,
     preStatementType *preStatement, AnalyzedObjectsAsFortran *asFortran) {
   UnparseVisitor visitor{out, 1, encoding, capitalizeKeywords, backslashEscapes,

--- a/lib/Semantics/attr.cpp
+++ b/lib/Semantics/attr.cpp
@@ -8,7 +8,7 @@
 
 #include "flang/Semantics/attr.h"
 #include "flang/Common/idioms.h"
-#include <ostream>
+#include "llvm/Support/raw_ostream.h"
 #include <stddef.h>
 
 namespace Fortran::semantics {
@@ -29,11 +29,11 @@ std::string AttrToString(Attr attr) {
   }
 }
 
-std::ostream &operator<<(std::ostream &o, Attr attr) {
+llvm::raw_ostream &operator<<(llvm::raw_ostream &o, Attr attr) {
   return o << AttrToString(attr);
 }
 
-std::ostream &operator<<(std::ostream &o, const Attrs &attrs) {
+llvm::raw_ostream &operator<<(llvm::raw_ostream &o, const Attrs &attrs) {
   std::size_t n{attrs.count()};
   std::size_t seen{0};
   for (std::size_t j{0}; seen < n; ++j) {

--- a/lib/Semantics/mod-file.cpp
+++ b/lib/Semantics/mod-file.cpp
@@ -20,7 +20,6 @@
 #include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <fstream>
-#include <ostream>
 #include <set>
 #include <string_view>
 #include <vector>
@@ -44,22 +43,23 @@ struct ModHeader {
 
 static std::optional<SourceName> GetSubmoduleParent(const parser::Program &);
 static SymbolVector CollectSymbols(const Scope &);
-static void PutEntity(std::ostream &, const Symbol &);
-static void PutObjectEntity(std::ostream &, const Symbol &);
-static void PutProcEntity(std::ostream &, const Symbol &);
-static void PutPassName(std::ostream &, const std::optional<SourceName> &);
-static void PutTypeParam(std::ostream &, const Symbol &);
+static void PutEntity(llvm::raw_ostream &, const Symbol &);
+static void PutObjectEntity(llvm::raw_ostream &, const Symbol &);
+static void PutProcEntity(llvm::raw_ostream &, const Symbol &);
+static void PutPassName(llvm::raw_ostream &, const std::optional<SourceName> &);
+static void PutTypeParam(llvm::raw_ostream &, const Symbol &);
 static void PutEntity(
-    std::ostream &, const Symbol &, std::function<void()>, Attrs);
-static void PutInit(std::ostream &, const Symbol &, const MaybeExpr &);
-static void PutInit(std::ostream &, const MaybeIntExpr &);
-static void PutBound(std::ostream &, const Bound &);
-static std::ostream &PutAttrs(std::ostream &, Attrs,
+    llvm::raw_ostream &, const Symbol &, std::function<void()>, Attrs);
+static void PutInit(llvm::raw_ostream &, const Symbol &, const MaybeExpr &);
+static void PutInit(llvm::raw_ostream &, const MaybeIntExpr &);
+static void PutBound(llvm::raw_ostream &, const Bound &);
+static llvm::raw_ostream &PutAttrs(llvm::raw_ostream &, Attrs,
     const MaybeExpr & = std::nullopt, std::string before = ","s,
     std::string after = ""s);
-static std::ostream &PutAttr(std::ostream &, Attr);
-static std::ostream &PutType(std::ostream &, const DeclTypeSpec &);
-static std::ostream &PutLower(std::ostream &, const std::string &);
+
+static llvm::raw_ostream &PutAttr(llvm::raw_ostream &, Attr);
+static llvm::raw_ostream &PutType(llvm::raw_ostream &, const DeclTypeSpec &);
+static llvm::raw_ostream &PutLower(llvm::raw_ostream &, const std::string &);
 static std::error_code WriteFile(
     const std::string &, const std::string &, bool = true);
 static bool FileContentsMatch(
@@ -143,7 +143,8 @@ void ModFileWriter::Write(const Symbol &symbol) {
 // Return the entire body of the module file
 // and clear saved uses, decls, and contains.
 std::string ModFileWriter::GetAsString(const Symbol &symbol) {
-  std::stringstream all;
+  std::string buf;
+  llvm::raw_string_ostream all{buf};
   auto &details{symbol.get<ModuleDetails>()};
   if (!details.isSubmodule()) {
     all << "module " << symbol.name();
@@ -157,13 +158,13 @@ std::string ModFileWriter::GetAsString(const Symbol &symbol) {
     all << ") " << symbol.name();
   }
   all << '\n' << uses_.str();
-  uses_.str(""s);
+  uses_.str().clear();
   all << useExtraAttrs_.str();
-  useExtraAttrs_.str(""s);
+  useExtraAttrs_.str().clear();
   all << decls_.str();
-  decls_.str(""s);
+  decls_.str().clear();
   auto str{contains_.str()};
-  contains_.str(""s);
+  contains_.str().clear();
   if (!str.empty()) {
     all << "contains\n" << str;
   }
@@ -173,7 +174,9 @@ std::string ModFileWriter::GetAsString(const Symbol &symbol) {
 
 // Put out the visible symbols from scope.
 void ModFileWriter::PutSymbols(const Scope &scope) {
-  std::stringstream typeBindings;  // stuff after CONTAINS in derived type
+  std::string buf;
+  llvm::raw_string_ostream typeBindings{
+      buf};  // stuff after CONTAINS in derived type
   for (const Symbol &symbol : CollectSymbols(scope)) {
     PutSymbol(typeBindings, symbol);
   }
@@ -186,7 +189,7 @@ void ModFileWriter::PutSymbols(const Scope &scope) {
 // Emit a symbol to decls_, except for bindings in a derived type (type-bound
 // procedures, type-bound generics, final procedures) which go to typeBindings.
 void ModFileWriter::PutSymbol(
-    std::stringstream &typeBindings, const Symbol &symbol) {
+    llvm::raw_ostream &typeBindings, const Symbol &symbol) {
   std::visit(
       common::visitors{
           [&](const ModuleDetails &) { /* should be current module */ },
@@ -301,13 +304,14 @@ void ModFileWriter::PutSubprogram(const Symbol &symbol) {
   Attrs prefixAttrs{subprogramPrefixAttrs & attrs};
   // emit any non-prefix attributes in an attribute statement
   attrs &= ~subprogramPrefixAttrs;
-  std::stringstream ss;
+  std::string ssBuf;
+  llvm::raw_string_ostream ss{ssBuf};
   PutAttrs(ss, attrs);
   if (!ss.str().empty()) {
     decls_ << ss.str().substr(1) << "::" << symbol.name() << '\n';
   }
   bool isInterface{details.isInterface()};
-  std::ostream &os{isInterface ? decls_ : contains_};
+  llvm::raw_ostream &os{isInterface ? decls_ : contains_};
   if (isInterface) {
     os << "interface\n";
   }
@@ -333,7 +337,8 @@ void ModFileWriter::PutSubprogram(const Symbol &symbol) {
 
   // walk symbols, collect ones needed
   ModFileWriter writer{context_};
-  std::stringstream typeBindings;
+  std::string typeBindingsBuf;
+  llvm::raw_string_ostream typeBindings{typeBindingsBuf};
   SubprogramSymbolCollector collector{symbol};
   collector.Collect();
   for (const Symbol &need : collector.symbols()) {
@@ -359,7 +364,8 @@ static bool IsIntrinsicOp(const Symbol &symbol) {
   }
 }
 
-static std::ostream &PutGenericName(std::ostream &os, const Symbol &symbol) {
+static llvm::raw_ostream &PutGenericName(
+    llvm::raw_ostream &os, const Symbol &symbol) {
   if (IsGenericDefinedOp(symbol)) {
     return os << "operator(" << symbol.name() << ')';
   } else {
@@ -440,7 +446,7 @@ SymbolVector CollectSymbols(const Scope &scope) {
   return sorted;
 }
 
-void PutEntity(std::ostream &os, const Symbol &symbol) {
+void PutEntity(llvm::raw_ostream &os, const Symbol &symbol) {
   std::visit(
       common::visitors{
           [&](const ObjectEntityDetails &) { PutObjectEntity(os, symbol); },
@@ -454,7 +460,7 @@ void PutEntity(std::ostream &os, const Symbol &symbol) {
       symbol.details());
 }
 
-void PutShapeSpec(std::ostream &os, const ShapeSpec &x) {
+void PutShapeSpec(llvm::raw_ostream &os, const ShapeSpec &x) {
   if (x.lbound().isAssumed()) {
     CHECK(x.ubound().isAssumed());
     os << "..";
@@ -468,7 +474,8 @@ void PutShapeSpec(std::ostream &os, const ShapeSpec &x) {
     }
   }
 }
-void PutShape(std::ostream &os, const ArraySpec &shape, char open, char close) {
+void PutShape(
+    llvm::raw_ostream &os, const ArraySpec &shape, char open, char close) {
   if (!shape.empty()) {
     os << open;
     bool first{true};
@@ -484,7 +491,7 @@ void PutShape(std::ostream &os, const ArraySpec &shape, char open, char close) {
   }
 }
 
-void PutObjectEntity(std::ostream &os, const Symbol &symbol) {
+void PutObjectEntity(llvm::raw_ostream &os, const Symbol &symbol) {
   auto &details{symbol.get<ObjectEntityDetails>()};
   PutEntity(os, symbol, [&]() { PutType(os, DEREF(symbol.GetType())); },
       symbol.attrs());
@@ -494,7 +501,7 @@ void PutObjectEntity(std::ostream &os, const Symbol &symbol) {
   os << '\n';
 }
 
-void PutProcEntity(std::ostream &os, const Symbol &symbol) {
+void PutProcEntity(llvm::raw_ostream &os, const Symbol &symbol) {
   if (symbol.attrs().test(Attr::INTRINSIC)) {
     os << "intrinsic::" << symbol.name() << '\n';
     return;
@@ -520,13 +527,13 @@ void PutProcEntity(std::ostream &os, const Symbol &symbol) {
   os << '\n';
 }
 
-void PutPassName(std::ostream &os, const std::optional<SourceName> &passName) {
+void PutPassName(
+    llvm::raw_ostream &os, const std::optional<SourceName> &passName) {
   if (passName) {
     os << ",pass(" << *passName << ')';
   }
 }
-
-void PutTypeParam(std::ostream &os, const Symbol &symbol) {
+void PutTypeParam(llvm::raw_ostream &os, const Symbol &symbol) {
   auto &details{symbol.get<TypeParamDetails>()};
   PutEntity(os, symbol,
       [&]() {
@@ -538,7 +545,8 @@ void PutTypeParam(std::ostream &os, const Symbol &symbol) {
   os << '\n';
 }
 
-void PutInit(std::ostream &os, const Symbol &symbol, const MaybeExpr &init) {
+void PutInit(
+    llvm::raw_ostream &os, const Symbol &symbol, const MaybeExpr &init) {
   if (init) {
     if (symbol.attrs().test(Attr::PARAMETER) ||
         symbol.owner().IsDerivedType()) {
@@ -548,13 +556,13 @@ void PutInit(std::ostream &os, const Symbol &symbol, const MaybeExpr &init) {
   }
 }
 
-void PutInit(std::ostream &os, const MaybeIntExpr &init) {
+void PutInit(llvm::raw_ostream &os, const MaybeIntExpr &init) {
   if (init) {
     init->AsFortran(os << '=');
   }
 }
 
-void PutBound(std::ostream &os, const Bound &x) {
+void PutBound(llvm::raw_ostream &os, const Bound &x) {
   if (x.isAssumed()) {
     os << '*';
   } else if (x.isDeferred()) {
@@ -566,7 +574,7 @@ void PutBound(std::ostream &os, const Bound &x) {
 
 // Write an entity (object or procedure) declaration.
 // writeType is called to write out the type.
-void PutEntity(std::ostream &os, const Symbol &symbol,
+void PutEntity(llvm::raw_ostream &os, const Symbol &symbol,
     std::function<void()> writeType, Attrs attrs) {
   writeType();
   MaybeExpr bindName;
@@ -584,8 +592,8 @@ void PutEntity(std::ostream &os, const Symbol &symbol,
 
 // Put out each attribute to os, surrounded by `before` and `after` and
 // mapped to lower case.
-std::ostream &PutAttrs(std::ostream &os, Attrs attrs, const MaybeExpr &bindName,
-    std::string before, std::string after) {
+llvm::raw_ostream &PutAttrs(llvm::raw_ostream &os, Attrs attrs,
+    const MaybeExpr &bindName, std::string before, std::string after) {
   attrs.set(Attr::PUBLIC, false);  // no need to write PUBLIC
   attrs.set(Attr::EXTERNAL, false);  // no need to write EXTERNAL
   if (bindName) {
@@ -601,15 +609,15 @@ std::ostream &PutAttrs(std::ostream &os, Attrs attrs, const MaybeExpr &bindName,
   return os;
 }
 
-std::ostream &PutAttr(std::ostream &os, Attr attr) {
+llvm::raw_ostream &PutAttr(llvm::raw_ostream &os, Attr attr) {
   return PutLower(os, AttrToString(attr));
 }
 
-std::ostream &PutType(std::ostream &os, const DeclTypeSpec &type) {
+llvm::raw_ostream &PutType(llvm::raw_ostream &os, const DeclTypeSpec &type) {
   return PutLower(os, type.AsFortran());
 }
 
-std::ostream &PutLower(std::ostream &os, const std::string &str) {
+llvm::raw_ostream &PutLower(llvm::raw_ostream &os, const std::string &str) {
   for (char c : str) {
     os << parser::ToLowerCaseLetter(c);
   }
@@ -764,8 +772,8 @@ Scope *ModFileReader::Read(const SourceName &name, Scope *ancestor) {
         sourceFile->path());
     return nullptr;
   }
-
-  parsing.Parse(nullptr);
+  llvm::raw_null_ostream NullStream;
+  parsing.Parse(NullStream);
   auto &parseTree{parsing.parseTree()};
   if (!parsing.messages().empty() || !parsing.consumedWholeFile() ||
       !parseTree) {

--- a/lib/Semantics/mod-file.h
+++ b/lib/Semantics/mod-file.h
@@ -10,13 +10,16 @@
 #define FORTRAN_SEMANTICS_MOD_FILE_H_
 
 #include "flang/Semantics/attr.h"
-#include <sstream>
 #include <string>
 
 namespace Fortran::parser {
 class CharBlock;
 class Message;
 class MessageFixedText;
+}
+
+namespace llvm {
+class raw_ostream;
 }
 
 namespace Fortran::semantics {
@@ -33,17 +36,23 @@ public:
 
 private:
   SemanticsContext &context_;
-  std::stringstream uses_;
-  std::stringstream useExtraAttrs_;  // attrs added to used entity
-  std::stringstream decls_;
-  std::stringstream contains_;
+  // Buffer to use with raw_string_ostream
+  std::string usesBuf_;
+  std::string useExtraAttrsBuf_;
+  std::string declsBuf_;
+  std::string containsBuf_;
+
+  llvm::raw_string_ostream uses_{usesBuf_};
+  llvm::raw_string_ostream useExtraAttrs_{useExtraAttrsBuf_};  // attrs added to used entity
+  llvm::raw_string_ostream decls_{declsBuf_};
+  llvm::raw_string_ostream contains_{containsBuf_};
 
   void WriteAll(const Scope &);
   void WriteOne(const Scope &);
   void Write(const Symbol &);
   std::string GetAsString(const Symbol &);
   void PutSymbols(const Scope &);
-  void PutSymbol(std::stringstream &, const Symbol &);
+  void PutSymbol(llvm::raw_ostream &, const Symbol &);
   void PutDerivedType(const Symbol &);
   void PutSubprogram(const Symbol &);
   void PutGeneric(const Symbol &);

--- a/lib/Semantics/pointer-assignment.cpp
+++ b/lib/Semantics/pointer-assignment.cpp
@@ -19,6 +19,7 @@
 #include "flang/Semantics/expression.h"
 #include "flang/Semantics/symbol.h"
 #include "flang/Semantics/tools.h"
+#include "llvm/Support/raw_ostream.h"
 #include <optional>
 #include <set>
 #include <string>
@@ -232,7 +233,8 @@ void PointerAssignmentChecker::Check(const evaluate::Designator<T> &d) {
   if (msg) {
     auto restorer{common::ScopedSet(lhs_, last)};
     if (auto *m{std::get_if<MessageFixedText>(&*msg)}) {
-      std::ostringstream ss;
+      std::string buf;
+      llvm::raw_string_ostream ss{buf};
       d.AsFortran(ss);
       Say(*m, description_, ss.str());
     } else {

--- a/lib/Semantics/resolve-names-utils.cpp
+++ b/lib/Semantics/resolve-names-utils.cpp
@@ -19,7 +19,6 @@
 #include "flang/Semantics/semantics.h"
 #include "flang/Semantics/tools.h"
 #include <initializer_list>
-#include <ostream>
 #include <variant>
 
 namespace Fortran::semantics {

--- a/lib/Semantics/resolve-names.cpp
+++ b/lib/Semantics/resolve-names.cpp
@@ -33,9 +33,9 @@
 #include "flang/Semantics/symbol.h"
 #include "flang/Semantics/tools.h"
 #include "flang/Semantics/type.h"
+#include "llvm/Support/raw_ostream.h"
 #include <list>
 #include <map>
-#include <ostream>
 #include <set>
 #include <stack>
 
@@ -86,8 +86,10 @@ private:
   // the default Fortran mappings nor the mapping defined in parents.
   std::map<char, common::Reference<const DeclTypeSpec>> map_;
 
-  friend std::ostream &operator<<(std::ostream &, const ImplicitRules &);
-  friend void ShowImplicitRule(std::ostream &, const ImplicitRules &, char);
+  friend llvm::raw_ostream &operator<<(
+      llvm::raw_ostream &, const ImplicitRules &);
+  friend void ShowImplicitRule(
+      llvm::raw_ostream &, const ImplicitRules &, char);
 };
 
 // scope -> implicit rules for that scope
@@ -1463,7 +1465,8 @@ char ImplicitRules::Incr(char ch) {
   }
 }
 
-std::ostream &operator<<(std::ostream &o, const ImplicitRules &implicitRules) {
+llvm::raw_ostream &operator<<(
+    llvm::raw_ostream &o, const ImplicitRules &implicitRules) {
   o << "ImplicitRules:\n";
   for (char ch = 'a'; ch; ch = ImplicitRules::Incr(ch)) {
     ShowImplicitRule(o, implicitRules, ch);
@@ -1474,7 +1477,7 @@ std::ostream &operator<<(std::ostream &o, const ImplicitRules &implicitRules) {
   return o;
 }
 void ShowImplicitRule(
-    std::ostream &o, const ImplicitRules &implicitRules, char ch) {
+    llvm::raw_ostream &o, const ImplicitRules &implicitRules, char ch) {
   auto it{implicitRules.map_.find(ch)};
   if (it != implicitRules.map_.end()) {
     o << "  " << ch << ": " << *it->second << '\n';

--- a/lib/Semantics/resolve-names.h
+++ b/lib/Semantics/resolve-names.h
@@ -13,6 +13,10 @@
 #include <string>
 #include <vector>
 
+namespace llvm {
+class raw_ostream;
+}
+
 namespace Fortran::parser {
 struct Program;
 }
@@ -24,7 +28,7 @@ class Symbol;
 
 bool ResolveNames(SemanticsContext &, const parser::Program &);
 void ResolveSpecificationParts(SemanticsContext &, const Symbol &);
-void DumpSymbols(std::ostream &);
+void DumpSymbols(llvm::raw_ostream &);
 
 }
 

--- a/lib/Semantics/scope.cpp
+++ b/lib/Semantics/scope.cpp
@@ -10,9 +10,9 @@
 #include "flang/Parser/characters.h"
 #include "flang/Semantics/symbol.h"
 #include "flang/Semantics/type.h"
+#include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <memory>
-#include <sstream>
 
 namespace Fortran::semantics {
 
@@ -32,7 +32,8 @@ bool EquivalenceObject::operator<(const EquivalenceObject &that) const {
 }
 
 std::string EquivalenceObject::AsFortran() const {
-  std::stringstream ss;
+  std::string buf;
+  llvm::raw_string_ostream ss{buf};
   ss << symbol.name().ToString();
   if (!subscripts.empty()) {
     char sep{'('};
@@ -283,7 +284,7 @@ void Scope::AddSourceRange(const parser::CharBlock &source) {
   }
 }
 
-std::ostream &operator<<(std::ostream &os, const Scope &scope) {
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Scope &scope) {
   os << Scope::EnumToString(scope.kind()) << " scope: ";
   if (auto *symbol{scope.symbol()}) {
     os << *symbol << ' ';

--- a/lib/Semantics/semantics.cpp
+++ b/lib/Semantics/semantics.cpp
@@ -35,12 +35,13 @@
 #include "flang/Semantics/expression.h"
 #include "flang/Semantics/scope.h"
 #include "flang/Semantics/symbol.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace Fortran::semantics {
 
 using NameToSymbolMap = std::map<const char *, SymbolRef>;
-static void DoDumpSymbols(std::ostream &, const Scope &, int indent = 0);
-static void PutIndent(std::ostream &, int indent);
+static void DoDumpSymbols(llvm::raw_ostream &, const Scope &, int indent = 0);
+static void PutIndent(llvm::raw_ostream &, int indent);
 
 static void GetSymbolNames(const Scope &scope, NameToSymbolMap &symbols) {
   // Finds all symbol names in the scope without collecting duplicates.
@@ -282,15 +283,15 @@ bool Semantics::Perform() {
       ModFileWriter{context_}.WriteAll();
 }
 
-void Semantics::EmitMessages(std::ostream &os) const {
+void Semantics::EmitMessages(llvm::raw_ostream &os) const {
   context_.messages().Emit(os, cooked_);
 }
 
-void Semantics::DumpSymbols(std::ostream &os) {
+void Semantics::DumpSymbols(llvm::raw_ostream &os) {
   DoDumpSymbols(os, context_.globalScope());
 }
 
-void Semantics::DumpSymbolsSources(std::ostream &os) const {
+void Semantics::DumpSymbolsSources(llvm::raw_ostream &os) const {
   NameToSymbolMap symbols;
   GetSymbolNames(context_.globalScope(), symbols);
   for (const auto &pair : symbols) {
@@ -306,7 +307,7 @@ void Semantics::DumpSymbolsSources(std::ostream &os) const {
   }
 }
 
-void DoDumpSymbols(std::ostream &os, const Scope &scope, int indent) {
+void DoDumpSymbols(llvm::raw_ostream &os, const Scope &scope, int indent) {
   PutIndent(os, indent);
   os << Scope::EnumToString(scope.kind()) << " scope:";
   if (const auto *symbol{scope.symbol()}) {
@@ -357,7 +358,7 @@ void DoDumpSymbols(std::ostream &os, const Scope &scope, int indent) {
   --indent;
 }
 
-static void PutIndent(std::ostream &os, int indent) {
+static void PutIndent(llvm::raw_ostream &os, int indent) {
   for (int i = 0; i < indent; ++i) {
     os << "  ";
   }

--- a/lib/Semantics/symbol.cpp
+++ b/lib/Semantics/symbol.cpp
@@ -12,32 +12,32 @@
 #include "flang/Semantics/scope.h"
 #include "flang/Semantics/semantics.h"
 #include "flang/Semantics/tools.h"
-#include <ostream>
+#include "llvm/Support/raw_ostream.h"
 #include <string>
 
 namespace Fortran::semantics {
 
 template<typename T>
-static void DumpOptional(std::ostream &os, const char *label, const T &x) {
+static void DumpOptional(llvm::raw_ostream &os, const char *label, const T &x) {
   if (x) {
     os << ' ' << label << ':' << *x;
   }
 }
 template<typename T>
-static void DumpExpr(std::ostream &os, const char *label,
+static void DumpExpr(llvm::raw_ostream &os, const char *label,
     const std::optional<evaluate::Expr<T>> &x) {
   if (x) {
     x->AsFortran(os << ' ' << label << ':');
   }
 }
 
-static void DumpBool(std::ostream &os, const char *label, bool x) {
+static void DumpBool(llvm::raw_ostream &os, const char *label, bool x) {
   if (x) {
     os << ' ' << label;
   }
 }
 
-static void DumpSymbolVector(std::ostream &os, const SymbolVector &list) {
+static void DumpSymbolVector(llvm::raw_ostream &os, const SymbolVector &list) {
   char sep{' '};
   for (const Symbol &elem : list) {
     os << sep << elem.name();
@@ -45,19 +45,19 @@ static void DumpSymbolVector(std::ostream &os, const SymbolVector &list) {
   }
 }
 
-static void DumpType(std::ostream &os, const Symbol &symbol) {
+static void DumpType(llvm::raw_ostream &os, const Symbol &symbol) {
   if (const auto *type{symbol.GetType()}) {
     os << *type << ' ';
   }
 }
-static void DumpType(std::ostream &os, const DeclTypeSpec *type) {
+static void DumpType(llvm::raw_ostream &os, const DeclTypeSpec *type) {
   if (type) {
     os << ' ' << *type;
   }
 }
 
 template<typename T>
-static void DumpList(std::ostream &os, const char *label, const T &list) {
+static void DumpList(llvm::raw_ostream &os, const char *label, const T &list) {
   if (!list.empty()) {
     os << ' ' << label << ':';
     char sep{' '};
@@ -81,7 +81,8 @@ void ModuleDetails::set_scope(const Scope *scope) {
   scope_ = scope;
 }
 
-std::ostream &operator<<(std::ostream &os, const SubprogramDetails &x) {
+llvm::raw_ostream &operator<<(
+    llvm::raw_ostream &os, const SubprogramDetails &x) {
   DumpBool(os, "isInterface", x.isInterface_);
   DumpExpr(os, "bindName", x.bindName_);
   if (x.result_) {
@@ -334,7 +335,7 @@ bool Symbol::IsFromModFile() const {
 ObjectEntityDetails::ObjectEntityDetails(EntityDetails &&d)
   : EntityDetails(d) {}
 
-std::ostream &operator<<(std::ostream &os, const EntityDetails &x) {
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const EntityDetails &x) {
   DumpBool(os, "dummy", x.isDummy());
   DumpBool(os, "funcResult", x.isFuncResult());
   if (x.type()) {
@@ -344,7 +345,8 @@ std::ostream &operator<<(std::ostream &os, const EntityDetails &x) {
   return os;
 }
 
-std::ostream &operator<<(std::ostream &os, const ObjectEntityDetails &x) {
+llvm::raw_ostream &operator<<(
+    llvm::raw_ostream &os, const ObjectEntityDetails &x) {
   os << *static_cast<const EntityDetails *>(&x);
   DumpList(os, "shape", x.shape());
   DumpList(os, "coshape", x.coshape());
@@ -352,13 +354,15 @@ std::ostream &operator<<(std::ostream &os, const ObjectEntityDetails &x) {
   return os;
 }
 
-std::ostream &operator<<(std::ostream &os, const AssocEntityDetails &x) {
+llvm::raw_ostream &operator<<(
+    llvm::raw_ostream &os, const AssocEntityDetails &x) {
   os << *static_cast<const EntityDetails *>(&x);
   DumpExpr(os, "expr", x.expr());
   return os;
 }
 
-std::ostream &operator<<(std::ostream &os, const ProcEntityDetails &x) {
+llvm::raw_ostream &operator<<(
+    llvm::raw_ostream &os, const ProcEntityDetails &x) {
   if (auto *symbol{x.interface_.symbol()}) {
     os << ' ' << symbol->name();
   } else {
@@ -376,13 +380,14 @@ std::ostream &operator<<(std::ostream &os, const ProcEntityDetails &x) {
   return os;
 }
 
-std::ostream &operator<<(std::ostream &os, const DerivedTypeDetails &x) {
+llvm::raw_ostream &operator<<(
+    llvm::raw_ostream &os, const DerivedTypeDetails &x) {
   DumpBool(os, "sequence", x.sequence_);
   DumpList(os, "components", x.componentNames_);
   return os;
 }
 
-std::ostream &operator<<(std::ostream &os, const Details &details) {
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Details &details) {
   os << DetailsToString(details);
   std::visit(
       common::visitors{
@@ -453,11 +458,12 @@ std::ostream &operator<<(std::ostream &os, const Details &details) {
   return os;
 }
 
-std::ostream &operator<<(std::ostream &o, Symbol::Flag flag) {
+llvm::raw_ostream &operator<<(llvm::raw_ostream &o, Symbol::Flag flag) {
   return o << Symbol::EnumToString(flag);
 }
 
-std::ostream &operator<<(std::ostream &o, const Symbol::Flags &flags) {
+llvm::raw_ostream &operator<<(
+    llvm::raw_ostream &o, const Symbol::Flags &flags) {
   std::size_t n{flags.count()};
   std::size_t seen{0};
   for (std::size_t j{0}; seen < n; ++j) {
@@ -472,7 +478,7 @@ std::ostream &operator<<(std::ostream &o, const Symbol::Flags &flags) {
   return o;
 }
 
-std::ostream &operator<<(std::ostream &os, const Symbol &symbol) {
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Symbol &symbol) {
   os << symbol.name();
   if (!symbol.attrs().empty()) {
     os << ", " << symbol.attrs();
@@ -487,7 +493,7 @@ std::ostream &operator<<(std::ostream &os, const Symbol &symbol) {
 // Output a unique name for a scope by qualifying it with the names of
 // parent scopes. For scopes without corresponding symbols, use the kind
 // with an index (e.g. Block1, Block2, etc.).
-static void DumpUniqueName(std::ostream &os, const Scope &scope) {
+static void DumpUniqueName(llvm::raw_ostream &os, const Scope &scope) {
   if (!scope.IsGlobal()) {
     DumpUniqueName(os, scope.parent());
     os << '/';
@@ -511,8 +517,8 @@ static void DumpUniqueName(std::ostream &os, const Scope &scope) {
 
 // Dump a symbol for UnparseWithSymbols. This will be used for tests so the
 // format should be reasonably stable.
-std::ostream &DumpForUnparse(
-    std::ostream &os, const Symbol &symbol, bool isDef) {
+llvm::raw_ostream &DumpForUnparse(
+    llvm::raw_ostream &os, const Symbol &symbol, bool isDef) {
   DumpUniqueName(os, symbol.owner());
   os << '/' << symbol.name();
   if (isDef) {

--- a/lib/Semantics/tools.cpp
+++ b/lib/Semantics/tools.cpp
@@ -17,9 +17,9 @@
 #include "flang/Semantics/symbol.h"
 #include "flang/Semantics/tools.h"
 #include "flang/Semantics/type.h"
+#include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <set>
-#include <sstream>
 #include <variant>
 
 namespace Fortran::semantics {
@@ -414,7 +414,8 @@ bool ExprTypeKindIsDefault(
 // If an analyzed expr or assignment is missing, dump the node and die.
 template<typename T> static void CheckMissingAnalysis(bool absent, const T &x) {
   if (absent) {
-    std::ostringstream ss;
+    std::string buf;
+    llvm::raw_string_ostream ss{buf};
     ss << "node has not been analyzed:\n";
     parser::DumpTree(ss, x);
     common::die(ss.str().c_str());

--- a/lib/Semantics/type.cpp
+++ b/lib/Semantics/type.cpp
@@ -12,8 +12,7 @@
 #include "flang/Semantics/scope.h"
 #include "flang/Semantics/symbol.h"
 #include "flang/Semantics/tools.h"
-#include <ostream>
-#include <sstream>
+#include "llvm/Support/raw_ostream.h"
 
 namespace Fortran::semantics {
 
@@ -272,7 +271,8 @@ void DerivedTypeSpec::Instantiate(
 }
 
 std::string DerivedTypeSpec::AsFortran() const {
-  std::stringstream ss;
+  std::string buf;
+  llvm::raw_string_ostream ss{buf};
   ss << name_;
   if (!rawParameters_.empty()) {
     CHECK(parameters_.empty());
@@ -306,13 +306,13 @@ std::string DerivedTypeSpec::AsFortran() const {
   return ss.str();
 }
 
-std::ostream &operator<<(std::ostream &o, const DerivedTypeSpec &x) {
+llvm::raw_ostream &operator<<(llvm::raw_ostream &o, const DerivedTypeSpec &x) {
   return o << x.AsFortran();
 }
 
 Bound::Bound(int bound) : expr_{bound} {}
 
-std::ostream &operator<<(std::ostream &o, const Bound &x) {
+llvm::raw_ostream &operator<<(llvm::raw_ostream &o, const Bound &x) {
   if (x.isAssumed()) {
     o << '*';
   } else if (x.isDeferred()) {
@@ -325,7 +325,7 @@ std::ostream &operator<<(std::ostream &o, const Bound &x) {
   return o;
 }
 
-std::ostream &operator<<(std::ostream &o, const ShapeSpec &x) {
+llvm::raw_ostream &operator<<(llvm::raw_ostream &o, const ShapeSpec &x) {
   if (x.lb_.isAssumed()) {
     CHECK(x.ub_.isAssumed());
     o << "..";
@@ -365,7 +365,8 @@ bool ArraySpec::IsAssumedRank() const {
   return Rank() == 1 && front().lbound().isAssumed();
 }
 
-std::ostream &operator<<(std::ostream &os, const ArraySpec &arraySpec) {
+llvm::raw_ostream &operator<<(
+    llvm::raw_ostream &os, const ArraySpec &arraySpec) {
   char sep{'('};
   for (auto &shape : arraySpec) {
     os << sep << shape;
@@ -398,7 +399,8 @@ std::string ParamValue::AsFortran() const {
   case Category::Deferred: return ":";
   case Category::Explicit:
     if (expr_) {
-      std::stringstream ss;
+      std::string buf;
+      llvm::raw_string_ostream ss{buf};
       expr_->AsFortran(ss);
       return ss.str();
     } else {
@@ -407,7 +409,7 @@ std::string ParamValue::AsFortran() const {
   }
 }
 
-std::ostream &operator<<(std::ostream &o, const ParamValue &x) {
+llvm::raw_ostream &operator<<(llvm::raw_ostream &o, const ParamValue &x) {
   return o << x.AsFortran();
 }
 
@@ -417,7 +419,8 @@ IntrinsicTypeSpec::IntrinsicTypeSpec(TypeCategory category, KindExpr &&kind)
 }
 
 static std::string KindAsFortran(const KindExpr &kind) {
-  std::stringstream ss;
+  std::string buf;
+  llvm::raw_string_ostream ss{buf};
   if (auto k{evaluate::ToInt64(kind)}) {
     ss << *k;  // emit unsuffixed kind code
   } else {
@@ -431,7 +434,8 @@ std::string IntrinsicTypeSpec::AsFortran() const {
       KindAsFortran(kind_) + ')';
 }
 
-std::ostream &operator<<(std::ostream &os, const IntrinsicTypeSpec &x) {
+llvm::raw_ostream &operator<<(
+    llvm::raw_ostream &os, const IntrinsicTypeSpec &x) {
   return os << x.AsFortran();
 }
 
@@ -439,7 +443,8 @@ std::string CharacterTypeSpec::AsFortran() const {
   return "CHARACTER(" + length_.AsFortran() + ',' + KindAsFortran(kind()) + ')';
 }
 
-std::ostream &operator<<(std::ostream &os, const CharacterTypeSpec &x) {
+llvm::raw_ostream &operator<<(
+    llvm::raw_ostream &os, const CharacterTypeSpec &x) {
   return os << x.AsFortran();
 }
 
@@ -494,7 +499,7 @@ std::string DeclTypeSpec::AsFortran() const {
   }
 }
 
-std::ostream &operator<<(std::ostream &o, const DeclTypeSpec &x) {
+llvm::raw_ostream &operator<<(llvm::raw_ostream &o, const DeclTypeSpec &x) {
   return o << x.AsFortran();
 }
 

--- a/lib/Semantics/unparse-with-symbols.cpp
+++ b/lib/Semantics/unparse-with-symbols.cpp
@@ -11,8 +11,8 @@
 #include "flang/Parser/parse-tree.h"
 #include "flang/Parser/unparse.h"
 #include "flang/Semantics/symbol.h"
+#include "llvm/Support/raw_ostream.h"
 #include <map>
-#include <ostream>
 #include <set>
 
 namespace Fortran::semantics {
@@ -24,7 +24,7 @@ namespace Fortran::semantics {
 class SymbolDumpVisitor {
 public:
   // Write out symbols referenced at this statement.
-  void PrintSymbols(const parser::CharBlock &, std::ostream &, int);
+  void PrintSymbols(const parser::CharBlock &, llvm::raw_ostream &, int);
 
   template<typename T> bool Pre(const T &) { return true; }
   template<typename T> void Post(const T &) {}
@@ -51,11 +51,11 @@ private:
   std::optional<SourceName> currStmt_;  // current statement we are processing
   std::multimap<const char *, const Symbol *> symbols_;  // location to symbol
   std::set<const Symbol *> symbolsDefined_;  // symbols that have been processed
-  void Indent(std::ostream &, int) const;
+  void Indent(llvm::raw_ostream &, int) const;
 };
 
 void SymbolDumpVisitor::PrintSymbols(
-    const parser::CharBlock &location, std::ostream &out, int indent) {
+    const parser::CharBlock &location, llvm::raw_ostream &out, int indent) {
   std::set<const Symbol *> done;  // prevent duplicates on this line
   auto range{symbols_.equal_range(location.begin())};
   for (auto it{range.first}; it != range.second; ++it) {
@@ -70,7 +70,7 @@ void SymbolDumpVisitor::PrintSymbols(
   }
 }
 
-void SymbolDumpVisitor::Indent(std::ostream &out, int indent) const {
+void SymbolDumpVisitor::Indent(llvm::raw_ostream &out, int indent) const {
   for (int i{0}; i < indent; ++i) {
     out << ' ';
   }
@@ -84,14 +84,13 @@ void SymbolDumpVisitor::Post(const parser::Name &name) {
   }
 }
 
-void UnparseWithSymbols(std::ostream &out, const parser::Program &program,
+void UnparseWithSymbols(llvm::raw_ostream &out, const parser::Program &program,
     parser::Encoding encoding) {
   SymbolDumpVisitor visitor;
   parser::Walk(program, visitor);
   parser::preStatementType preStatement{
-      [&](const parser::CharBlock &location, std::ostream &out, int indent) {
-        visitor.PrintSymbols(location, out, indent);
-      }};
+      [&](const parser::CharBlock &location, llvm::raw_ostream &out,
+          int indent) { visitor.PrintSymbols(location, out, indent); }};
   parser::Unparse(out, program, encoding, false, true, &preStatement);
 }
 }

--- a/tools/f18/dump.cpp
+++ b/tools/f18/dump.cpp
@@ -8,26 +8,26 @@
 
 // This file defines Dump routines available for calling from the debugger.
 // Each is based on operator<< for that type. There are overloadings for
-// reference and pointer, and for dumping to a provided ostream or cerr.
+// reference and pointer, and for dumping to a provided raw_ostream or errs().
 
 #ifdef DEBUGF18
 
-#include <iostream>
+#include "llvm/Support/raw_ostream.h"
 
 #define DEFINE_DUMP(ns, name) \
   namespace ns { \
   class name; \
-  std::ostream &operator<<(std::ostream &, const name &); \
+  llvm::raw_ostream &operator<<(llvm::raw_ostream &, const name &); \
   } \
-  void Dump(std::ostream &os, const ns::name &x) { os << x << '\n'; } \
-  void Dump(std::ostream &os, const ns::name *x) { \
+  void Dump(llvm::raw_ostream &os, const ns::name &x) { os << x << '\n'; } \
+  void Dump(llvm::raw_ostream &os, const ns::name *x) { \
     if (x == nullptr) \
       os << "null\n"; \
     else \
       Dump(os, *x); \
   } \
-  void Dump(const ns::name &x) { Dump(std::cerr, x); } \
-  void Dump(const ns::name *x) { Dump(std::cerr, *x); }
+  void Dump(const ns::name &x) { Dump(llvm::errs(), x); } \
+  void Dump(const ns::name *x) { Dump(llvm::errs(), *x); }
 
 namespace Fortran {
 DEFINE_DUMP(parser, Name)

--- a/unittests/Decimal/CMakeLists.txt
+++ b/unittests/Decimal/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(quick-sanity-test
 
 target_link_libraries(quick-sanity-test
   FortranDecimal
+  LLVMSupport
 )
 
 add_executable(thorough-test
@@ -20,6 +21,7 @@ add_executable(thorough-test
 
 target_link_libraries(thorough-test
   FortranDecimal
+  LLVMSupport
 )
 
 add_test(Sanity quick-sanity-test)

--- a/unittests/Evaluate/CMakeLists.txt
+++ b/unittests/Evaluate/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(leading-zero-bit-count-test
 
 target_link_libraries(leading-zero-bit-count-test
   FortranEvaluateTesting
+  LLVMSupport
 )
 
 add_executable(bit-population-count-test
@@ -25,6 +26,7 @@ add_executable(bit-population-count-test
 
 target_link_libraries(bit-population-count-test
   FortranEvaluateTesting
+  LLVMSupport
 )
 
 add_executable(uint128-test
@@ -33,6 +35,7 @@ add_executable(uint128-test
 
 target_link_libraries(uint128-test
   FortranEvaluateTesting
+  LLVMSupport
 )
 
 # These routines live in lib/Common but we test them here.
@@ -49,6 +52,7 @@ target_link_libraries(expression-test
   FortranEvaluate
   FortranSemantics
   FortranParser
+  LLVMSupport
 )
 
 add_executable(integer-test
@@ -59,6 +63,7 @@ target_link_libraries(integer-test
   FortranEvaluateTesting
   FortranEvaluate
   FortranSemantics
+  LLVMSupport
 )
 
 add_executable(intrinsics-test
@@ -72,6 +77,7 @@ target_link_libraries(intrinsics-test
   FortranSemantics
   FortranParser
   FortranRuntime
+  LLVMSupport
 )
 
 add_executable(logical-test
@@ -82,6 +88,7 @@ target_link_libraries(logical-test
   FortranEvaluateTesting
   FortranEvaluate
   FortranSemantics
+  LLVMSupport
 )
 
 # GCC -fno-exceptions breaks the fenv.h interfaces needed to capture
@@ -98,6 +105,7 @@ target_link_libraries(real-test
   FortranEvaluate
   FortranDecimal
   FortranSemantics
+  LLVMSupport
 )
 
 add_executable(reshape-test
@@ -109,6 +117,7 @@ target_link_libraries(reshape-test
   FortranSemantics
   FortranEvaluate
   FortranRuntime
+  LLVMSupport
 )
 
 add_executable(ISO-Fortran-binding-test
@@ -120,6 +129,7 @@ target_link_libraries(ISO-Fortran-binding-test
   FortranEvaluate
   FortranSemantics
   FortranRuntime
+  LLVMSupport
 )
 
 add_executable(folding-test
@@ -130,6 +140,7 @@ target_link_libraries(folding-test
   FortranEvaluateTesting
   FortranEvaluate
   FortranSemantics
+  LLVMSupport
 )
 
 add_test(Expression expression-test)

--- a/unittests/Evaluate/ISO-Fortran-binding.cpp
+++ b/unittests/Evaluate/ISO-Fortran-binding.cpp
@@ -1,10 +1,8 @@
 #include "testing.h"
 #include "../../include/flang/ISO_Fortran_binding.h"
 #include "../../runtime/descriptor.h"
+#include "llvm/Support/raw_ostream.h"
 #include <type_traits>
-#ifdef VERBOSE
-#include <iostream>
-#endif
 
 using namespace Fortran::runtime;
 using namespace Fortran::ISO;
@@ -71,13 +69,13 @@ static void AddNoiseToCdesc(CFI_cdesc_t *dv, CFI_rank_t rank) {
 static void DumpTestWorld(const void *bAddr, CFI_attribute_t attr,
     CFI_type_t ty, std::size_t eLen, CFI_rank_t rank,
     const CFI_index_t *eAddr) {
-  std::cout << " base_addr: " << std::hex
-            << reinterpret_cast<std::intptr_t>(bAddr)
-            << " attribute: " << static_cast<int>(attr) << std::dec
-            << " type: " << static_cast<int>(ty) << " elem_len: " << eLen
-            << " rank: " << static_cast<int>(rank) << " extent: " << std::hex
-            << reinterpret_cast<std::intptr_t>(eAddr) << std::endl
-            << std::dec;
+  llvm::outs() << " base_addr: ";
+  llvm::outs().write_hex(reinterpret_cast<std::intptr_t>(bAddr))
+      << " attribute: " << static_cast<int>(attr)
+      << " type: " << static_cast<int>(ty) << " elem_len: " << eLen
+      << " rank: " << static_cast<int>(rank) << " extent: ";
+  llvm::outs().write_hex(reinterpret_cast<std::intptr_t>(eAddr)) << '\n';
+  llvm::outs().flush();
 }
 #endif
 

--- a/unittests/Evaluate/fp-testing.cpp
+++ b/unittests/Evaluate/fp-testing.cpp
@@ -1,4 +1,5 @@
 #include "fp-testing.h"
+#include "llvm/Support/Errno.h"
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -15,11 +16,13 @@ ScopedHostFloatingPointEnvironment::ScopedHostFloatingPointEnvironment(
 ) {
   errno = 0;
   if (feholdexcept(&originalFenv_) != 0) {
-    std::fprintf(stderr, "feholdexcept() failed: %s\n", std::strerror(errno));
+    std::fprintf(stderr, "feholdexcept() failed: %s\n",
+        llvm::sys::StrError(errno).c_str());
     std::abort();
   }
   if (fegetenv(&currentFenv_) != 0) {
-    std::fprintf(stderr, "fegetenv() failed: %s\n", std::strerror(errno));
+    std::fprintf(
+        stderr, "fegetenv() failed: %s\n", llvm::sys::StrError(errno).c_str());
     std::abort();
   }
 #if __x86_64__
@@ -38,7 +41,8 @@ ScopedHostFloatingPointEnvironment::ScopedHostFloatingPointEnvironment(
 #endif
   errno = 0;
   if (fesetenv(&currentFenv_) != 0) {
-    std::fprintf(stderr, "fesetenv() failed: %s\n", std::strerror(errno));
+    std::fprintf(
+        stderr, "fesetenv() failed: %s\n", llvm::sys::StrError(errno).c_str());
     std::abort();
   }
 }
@@ -46,7 +50,8 @@ ScopedHostFloatingPointEnvironment::ScopedHostFloatingPointEnvironment(
 ScopedHostFloatingPointEnvironment::~ScopedHostFloatingPointEnvironment() {
   errno = 0;
   if (fesetenv(&originalFenv_) != 0) {
-    std::fprintf(stderr, "fesetenv() failed: %s\n", std::strerror(errno));
+    std::fprintf(
+        stderr, "fesetenv() failed: %s\n", llvm::sys::StrError(errno).c_str());
     std::abort();
   }
 }

--- a/unittests/Evaluate/real.cpp
+++ b/unittests/Evaluate/real.cpp
@@ -1,10 +1,10 @@
 #include "fp-testing.h"
 #include "testing.h"
 #include "flang/Evaluate/type.h"
+#include "llvm/Support/raw_ostream.h"
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
-#include <sstream>
 #include <type_traits>
 
 using namespace Fortran::evaluate;
@@ -149,7 +149,8 @@ template<typename R> void basicTests(int rm, Rounding rounding) {
       TEST(ivf.flags.empty())(ldesc);
       MATCH(x, ivf.value.ToUInt64())(ldesc);
       if (rounding.mode == RoundingMode::TiesToEven) {  // to match stold()
-        std::stringstream ss;
+        std::string buf;
+        llvm::raw_string_ostream ss{buf};
         vr.value.AsFortran(ss, kind, false /*exact*/);
         std::string decimal{ss.str()};
         const char *p{decimal.data()};
@@ -398,7 +399,9 @@ void subsetTests(int pass, Rounding rounding, std::uint32_t opds) {
       ("%d IsInfinite(0x%jx)", pass, static_cast<std::intmax_t>(rj));
 
       static constexpr int kind{REAL::bits / 8};
-      std::stringstream ss, css;
+      std::string ssBuf, cssBuf;
+      llvm::raw_string_ostream ss{ssBuf};
+      llvm::raw_string_ostream css{cssBuf};
       x.AsFortran(ss, kind, false /*exact*/);
       std::string s{ss.str()};
       if (IsNaN(rj)) {

--- a/unittests/Evaluate/testing.cpp
+++ b/unittests/Evaluate/testing.cpp
@@ -1,8 +1,8 @@
 #include "testing.h"
+#include "llvm/Support/raw_ostream.h"
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
-#include <iostream>
 
 namespace testing {
 
@@ -103,22 +103,22 @@ FailureDetailPrinter Compare(const char *file, int line, const char *xs,
 int Complete() {
   if (failures == 0) {
     if (passes == 1) {
-      std::cout << "single test PASSES\n";
+      llvm::outs() << "single test PASSES\n";
     } else {
-      std::cout << "all " << std::dec << passes << " tests PASS\n";
+      llvm::outs() << "all " << passes << " tests PASS\n";
     }
     passes = 0;
     return EXIT_SUCCESS;
   } else {
     if (passes == 1) {
-      std::cerr << "1 test passes, ";
+      llvm::errs() << "1 test passes, ";
     } else {
-      std::cerr << std::dec << passes << " tests pass, ";
+      llvm::errs() << passes << " tests pass, ";
     }
     if (failures == 1) {
-      std::cerr << "1 test FAILS\n";
+      llvm::errs() << "1 test FAILS\n";
     } else {
-      std::cerr << std::dec << failures << " tests FAIL\n";
+      llvm::errs() << failures << " tests FAIL\n";
     }
     passes = failures = 0;
     return EXIT_FAILURE;

--- a/unittests/Evaluate/uint128.cpp
+++ b/unittests/Evaluate/uint128.cpp
@@ -1,8 +1,8 @@
 #define AVOID_NATIVE_UINT128_T 1
 #include "flang/Common/uint128.h"
 #include "testing.h"
+#include "llvm/Support/raw_ostream.h"
 #include <cinttypes>
-#include <iostream>
 
 #if (defined __GNUC__ || defined __clang__) && defined __SIZEOF_INT128__
 #define HAS_NATIVE_UINT128_T 1
@@ -123,10 +123,10 @@ int main() {
     }
   }
 #if HAS_NATIVE_UINT128_T
-  std::cout << "Environment has native __uint128_t\n";
+  llvm::outs() << "Environment has native __uint128_t\n";
   TestVsNative();
 #else
-  std::cout << "Environment lacks native __uint128_t\n";
+  llvm::outs() << "Environment lacks native __uint128_t\n";
 #endif
   return testing::Complete();
 }

--- a/unittests/Runtime/CMakeLists.txt
+++ b/unittests/Runtime/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(format-test
 target_link_libraries(format-test
   FortranRuntime
   RuntimeTesting
+  LLVMSupport
 )
 
 add_test(Format format-test)
@@ -32,6 +33,7 @@ add_executable(hello-world
 target_link_libraries(hello-world
   FortranRuntime
   RuntimeTesting
+  LLVMSupport
 )
 
 add_test(HelloWorld hello-world)
@@ -42,6 +44,7 @@ add_executable(external-hello-world
 
 target_link_libraries(external-hello-world
   FortranRuntime
+  LLVMSupport
 )
 
 add_executable(list-input-test
@@ -51,6 +54,7 @@ add_executable(list-input-test
 target_link_libraries(list-input-test
   FortranRuntime
   RuntimeTesting
+  LLVMSupport
 )
 
 add_test(ListInput list-input-test)

--- a/unittests/Runtime/format.cpp
+++ b/unittests/Runtime/format.cpp
@@ -3,9 +3,9 @@
 #include "testing.h"
 #include "../runtime/format-implementation.h"
 #include "../runtime/io-error.h"
+#include "llvm/Support/raw_ostream.h"
 #include <cstdarg>
 #include <cstring>
-#include <iostream>
 #include <string>
 #include <vector>
 
@@ -93,13 +93,13 @@ void TestFormatContext::Check(Results &expect) {
   if (expect != results) {
     Fail() << "expected:";
     for (const std::string &s : expect) {
-      std::cerr << ' ' << s;
+      llvm::errs() << ' ' << s;
     }
-    std::cerr << "\ngot:";
+    llvm::errs() << "\ngot:";
     for (const std::string &s : results) {
-      std::cerr << ' ' << s;
+      llvm::errs() << ' ' << s;
     }
-    std::cerr << '\n';
+    llvm::errs() << '\n';
   }
   expect.clear();
   results.clear();

--- a/unittests/Runtime/hello.cpp
+++ b/unittests/Runtime/hello.cpp
@@ -3,8 +3,8 @@
 #include "testing.h"
 #include "../../runtime/descriptor.h"
 #include "../../runtime/io-api.h"
+#include "llvm/Support/raw_ostream.h"
 #include <cstring>
-#include <iostream>
 
 using namespace Fortran::runtime;
 using namespace Fortran::runtime::io;
@@ -110,8 +110,8 @@ static void realInTest(
     Fail() << '\'' << format << "' failed reading '" << data << "', status "
            << static_cast<int>(status) << " iomsg '" << iomsg << "'\n";
   } else if (u.raw != want) {
-    Fail() << '\'' << format << "' failed reading '" << data << "', want 0x"
-           << std::hex << want << ", got 0x" << u.raw << std::dec << '\n';
+    Fail() << '\'' << format << "' failed reading '" << data << "', want 0x";
+    Fail().write_hex(want) << ", got 0x" << u.raw << '\n';
   }
 }
 

--- a/unittests/Runtime/list-input.cpp
+++ b/unittests/Runtime/list-input.cpp
@@ -4,9 +4,9 @@
 #include "../../runtime/descriptor.h"
 #include "../../runtime/io-api.h"
 #include "../../runtime/io-error.h"
+#include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <cstring>
-#include <iostream>
 
 using namespace Fortran::runtime;
 using namespace Fortran::runtime::io;

--- a/unittests/Runtime/testing.cpp
+++ b/unittests/Runtime/testing.cpp
@@ -1,10 +1,10 @@
 #include "testing.h"
 #include "../../runtime/terminator.h"
+#include "llvm/Support/raw_ostream.h"
 #include <algorithm>
 #include <cstdarg>
 #include <cstdio>
 #include <cstring>
-#include <iostream>
 #include <string>
 
 static int failures{0};
@@ -21,16 +21,16 @@ void StartTests() {
   Fortran::runtime::Terminator::RegisterCrashHandler(CatchCrash);
 }
 
-std::ostream &Fail() {
+llvm::raw_ostream &Fail() {
   ++failures;
-  return std::cerr;
+  return llvm::errs();
 }
 
 int EndTests() {
   if (failures == 0) {
-    std::cout << "PASS\n";
+    llvm::outs() << "PASS\n";
   } else {
-    std::cout << "FAIL " << failures << " tests\n";
+    llvm::outs() << "FAIL " << failures << " tests\n";
   }
   return failures != 0;
 }

--- a/unittests/Runtime/testing.h
+++ b/unittests/Runtime/testing.h
@@ -4,8 +4,12 @@
 #include <cstddef>
 #include <iosfwd>
 
+namespace llvm {
+ class raw_ostream;
+}
+
 void StartTests();
-std::ostream &Fail();
+llvm::raw_ostream &Fail();
 int EndTests();
 
 void SetCharacter(char *, std::size_t, const char *);


### PR DESCRIPTION
[LLVMify F18] Replace the use std::ostream with LLVM streams llvm::ostream

This patch replaces the occurrence of std::ostream by llvm::raw_ostream,
because  LLVM Coding Standards[1] says that "All new code should use raw_ostream instead of ostream".[1]

As a consequence, this patch also replaces the use of:
   std:stringstream by llvm::raw_string_ostream
   std::ofstream by llvm::raw_fd_ostream
   std::cout by llvm::outs()   and
   std::cerr by llvm::errs()
where it is needed, because of the use of llvm::raw_ostream.

[1]https://llvm.org/docs/CodingStandards.html

Signed-off-by: Caroline Concatto <caroline.concatto@arm.com>