### PR TITLE
[LLVMify F18] Use llvm_unreachable for unreachable code cases #966

### DIFF
--- a/include/flang/Common/enum-set.h
+++ b/include/flang/Common/enum-set.h
@@ -187,7 +187,8 @@ public:
           return {enumerator};
         }
       }
-      die("EnumSet::LeastElement(): no bit found in non-empty std::bitset");
+      llvm_unreachable(
+          "EnumSet::LeastElement(): no bit found in non-empty std::bitset");
     }
   }
 

--- a/include/flang/Common/idioms.h
+++ b/include/flang/Common/idioms.h
@@ -23,6 +23,7 @@
 #error g++ >= 7.2 is required
 #endif
 
+#include "llvm/Support/ErrorHandling.h"
 #include <functional>
 #include <list>
 #include <optional>
@@ -63,10 +64,8 @@ template<typename... LAMBDAS> visitors(LAMBDAS... x)->visitors<LAMBDAS...>;
 // Calls std::fprintf(stderr, ...), then abort().
 [[noreturn]] void die(const char *, ...);
 
-#define DIE(x) Fortran::common::die(x " at " __FILE__ "(%d)", __LINE__)
-
 // For switch statement default: labels.
-#define CRASH_NO_CASE DIE("no case")
+#define CRASH_NO_CASE llvm_unreachable("no case")
 
 // clang-format off
 // For switch statements whose cases have return statements for
@@ -82,7 +81,7 @@ template<typename... LAMBDAS> visitors(LAMBDAS... x)->visitors<LAMBDAS...>;
 // For cheap assertions that should be applied in production.
 // To disable, compile with '-DCHECK=(void)'
 #ifndef CHECK
-#define CHECK(x) ((x) || (DIE("CHECK(" #x ") failed"), false))
+#define CHECK(x) ((x) || (llvm_unreachable("CHECK(" #x ") failed"), false))
 #endif
 
 // User-defined type traits that default to false:

--- a/lib/Common/CMakeLists.txt
+++ b/lib/Common/CMakeLists.txt
@@ -13,6 +13,10 @@ add_library(FortranCommon
   idioms.cpp
 )
 
+target_link_libraries(FortranCommon
+  LLVMSupport
+)
+
 install (TARGETS FortranCommon
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib

--- a/lib/Evaluate/call.cpp
+++ b/lib/Evaluate/call.cpp
@@ -105,7 +105,7 @@ int ProcedureDesignator::Rank() const {
       }
     }
   }
-  DIE("ProcedureDesignator::Rank(): no case");
+  llvm_unreachable("ProcedureDesignator::Rank(): no case");
   return 0;
 }
 
@@ -128,7 +128,7 @@ bool ProcedureDesignator::IsElemental() const {
     return intrinsic->characteristics.value().attrs.test(
         characteristics::Procedure::Attr::Elemental);
   } else {
-    DIE("ProcedureDesignator::IsElemental(): no case");
+    llvm_unreachable("ProcedureDesignator::IsElemental(): no case");
   }
   return false;
 }

--- a/lib/Evaluate/characteristics.cpp
+++ b/lib/Evaluate/characteristics.cpp
@@ -405,7 +405,7 @@ void DummyArgument::SetOptional(bool value) {
           [value](DummyProcedure &proc) {
             proc.attrs.set(DummyProcedure::Attr::Optional, value);
           },
-          [](AlternateReturn &) { DIE("cannot set optional"); },
+          [](AlternateReturn &) { llvm_unreachable("cannot set optional"); },
       },
       u);
 }
@@ -639,7 +639,7 @@ std::optional<Procedure> Procedure::Characterize(
                     return result;
                   }
                 }
-                DIE("PASS argument missing");
+                llvm_unreachable("PASS argument missing");
               }
               return result;
             } else {

--- a/lib/Evaluate/fold-implementation.h
+++ b/lib/Evaluate/fold-implementation.h
@@ -1459,7 +1459,7 @@ Expr<Type<TypeCategory::Real, KIND>> ToReal(
         } else if constexpr (IsNumericCategoryExpr<From>()) {
           result = Fold(context, ConvertToType<Result>(std::move(x)));
         } else {
-          common::die("ToReal: bad argument expression");
+          llvm_unreachable("ToReal: bad argument expression");
         }
       },
       std::move(expr.u));

