### PR TITLE
Support forward references to sibling module procedures

### DIFF
--- a/include/flang/Evaluate/check-expression.h
+++ b/include/flang/Evaluate/check-expression.h
@@ -31,6 +31,7 @@ class IntrinsicProcTable;
 template<typename A> bool IsConstantExpr(const A &);
 extern template bool IsConstantExpr(const Expr<SomeType> &);
 extern template bool IsConstantExpr(const Expr<SomeInteger> &);
+extern template bool IsConstantExpr(const Expr<SubscriptInteger> &);
 
 // Checks whether an expression is an object designator with
 // constant addressing and no vector-valued subscript.
@@ -44,6 +45,13 @@ void CheckSpecificationExpr(
     const A &, parser::ContextualMessages &, const semantics::Scope &);
 extern template void CheckSpecificationExpr(const Expr<SomeType> &x,
     parser::ContextualMessages &, const semantics::Scope &);
+extern template void CheckSpecificationExpr(const Expr<SomeInteger> &x,
+    parser::ContextualMessages &, const semantics::Scope &);
+extern template void CheckSpecificationExpr(const Expr<SubscriptInteger> &x,
+    parser::ContextualMessages &, const semantics::Scope &);
+extern template void CheckSpecificationExpr(
+    const std::optional<Expr<SomeType>> &x, parser::ContextualMessages &,
+    const semantics::Scope &);
 extern template void CheckSpecificationExpr(
     const std::optional<Expr<SomeInteger>> &x, parser::ContextualMessages &,
     const semantics::Scope &);

--- a/include/flang/Semantics/expression.h
+++ b/include/flang/Semantics/expression.h
@@ -353,6 +353,7 @@ private:
       parser::CharBlock, const ProcedureDesignator &, ActualArguments &);
   using AdjustActuals =
       std::optional<std::function<bool(const Symbol &, ActualArguments &)>>;
+  bool ResolveForward(const Symbol &);
   const Symbol *ResolveGeneric(const Symbol &, const ActualArguments &,
       const AdjustActuals &, bool mightBeStructureConstructor = false);
   void EmitGenericResolutionError(const Symbol &);

--- a/include/flang/Semantics/symbol.h
+++ b/include/flang/Semantics/symbol.h
@@ -27,6 +27,7 @@ namespace Fortran::semantics {
 
 class Scope;
 class Symbol;
+class ProgramTree;
 
 using SymbolRef = common::Reference<const Symbol>;
 using SymbolVector = std::vector<SymbolRef>;
@@ -91,12 +92,15 @@ ENUM_CLASS(SubprogramKind, Module, Internal)
 // type information.
 class SubprogramNameDetails {
 public:
-  SubprogramNameDetails(SubprogramKind kind) : kind_{kind} {}
+  SubprogramNameDetails(SubprogramKind kind, ProgramTree &node)
+    : kind_{kind}, node_{node} {}
   SubprogramNameDetails() = delete;
   SubprogramKind kind() const { return kind_; }
+  ProgramTree &node() const { return *node_; }
 
 private:
   SubprogramKind kind_;
+  common::Reference<ProgramTree> node_;
 };
 
 // A name from an entity-decl -- could be object or function.

--- a/lib/Evaluate/check-expression.cpp
+++ b/lib/Evaluate/check-expression.cpp
@@ -63,6 +63,7 @@ template<typename A> bool IsConstantExpr(const A &x) {
 }
 template bool IsConstantExpr(const Expr<SomeType> &);
 template bool IsConstantExpr(const Expr<SomeInteger> &);
+template bool IsConstantExpr(const Expr<SubscriptInteger> &);
 
 // Object pointer initialization checking predicate IsInitialDataTarget().
 // This code determines whether an expression is allowable as the static
@@ -243,6 +244,12 @@ void CheckSpecificationExpr(const A &x, parser::ContextualMessages &messages,
 }
 
 template void CheckSpecificationExpr(const Expr<SomeType> &,
+    parser::ContextualMessages &, const semantics::Scope &);
+template void CheckSpecificationExpr(const Expr<SomeInteger> &,
+    parser::ContextualMessages &, const semantics::Scope &);
+template void CheckSpecificationExpr(const Expr<SubscriptInteger> &,
+    parser::ContextualMessages &, const semantics::Scope &);
+template void CheckSpecificationExpr(const std::optional<Expr<SomeType>> &,
     parser::ContextualMessages &, const semantics::Scope &);
 template void CheckSpecificationExpr(const std::optional<Expr<SomeInteger>> &,
     parser::ContextualMessages &, const semantics::Scope &);

--- a/lib/Semantics/program-tree.h
+++ b/lib/Semantics/program-tree.h
@@ -11,6 +11,7 @@
 
 #include "flang/Parser/parse-tree.h"
 #include "flang/Semantics/symbol.h"
+#include <list>
 #include <variant>
 
 // A ProgramTree represents a tree of program units and their contained
@@ -56,11 +57,17 @@ public:
   const parser::Name &name() const { return name_; }
   Kind GetKind() const;
   const Stmt &stmt() const { return stmt_; }
+  bool isSpecificationPartResolved() const {
+    return isSpecificationPartResolved_;
+  }
+  void set_isSpecificationPartResolved(bool yes = true) {
+    isSpecificationPartResolved_ = yes;
+  }
   const parser::ParentIdentifier &GetParentId() const;  // only for Submodule
   const parser::SpecificationPart &spec() const { return spec_; }
   const parser::ExecutionPart *exec() const { return exec_; }
-  std::vector<ProgramTree> &children() { return children_; }
-  const std::vector<ProgramTree> &children() const { return children_; }
+  std::list<ProgramTree> &children() { return children_; }
+  const std::list<ProgramTree> &children() const { return children_; }
   Symbol::Flag GetSubpFlag() const;
   bool IsModule() const;  // Module or Submodule
   bool HasModulePrefix() const;  // in function or subroutine stmt
@@ -84,9 +91,10 @@ private:
       static_cast<const parser::Statement<parser::ProgramStmt> *>(nullptr)};
   const parser::SpecificationPart &spec_;
   const parser::ExecutionPart *exec_{nullptr};
