### PR TITLE
[mlir rebase] MLIR cmake config change and VectorOpsDialect rename

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,13 @@ set(LLVM_EXTERNAL_LIT ${LLVM_TOOLS_BINARY_DIR}/llvm-lit CACHE STRING "Command us
 
 if(LINK_WITH_FIR)
   include(TableGen)
+
+  find_package(MLIR REQUIRED CONFIG)
+  # Use SYSTEM for the same reasons as for LLVM includes
+  include_directories(SYSTEM ${MLIR_INCLUDE_DIRS})
+  list(APPEND CMAKE_MODULE_PATH ${MLIR_DIR})
   include(AddMLIR)
+
   find_program(MLIR_TABLEGEN_EXE "mlir-tblgen" ${LLVM_TOOLS_BINARY_DIR}
   NO_DEFAULT_PATH)
   # tco tool and FIR lib output directories

--- a/include/flang/Optimizer/Dialect/FIRDialect.h
+++ b/include/flang/Optimizer/Dialect/FIRDialect.h
@@ -54,7 +54,7 @@ inline void registerFIR() {
     mlir::registerDialect<mlir::LLVM::LLVMDialect>();
     mlir::registerDialect<mlir::loop::LoopOpsDialect>();
     mlir::registerDialect<mlir::StandardOpsDialect>();
-    mlir::registerDialect<mlir::vector::VectorOpsDialect>();
+    mlir::registerDialect<mlir::vector::VectorDialect>();
     mlir::registerDialect<FIROpsDialect>();
     return true;
   }();


### PR DESCRIPTION
MLIR cmake changes:
https://github.com/llvm/llvm-project/commit/7ca473a27bd589457d427eee9187d49a88fc9b01
VectorOpsDialect renamed to VectorOp:
https://github.com/llvm/llvm-project/commit/4d60f47b082f20d93f621fb5cd4bb978c26b7bf1

Patch tested to work with LLVM head from 20-march-2020 8am PCT:
https://github.com/llvm/llvm-project/commit/ece6cf0fa56687d4f9fd918a7dc367cd1277d0c4

LLVM versions older than f7d4bd814439dc0e4c0a5ffe9bea5e304e17b681 are not expected to
work anymore with FIR after this patch.

You can test this patch with LLVM head, I will only update the LLVM fork that is guaranteed to be compatible with f18  (f18 branch of [f18-llvm-project](https://github.com/flang-compiler/f18-llvm-project/)) when merging this patch.