--- a/lib/Evaluate/fold-integer.cpp
+++ b/lib/Evaluate/fold-integer.cpp
@@ -232,7 +232,7 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldIntrinsicFunction(
           },
           sx->u);
     } else {
-      DIE("exponent argument must be real");
+      llvm_unreachable("exponent argument must be real");
     }
   } else if (name == "huge") {
     return Expr<T>{Scalar<T>::HUGE()};
@@ -329,7 +329,7 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldIntrinsicFunction(
           },
           charExpr->u);
     } else {
-      DIE("first argument must be CHARACTER");
+      llvm_unreachable("first argument must be CHARACTER");
     }
   } else if (name == "int") {
     if (auto *expr{UnwrapExpr<Expr<SomeType>>(args[0])}) {
@@ -340,7 +340,7 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldIntrinsicFunction(
                 IsNumericCategoryExpr<From>()) {
               return Fold(context, ConvertToType<T>(std::move(x)));
             }
-            DIE("int() argument type not valid");
+            llvm_unreachable("int() argument type not valid");
           },
           std::move(expr->u));
     }
@@ -350,7 +350,7 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldIntrinsicFunction(
     if constexpr (common::HasMember<T, IntegerTypes>) {
       return Expr<T>{args[0].value().GetType()->kind()};
     } else {
-      DIE("kind() result not integral");
+      llvm_unreachable("kind() result not integral");
     }
   } else if (name == "lbound") {
     return LBOUND(context, std::move(funcRef));
@@ -383,7 +383,7 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldIntrinsicFunction(
           },
           sn->u);
     } else {
-      DIE("leadz argument must be integer");
+      llvm_unreachable("leadz argument must be integer");
     }
   } else if (name == "len") {
     if (auto *charExpr{UnwrapExpr<Expr<SomeCharacter>>(args[0])}) {
@@ -397,7 +397,7 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldIntrinsicFunction(
           },
           charExpr->u);
     } else {
-      DIE("len() argument must be of character type");
+      llvm_unreachable("len() argument must be of character type");
     }
   } else if (name == "len_trim") {
     if (auto *charExpr{UnwrapExpr<Expr<SomeCharacter>>(args[0])}) {
@@ -411,7 +411,7 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldIntrinsicFunction(
           },
           charExpr->u);
     } else {
-      DIE("len_trim() argument must be of character type");
+      llvm_unreachable("len_trim() argument must be of character type");
     }
   } else if (name == "maskl" || name == "maskr") {
     // Argument can be of any kind but value has to be smaller than BIT_SIZE.

--- a/lib/Evaluate/fold-logical.cpp
+++ b/lib/Evaluate/fold-logical.cpp
@@ -166,7 +166,7 @@ Expr<Type<TypeCategory::Logical, KIND>> FoldOperation(
     case LogicalOperator::Or: result = xt || yt; break;
     case LogicalOperator::Eqv: result = xt == yt; break;
     case LogicalOperator::Neqv: result = xt != yt; break;
-    case LogicalOperator::Not: DIE("not a binary operator");
+    case LogicalOperator::Not: llvm_unreachable("not a binary operator");
     }
     return Expr<LOGICAL>{Constant<LOGICAL>{result}};
   }

--- a/lib/Evaluate/fold-real.cpp
+++ b/lib/Evaluate/fold-real.cpp
@@ -82,7 +82,7 @@ Expr<Type<TypeCategory::Real, KIND>> FoldIntrinsicFunction(
             "abs(complex(kind=%d)) cannot be folded on host"_en_US, KIND);
       }
     } else {
-      common::die(" unexpected argument type inside abs");
+      llvm_unreachable(" unexpected argument type inside abs");
     }
   } else if (name == "aimag") {
     return FoldElementalIntrinsic<T, ComplexT>(

--- a/lib/Evaluate/intrinsics-library-templates.h
+++ b/lib/Evaluate/intrinsics-library-templates.h
@@ -101,8 +101,9 @@ template<typename TR, typename... ArgInfo> struct CallableHostWrapper {
       hostFPE.CheckAndRestoreFloatingPointEnvironment(context);
       return result;
     } else {
-      common::die("Internal error: Host does not supports this function type."
-                  "This should not have been called for folding");
+      llvm_unreachable(
+          "Internal error: Host does not supports this function type."
+          "This should not have been called for folding");
     }
   }
   static constexpr inline auto MakeScalarCallable() { return &scalarCallable; }

--- a/lib/Evaluate/tools.cpp
+++ b/lib/Evaluate/tools.cpp
@@ -532,7 +532,7 @@ std::optional<Expr<LogicalResult>> Relate(parser::ContextualMessages &messages,
           },
           // Default case
           [&](auto &&, auto &&) {
-            DIE("invalid types for relational operator");
+            llvm_unreachable("invalid types for relational operator");
             return std::optional<Expr<LogicalResult>>{};
           },
       },

