### PR TITLE
Complete formatting of pointer assignments

### DIFF
--- a/lib/Evaluate/expression.cpp
+++ b/lib/Evaluate/expression.cpp
@@ -222,42 +222,6 @@ StructureConstructor &StructureConstructor::Add(
 
 GenericExprWrapper::~GenericExprWrapper() {}
 
-std::ostream &Assignment::AsFortran(std::ostream &o) const {
-  std::visit(
-      common::visitors{
-          [&](const Assignment::Intrinsic &) {
-            rhs.AsFortran(lhs.AsFortran(o) << '=');
-          },
-          [&](const ProcedureRef &proc) { proc.AsFortran(o << "CALL "); },
-          [&](const BoundsSpec &bounds) {
-            lhs.AsFortran(o);
-            if (!bounds.empty()) {
-              char sep{'('};
-              for (const auto &bound : bounds) {
-                bound.AsFortran(o << sep) << ':';
-                sep = ',';
-              }
-              o << ')';
-            }
-          },
-          [&](const BoundsRemapping &bounds) {
-            lhs.AsFortran(o);
-            if (!bounds.empty()) {
-              char sep{'('};
-              for (const auto &bound : bounds) {
-                bound.first.AsFortran(o << sep) << ':';
-                bound.second.AsFortran(o);
-                sep = ',';
-              }
-              o << ')';
-            }
-            rhs.AsFortran(o << " => ");
-          },
-      },
-      u);
-  return o;
-}
-
 GenericAssignmentWrapper::~GenericAssignmentWrapper() {}
 
 template<TypeCategory CAT> int Expr<SomeKind<CAT>>::GetKind() const {


### PR DESCRIPTION
And move that formatting to formatting.cpp with the rest of AsFortran() member functions.