### PR TITLE
Semantic checks for 5 data constraints: C874, C875, C878, C880, C881

### DIFF
--- a/lib/Semantics/check-data.h
+++ b/lib/Semantics/check-data.h
@@ -25,10 +25,9 @@ public:
 
 private:
   SemanticsContext &context_;
-  void CheckIfConstantExpr(const parser::Expr &);
+  template<typename T> void CheckIfConstantSubscript(const T &);
   void CheckSubscript(const parser::SectionSubscript &);
-  bool CheckAllSubscriptsInDataRef(
-      const parser::DataRef &, parser::CharBlock);
+  bool CheckAllSubscriptsInDataRef(const parser::DataRef &, parser::CharBlock);
 };
 }
 #endif  // FORTRAN_SEMANTICS_CHECK_DATA_H_

--- a/lib/Semantics/check-data.h
+++ b/lib/Semantics/check-data.h
@@ -20,9 +20,15 @@ public:
   DataChecker(SemanticsContext &context) : context_{context} {}
   void Leave(const parser::DataStmtRepeat &);
   void Leave(const parser::DataStmtConstant &);
+  void Leave(const parser::DataStmtObject &);
+  void Leave(const parser::DataImpliedDo &);
 
 private:
   SemanticsContext &context_;
+  void CheckIfConstantExpr(const parser::Expr &);
+  void CheckSubscript(const parser::SectionSubscript &);
+  bool CheckAllSubscriptsInDataRef(
+      const parser::DataRef &, parser::CharBlock);
 };
 }
 #endif  // FORTRAN_SEMANTICS_CHECK_DATA_H_

--- a/test/Semantics/data03.f90
+++ b/test/Semantics/data03.f90
@@ -1,5 +1,5 @@
 ! RUN: %S/test_errors.sh %s %flang %t
-!Test data constraints : C874 - C875, C878, C880, C881 
+!Testing data constraints : C874 - C875, C878 - C881 
 module m
   contains
     function f(i)
@@ -40,16 +40,16 @@ module m
       !ERROR: Data object must not be a coindexed variable
       DATA(a[i], i = 1, 5) / 5 * 1 /
       !C875
-      !ERROR: Data object variable must be a designator
+      !ERROR: Data object variable must not be a function reference
       DATA f(1) / 1 / 
       !C875
-      !ERROR: Subscript must be a constant
+      !ERROR: Data object must have constant bounds
       DATA b(ind) / 1 /
       !C875
-      !ERROR: Subscript must be a constant
+      !ERROR: Data object must have constant bounds
       DATA name( : ind) / 'Ancd' /
       !C875
-      !ERROR: Subscript must be a constant
+      !ERROR: Data object must have constant bounds
       DATA name(ind:) / 'Ancd' /
       !C878
       !ERROR: Data implied do object must be a variable
@@ -63,12 +63,12 @@ module m
       DATA(nums % one, i = 1, 5) / 5 * 1 /
       !C880
       !OK: Correct use
-      DATA(largeArray(j) % nums % one, j = 1, 10) / 100 * 1 /
+      DATA(largeArray(j) % nums % one, j = 1, 10) / 10 * 1 /
       !C880
       !OK: Correct use
-      DATA(largeNumber % numsArray(j) % one, j = 1, 10) / 100 * 1 /
+      DATA(largeNumber % numsArray(j) % one, j = 1, 10) / 10 * 1 /
       !C881
-      !ERROR: Subscript must be a constant
+      !ERROR: Data object must have constant bounds
       DATA(b(x), i = 1, 5) / 5 * 1 /
       !C881 
       !OK: Correct use
@@ -78,6 +78,6 @@ module m
       DATA((d(i, j), i = 1, 10), j = 1, 10) / 100 * 1 /
       !C881
       !OK: Correct use
-      DATA(d(i, 1), i = 1, 10) / 100 * 1 /
+      DATA(d(i, 1), i = 1, 10) / 10 * 1 /
     end 
   end

--- a/test/Semantics/data03.f90
+++ b/test/Semantics/data03.f90
@@ -1,0 +1,83 @@
+! RUN: %S/test_errors.sh %s %flang %t
+!Test data constraints : C874 - C875, C878, C880, C881 
+module m
+  contains
+    function f(i)
+      integer ::i
+      integer ::result
+      result = i *1024 
+    end
+    subroutine CheckObject 
+      type specialNumbers
+        integer one
+        integer numbers(5)
+      end type
+      type large
+        integer elt(10)
+        integer val
+        type(specialNumbers) nums
+        type(specialNumbers) numsArray(5)
+      end type
+      type(specialNumbers), parameter ::newNums = &
+              specialNumbers(1, (/ 1, 2, 3, 4, 5 /))
+      type(specialNumbers), parameter ::newNumsArray(2) = &
+              (/ SpecialNumbers(1, (/ 1, 2, 3, 4, 5 /)), &
+              SpecialNumbers(1, (/ 1, 2, 3,4, 5 /)) /)
+      type(specialNumbers) nums
+      type(large) largeArray(5)
+      type(large) largeNumber
+      real :: a[*]
+      real :: b(5)
+      integer :: x
+      real,parameter :: c(5) = (/ 1, 2, 3, 4, 5 /)
+      integer :: d(10, 10)
+      character :: name(12)
+      integer :: ind = 2
+      !C874
+      !ERROR: Data object must not be a coindexed variable
+      DATA a[1] / 1 /
+      !C874
+      !ERROR: Data object must not be a coindexed variable
+      DATA(a[i], i = 1, 5) / 5 * 1 /
+      !C875
+      !ERROR: Data object variable must be a designator
+      DATA f(1) / 1 / 
+      !C875
+      !ERROR: Subscript must be a constant
+      DATA b(ind) / 1 /
+      !C875
+      !ERROR: Subscript must be a constant
+      DATA name( : ind) / 'Ancd' /
+      !C875
+      !ERROR: Subscript must be a constant
+      DATA name(ind:) / 'Ancd' /
+      !C878
+      !ERROR: Data implied do object must be a variable
+      DATA(c(i), i = 1, 5) / 5 * 1 /
+      !C878
+      !ERROR: Data implied do object must be a variable
+      DATA(newNumsArray(i), i = 1, 2) &
+              / specialNumbers(1, 2 * (/ 1, 2, 3, 4, 5 /)) /
+      !C880
+      !ERROR: Data implied do object must be subscripted
+      DATA(nums % one, i = 1, 5) / 5 * 1 /
+      !C880
+      !OK: Correct use
+      DATA(largeArray(j) % nums % one, j = 1, 10) / 100 * 1 /
+      !C880
+      !OK: Correct use
+      DATA(largeNumber % numsArray(j) % one, j = 1, 10) / 100 * 1 /
+      !C881
+      !ERROR: Subscript must be a constant
+      DATA(b(x), i = 1, 5) / 5 * 1 /
+      !C881 
+      !OK: Correct use
+      DATA(nums % numbers(i), i = 1, 5) / 5 * 1 /
+      !C881
+      !OK: Correct use
+      DATA((d(i, j), i = 1, 10), j = 1, 10) / 100 * 1 /
+      !C881
+      !OK: Correct use
+      DATA(d(i, 1), i = 1, 10) / 100 * 1 /
+    end 
+  end


### PR DESCRIPTION
This commit  has implementation of semantic checks for 5 constraints on data object. 3 more constraint-checks need to be implemented. 