--- a/lib/Evaluate/type.cpp
+++ b/lib/Evaluate/type.cpp
@@ -372,7 +372,7 @@ std::optional<DynamicType> DynamicType::From(
   } else if (type.category() == semantics::DeclTypeSpec::TypeStar) {
     return DynamicType::AssumedType();
   } else {
-    common::die("DynamicType::From(DeclTypeSpec): failed");
+    llvm_unreachable("DynamicType::From(DeclTypeSpec): failed");
   }
   return std::nullopt;
 }

--- a/lib/Evaluate/variable.cpp
+++ b/lib/Evaluate/variable.cpp
@@ -327,7 +327,7 @@ std::optional<Expr<SubscriptInteger>> Designator<T>::LEN() const {
         },
         u);
   } else {
-    common::die("Designator<non-char>::LEN() called");
+    llvm_unreachable("Designator<non-char>::LEN() called");
     return std::nullopt;
   }
 }

--- a/lib/Parser/parse-tree.cpp
+++ b/lib/Parser/parse-tree.cpp
@@ -146,7 +146,7 @@ static Expr ActualArgToExpr(ActualArgSpec &arg) {
                 },
                 y.value().u);
           },
-          [&](auto &) -> Expr { common::die("unexpected type"); },
+          [&](auto &) -> Expr { llvm_unreachable("unexpected type"); },
       },
       std::get<ActualArg>(arg.t).u);
 }

--- a/lib/Parser/prescan.cpp
+++ b/lib/Parser/prescan.cpp
@@ -54,7 +54,7 @@ static void NormalizeCompilerDirectiveCommentMarker(TokenSequence &dir) {
       return;
     }
   }
-  DIE("compiler directive all blank");
+  llvm_unreachable("compiler directive all blank");
 }
 
 void Prescanner::Prescan(ProvenanceRange range) {

--- a/lib/Semantics/attr.cpp
+++ b/lib/Semantics/attr.cpp
@@ -15,7 +15,7 @@ namespace Fortran::semantics {
 
 void Attrs::CheckValid(const Attrs &allowed) const {
   if (!allowed.HasAll(*this)) {
-    common::die("invalid attribute");
+    llvm_unreachable("invalid attribute");
   }
 }
 

--- a/lib/Semantics/check-allocate.cpp
+++ b/lib/Semantics/check-allocate.cpp
@@ -385,7 +385,7 @@ static bool HaveCompatibleKindParameters(
     return HaveCompatibleKindParameters(
         *derivedType1, type2.GetDerivedTypeSpec());
   } else {
-    common::die("unexpected type1 category");
+    llvm_unreachable("unexpected type1 category");
   }
 }
 
@@ -400,7 +400,7 @@ static bool HaveCompatibleKindParameters(
     return HaveCompatibleKindParameters(
         *derivedType1, DEREF(type2.AsDerived()));
   } else {
-    common::die("unexpected type1 category");
+    llvm_unreachable("unexpected type1 category");
   }
 }
 

