### PR TITLE
Extend shape analysis to cope better with ASSOCIATE construct entities

### DIFF
--- a/include/flang/Evaluate/shape.h
+++ b/include/flang/Evaluate/shape.h
@@ -53,6 +53,8 @@ std::optional<ConstantSubscripts> AsConstantExtents(
 
 inline int GetRank(const Shape &s) { return static_cast<int>(s.size()); }
 
+template<typename A> std::optional<Shape> GetShape(FoldingContext &, const A &);
+
 // The dimension argument to these inquiries is zero-based,
 // unlike the DIM= arguments to many intrinsics.
 ExtentExpr GetLowerBound(FoldingContext &, const NamedEntity &, int dimension);
@@ -80,16 +82,13 @@ MaybeExtentExpr GetSize(Shape &&);
 // Utility predicate: does an expression reference any implied DO index?
 bool ContainsAnyImpliedDoIndex(const ExtentExpr &);
 
-// GetShape()
-template<typename A> std::optional<Shape> GetShape(FoldingContext &, const A &);
-
 class GetShapeHelper
   : public AnyTraverse<GetShapeHelper, std::optional<Shape>> {
 public:
   using Result = std::optional<Shape>;
   using Base = AnyTraverse<GetShapeHelper, Result>;
   using Base::operator();
-  GetShapeHelper(FoldingContext &c) : Base{*this}, context_{c} {}
+  explicit GetShapeHelper(FoldingContext &c) : Base{*this}, context_{c} {}
 
   Result operator()(const ImpliedDoIndex &) const { return Scalar(); }
   Result operator()(const DescriptorInquiry &) const { return Scalar(); }

--- a/lib/Evaluate/shape.cpp
+++ b/lib/Evaluate/shape.cpp
@@ -256,6 +256,13 @@ MaybeExtentExpr GetExtent(
         }
       }
     }
+  } else if (const auto *assoc{
+                 symbol.detailsIf<semantics::AssocEntityDetails>()}) {
+    if (auto shape{GetShape(context, assoc->expr())}) {
+      if (dimension < static_cast<int>(shape->size())) {
+        return std::move(shape->at(dimension));
+      }
+    }
   }
   return std::nullopt;
 }
@@ -314,6 +321,13 @@ MaybeExtentExpr GetUpperBound(
               GetLowerBound(context, base, dimension),
               GetExtent(context, base, dimension));
         }
+      }
+    }
+  } else if (const auto *assoc{
+                 symbol.detailsIf<semantics::AssocEntityDetails>()}) {
+    if (auto shape{GetShape(context, assoc->expr())}) {
+      if (dimension < static_cast<int>(shape->size())) {
+        return std::move(shape->at(dimension));
       }
     }
   }

--- a/module/iso_c_binding.f90
+++ b/module/iso_c_binding.f90
@@ -91,7 +91,7 @@ module iso_c_binding
 
   function c_loc(x)
     type(c_ptr) :: c_loc
-    type(*), dimension(:), intent(in) :: x
+    type(*), dimension(..), intent(in) :: x
     c_loc = c_ptr(loc(x))
   end function c_loc
 


### PR DESCRIPTION
This change fixes some recent regressions with spurious error messages about array assignments to assumed-size left-hand sides when the LHS was actually an `ASSOCIATE` construct entity.