### PR TITLE
Rename EXTERN_C_END to FORTRAN_EXTERN_C_END

### DIFF
--- a/runtime/c-or-cpp.h
+++ b/runtime/c-or-cpp.h
@@ -20,8 +20,8 @@
 #define DEFAULT_VALUE(x)
 #endif
 
-#define EXTERN_C_BEGIN IF_CPLUSPLUS(extern "C" {)
-#define EXTERN_C_END IF_CPLUSPLUS( \
+#define FORTRAN_EXTERN_C_BEGIN IF_CPLUSPLUS(extern "C" {)
+#define FORTRAN_EXTERN_C_END IF_CPLUSPLUS( \
   })
 #define NORETURN IF_CPLUSPLUS([[noreturn]])
 #define NO_ARGUMENTS IF_NOT_CPLUSPLUS(void)

--- a/runtime/main.h
+++ b/runtime/main.h
@@ -12,8 +12,8 @@
 #include "c-or-cpp.h"
 #include "entry-names.h"
 
-EXTERN_C_BEGIN
+FORTRAN_EXTERN_C_BEGIN
 void RTNAME(ProgramStart)(int, const char *[], const char *[]);
-EXTERN_C_END
+FORTRAN_EXTERN_C_END
 
 #endif  // FORTRAN_RUNTIME_MAIN_H_

--- a/runtime/stop.h
+++ b/runtime/stop.h
@@ -13,7 +13,7 @@
 #include "entry-names.h"
 #include <stdlib.h>
 
-EXTERN_C_BEGIN
+FORTRAN_EXTERN_C_BEGIN
 
 // Program-initiated image stop
 NORETURN void RTNAME(StopStatement)(int code DEFAULT_VALUE(EXIT_SUCCESS),
@@ -23,6 +23,6 @@ NORETURN void RTNAME(StopStatementText)(const char *,
 NORETURN void RTNAME(FailImageStatement)(NO_ARGUMENTS);
 NORETURN void RTNAME(ProgramEndStatement)(NO_ARGUMENTS);
 
-EXTERN_C_END
+FORTRAN_EXTERN_C_END
 
 #endif  // FORTRAN_RUNTIME_STOP_H_


### PR DESCRIPTION
Since EXTERN_C_END is a macro defined in Windows system headers

Fixes https://github.com/flang-compiler/f18/issues/1007