--- a/lib/Semantics/check-declarations.cpp
+++ b/lib/Semantics/check-declarations.cpp
@@ -654,7 +654,7 @@ static bool ConflictsWithIntrinsicOperator(
         common::visitors{
             [&](common::NumericOperator) { return IsIntrinsicNumeric(type0); },
             [&](common::LogicalOperator) { return IsIntrinsicLogical(type0); },
-            [](const auto &) -> bool { DIE("bad generic kind"); },
+            [](const auto &) -> bool { llvm_unreachable("bad generic kind"); },
         },
         kind.u);
   } else {  // binary
@@ -677,7 +677,7 @@ static bool ConflictsWithIntrinsicOperator(
               CHECK(x == GenericKind::OtherKind::Concat);
               return IsIntrinsicConcat(type0, rank0, type1, rank1);
             },
-            [](const auto &) -> bool { DIE("bad generic kind"); },
+            [](const auto &) -> bool { llvm_unreachable("bad generic kind"); },
         },
         kind.u);
   }
@@ -734,7 +734,7 @@ std::optional<parser::MessageFixedText> CheckHelper::CheckNumberOfArgs(
           [](const GenericKind::OtherKind &x) {
             CHECK(x == GenericKind::OtherKind::Concat);
           },
-          [](const auto &) { DIE("expected intrinsic operator"); },
+          [](const auto &) { llvm_unreachable("expected intrinsic operator"); },
       },
       kind.u);
   if (nargs >= min && nargs <= max) {
@@ -821,7 +821,7 @@ bool CheckHelper::CheckDefinedAssignmentArg(
             " argument '%s' must have INTENT(IN) or VALUE attribute"_err_en_US;
       }
     } else {
-      DIE("pos must be 0 or 1");
+      llvm_unreachable("pos must be 0 or 1");
     }
   } else {
     msg = "In defined assignment subroutine '%s', dummy argument '%s'"

--- a/lib/Semantics/expression.cpp
+++ b/lib/Semantics/expression.cpp
@@ -208,7 +208,7 @@ MaybeExpr ExpressionAnalyzer::Designate(DataRef &&ref) {
     if (auto *component{std::get_if<Component>(&ref.u)}) {
       return Expr<SomeType>{ProcedureDesignator{std::move(*component)}};
     } else if (!std::holds_alternative<SymbolRef>(ref.u)) {
-      DIE("unexpected alternative in DataRef");
+      llvm_unreachable("unexpected alternative in DataRef");
     } else if (!symbol.attrs().test(semantics::Attr::INTRINSIC)) {
       return Expr<SomeType>{ProcedureDesignator{symbol}};
     } else if (auto interface{context_.intrinsics().IsSpecificIntrinsicFunction(
@@ -284,7 +284,7 @@ MaybeExpr ExpressionAnalyzer::ApplySubscripts(
                 ArrayRef{std::move(c), std::move(subscripts)});
           },
           [&](auto &&) -> MaybeExpr {
-            DIE("bad base for ArrayRef");
+            llvm_unreachable("bad base for ArrayRef");
             return std::nullopt;
           },
       },
@@ -1014,7 +1014,7 @@ MaybeExpr ExpressionAnalyzer::Analyze(const parser::StructureComponent &sc) {
       return MakeFunctionRef(
           name, ActualArguments{ActualArgument{std::move(*base)}});
     } else {
-      DIE("unexpected MiscDetails::Kind");
+      llvm_unreachable("unexpected MiscDetails::Kind");
     }
   } else {
     Say(name, "derived type required before component reference"_err_en_US);
@@ -1576,7 +1576,7 @@ static int GetPassIndex(const Symbol &proc) {
     }
     ++index;
   }
-  DIE("PASS argument name not in dummy argument list");
+  llvm_unreachable("PASS argument name not in dummy argument list");
 }
 
 // Injects an expression into an actual argument list as the "passed object"
@@ -2187,7 +2187,7 @@ MaybeExpr ExpressionAnalyzer::Analyze(const parser::Expr::Concat &x) {
           if constexpr (std::is_same_v<T, ResultType<decltype(y)>>) {
             return AsGenericExpr(Concat<T::kind>{std::move(x), std::move(y)});
           } else {
-            DIE("different types for intrinsic concat");
+            llvm_unreachable("different types for intrinsic concat");
           }
         },
         std::move(std::get<Expr<SomeCharacter>>(analyzer.MoveExpr(0).u).u),
@@ -2358,7 +2358,7 @@ static void FixMisparsedFunctionReference(
           CheckFuncRefToArrayElementRefHasSubscripts(context, funcRef);
           u = common::Indirection{funcRef.ConvertToArrayElementRef()};
         } else {
-          DIE("can't fix misparsed function as array reference");
+          llvm_unreachable("can't fix misparsed function as array reference");
         }
       }
     }
