### PR TITLE
Add explicit nullptr check in initialisation of inDoConstruct.

### DIFF
--- a/lib/Semantics/check-do-forall.cpp
+++ b/lib/Semantics/check-do-forall.cpp
@@ -912,7 +912,7 @@ void DoForallChecker::CheckForBadLeave(
 static bool StmtMatchesConstruct(const parser::Name *stmtName,
     StmtType stmtType, const parser::Name *constructName,
     const ConstructNode &construct) {
-  bool inDoConstruct{MaybeGetDoConstruct(construct)};
+  bool inDoConstruct{MaybeGetDoConstruct(construct) != nullptr};
   if (!stmtName) {
     return inDoConstruct;  // Unlabeled statements match all DO constructs
   } else if (constructName && constructName->source == stmtName->source) {


### PR DESCRIPTION
This static cast is needed as we are using braced initialisation here so
implicit narrowing conversions (such as pointer to bool) are not allowed.

Fixes #1079 