### PR TITLE
Support latest LLVM head with FIR - MLIR SideEffects interface change

### DIFF
--- a/include/flang/Optimizer/Dialect/FIROps.td
+++ b/include/flang/Optimizer/Dialect/FIROps.td
@@ -15,6 +15,7 @@
 #define FIR_DIALECT_FIR_OPS
 
 include "mlir/Interfaces/ControlFlowInterfaces.td"
+include "mlir/Interfaces/SideEffects.td"
 
 def fir_Dialect : Dialect {
   let name = "fir";


### PR DESCRIPTION
Include new .td after LLVM changes:
https://github.com/llvm/llvm-project/commit/0ddba0bd59c337f16b51a00cb205ecfda46f97fa

Tested to work with LLVM head https://github.com/llvm/llvm-project/commit/ecd3e678bbb11cf899603037ec2c5949b8d7fa6c
from 2020-03-13 01:45 am PCT

Backwards compatible with previous known compatible heads at least back to
https://github.com/llvm/llvm-project/commit/fde9d33f7101bac631b26990d17822474d3a34e9 from 2020-03-10, so need to
update LLVM builds if they previously worked with FIR.