@@ -2830,7 +2830,7 @@ void ArgumentAnalyzer::Dump(std::ostream &os) {
     } else if (const Expr<SomeType> *expr{actual->UnwrapExpr()}) {
       expr->AsFortran(os << "- expr: ") << '\n';
     } else {
-      DIE("bad ActualArgument");
+      llvm_unreachable("bad ActualArgument");
     }
   }
 }

--- a/lib/Semantics/pointer-assignment.cpp
+++ b/lib/Semantics/pointer-assignment.cpp
@@ -383,7 +383,7 @@ static bool CheckPointerBounds(
             return bounds.size();
           },
           [](const auto &) -> std::size_t {
-            DIE("not valid for pointer assignment");
+            llvm_unreachable("not valid for pointer assignment");
           },
       },
       assignment.u)};

--- a/lib/Semantics/resolve-names.cpp
+++ b/lib/Semantics/resolve-names.cpp
@@ -93,7 +93,7 @@ private:
 // Track statement source locations and save messages.
 class MessageHandler {
 public:
-  MessageHandler() { DIE("MessageHandler: default-constructed"); }
+  MessageHandler() { llvm_unreachable("MessageHandler: default-constructed"); }
   explicit MessageHandler(SemanticsContext &c) : context_{&c} {}
   Messages &messages() { return context_->messages(); };
   const std::optional<SourceName> &currStmtSource() {
@@ -134,7 +134,7 @@ private:
 
 class BaseVisitor {
 public:
-  BaseVisitor() { DIE("BaseVisitor: default-constructed"); }
+  BaseVisitor() { llvm_unreachable("BaseVisitor: default-constructed"); }
   BaseVisitor(SemanticsContext &c, ResolveNamesVisitor &v)
     : this_{&v}, context_{&c}, messageHandler_{c} {}
   template<typename T> void Walk(const T &);
@@ -273,7 +273,7 @@ protected:
     case parser::AccessSpec::Kind::Public: return Attr::PUBLIC;
     case parser::AccessSpec::Kind::Private: return Attr::PRIVATE;
     }
-    common::die("unreachable");  // suppress g++ warning
+    llvm_unreachable("unreachable");  // suppress g++ warning
   }
   Attr IntentSpecToAttr(const parser::IntentSpec &x) {
     switch (x.v) {
@@ -281,7 +281,7 @@ protected:
     case parser::IntentSpec::Intent::Out: return Attr::INTENT_OUT;
     case parser::IntentSpec::Intent::InOut: return Attr::INTENT_INOUT;
     }
-    common::die("unreachable");  // suppress g++ warning
+    llvm_unreachable("unreachable");  // suppress g++ warning
   }
 
 private:
@@ -916,7 +916,7 @@ private:
             "Declaration of '%s' conflicts with its use as internal procedure"_err_en_US,
             symbol, "Internal procedure definition"_en_US);
       } else {
-        DIE("unexpected kind");
+        llvm_unreachable("unexpected kind");
       }
     } else if (std::is_same_v<ObjectEntityDetails, T> &&
         symbol.has<ProcEntityDetails>()) {
@@ -1360,13 +1360,19 @@ public:
   bool Pre(const parser::ProgramUnit &);
 
   // These nodes should never be reached: they are handled in ProgramUnit
-  bool Pre(const parser::MainProgram &) { DIE("unreachable"); }
-  bool Pre(const parser::FunctionSubprogram &) { DIE("unreachable"); }
-  bool Pre(const parser::SubroutineSubprogram &) { DIE("unreachable"); }
-  bool Pre(const parser::SeparateModuleSubprogram &) { DIE("unreachable"); }
-  bool Pre(const parser::Module &) { DIE("unreachable"); }
-  bool Pre(const parser::Submodule &) { DIE("unreachable"); }
-  bool Pre(const parser::BlockData &) { DIE("unreachable"); }
+  bool Pre(const parser::MainProgram &) { llvm_unreachable("unreachable"); }
+  bool Pre(const parser::FunctionSubprogram &) {
+    llvm_unreachable("unreachable");
+  }
+  bool Pre(const parser::SubroutineSubprogram &) {
+    llvm_unreachable("unreachable");
+  }
+  bool Pre(const parser::SeparateModuleSubprogram &) {
+    llvm_unreachable("unreachable");
+  }
+  bool Pre(const parser::Module &) { llvm_unreachable("unreachable"); }
+  bool Pre(const parser::Submodule &) { llvm_unreachable("unreachable"); }
+  bool Pre(const parser::BlockData &) { llvm_unreachable("unreachable"); }
 
   void NoteExecutablePartCall(Symbol::Flag, const parser::Call &);
 
@@ -1512,7 +1518,7 @@ bool AttrsVisitor::SetPassNameOn(Symbol &symbol) {
       common::visitors{
           [&](ProcEntityDetails &x) { x.set_passName(*passName_); },
           [&](ProcBindingDetails &x) { x.set_passName(*passName_); },
-          [](auto &) { common::die("unexpected pass name"); },
+          [](auto &) { llvm_unreachable("unexpected pass name"); },
       },
       symbol.details());
   return true;
@@ -1529,7 +1535,7 @@ bool AttrsVisitor::SetBindNameOn(Symbol &symbol) {
           [&](ProcEntityDetails &x) { x.set_bindName(std::move(bindName_)); },
           [&](SubprogramDetails &x) { x.set_bindName(std::move(bindName_)); },
           [&](CommonBlockDetails &x) { x.set_bindName(std::move(bindName_)); },
-          [](auto &) { common::die("unexpected bind name"); },
+          [](auto &) { llvm_unreachable("unexpected bind name"); },
       },
       symbol.details());
   return true;
