### PR TITLE
Fixes for separate module procedures

### DIFF
--- a/include/flang/Evaluate/characteristics.h
+++ b/include/flang/Evaluate/characteristics.h
@@ -47,6 +47,11 @@ bool Distinguishable(const Procedure &, const Procedure &);
 // Are these procedures distinguishable for a generic operator or assignment?
 bool DistinguishableOpOrAssign(const Procedure &, const Procedure &);
 
+// Shapes of function results and dummy arguments have to have
+// the same rank, the same deferred dimensions, and the same
+// values for explicit dimensions when constant.
+bool ShapesAreCompatible(const Shape &, const Shape &);
+
 class TypeAndShape {
 public:
   ENUM_CLASS(

--- a/include/flang/Semantics/scope.h
+++ b/include/flang/Semantics/scope.h
@@ -78,6 +78,7 @@ public:
   Kind kind() const { return kind_; }
   bool IsGlobal() const { return kind_ == Kind::Global; }
   bool IsModule() const;  // only module, not submodule
+  bool IsSubmodule() const;
   bool IsDerivedType() const { return kind_ == Kind::DerivedType; }
   bool IsParameterizedDerivedType() const;
   Symbol *symbol() { return symbol_; }

--- a/include/flang/Semantics/scope.h
+++ b/include/flang/Semantics/scope.h
@@ -134,6 +134,8 @@ public:
     Symbol &symbol{MakeSymbol(name, attrs, std::move(details))};
     return symbols_.emplace(name, symbol);
   }
+  // Make a copy of a symbol in this scope; nullptr if one is already there
+  Symbol *CopySymbol(const Symbol &);
 
   const std::list<EquivalenceSet> &equivalenceSets() const;
   void add_equivalenceSet(EquivalenceSet &&);

--- a/lib/Evaluate/characteristics.cpp
+++ b/lib/Evaluate/characteristics.cpp
@@ -37,7 +37,7 @@ static void CopyAttrs(const semantics::Symbol &src, A &dst,
 // Shapes of function results and dummy arguments have to have
 // the same rank, the same deferred dimensions, and the same
 // values for explicit dimensions when constant.
-static bool ShapesAreCompatible(const Shape &x, const Shape &y) {
+bool ShapesAreCompatible(const Shape &x, const Shape &y) {
   if (x.size() != y.size()) {
     return false;
   }
@@ -158,10 +158,9 @@ void TypeAndShape::AcquireShape(const semantics::ObjectEntityDetails &object) {
   for (const semantics::ShapeSpec &dim : object.shape()) {
     if (dim.ubound().GetExplicit()) {
       Expr<SubscriptInteger> extent{*dim.ubound().GetExplicit()};
-      if (dim.lbound().GetExplicit()) {
-        extent = std::move(extent) +
-            common::Clone(*dim.lbound().GetExplicit()) -
-            Expr<SubscriptInteger>{1};
+      if (auto lbound{dim.lbound().GetExplicit()}) {
+        extent =
+            std::move(extent) + Expr<SubscriptInteger>{1} - std::move(*lbound);
       }
       shape_.emplace_back(std::move(extent));
     } else {

--- a/lib/Semantics/resolve-names.cpp
+++ b/lib/Semantics/resolve-names.cpp
@@ -3603,6 +3603,7 @@ void DeclarationVisitor::Post(const parser::ProcDecl &x) {
     attrs.set(Attr::EXTERNAL);
   }
   Symbol &symbol{DeclareProcEntity(name, attrs, interface)};
+  symbol.ReplaceName(name.source);
   if (dtDetails) {
     dtDetails->add_component(symbol);
   }

--- a/lib/Semantics/scope.cpp
+++ b/lib/Semantics/scope.cpp
@@ -110,6 +110,18 @@ bool Scope::Contains(const Scope &that) const {
   }
 }
 
+Symbol *Scope::CopySymbol(const Symbol &symbol) {
+  auto pair{try_emplace(symbol.name(), symbol.attrs())};
+  if (!pair.second) {
+    return nullptr;  // already exists
+  } else {
+    Symbol &result{*pair.first->second};
+    result.flags() = symbol.flags();
+    result.set_details(common::Clone(symbol.details()));
+    return &result;
+  }
+}
+
 const std::list<EquivalenceSet> &Scope::equivalenceSets() const {
   return equivalenceSets_;
 }

--- a/lib/Semantics/scope.cpp
+++ b/lib/Semantics/scope.cpp
@@ -51,6 +51,9 @@ std::string EquivalenceObject::AsFortran() const {
 bool Scope::IsModule() const {
   return kind_ == Kind::Module && !symbol_->get<ModuleDetails>().isSubmodule();
 }
+bool Scope::IsSubmodule() const {
+  return kind_ == Kind::Module && symbol_->get<ModuleDetails>().isSubmodule();
+}
 
 Scope &Scope::MakeScope(Kind kind, Symbol *symbol) {
   return children_.emplace_back(*this, kind, symbol);

--- a/lib/Semantics/symbol.cpp
+++ b/lib/Semantics/symbol.cpp
@@ -85,20 +85,25 @@ std::ostream &operator<<(std::ostream &os, const SubprogramDetails &x) {
   DumpBool(os, "isInterface", x.isInterface_);
   DumpExpr(os, "bindName", x.bindName_);
   if (x.result_) {
-    os << " result:" << x.result_->name();
+    DumpType(os << " result:", x.result());
+    os << x.result_->name();
     if (!x.result_->attrs().empty()) {
       os << ", " << x.result_->attrs();
     }
   }
-  if (x.dummyArgs_.empty()) {
-    char sep{'('};
-    os << ' ';
-    for (const auto *arg : x.dummyArgs_) {
-      os << sep << arg->name();
-      sep = ',';
+  char sep{'('};
+  os << ' ';
+  for (const Symbol *arg : x.dummyArgs_) {
+    os << sep;
+    sep = ',';
+    if (arg) {
+      DumpType(os, *arg);
+      os << arg->name();
+    } else {
+      os << '*';
     }
-    os << (sep == '(' ? "()" : ")");
   }
+  os << (sep == '(' ? "()" : ")");
   return os;
 }
 
@@ -398,23 +403,6 @@ std::ostream &operator<<(std::ostream &os, const Details &details) {
               }
               os << ")";
             }
-          },
-          [&](const SubprogramDetails &x) {
-            os << " (";
-            int n = 0;
-            for (const auto &dummy : x.dummyArgs()) {
-              if (n++ > 0) os << ", ";
-              DumpType(os, *dummy);
-              os << dummy->name();
-            }
-            os << ')';
-            DumpExpr(os, "bindName", x.bindName());
-            if (x.isFunction()) {
-              os << " result(";
-              DumpType(os, x.result());
-              os << x.result().name() << ')';
-            }
-            DumpBool(os, "interface", x.isInterface());
           },
           [&](const SubprogramNameDetails &x) {
             os << ' ' << EnumToString(x.kind());

--- a/test/Semantics/call02.f90
+++ b/test/Semantics/call02.f90
@@ -9,9 +9,9 @@ subroutine s01(elem, subr)
     subroutine subr(dummy)
       procedure(sin) :: dummy
     end subroutine
-    !ERROR: A dummy procedure may not be ELEMENTAL
     subroutine badsubr(dummy)
       import :: elem
+      !ERROR: A dummy procedure may not be ELEMENTAL
       procedure(elem) :: dummy
     end subroutine
   end interface

--- a/test/Semantics/call09.f90
+++ b/test/Semantics/call09.f90
@@ -28,8 +28,8 @@ module m
     real, intent(in) :: x
     elemfunc = x
   end function
-  !ERROR: A dummy procedure may not be ELEMENTAL
   subroutine selemental2(p)
+    !ERROR: A dummy procedure may not be ELEMENTAL
     procedure(elemfunc) :: p
   end subroutine
 

--- a/test/Semantics/call10.f90
+++ b/test/Semantics/call10.f90
@@ -109,8 +109,8 @@ module m
       real, volatile :: v2
     end block
   end subroutine
-  !ERROR: A dummy procedure of a pure subprogram must be pure
   pure subroutine s07(p) ! C1590
+    !ERROR: A dummy procedure of a pure subprogram must be pure
     procedure(impure) :: p
   end subroutine
   ! C1591 is tested in call11.f90.

--- a/test/Semantics/resolve36.f90
+++ b/test/Semantics/resolve36.f90
@@ -1,4 +1,8 @@
 ! RUN: %S/test_errors.sh %s %flang %t
+
+! C1568 The procedure-name shall have been declared to be a separate module
+! procedure in the containing program unit or an ancestor of that program unit.
+
 module m1
   interface
     module subroutine sub1(arg1)

--- a/test/Semantics/resolve76.f90
+++ b/test/Semantics/resolve76.f90
@@ -1,0 +1,30 @@
+! RUN: %S/test_errors.sh %s %flang %t
+
+! 15.6.2.5(3)
+
+module m1
+  implicit logical(a-b)
+  interface
+    module subroutine sub1(a, b)
+      real, intent(in) :: a
+      real, intent(out) :: b
+    end
+    logical module function f()
+    end
+  end interface
+end
+submodule(m1) sm1
+contains
+  module procedure sub1
+    !ERROR: Left-hand side of assignment is not modifiable
+    a = 1.0
+    b = 2.0
+    !ERROR: No intrinsic or user-defined ASSIGNMENT(=) matches operand types REAL(4) and LOGICAL(4)
+    b = .false.
+  end
+  module procedure f
+    f = .true.
+    !ERROR: No intrinsic or user-defined ASSIGNMENT(=) matches operand types LOGICAL(4) and REAL(4)
+    f = 1.0
+  end
+end

--- a/test/Semantics/separate-mp01.f90
+++ b/test/Semantics/separate-mp01.f90
@@ -1,11 +1,4 @@
 ! RUN: %S/test_errors.sh %s %flang %t
-!===--- separate-module-procs.f90 - Test separate module procedure ---------===
-!
-! Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-! See https://llvm.org/LICENSE.txt for license information.
-! SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-!
-!===------------------------------------------------------------------------===
 
 ! case 1: ma_create_new_fun' was not declared a separate module procedure
 module m1

--- a/test/Semantics/separate-mp02.f90
+++ b/test/Semantics/separate-mp02.f90
@@ -1,0 +1,285 @@
+! RUN: %S/test_errors.sh %s %flang %t
+
+! When a module subprogram has the MODULE prefix the following must match
+! with the corresponding separate module procedure interface body:
+! - C1549: characteristics and dummy argument names
+! - C1550: binding label
+! - C1551: NON_RECURSIVE prefix
+
+module m1
+  interface
+    module subroutine s4(x)
+      real, intent(in) :: x
+    end
+    module subroutine s5(x, y)
+      real, pointer :: x
+      real, value :: y
+    end
+    module subroutine s6(x, y)
+      real :: x
+      real :: y
+    end
+    module subroutine s7(x, y, z)
+      real :: x(8)
+      real :: y(8)
+      real :: z(8)
+    end
+    module subroutine s8(x, y, z)
+      real :: x(8)
+      real :: y(*)
+      real :: z(*)
+    end
+    module subroutine s9(x, y, z, w)
+      character(len=4) :: x
+      character(len=4) :: y
+      character(len=*) :: z
+      character(len=*) :: w
+    end
+  end interface
+end
+
+submodule(m1) sm1
+contains
+  module subroutine s4(x)
+    !ERROR: The intent of dummy argument 'x' does not match the intent of the corresponding argument in the interface body
+    real, intent(out) :: x
+  end
+  module subroutine s5(x, y)
+    !ERROR: Dummy argument 'x' has the OPTIONAL attribute; the corresponding argument in the interface body does not
+    real, pointer, optional :: x
+    !ERROR: Dummy argument 'y' does not have the VALUE attribute; the corresponding argument in the interface body does
+    real :: y
+  end
+  module subroutine s6(x, y)
+    !ERROR: Dummy argument 'x' has type INTEGER(4); the corresponding argument in the interface body has type REAL(4)
+    integer :: x
+    !ERROR: Dummy argument 'y' has type REAL(8); the corresponding argument in the interface body has type REAL(4)
+    real(8) :: y
+  end
+  module subroutine s7(x, y, z)
+    integer, parameter :: n = 8
+    real :: x(n)
+    real :: y(2:n+1)
+    !ERROR: The shape of dummy argument 'z' does not match the shape of the corresponding argument in the interface body
+    real :: z(n+1)
+  end
+  module subroutine s8(x, y, z)
+    !ERROR: The shape of dummy argument 'x' does not match the shape of the corresponding argument in the interface body
+    real :: x(*)
+    real :: y(*)
+    !ERROR: The shape of dummy argument 'z' does not match the shape of the corresponding argument in the interface body
+    real :: z(8)
+  end
+  module subroutine s9(x, y, z, w)
+    character(len=4) :: x
+    !ERROR: Dummy argument 'y' has type CHARACTER(KIND=1,LEN=5_4); the corresponding argument in the interface body has type CHARACTER(KIND=1,LEN=4_4)
+    character(len=5) :: y
+    character(len=*) :: z
+    !ERROR: Dummy argument 'w' has type CHARACTER(KIND=1,LEN=4_4); the corresponding argument in the interface body has type CHARACTER(KIND=1,LEN=*)
+    character(len=4) :: w
+  end
+end
+
+module m2
+  interface
+    module subroutine s1(x, y)
+      real, intent(in) :: x
+      real, intent(out) :: y
+    end
+    module subroutine s2(x, y)
+      real, intent(in) :: x
+      real, intent(out) :: y
+    end
+    module subroutine s3(x, y)
+      real(4) :: x
+      procedure(real) :: y
+    end
+    module subroutine s4()
+    end
+    non_recursive module subroutine s5()
+    end
+  end interface
+end
+
+submodule(m2) sm2
+contains
+  !ERROR: Module subprogram 's1' has 3 args but the corresponding interface body has 2
+  module subroutine s1(x, y, z)
+    real, intent(in) :: x
+    real, intent(out) :: y
+    real :: z
+  end
+  !ERROR: Dummy argument name 'z' does not match corresponding name 'y' in interface body
+  module subroutine s2(x, z)
+    real, intent(in) :: x
+    real, intent(out) :: y
+  end
+  module subroutine s3(x, y)
+    !ERROR: Dummy argument 'x' is a procedure; the corresponding argument in the interface body is not
+    procedure(real) :: x
+    !ERROR: Dummy argument 'y' is a data object; the corresponding argument in the interface body is not
+    real :: y
+  end
+  !ERROR: Module subprogram 's4' has NON_RECURSIVE prefix but the corresponding interface body does not
+  non_recursive module subroutine s4()
+  end
+  !ERROR: Module subprogram 's5' does not have NON_RECURSIVE prefix but the corresponding interface body does
+  module subroutine s5()
+  end
+end
+
+module m2b
+  interface
+    module subroutine s1()
+    end
+    module subroutine s2() bind(c, name="s2")
+    end
+    module subroutine s3() bind(c, name="s3")
+    end
+  end interface
+end
+
+submodule(m2b) sm2b
+  character(*), parameter :: suffix = "_xxx"
+contains
+  !ERROR: Module subprogram 's1' has a binding label but the corresponding interface body does not
+  module subroutine s1() bind(c, name="s1")
+  end
+  !ERROR: Module subprogram 's2' does not have a binding label but the corresponding interface body does
+  module subroutine s2()
+  end
+  !ERROR: Module subprogram 's3' has binding label "s3_xxx" but the corresponding interface body has "s3"
+  module subroutine s3() bind(c, name="s3" // suffix)
+  end
+end
+
+
+module m3
+  interface
+    module subroutine s1(x, y, z)
+      procedure(real), intent(in) :: x
+      procedure(real), intent(out) :: y
+      procedure(real), intent(out) :: z
+    end
+    module subroutine s2(x, y)
+      procedure(real), pointer :: x
+      procedure(real) :: y
+    end
+  end interface
+end
+
+submodule(m3) sm3
+contains
+  module subroutine s1(x, y, z)
+    procedure(real), intent(in) :: x
+    !ERROR: The intent of dummy argument 'y' does not match the intent of the corresponding argument in the interface body
+    procedure(real), intent(inout) :: y
+    !ERROR: The intent of dummy argument 'z' does not match the intent of the corresponding argument in the interface body
+    procedure(real) :: z
+  end
+  module subroutine s2(x, y)
+    !ERROR: Dummy argument 'x' has the OPTIONAL attribute; the corresponding argument in the interface body does not
+    !ERROR: Dummy argument 'x' does not have the POINTER attribute; the corresponding argument in the interface body does
+    procedure(real), optional :: x
+    !ERROR: Dummy argument 'y' has the POINTER attribute; the corresponding argument in the interface body does not
+    procedure(real), pointer :: y
+  end
+end
+
+module m4
+  interface
+    subroutine s_real(x)
+      real :: x
+    end
+    subroutine s_real2(x)
+      real :: x
+    end
+    subroutine s_integer(x)
+      integer :: x
+    end
+    module subroutine s1(x)
+      procedure(s_real) :: x
+    end
+    module subroutine s2(x)
+      procedure(s_real) :: x
+    end
+  end interface
+end
+
+submodule(m4) sm4
+contains
+  module subroutine s1(x)
+    !OK
+    procedure(s_real2) :: x
+  end
+  module subroutine s2(x)
+    !ERROR: Dummy procedure 'x' does not match the corresponding argument in the interface body
+    procedure(s_integer) :: x
+  end
+end
+
+module m5
+  interface
+    module function f1()
+      real :: f1
+    end
+    module subroutine s2()
+    end
+  end interface
+end
+
+submodule(m5) sm5
+contains
+  !ERROR: Module subroutine 'f1' was declared as a function in the corresponding interface body
+  module subroutine f1()
+  end
+  !ERROR: Module function 's2' was declared as a subroutine in the corresponding interface body
+  module function s2()
+  end
+end
+
+module m6
+  interface
+    module function f1()
+      real :: f1
+    end
+    module function f2()
+      real :: f2
+    end
+    module function f3()
+      real :: f3
+    end
+  end interface
+end
+
+submodule(m6) ms6
+contains
+  !OK
+  real module function f1()
+  end
+  !ERROR: Return type of function 'f2' does not match return type of the corresponding interface body
+  integer module function f2()
+  end
+  !ERROR: Return type of function 'f3' does not match return type of the corresponding interface body
+  module function f3()
+    real :: f3
+    pointer :: f3
+  end
+end
+
+module m7
+  interface
+    module subroutine s1(x, *)
+      real :: x
+    end
+  end interface
+end
+
+submodule(m7) sm7
+contains
+  !ERROR: Dummy argument 1 of 's1' is an alternate return indicator but the corresponding argument in the interface body is not
+  !ERROR: Dummy argument 2 of 's1' is not an alternate return indicator but the corresponding argument in the interface body is
+  module subroutine s1(*, x)
+    real :: x
+  end
+end


### PR DESCRIPTION
Check module subprogram with MODULE prefix against the corresponding separate module procedure interface body.

Create symbols for dummy arguments and function return values in separate modules procedures declared with `module procedure ...`.

Fix the location of the name of a Symbol declared with a ProcDecl.