-  std::vector<ProgramTree> children_;
+  std::list<ProgramTree> children_;
   Scope *scope_{nullptr};
   const parser::CharBlock *endStmt_{nullptr};
+  bool isSpecificationPartResolved_{false};
 };
 
 }

--- a/lib/Semantics/resolve-names.h
+++ b/lib/Semantics/resolve-names.h
@@ -20,8 +20,10 @@ struct Program;
 namespace Fortran::semantics {
 
 class SemanticsContext;
+class Symbol;
 
 bool ResolveNames(SemanticsContext &, const parser::Program &);
+void ResolveSpecificationParts(SemanticsContext &, const Symbol &);
 void DumpSymbols(std::ostream &);
 
 }

--- a/lib/Semantics/tools.cpp
+++ b/lib/Semantics/tools.cpp
@@ -607,8 +607,7 @@ bool IsOrContainsEventOrLockComponent(const Symbol &symbol) {
 
 bool IsSaved(const Symbol &symbol) {
   auto scopeKind{symbol.owner().kind()};
-  if (scopeKind == Scope::Kind::MainProgram ||
-      scopeKind == Scope::Kind::Module) {
+  if (scopeKind == Scope::Kind::Module || scopeKind == Scope::Kind::BlockData) {
     return true;
   } else if (scopeKind == Scope::Kind::DerivedType) {
     return false;  // this is a component

--- a/test/Semantics/expr-errors02.f90
+++ b/test/Semantics/expr-errors02.f90
@@ -29,7 +29,7 @@ module m
     integer :: local
     !ERROR: Invalid specification expression: reference to local entity 'local'
     type(t(local)) :: x2
-    !ERROR: The internal function 'internal' cannot be referenced in a specification expression
+    !ERROR: The internal function 'internal' may not be referenced in a specification expression
     type(t(internal(0))) :: x3
     integer, intent(out) :: out
     !ERROR: Invalid specification expression: reference to INTENT(OUT) dummy argument 'out'
@@ -43,7 +43,6 @@ module m
     type(t(coarray[1])) :: x7
     type(t(kind(foo()))) :: x101 ! ok
     type(t(modulefunc1(0))) :: x102 ! ok
-    !ERROR: The module function 'modulefunc2' must have been previously defined when referenced in a specification expression
     type(t(modulefunc2(0))) :: x103 ! ok
    contains
     pure integer function internal(n)

--- a/test/Semantics/resolve59.f90
+++ b/test/Semantics/resolve59.f90
@@ -41,7 +41,7 @@ contains
     f4 => rf
     ! OK call to f4 pointer (rf)
     x = acos(f4())
-    !ERROR: Typeless item not allowed for 'x=' argument
+    !ERROR: Actual argument for 'x=' may not be a procedure
     x = acos(f4)
   end function
   function f5(x)
@@ -55,7 +55,7 @@ contains
     f5 => rfunc
     ! OK call to f5 pointer
     x = acos(f5(x+1))
-    !ERROR: Typeless item not allowed for 'x=' argument
+    !ERROR: Actual argument for 'x=' may not be a procedure
     x = acos(f5)
   end function
   ! Sanity test: f18 handles C1560 violation by ignoring RESULT
@@ -78,21 +78,21 @@ contains
   function f1() result(r)
     real :: r
     r = acos(f1()) !OK, recursive call
-    !ERROR: Typeless item not allowed for 'x=' argument
+    !ERROR: Actual argument for 'x=' may not be a procedure
     x = acos(f1)
   end function
   function f2(i) result(r)
     integer i
     real :: r
     r = acos(f2(i+1)) ! OK, recursive call
-    !ERROR: Typeless item not allowed for 'x=' argument
+    !ERROR: Actual argument for 'x=' may not be a procedure
     r = acos(f2)
   end function
   function f3(i) result(r)
     integer i
     real :: r(1)
     r = acos(f3(i+1)) !OK recursive call
-    !ERROR: Typeless item not allowed for 'x=' argument
+    !ERROR: Actual argument for 'x=' may not be a procedure
     r = sum(acos(f3))
   end function
 
@@ -104,9 +104,9 @@ contains
     real :: x
     procedure(rf), pointer :: r
     r => rf
-    !ERROR: Typeless item not allowed for 'x=' argument
+    !ERROR: Actual argument for 'x=' may not be a procedure
     x = acos(f4()) ! recursive call
-    !ERROR: Typeless item not allowed for 'x=' argument
+    !ERROR: Actual argument for 'x=' may not be a procedure
     x = acos(f4)
     x = acos(r()) ! OK
   end function
@@ -114,9 +114,9 @@ contains
     real :: x
     procedure(acos), pointer :: r
     r => acos
-    !ERROR: Typeless item not allowed for 'x=' argument
+    !ERROR: Actual argument for 'x=' may not be a procedure
     x = acos(f5(x+1)) ! recursive call
-    !ERROR: Typeless item not allowed for 'x=' argument
+    !ERROR: Actual argument for 'x=' may not be a procedure
     x = acos(f5)
     x = acos(r(x+1)) ! OK
   end function

--- a/test/Semantics/resolve77.f90
+++ b/test/Semantics/resolve77.f90
@@ -1,0 +1,52 @@
+! RUN: %S/test_errors.sh %s %flang %t
+! Tests valid and invalid usage of forward references to procedures
+! in specification expressions.
+module m
+  interface ifn2
+    module procedure if2
+  end interface
+  interface ifn3
+    module procedure if3
+  end interface
+  !ERROR: Specification expression must be constant in declaration of 'a' with the SAVE attribute
+  real :: a(if1(1))
+  !ERROR: No specific procedure of generic 'ifn2' matches the actual arguments
+  real :: b(ifn2(1))
+ contains
+  subroutine t1(n)
+    integer :: iarr(if1(n))
+  end subroutine
+  pure integer function if1(n)
+    integer, intent(in) :: n
+    if1 = n
+  end function
+  subroutine t2(n)
+    integer :: iarr(ifn3(n)) ! should resolve to if3
+  end subroutine
+  pure integer function if2(n)
+    integer, intent(in) :: n
+    if2 = n
+  end function
+  pure integer function if3(n)
+    integer, intent(in) :: n
+    if3 = n
+  end function
+end module
+
+subroutine nester
+  !ERROR: The internal function 'if1' may not be referenced in a specification expression
+  real :: a(if1(1))
+ contains
+  subroutine t1(n)
+    !ERROR: The internal function 'if2' may not be referenced in a specification expression
+    integer :: iarr(if2(n))
+  end subroutine
+  pure integer function if1(n)
+    integer, intent(in) :: n
+    if1 = n
+  end function
+  pure integer function if2(n)
+    integer, intent(in) :: n
+    if2 = n
+  end function
+end subroutine


### PR DESCRIPTION
Enable additional instances of `ResolveNamesVisitor` to be created to recursively handle calls to unresolved functions in specification expressions in an "on demand" fashion.

And improve error message for procedure passed as invalid argument to an intrinsic.