@@ -1900,7 +1906,7 @@ Scope &ScopeHandler::InclusiveScope() {
       return *scope;
     }
   }
-  DIE("inclusive scope not found");
+  llvm_unreachable("inclusive scope not found");
 }
 
 void ScopeHandler::PushScope(Scope::Kind kind, Symbol *symbol) {
@@ -5400,7 +5406,7 @@ void ResolveNamesVisitor::HandleProcedureName(
     ConvertToProcEntity(*symbol);
     SetProcFlag(name, *symbol, flag);
   } else if (symbol->has<UnknownDetails>()) {
-    DIE("unexpected UnknownDetails");
+    llvm_unreachable("unexpected UnknownDetails");
   } else if (CheckUseError(name)) {
     // error was reported
   } else {

--- a/lib/Semantics/semantics.cpp
+++ b/lib/Semantics/semantics.cpp
@@ -198,7 +198,7 @@ Scope &SemanticsContext::FindScope(parser::CharBlock source) {
   if (auto *scope{globalScope_.FindScope(source)}) {
     return *scope;
   } else {
-    common::die("SemanticsContext::FindScope(): invalid source location");
+    llvm_unreachable("SemanticsContext::FindScope(): invalid source location");
   }
 }
 

--- a/lib/Semantics/symbol.cpp
+++ b/lib/Semantics/symbol.cpp
@@ -636,7 +636,7 @@ Symbol &Symbol::InstantiateComponent(
         details->ReplaceType(
             InstantiateIntrinsicType(scope, *origType, context));
       } else if (origType->category() != DeclTypeSpec::ClassStar) {
-        DIE("instantiated component has type that is "
+        llvm_unreachable("instantiated component has type that is "
             "neither intrinsic, derived, nor CLASS(*)");
       }
     }

--- a/lib/Semantics/tools.cpp
+++ b/lib/Semantics/tools.cpp
@@ -417,7 +417,7 @@ template<typename T> static void CheckMissingAnalysis(bool absent, const T &x) {
     std::ostringstream ss;
     ss << "node has not been analyzed:\n";
     parser::DumpTree(ss, x);
-    common::die(ss.str().c_str());
+    llvm_unreachable(ss.str().c_str());
   }
 }
 


### PR DESCRIPTION
Current implementation of DIE in f18 is exact replica of llvm_unreachable from llvm.
Since f18(flang) will be part of llvm mono repo very soon, it would be good to use  llvm_unreachable. 
In this commit, f18 specific DIE macro and its references are replaced with llvm_unreachable.