### PR TITLE
Changes that enable f18 build with latest clang

### DIFF
--- a/include/flang/Common/reference.h
+++ b/include/flang/Common/reference.h
@@ -45,8 +45,15 @@ public:
   type &get() const noexcept { return *p_; }
   type *operator->() const { return p_; }
   type &operator*() const { return *p_; }
-  bool operator==(Reference that) const { return *p_ == *that.p_; }
-  bool operator!=(Reference that) const { return *p_ != *that.p_; }
+
+  bool operator==(std::add_const_t<A> &that) const {
+    return p_ == &that || *p_ == that;
+  }
+  bool operator!=(std::add_const_t<A> &that) const { return !(*this == that); }
+  bool operator==(const Reference &that) const {
+    return p_ == that.p_ || *this == *that.p_;
+  }
+  bool operator!=(const Reference &that) const { return !(*this == that); }
 
 private:
   type *p_;  // never null

--- a/include/flang/Common/uint128.h
+++ b/include/flang/Common/uint128.h
@@ -25,11 +25,18 @@ namespace Fortran::common {
 class UnsignedInt128 {
 public:
   constexpr UnsignedInt128() {}
-  constexpr UnsignedInt128(std::uint64_t n) : low_{n} {}
-  constexpr UnsignedInt128(std::int64_t n)
+  // This means of definition provides some portability for
+  // "size_t" operands.
+  constexpr UnsignedInt128(unsigned n) : low_{n} {}
+  constexpr UnsignedInt128(unsigned long n) : low_{n} {}
+  constexpr UnsignedInt128(unsigned long long n) : low_{n} {}
+  constexpr UnsignedInt128(int n)
     : low_{static_cast<std::uint64_t>(n)}, high_{-static_cast<std::uint64_t>(
                                                n < 0)} {}
-  constexpr UnsignedInt128(int n)
+  constexpr UnsignedInt128(long n)
+    : low_{static_cast<std::uint64_t>(n)}, high_{-static_cast<std::uint64_t>(
+                                               n < 0)} {}
+  constexpr UnsignedInt128(long long n)
     : low_{static_cast<std::uint64_t>(n)}, high_{-static_cast<std::uint64_t>(
                                                n < 0)} {}
   constexpr UnsignedInt128(const UnsignedInt128 &) = default;

--- a/include/flang/Evaluate/common.h
+++ b/include/flang/Evaluate/common.h
@@ -195,7 +195,7 @@ using HostUnsignedInt =
 #define EVALUATE_UNION_CLASS_BOILERPLATE(t) \
   CLASS_BOILERPLATE(t) \
   UNION_CONSTRUCTORS(t) \
-  bool operator==(const t &that) const { return u == that.u; }
+  bool operator==(const t &) const;
 
 // Forward definition of Expr<> so that it can be indirectly used in its own
 // definition

--- a/include/flang/Evaluate/expression.h
+++ b/include/flang/Evaluate/expression.h
@@ -780,7 +780,6 @@ using TypelessExpression = std::variant<BOZLiteralConstant, NullPointer,
 template<> class Expr<SomeType> : public ExpressionBase<SomeType> {
 public:
   using Result = SomeType;
-
   EVALUATE_UNION_CLASS_BOILERPLATE(Expr)
 
   // Owning references to these generic expressions can appear in other

--- a/include/flang/Evaluate/variable.h
+++ b/include/flang/Evaluate/variable.h
@@ -43,27 +43,12 @@ using SymbolVector = std::vector<SymbolRef>;
 struct DataRef;
 template<typename T> struct Variable;
 
-bool AreSameSymbol(const Symbol &, const Symbol &);
-
-// Implements operator==() for a union type, using special case handling
-// for Symbol references.
-template<typename A> bool TestVariableEquality(const A &x, const A &y) {
-  const SymbolRef *xSymbol{std::get_if<SymbolRef>(&x.u)};
-  if (const SymbolRef * ySymbol{std::get_if<SymbolRef>(&y.u)}) {
-    return xSymbol && AreSameSymbol(*xSymbol, *ySymbol);
-  } else {
-    return x.u == y.u;
-  }
-}
-
 // Reference a base object in memory.  This can be a Fortran symbol,
 // static data (e.g., CHARACTER literal), or compiler-created temporary.
 struct BaseObject {
-  CLASS_BOILERPLATE(BaseObject)
-  UNION_CONSTRUCTORS(BaseObject)
+  EVALUATE_UNION_CLASS_BOILERPLATE(BaseObject)
   int Rank() const;
   std::optional<Expr<SubscriptInteger>> LEN() const;
-  bool operator==(const BaseObject &) const;
   std::ostream &AsFortran(std::ostream &) const;
   const Symbol *symbol() const {
     if (const auto *result{std::get_if<SymbolRef>(&u)}) {
@@ -296,10 +281,7 @@ private:
 // a terminal substring range or complex component designator; use
 // R901 designator for that.
 struct DataRef {
-  CLASS_BOILERPLATE(DataRef)
-  UNION_CONSTRUCTORS(DataRef)
-
-  bool operator==(const DataRef &) const;
+  EVALUATE_UNION_CLASS_BOILERPLATE(DataRef)
   int Rank() const;
   const Symbol &GetFirstSymbol() const;
   const Symbol &GetLastSymbol() const;
@@ -395,15 +377,11 @@ public:
   using Result = T;
   static_assert(
       IsSpecificIntrinsicType<Result> || std::is_same_v<Result, SomeDerived>);
-  CLASS_BOILERPLATE(Designator)
-  UNION_CONSTRUCTORS(Designator)
+  EVALUATE_UNION_CLASS_BOILERPLATE(Designator)
   Designator(const DataRef &that) : u{common::CopyVariant<Variant>(that.u)} {}
   Designator(DataRef &&that)
     : u{common::MoveVariant<Variant>(std::move(that.u))} {}
 
-  bool operator==(const Designator &that) const {
-    return TestVariableEquality(*this, that);
-  }
   std::optional<DynamicType> GetType() const;
   int Rank() const;
   BaseObject GetBaseObject() const;

--- a/lib/Evaluate/call.cpp
+++ b/lib/Evaluate/call.cpp
@@ -79,6 +79,10 @@ bool SpecificIntrinsic::operator==(const SpecificIntrinsic &that) const {
 ProcedureDesignator::ProcedureDesignator(Component &&c)
   : u{common::CopyableIndirection<Component>::Make(std::move(c))} {}
 
+bool ProcedureDesignator::operator==(const ProcedureDesignator &that) const {
+  return u == that.u;
+}
+
 std::optional<DynamicType> ProcedureDesignator::GetType() const {
   if (const auto *intrinsic{std::get_if<SpecificIntrinsic>(&u)}) {
     if (const auto &result{intrinsic->characteristics.value().functionResult}) {

--- a/lib/Evaluate/expression.cpp
+++ b/lib/Evaluate/expression.cpp
@@ -101,7 +101,7 @@ template<typename A> int ExpressionBase<A>::Rank() const {
       derived().u);
 }
 
-// Equality testing for classes without EVALUATE_UNION_CLASS_BOILERPLATE()
+// Equality testing
 
 bool ImpliedDoIndex::operator==(const ImpliedDoIndex &that) const {
   return name == that.name;
@@ -112,6 +112,12 @@ bool ImpliedDo<T>::operator==(const ImpliedDo<T> &that) const {
   return name_ == that.name_ && lower_ == that.lower_ &&
       upper_ == that.upper_ && stride_ == that.stride_ &&
       values_ == that.values_;
+}
+
+template<typename T>
+bool ArrayConstructorValue<T>::operator==(
+    const ArrayConstructorValue<T> &that) const {
+  return u == that.u;
 }
 
 template<typename R>
@@ -144,6 +150,57 @@ StructureConstructor::StructureConstructor(
 
 bool StructureConstructor::operator==(const StructureConstructor &that) const {
   return result_ == that.result_ && values_ == that.values_;
+}
+
+bool Relational<SomeType>::operator==(const Relational<SomeType> &that) const {
+  return u == that.u;
+}
+
+template<int KIND>
+bool Expr<Type<TypeCategory::Integer, KIND>>::operator==(
+    const Expr<Type<TypeCategory::Integer, KIND>> &that) const {
+  return u == that.u;
+}
+
+template<int KIND>
+bool Expr<Type<TypeCategory::Real, KIND>>::operator==(
+    const Expr<Type<TypeCategory::Real, KIND>> &that) const {
+  return u == that.u;
+}
+
+template<int KIND>
+bool Expr<Type<TypeCategory::Complex, KIND>>::operator==(
+    const Expr<Type<TypeCategory::Complex, KIND>> &that) const {
+  return u == that.u;
+}
+
+template<int KIND>
+bool Expr<Type<TypeCategory::Logical, KIND>>::operator==(
+    const Expr<Type<TypeCategory::Logical, KIND>> &that) const {
+  return u == that.u;
+}
+
+template<int KIND>
+bool Expr<Type<TypeCategory::Character, KIND>>::operator==(
+    const Expr<Type<TypeCategory::Character, KIND>> &that) const {
+  return u == that.u;
+}
+
+template<TypeCategory CAT>
+bool Expr<SomeKind<CAT>>::operator==(const Expr<SomeKind<CAT>> &that) const {
+  return u == that.u;
+}
+
+bool Expr<SomeDerived>::operator==(const Expr<SomeDerived> &that) const {
+  return u == that.u;
+}
+
+bool Expr<SomeCharacter>::operator==(const Expr<SomeCharacter> &that) const {
+  return u == that.u;
+}
+
+bool Expr<SomeType>::operator==(const Expr<SomeType> &that) const {
+  return u == that.u;
 }
 
 DynamicType StructureConstructor::GetType() const { return result_.GetType(); }

--- a/lib/Semantics/resolve-labels.cpp
+++ b/lib/Semantics/resolve-labels.cpp
@@ -818,7 +818,7 @@ LabeledStatementInfoTuplePOD GetLabel(
 void CheckBranchesIntoDoBody(const SourceStmtList &branches,
     const TargetStmtMap &labels, const IndexList &loopBodies,
     SemanticsContext &context) {
-  for (const auto branch : branches) {
+  for (const auto &branch : branches) {
     const auto &label{branch.parserLabel};
     auto branchTarget{GetLabel(labels, label)};
     if (HasScope(branchTarget.proxyForScope)) {
@@ -870,7 +870,7 @@ void CheckLabelDoConstraints(const SourceStmtList &dos,
     const SourceStmtList &branches, const TargetStmtMap &labels,
     const std::vector<ProxyForScope> &scopes, SemanticsContext &context) {
   IndexList loopBodies;
-  for (const auto stmt : dos) {
+  for (const auto &stmt : dos) {
     const auto &label{stmt.parserLabel};
     const auto &scope{stmt.proxyForScope};
     const auto &position{stmt.parserCharBlock};
@@ -924,7 +924,7 @@ void CheckLabelDoConstraints(const SourceStmtList &dos,
 void CheckScopeConstraints(const SourceStmtList &stmts,
     const TargetStmtMap &labels, const std::vector<ProxyForScope> &scopes,
     SemanticsContext &context) {
-  for (const auto stmt : stmts) {
+  for (const auto &stmt : stmts) {
     const auto &label{stmt.parserLabel};
     const auto &scope{stmt.proxyForScope};
     const auto &position{stmt.parserCharBlock};
@@ -943,7 +943,7 @@ void CheckScopeConstraints(const SourceStmtList &stmts,
 
 void CheckBranchTargetConstraints(const SourceStmtList &stmts,
     const TargetStmtMap &labels, SemanticsContext &context) {
-  for (const auto stmt : stmts) {
+  for (const auto &stmt : stmts) {
     const auto &label{stmt.parserLabel};
     auto branchTarget{GetLabel(labels, label)};
     if (HasScope(branchTarget.proxyForScope)) {
@@ -981,7 +981,7 @@ void CheckBranchConstraints(const SourceStmtList &branches,
 
 void CheckDataXferTargetConstraints(const SourceStmtList &stmts,
     const TargetStmtMap &labels, SemanticsContext &context) {
-  for (const auto stmt : stmts) {
+  for (const auto &stmt : stmts) {
     const auto &label{stmt.parserLabel};
     auto ioTarget{GetLabel(labels, label)};
     if (HasScope(ioTarget.proxyForScope)) {

--- a/lib/Semantics/resolve-names.cpp
+++ b/lib/Semantics/resolve-names.cpp
@@ -3618,7 +3618,7 @@ void DeclarationVisitor::Post(const parser::TypeBoundProcedurePart &) {
   // track specifics seen for the current generic to detect duplicates:
   const Symbol *currGeneric{nullptr};
   std::set<SourceName> specifics;
-  for (const auto [generic, bindingName] : genericBindings_) {
+  for (const auto &[generic, bindingName] : genericBindings_) {
     if (generic != currGeneric) {
       currGeneric = generic;
       specifics.clear();


### PR DESCRIPTION
These changes silence new warnings and errors (valid or not -- we may have been getting away with something until now) emitted by the llvm-project clang compiler while building f18.  The one big change was avoiding inline `operator==` member functions operating on sum types containing references to types that are necessarily forward-referenced in header files; these comparisons were taken out-of-line into C++ source files where all of the relevant types are fully defined.  Also, a porting problem to OSX that Tim encountered with another PR is fixed here so that we don't have to wait for that big PR to merge.

f18 still builds with gcc (9.2.0 at least, will confirm 8.3.0 and 7.2.0 before merging) too.