### PR TITLE
Test cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ To run all tests:
 ```
 cd ~/f18/build
 cmake -DLLVM_DIR=$LLVM ~/f18/src
-make check-all
+make test check-all
 ```
 
 To run individual regression tests llvm-lit needs to know the lit

--- a/test/Semantics/omp-nested01.f90
+++ b/test/Semantics/omp-nested01.f90
@@ -1,5 +1,4 @@
 ! RUN: %S/test_errors.sh %s %flang %t
-!XFAIL: *
 ! OPTIONS: -fopenmp
 
 ! Check OpenMP 2.17 Nesting of Regions
@@ -9,7 +8,7 @@
   do i = 1, N
      !ERROR: A worksharing region may not be closely nested inside a worksharing, explicit task, taskloop, critical, ordered, atomic, or master region
      !$omp do
-     do i = 1, N
+     do j = 1, N
         a = 3.14
      enddo
   enddo


### PR DESCRIPTION
Fix omp-nested01.f90 so that it is not an expected failure. The test was
never enabled but I'm guessing this is what it's supposed to do.

Fix the instructions to include "make test" as part of running tests.