### PR TITLE
Semantics and test for ENTRY statements

### DIFF
--- a/include/flang/Semantics/symbol.h
+++ b/include/flang/Semantics/symbol.h
@@ -61,6 +61,9 @@ public:
   bool isFunction() const { return result_ != nullptr; }
   bool isInterface() const { return isInterface_; }
   void set_isInterface(bool value = true) { isInterface_ = value; }
+  Scope *entryScope() { return entryScope_; }
+  const Scope *entryScope() const { return entryScope_; }
+  void set_entryScope(Scope &scope) { entryScope_ = &scope; }
   MaybeExpr bindName() const { return bindName_; }
   void set_bindName(MaybeExpr &&expr) { bindName_ = std::move(expr); }
   const Symbol &result() const {
@@ -82,8 +85,10 @@ private:
   MaybeExpr bindName_;
   std::vector<Symbol *> dummyArgs_;  // nullptr -> alternate return indicator
   Symbol *result_{nullptr};
+  Scope *entryScope_{nullptr};  // if ENTRY, points to subprogram's scope
   MaybeExpr stmtFunction_;
-  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const SubprogramDetails &);
+  friend llvm::raw_ostream &operator<<(
+      llvm::raw_ostream &, const SubprogramDetails &);
 };
 
 // For SubprogramNameDetails, the kind indicates whether it is the name
@@ -115,17 +120,19 @@ public:
   void set_type(const DeclTypeSpec &);
   void ReplaceType(const DeclTypeSpec &);
   bool isDummy() const { return isDummy_; }
+  void set_isDummy(bool value = true) { isDummy_ = value; }
   bool isFuncResult() const { return isFuncResult_; }
   void set_funcResult(bool x) { isFuncResult_ = x; }
   MaybeExpr bindName() const { return bindName_; }
   void set_bindName(MaybeExpr &&expr) { bindName_ = std::move(expr); }
 
 private:
-  bool isDummy_;
+  bool isDummy_{false};
   bool isFuncResult_{false};
   const DeclTypeSpec *type_{nullptr};
   MaybeExpr bindName_;
-  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const EntityDetails &);
+  friend llvm::raw_ostream &operator<<(
+      llvm::raw_ostream &, const EntityDetails &);
 };
 
 // Symbol is associated with a name or expression in a SELECT TYPE or ASSOCIATE.
@@ -180,7 +187,8 @@ private:
   ArraySpec shape_;
   ArraySpec coshape_;
   const Symbol *commonBlock_{nullptr};  // common block this object is in
-  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const ObjectEntityDetails &);
+  friend llvm::raw_ostream &operator<<(
+      llvm::raw_ostream &, const ObjectEntityDetails &);
 };
 
 // Mixin for details with passed-object dummy argument.
@@ -217,7 +225,8 @@ public:
 private:
   ProcInterface interface_;
   std::optional<const Symbol *> init_;
-  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const ProcEntityDetails &);
+  friend llvm::raw_ostream &operator<<(
+      llvm::raw_ostream &, const ProcEntityDetails &);
 };
 
 // These derived type details represent the characteristics of a derived
@@ -263,7 +272,8 @@ private:
   std::list<SourceName> componentNames_;
   bool sequence_{false};
   bool isForwardReferenced_{false};
-  friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const DerivedTypeDetails &);
+  friend llvm::raw_ostream &operator<<(
+      llvm::raw_ostream &, const DerivedTypeDetails &);
 };
 
 class ProcBindingDetails : public WithPassArg {
@@ -570,7 +580,6 @@ public:
   bool IsFuncResult() const;
   bool IsObjectArray() const;
   bool IsSubprogram() const;
-  bool IsSeparateModuleProc() const;
   bool IsFromModFile() const;
   bool HasExplicitInterface() const {
     return std::visit(
@@ -662,7 +671,8 @@ private:
   Symbol() {}  // only created in class Symbols
   const std::string GetDetailsName() const;
   friend llvm::raw_ostream &operator<<(llvm::raw_ostream &, const Symbol &);
-  friend llvm::raw_ostream &DumpForUnparse(llvm::raw_ostream &, const Symbol &, bool);
+  friend llvm::raw_ostream &DumpForUnparse(
+      llvm::raw_ostream &, const Symbol &, bool);
 
   // If a derived type's symbol refers to an extended derived type,
   // return the parent component's symbol.  The scope of the derived type

--- a/include/flang/Semantics/tools.h
+++ b/include/flang/Semantics/tools.h
@@ -108,6 +108,7 @@ bool IsSaved(const Symbol &);
 bool CanBeTypeBoundProc(const Symbol *);
 bool IsInitialized(const Symbol &);
 bool HasIntrinsicTypeName(const Symbol &);
+bool IsSeparateModuleProcedureInterface(const Symbol *);
 
 // Return an ultimate component of type that matches predicate, or nullptr.
 const Symbol *FindUltimateComponent(const DerivedTypeSpec &type,
@@ -164,7 +165,7 @@ inline bool IsAssumedRankArray(const Symbol &symbol) {
   return details && details->IsAssumedRank();
 }
 bool IsAssumedLengthCharacter(const Symbol &);
-bool IsAssumedLengthExternalCharacterFunction(const Symbol &);
+bool IsExternal(const Symbol &);
 // Is the symbol modifiable in this scope
 std::optional<parser::MessageFixedText> WhyNotModifiable(
     const Symbol &, const Scope &);
@@ -199,6 +200,11 @@ std::list<SourceName> OrderParameterNames(const Symbol &);
 // Return an existing or new derived type instance
 const DeclTypeSpec &FindOrInstantiateDerivedType(Scope &, DerivedTypeSpec &&,
     SemanticsContext &, DeclTypeSpec::Category = DeclTypeSpec::TypeDerived);
+
+// When a subprogram defined in a submodule defines a separate module
+// procedure whose interface is defined in an ancestor (sub)module,
+// returns a pointer to that interface, else null.
+const Symbol *FindSeparateModuleSubprogramInterface(const Symbol *);
 
 // Determines whether an object might be visible outside a
 // pure function (C1594); returns a non-null Symbol pointer for

--- a/lib/Semantics/expression.cpp
+++ b/lib/Semantics/expression.cpp
@@ -1889,7 +1889,7 @@ void ExpressionAnalyzer::CheckForBadRecursion(
       if (proc.attrs().test(semantics::Attr::NON_RECURSIVE)) {  // 15.6.2.1(3)
         msg = Say("NON_RECURSIVE procedure '%s' cannot call itself"_err_en_US,
             callSite);
-      } else if (IsAssumedLengthExternalCharacterFunction(proc)) {
+      } else if (IsAssumedLengthCharacter(proc) && IsExternal(proc)) {
         msg = Say(  // 15.6.2.1(3)
             "Assumed-length CHARACTER(*) function '%s' cannot call itself"_err_en_US,
             callSite);
@@ -2046,7 +2046,8 @@ static bool IsExternalCalledImplicitly(
   if (const auto *symbol{proc.GetSymbol()}) {
     return symbol->has<semantics::SubprogramDetails>() &&
         symbol->owner().IsGlobal() &&
-        !symbol->scope()->sourceRange().Contains(callSite);
+        (!symbol->scope() /*ENTRY*/ ||
+            !symbol->scope()->sourceRange().Contains(callSite));
   } else {
     return false;
   }

--- a/lib/Semantics/resolve-names.cpp
+++ b/lib/Semantics/resolve-names.cpp
@@ -43,7 +43,7 @@ namespace Fortran::semantics {
 
 using namespace parser::literals;
 
-template<typename T> using Indirection = common::Indirection<T>;
+template <typename T> using Indirection = common::Indirection<T>;
 using Message = parser::Message;
 using Messages = parser::Messages;
 using MessageFixedText = parser::MessageFixedText;
@@ -58,7 +58,7 @@ class ResolveNamesVisitor;
 class ImplicitRules {
 public:
   ImplicitRules(SemanticsContext &context, ImplicitRules *parent)
-    : parent_{parent}, context_{context} {
+      : parent_{parent}, context_{context} {
     inheritFromParent_ = parent != nullptr;
   }
   bool isImplicitNoneType() const;
@@ -78,7 +78,7 @@ private:
 
   ImplicitRules *parent_;
   SemanticsContext &context_;
-  bool inheritFromParent_{false};  // look in parent if not specified here
+  bool inheritFromParent_{false}; // look in parent if not specified here
   bool isImplicitNoneType_{false};
   bool isImplicitNoneExternal_{false};
   // map_ contains the mapping between letters and types that were defined
@@ -114,7 +114,7 @@ public:
   // Emit a message about a SourceName
   Message &Say(const SourceName &, MessageFixedText &&);
   // Emit a formatted message associated with a source location.
-  template<typename... A>
+  template <typename... A>
   Message &Say(const SourceName &source, MessageFixedText &&msg, A &&... args) {
     return context_->Say(source, std::move(msg), std::forward<A>(args)...);
   }
@@ -142,8 +142,9 @@ public:
   BaseVisitor() { DIE("BaseVisitor: default-constructed"); }
   BaseVisitor(
       SemanticsContext &c, ResolveNamesVisitor &v, ImplicitRulesMap &rules)
-    : implicitRulesMap_{&rules}, this_{&v}, context_{&c}, messageHandler_{c} {}
-  template<typename T> void Walk(const T &);
+      : implicitRulesMap_{&rules}, this_{&v}, context_{&c}, messageHandler_{c} {
+  }
+  template <typename T> void Walk(const T &);
 
   MessageHandler &messageHandler() { return messageHandler_; }
   const std::optional<SourceName> &currStmtSource() {
@@ -158,15 +159,15 @@ public:
   // It is not in any scope and always has MiscDetails.
   void MakePlaceholder(const parser::Name &, MiscDetails::Kind);
 
-  template<typename T> common::IfNoLvalue<T, T> FoldExpr(T &&expr) {
+  template <typename T> common::IfNoLvalue<T, T> FoldExpr(T &&expr) {
     return evaluate::Fold(GetFoldingContext(), std::move(expr));
   }
 
-  template<typename T> MaybeExpr EvaluateExpr(const T &expr) {
+  template <typename T> MaybeExpr EvaluateExpr(const T &expr) {
     return FoldExpr(AnalyzeExpr(*context_, expr));
   }
 
-  template<typename T>
+  template <typename T>
   MaybeExpr EvaluateConvertedExpr(
       const Symbol &symbol, const T &expr, parser::CharBlock source) {
     if (context().HasError(symbol)) {
@@ -193,7 +194,7 @@ public:
     return FoldExpr(std::move(*converted));
   }
 
-  template<typename T> MaybeIntExpr EvaluateIntExpr(const T &expr) {
+  template <typename T> MaybeIntExpr EvaluateIntExpr(const T &expr) {
     if (MaybeExpr maybeExpr{EvaluateExpr(expr)}) {
       if (auto *intExpr{evaluate::UnwrapExpr<SomeIntExpr>(*maybeExpr)}) {
         return std::move(*intExpr);
@@ -202,7 +203,7 @@ public:
     return std::nullopt;
   }
 
-  template<typename T>
+  template <typename T>
   MaybeSubscriptIntExpr EvaluateSubscriptIntExpr(const T &expr) {
     if (MaybeIntExpr maybeIntExpr{EvaluateIntExpr(expr)}) {
       return FoldExpr(evaluate::ConvertToType<evaluate::SubscriptInteger>(
@@ -212,10 +213,10 @@ public:
     }
   }
 
-  template<typename... A> Message &Say(A &&... args) {
+  template <typename... A> Message &Say(A &&... args) {
     return messageHandler_.Say(std::forward<A>(args)...);
   }
-  template<typename... A>
+  template <typename... A>
   Message &Say(
       const parser::Name &name, MessageFixedText &&text, const A &... args) {
     return messageHandler_.Say(name.source, std::move(text), args...);
@@ -233,7 +234,7 @@ private:
 // Provide Post methods to collect attributes into a member variable.
 class AttrsVisitor : public virtual BaseVisitor {
 public:
-  bool BeginAttrs();  // always returns true
+  bool BeginAttrs(); // always returns true
   Attrs GetAttrs();
   Attrs EndAttrs();
   bool SetPassNameOn(Symbol &);
@@ -281,18 +282,23 @@ protected:
 
   Attr AccessSpecToAttr(const parser::AccessSpec &x) {
     switch (x.v) {
-    case parser::AccessSpec::Kind::Public: return Attr::PUBLIC;
-    case parser::AccessSpec::Kind::Private: return Attr::PRIVATE;
+    case parser::AccessSpec::Kind::Public:
+      return Attr::PUBLIC;
+    case parser::AccessSpec::Kind::Private:
+      return Attr::PRIVATE;
     }
-    common::die("unreachable");  // suppress g++ warning
+    common::die("unreachable"); // suppress g++ warning
   }
   Attr IntentSpecToAttr(const parser::IntentSpec &x) {
     switch (x.v) {
-    case parser::IntentSpec::Intent::In: return Attr::INTENT_IN;
-    case parser::IntentSpec::Intent::Out: return Attr::INTENT_OUT;
-    case parser::IntentSpec::Intent::InOut: return Attr::INTENT_INOUT;
+    case parser::IntentSpec::Intent::In:
+      return Attr::INTENT_IN;
+    case parser::IntentSpec::Intent::Out:
+      return Attr::INTENT_OUT;
+    case parser::IntentSpec::Intent::InOut:
+      return Attr::INTENT_INOUT;
     }
-    common::die("unreachable");  // suppress g++ warning
+    common::die("unreachable"); // suppress g++ warning
   }
 
 private:
@@ -300,8 +306,8 @@ private:
   bool HaveAttrConflict(Attr, Attr, Attr);
   bool IsConflictingAttr(Attr);
 
-  MaybeExpr bindName_;  // from BIND(C, NAME="...")
-  std::optional<SourceName> passName_;  // from PASS(...)
+  MaybeExpr bindName_; // from BIND(C, NAME="...")
+  std::optional<SourceName> passName_; // from PASS(...)
 };
 
 // Find and create types from declaration-type-spec nodes.
@@ -319,7 +325,7 @@ public:
 
 protected:
   struct State {
-    bool expectDeclTypeSpec{false};  // should see decl-type-spec only when true
+    bool expectDeclTypeSpec{false}; // should see decl-type-spec only when true
     const DeclTypeSpec *declTypeSpec{nullptr};
     struct {
       DerivedTypeSpec *type{nullptr};
@@ -336,7 +342,7 @@ protected:
   }
 
   // Walk the parse tree of a type spec and return the DeclTypeSpec for it.
-  template<typename T>
+  template <typename T>
   const DeclTypeSpec *ProcessTypeSpec(const T &x, bool allowForward = false) {
     auto restorer{common::ScopedSet(state_, State{})};
     set_allowForwardReferenceToDerivedType(allowForward);
@@ -446,6 +452,8 @@ public:
 
   Scope &currScope() { return DEREF(currScope_); }
   // The enclosing scope, skipping blocks and derived types.
+  // TODO: Will return the scope of a FORALL or implied DO loop; is this ok?
+  // If not, should call FindProgramUnitContaining() instead.
   Scope &InclusiveScope();
 
   // Create a new scope and push it on the scope stack.
@@ -454,12 +462,12 @@ public:
   void PopScope();
   void SetScope(Scope &);
 
-  template<typename T> bool Pre(const parser::Statement<T> &x) {
+  template <typename T> bool Pre(const parser::Statement<T> &x) {
     messageHandler().set_currStmtSource(x.source);
     currScope_->AddSourceRange(x.source);
     return true;
   }
-  template<typename T> void Post(const parser::Statement<T> &) {
+  template <typename T> void Post(const parser::Statement<T> &) {
     messageHandler().set_currStmtSource(std::nullopt);
   }
 
@@ -500,19 +508,19 @@ public:
   Symbol &MakeSymbol(const SourceName &, Attrs = Attrs{});
   Symbol &MakeSymbol(const parser::Name &, Attrs = Attrs{});
 
-  template<typename D>
+  template <typename D>
   common::IfNoLvalue<Symbol &, D> MakeSymbol(
       const parser::Name &name, D &&details) {
     return MakeSymbol(name, Attrs{}, std::move(details));
   }
 
-  template<typename D>
+  template <typename D>
   common::IfNoLvalue<Symbol &, D> MakeSymbol(
       const parser::Name &name, const Attrs &attrs, D &&details) {
     return Resolve(name, MakeSymbol(name.source, attrs, std::move(details)));
   }
 
-  template<typename D>
+  template <typename D>
   common::IfNoLvalue<Symbol &, D> MakeSymbol(
       const SourceName &name, const Attrs &attrs, D &&details) {
     // Note: don't use FindSymbol here. If this is a derived type scope,
@@ -633,10 +641,10 @@ private:
   // A new GenericInfo is pushed for each interface block and generic stmt
   struct GenericInfo {
     GenericInfo(bool isInterface, bool isAbstract = false)
-      : isInterface{isInterface}, isAbstract{isAbstract} {}
-    bool isInterface;  // in interface block
-    bool isAbstract;  // in abstract interface block
-    Symbol *symbol{nullptr};  // the generic symbol being defined
+        : isInterface{isInterface}, isAbstract{isAbstract} {}
+    bool isInterface; // in interface block
+    bool isAbstract; // in abstract interface block
+    Symbol *symbol{nullptr}; // the generic symbol being defined
   };
   std::stack<GenericInfo> genericInfo_;
   const GenericInfo &GetGenericInfo() const { return genericInfo_.top(); }
@@ -658,6 +666,8 @@ public:
   void Post(const parser::SubroutineStmt &);
   bool Pre(const parser::FunctionStmt &);
   void Post(const parser::FunctionStmt &);
+  bool Pre(const parser::EntryStmt &);
+  void Post(const parser::EntryStmt &);
   bool Pre(const parser::InterfaceBody::Subroutine &);
   void Post(const parser::InterfaceBody::Subroutine &);
   bool Pre(const parser::InterfaceBody::Function &);
@@ -675,6 +685,7 @@ public:
 protected:
   // Set when we see a stmt function that is really an array element assignment
   bool badStmtFuncFound_{false};
+  bool inExecutionPart_{false};
 
 private:
   // Info about the current function: parse tree of the type in the PrefixSpec;
@@ -687,6 +698,7 @@ private:
   } funcInfo_;
 
   // Create a subprogram symbol in the current scope and push a new scope.
+  void CheckExtantExternal(const parser::Name &, Symbol::Flag);
   Symbol &PushSubprogramScope(const parser::Name &, Symbol::Flag);
   Symbol *GetSpecificFromGeneric(const parser::Name &);
   SubprogramDetails &PostSubprogramStmt(const parser::Name &);
@@ -762,7 +774,7 @@ public:
   void Post(const parser::ComponentDecl &);
   bool Pre(const parser::ProcedureDeclarationStmt &);
   void Post(const parser::ProcedureDeclarationStmt &);
-  bool Pre(const parser::DataComponentDefStmt &);  // returns false
+  bool Pre(const parser::DataComponentDefStmt &); // returns false
   bool Pre(const parser::ProcComponentDefStmt &);
   void Post(const parser::ProcComponentDefStmt &);
   bool Pre(const parser::ProcPointerInit &);
@@ -843,25 +855,25 @@ private:
   } charInfo_;
   // Info about current derived type while walking DerivedTypeDef
   struct {
-    const parser::Name *extends{nullptr};  // EXTENDS(name)
-    bool privateComps{false};  // components are private by default
-    bool privateBindings{false};  // bindings are private by default
-    bool sawContains{false};  // currently processing bindings
-    bool sequence{false};  // is a sequence type
-    const Symbol *type{nullptr};  // derived type being defined
+    const parser::Name *extends{nullptr}; // EXTENDS(name)
+    bool privateComps{false}; // components are private by default
+    bool privateBindings{false}; // bindings are private by default
+    bool sawContains{false}; // currently processing bindings
+    bool sequence{false}; // is a sequence type
+    const Symbol *type{nullptr}; // derived type being defined
   } derivedTypeInfo_;
   // Collect equivalence sets and process at end of specification part
   std::vector<const std::list<parser::EquivalenceObject> *> equivalenceSets_;
   // Info about common blocks in the current scope
   struct {
-    Symbol *curr{nullptr};  // common block currently being processed
-    std::set<SourceName> names;  // names in any common block of scope
+    Symbol *curr{nullptr}; // common block currently being processed
+    std::set<SourceName> names; // names in any common block of scope
   } commonBlockInfo_;
   // Info about about SAVE statements and attributes in current scope
   struct {
-    std::optional<SourceName> saveAll;  // "SAVE" without entity list
-    std::set<SourceName> entities;  // names of entities with save attr
-    std::set<SourceName> commons;  // names of common blocks with save attr
+    std::optional<SourceName> saveAll; // "SAVE" without entity list
+    std::set<SourceName> entities; // names of entities with save attr
+    std::set<SourceName> commons; // names of common blocks with save attr
   } saveInfo_;
   // In a ProcedureDeclarationStmt or ProcComponentDefStmt, this is
   // the interface name, if any.
@@ -903,7 +915,7 @@ private:
 
   // Declare an object or procedure entity.
   // T is one of: EntityDetails, ObjectEntityDetails, ProcEntityDetails
-  template<typename T>
+  template <typename T>
   Symbol &DeclareEntity(const parser::Name &name, Attrs attrs) {
     Symbol &symbol{MakeSymbol(name, attrs)};
     if (symbol.has<T>()) {
@@ -987,7 +999,7 @@ public:
   bool Pre(const parser::ForallConstructStmt &x) { return CheckDef(x.t); }
   bool Pre(const parser::CriticalStmt &x) { return CheckDef(x.t); }
   bool Pre(const parser::LabelDoStmt &) {
-    return false;  // error recovery
+    return false; // error recovery
   }
   bool Pre(const parser::NonLabelDoStmt &x) { return CheckDef(x.t); }
   bool Pre(const parser::IfThenStmt &x) { return CheckDef(x.t); }
@@ -1024,7 +1036,7 @@ private:
   struct Selector {
     Selector() {}
     Selector(const SourceName &source, MaybeExpr &&expr)
-      : source{source}, expr{std::move(expr)} {}
+        : source{source}, expr{std::move(expr)} {}
     operator bool() const { return expr.has_value(); }
     parser::CharBlock source;
     MaybeExpr expr;
@@ -1036,10 +1048,10 @@ private:
   };
   std::vector<Association> associationStack_;
 
-  template<typename T> bool CheckDef(const T &t) {
+  template <typename T> bool CheckDef(const T &t) {
     return CheckDef(std::get<std::optional<parser::Name>>(t));
   }
-  template<typename T> void CheckRef(const T &t) {
+  template <typename T> void CheckRef(const T &t) {
     CheckRef(std::get<std::optional<parser::Name>>(t));
   }
   bool CheckDef(const std::optional<parser::Name> &);
@@ -1128,8 +1140,10 @@ bool OmpVisitor::NeedsScope(const parser::OpenMPBlockConstruct &x) {
   switch (beginDir.v) {
   case parser::OmpBlockDirective::Directive::TargetData:
   case parser::OmpBlockDirective::Directive::Master:
-  case parser::OmpBlockDirective::Directive::Ordered: return false;
-  default: return true;
+  case parser::OmpBlockDirective::Directive::Ordered:
+    return false;
+  default:
+    return true;
   }
 }
 
@@ -1156,12 +1170,12 @@ class OmpAttributeVisitor {
 public:
   explicit OmpAttributeVisitor(
       SemanticsContext &context, ResolveNamesVisitor &resolver)
-    : context_{context}, resolver_{resolver} {}
+      : context_{context}, resolver_{resolver} {}
 
-  template<typename A> void Walk(const A &x) { parser::Walk(x, *this); }
+  template <typename A> void Walk(const A &x) { parser::Walk(x, *this); }
 
-  template<typename A> bool Pre(const A &) { return true; }
-  template<typename A> void Post(const A &) {}
+  template <typename A> bool Pre(const A &) { return true; }
+  template <typename A> void Post(const A &) {}
 
   bool Pre(const parser::SpecificationPart &x) {
     Walk(std::get<std::list<parser::OpenMPDeclarativeConstruct>>(x.t));
@@ -1211,7 +1225,7 @@ public:
 private:
   struct OmpContext {
     OmpContext(const parser::CharBlock &source, OmpDirective d, Scope &s)
-      : directiveSource{source}, directive{d}, scope{s} {}
+        : directiveSource{source}, directive{d}, scope{s} {}
     parser::CharBlock directiveSource;
     OmpDirective directive;
     Scope &scope;
@@ -1312,11 +1326,11 @@ private:
   Symbol *DeclareOrMarkOtherAccessEntity(Symbol &, Symbol::Flag);
   void CheckMultipleAppearances(
       const parser::Name &, const Symbol &, Symbol::Flag);
-  SymbolSet dataSharingAttributeObjects_;  // on one directive
+  SymbolSet dataSharingAttributeObjects_; // on one directive
 
   SemanticsContext &context_;
   ResolveNamesVisitor &resolver_;
-  std::vector<OmpContext> ompContext_;  // used as a stack
+  std::vector<OmpContext> ompContext_; // used as a stack
 };
 
 // Walk the parse tree and resolve names to symbols.
@@ -1345,13 +1359,13 @@ public:
   using SubprogramVisitor::Pre;
 
   ResolveNamesVisitor(SemanticsContext &context, ImplicitRulesMap &rules)
-    : BaseVisitor{context, *this, rules} {
+      : BaseVisitor{context, *this, rules} {
     PushScope(context.globalScope());
   }
 
   // Default action for a parse tree node is to visit children.
-  template<typename T> bool Pre(const T &) { return true; }
-  template<typename T> void Post(const T &) {}
+  template <typename T> bool Pre(const T &) { return true; }
+  template <typename T> void Post(const T &) {}
 
   bool Pre(const parser::SpecificationPart &);
   void Post(const parser::Program &);
@@ -1360,7 +1374,7 @@ public:
   void Post(const parser::AllocateObject &);
   bool Pre(const parser::PointerAssignmentStmt &);
   void Post(const parser::Designator &);
-  template<typename A, typename B>
+  template <typename A, typename B>
   void Post(const parser::LoopBounds<A, B> &x) {
     ResolveName(*parser::Unwrap<parser::Name>(x.name));
   }
@@ -1417,7 +1431,7 @@ bool ImplicitRules::isImplicitNoneType() const {
   } else if (map_.empty() && inheritFromParent_) {
     return parent_->isImplicitNoneType();
   } else {
-    return false;  // default if not specified
+    return false; // default if not specified
   }
 }
 
@@ -1427,7 +1441,7 @@ bool ImplicitRules::isImplicitNoneExternal() const {
   } else if (inheritFromParent_) {
     return parent_->isImplicitNoneExternal();
   } else {
-    return false;  // default if not specified
+    return false; // default if not specified
   }
 }
 
@@ -1465,10 +1479,14 @@ void ImplicitRules::SetTypeMapping(const DeclTypeSpec &type,
 // Return '\0' for the char after 'z'.
 char ImplicitRules::Incr(char ch) {
   switch (ch) {
-  case 'i': return 'j';
-  case 'r': return 's';
-  case 'z': return '\0';
-  default: return ch + 1;
+  case 'i':
+    return 'j';
+  case 'r':
+    return 's';
+  case 'z':
+    return '\0';
+  default:
+    return ch + 1;
   }
 }
 
@@ -1491,7 +1509,7 @@ void ShowImplicitRule(
   }
 }
 
-template<typename T> void BaseVisitor::Walk(const T &x) {
+template <typename T> void BaseVisitor::Walk(const T &x) {
   parser::Walk(x, *this_);
 }
 
@@ -1657,14 +1675,17 @@ void DeclTypeSpecVisitor::Post(const parser::TypeSpec &typeSpec) {
     switch (spec->category()) {
     case DeclTypeSpec::Numeric:
     case DeclTypeSpec::Logical:
-    case DeclTypeSpec::Character: typeSpec.declTypeSpec = spec; break;
+    case DeclTypeSpec::Character:
+      typeSpec.declTypeSpec = spec;
+      break;
     case DeclTypeSpec::TypeDerived:
       if (const DerivedTypeSpec * derived{spec->AsDerived()}) {
-        CheckForAbstractType(derived->typeSymbol());  // C703
+        CheckForAbstractType(derived->typeSymbol()); // C703
         typeSpec.declTypeSpec = spec;
       }
       break;
-    default: CRASH_NO_CASE;
+    default:
+      CRASH_NO_CASE;
     }
   }
 }
@@ -2042,7 +2063,7 @@ Symbol &ScopeHandler::MakeSymbol(
     return *symbol;
   } else {
     const auto pair{scope.try_emplace(name, attrs, UnknownDetails{})};
-    CHECK(pair.second);  // name was not found, so must be able to add
+    CHECK(pair.second); // name was not found, so must be able to add
     return *pair.first->second;
   }
 }
@@ -2184,7 +2205,7 @@ const DeclTypeSpec &ScopeHandler::MakeLogicalType(
 void ScopeHandler::MakeExternal(Symbol &symbol) {
   if (!symbol.attrs().test(Attr::EXTERNAL)) {
     symbol.attrs().set(Attr::EXTERNAL);
-    if (symbol.attrs().test(Attr::INTRINSIC)) {  // C840
+    if (symbol.attrs().test(Attr::INTRINSIC)) { // C840
       Say(symbol.name(),
           "Symbol '%s' cannot have both EXTERNAL and INTRINSIC attributes"_err_en_US,
           symbol.name());
@@ -2282,7 +2303,7 @@ ModuleVisitor::SymbolRename ModuleVisitor::AddUse(
 ModuleVisitor::SymbolRename ModuleVisitor::AddUse(
     const SourceName &localName, const SourceName &useName, Symbol *useSymbol) {
   if (!useModuleScope_) {
-    return {};  // error occurred finding module
+    return {}; // error occurred finding module
   }
   if (!useSymbol) {
     Say(useName,
@@ -2400,7 +2421,7 @@ bool ModuleVisitor::BeginSubmodule(
   if (!parentScope) {
     return false;
   }
-  PushScope(*parentScope);  // submodule is hosted in parent
+  PushScope(*parentScope); // submodule is hosted in parent
   BeginModule(name, true);
   if (!ancestor->AddSubmodule(name.source, currScope())) {
     Say(name, "Module '%s' already has a submodule named '%s'"_err_en_US,
@@ -2432,7 +2453,7 @@ Scope *ModuleVisitor::FindModule(const parser::Name &name, Scope *ancestor) {
     Say(name, "'%s' is not a module"_err_en_US);
     return nullptr;
   }
-  if (DoesScopeContain(scope, currScope())) {  // 14.2.2(1)
+  if (DoesScopeContain(scope, currScope())) { // 14.2.2(1)
     Say(name, "Module '%s' cannot USE itself"_err_en_US);
   }
   Resolve(name, scope->symbol());
@@ -2519,7 +2540,7 @@ void InterfaceVisitor::AddSpecificProcs(
 // this generic interface. Resolve those names to symbols.
 void InterfaceVisitor::ResolveSpecificsInGeneric(Symbol &generic) {
   auto &details{generic.get<GenericDetails>()};
-  std::set<SourceName> namesSeen;  // to check for duplicate names
+  std::set<SourceName> namesSeen; // to check for duplicate names
   for (const Symbol &symbol : details.specificProcs()) {
     namesSeen.insert(symbol.name());
   }
@@ -2597,7 +2618,7 @@ void InterfaceVisitor::CheckGenericProcedures(Symbol &generic) {
   const Symbol &firstSpecific{specifics.front()};
   bool isFunction{firstSpecific.test(Symbol::Flag::Function)};
   for (const Symbol &specific : specifics) {
-    if (isFunction != specific.test(Symbol::Flag::Function)) {  // C1514
+    if (isFunction != specific.test(Symbol::Flag::Function)) { // C1514
       auto &msg{Say(generic.name(),
           "Generic interface '%s' has both a function and a subroutine"_err_en_US)};
       if (isFunction) {
@@ -2633,14 +2654,14 @@ bool SubprogramVisitor::HandleStmtFunction(const parser::StmtFunctionStmt &x) {
     }
     // TODO: check that attrs are compatible with stmt func
     resultType = details->type();
-    symbol->details() = UnknownDetails{};  // will be replaced below
+    symbol->details() = UnknownDetails{}; // will be replaced below
   }
   if (badStmtFuncFound_) {
     Say(name, "'%s' has not been declared as an array"_err_en_US);
     return true;
   }
   auto &symbol{PushSubprogramScope(name, Symbol::Flag::Function)};
-  EraseSymbol(symbol);  // removes symbol added by PushSubprogramScope
+  EraseSymbol(symbol); // removes symbol added by PushSubprogramScope
   auto &details{symbol.get<SubprogramDetails>()};
   for (const auto &dummyName : std::get<std::list<parser::Name>>(x.t)) {
     ObjectEntityDetails dummyDetails{true};
@@ -2684,7 +2705,7 @@ bool SubprogramVisitor::Pre(const parser::Suffix &suffix) {
 bool SubprogramVisitor::Pre(const parser::PrefixSpec &x) {
   // Save this to process after UseStmt and ImplicitPart
   if (const auto *parsedType{std::get_if<parser::DeclarationTypeSpec>(&x.u)}) {
-    if (funcInfo_.parsedType) {  // C1543
+    if (funcInfo_.parsedType) { // C1543
       Say(currStmtSource().value(),
           "FUNCTION prefix cannot specify the type more than once"_err_en_US);
       return false;
@@ -2732,6 +2753,7 @@ bool SubprogramVisitor::Pre(const parser::SubroutineStmt &) {
 bool SubprogramVisitor::Pre(const parser::FunctionStmt &) {
   return BeginAttrs();
 }
+bool SubprogramVisitor::Pre(const parser::EntryStmt &) { return BeginAttrs(); }
 
 void SubprogramVisitor::Post(const parser::SubroutineStmt &stmt) {
   const auto &name{std::get<parser::Name>(stmt.t)};
@@ -2758,7 +2780,7 @@ void SubprogramVisitor::Post(const parser::FunctionStmt &stmt) {
     // Note that RESULT is ignored if it has the same name as the function.
     funcResultName = funcInfo_.resultName;
   } else {
-    EraseSymbol(name);  // was added by PushSubprogramScope
+    EraseSymbol(name); // was added by PushSubprogramScope
     funcResultName = &name;
   }
   // add function result to function scope
@@ -2768,7 +2790,7 @@ void SubprogramVisitor::Post(const parser::FunctionStmt &stmt) {
       &MakeSymbol(*funcResultName, std::move(funcResultDetails));
   details.set_result(*funcInfo_.resultSymbol);
 
-  // C1560. TODO also enforce on entry names when entry implemented
+  // C1560.
   if (funcInfo_.resultName && funcInfo_.resultName->source == name.source) {
     Say(funcInfo_.resultName->source,
         "The function name should not appear in RESULT, references to '%s' "
@@ -2781,7 +2803,10 @@ void SubprogramVisitor::Post(const parser::FunctionStmt &stmt) {
     // should be resolved to avoid internal errors.
     Resolve(*funcInfo_.resultName, funcInfo_.resultSymbol);
   }
-  name.symbol = currScope().symbol();  // must not be function result symbol
+  name.symbol = currScope().symbol(); // must not be function result symbol
+  // Clear the RESULT() name now in case an ENTRY statement in the implicit-part
+  // has a RESULT() suffix.
+  funcInfo_.resultName = nullptr;
 }
 
 SubprogramDetails &SubprogramVisitor::PostSubprogramStmt(
@@ -2796,13 +2821,160 @@ SubprogramDetails &SubprogramVisitor::PostSubprogramStmt(
   return symbol.get<SubprogramDetails>();
 }
 
+void SubprogramVisitor::Post(const parser::EntryStmt &stmt) {
+  auto attrs{EndAttrs()}; // needs to be called even if early return
+  Scope &inclusiveScope{InclusiveScope()};
+  const Symbol *subprogram{inclusiveScope.symbol()};
+  if (!subprogram) {
+    CHECK(context().AnyFatalError());
+    return;
+  }
+  const auto &name{std::get<parser::Name>(stmt.t)};
+  const auto *parentDetails{subprogram->detailsIf<SubprogramDetails>()};
+  bool inFunction{parentDetails && parentDetails->isFunction()};
+  const parser::Name *resultName{funcInfo_.resultName};
+  if (resultName) { // RESULT(result) is present
+    funcInfo_.resultName = nullptr;
+    if (!inFunction) {
+      Say2(resultName->source,
+          "RESULT(%s) may appear only in a function"_err_en_US,
+          subprogram->name(), "Containing subprogram"_en_US);
+    } else if (resultName->source == subprogram->name()) { // C1574
+      Say2(resultName->source,
+          "RESULT(%s) may not have the same name as the function"_err_en_US,
+          subprogram->name(), "Containing function"_en_US);
+    } else if (const Symbol *
+        symbol{FindSymbol(inclusiveScope.parent(), *resultName)}) { // C1574
+      if (const auto *details{symbol->detailsIf<SubprogramDetails>()}) {
+        if (details->entryScope() == &inclusiveScope) {
+          Say2(resultName->source,
+              "RESULT(%s) may not have the same name as an ENTRY in the function"_err_en_US,
+              symbol->name(), "Conflicting ENTRY"_en_US);
+        }
+      }
+    }
+    if (Symbol * symbol{FindSymbol(name)}) { // C1570
+      // When RESULT() appears, ENTRY name can't have been already declared
+      if (inclusiveScope.Contains(symbol->owner())) {
+        Say2(name,
+            "ENTRY name '%s' may not be declared when RESULT() is present"_err_en_US,
+            *symbol, "Previous declaration of '%s'"_en_US);
+      }
+    }
+    if (resultName->source == name.source) {
+      // ignore RESULT() hereafter when it's the same name as the ENTRY
+      resultName = nullptr;
+    }
+  }
+  SubprogramDetails entryDetails;
+  entryDetails.set_entryScope(inclusiveScope);
+  if (inFunction) {
+    // Create the entity to hold the function result, if necessary.
+    Symbol *resultSymbol{nullptr};
+    auto &effectiveResultName{*(resultName ? resultName : &name)};
+    resultSymbol = FindInScope(currScope(), effectiveResultName);
+    if (resultSymbol) { // C1574
+      std::visit(
+          common::visitors{[](EntityDetails &x) { x.set_funcResult(true); },
+              [](ObjectEntityDetails &x) { x.set_funcResult(true); },
+              [](ProcEntityDetails &x) { x.set_funcResult(true); },
+              [&](const auto &) {
+                Say2(effectiveResultName.source,
+                    "'%s' was previously declared as an item that may not be used as a function result"_err_en_US,
+                    resultSymbol->name(), "Previous declaration of '%s'"_en_US);
+              }},
+          resultSymbol->details());
+    } else if (inExecutionPart_) {
+      ObjectEntityDetails entity;
+      entity.set_funcResult(true);
+      resultSymbol = &MakeSymbol(effectiveResultName, std::move(entity));
+      ApplyImplicitRules(*resultSymbol);
+    } else {
+      EntityDetails entity;
+      entity.set_funcResult(true);
+      resultSymbol = &MakeSymbol(effectiveResultName, std::move(entity));
+    }
+    if (!resultName) {
+      name.symbol = nullptr; // symbol will be used for entry point below
+    }
+    entryDetails.set_result(*resultSymbol);
+  }
+
+  for (const auto &dummyArg : std::get<std::list<parser::DummyArg>>(stmt.t)) {
+    if (const auto *dummyName{std::get_if<parser::Name>(&dummyArg.u)}) {
+      Symbol *dummy{FindSymbol(*dummyName)};
+      if (dummy) {
+        std::visit(
+            common::visitors{[](EntityDetails &x) { x.set_isDummy(); },
+                [](ObjectEntityDetails &x) { x.set_isDummy(); },
+                [](ProcEntityDetails &x) { x.set_isDummy(); },
+                [&](const auto &) {
+                  Say2(dummyName->source,
+                      "ENTRY dummy argument '%s' is previously declared as an item that may not be used as a dummy argument"_err_en_US,
+                      dummy->name(), "Previous declaration of '%s'"_en_US);
+                }},
+            dummy->details());
+      } else {
+        dummy = &MakeSymbol(*dummyName, EntityDetails(true));
+      }
+      entryDetails.add_dummyArg(*dummy);
+    } else {
+      if (inFunction) { // C1573
+        Say(name,
+            "ENTRY in a function may not have an alternate return dummy argument"_err_en_US);
+        break;
+      }
+      entryDetails.add_alternateReturn();
+    }
+  }
+
+  Symbol::Flag subpFlag{
+      inFunction ? Symbol::Flag::Function : Symbol::Flag::Subroutine};
+  CheckExtantExternal(name, subpFlag);
+  Scope &outer{inclusiveScope.parent()}; // global or module scope
+  if (Symbol * extant{FindSymbol(outer, name)}) {
+    if (extant->has<ProcEntityDetails>()) {
+      if (!extant->test(subpFlag)) {
+        Say2(name,
+            subpFlag == Symbol::Flag::Function
+                ? "'%s' was previously called as a subroutine"_err_en_US
+                : "'%s' was previously called as a function"_err_en_US,
+            *extant, "Previous call of '%s'"_en_US);
+      }
+      if (extant->attrs().test(Attr::PRIVATE)) {
+        attrs.set(Attr::PRIVATE);
+      }
+      outer.erase(extant->name());
+    } else {
+      if (outer.IsGlobal()) {
+        Say2(name, "'%s' is already defined as a global identifier"_err_en_US,
+            *extant, "Previous definition of '%s'"_en_US);
+      } else {
+        SayAlreadyDeclared(name, *extant);
+      }
+      return;
+    }
+  }
+  if (outer.IsModule() && !attrs.test(Attr::PRIVATE)) {
+    attrs.set(Attr::PUBLIC);
+  }
+  Symbol &entrySymbol{MakeSymbol(outer, name.source, attrs)};
+  entrySymbol.set_details(std::move(entryDetails));
+  if (outer.IsGlobal()) {
+    MakeExternal(entrySymbol);
+  }
+  SetBindNameOn(entrySymbol);
+  entrySymbol.set(subpFlag);
+  Resolve(name, entrySymbol);
+}
+
 // A subprogram declared with MODULE PROCEDURE
 bool SubprogramVisitor::BeginMpSubprogram(const parser::Name &name) {
   auto *symbol{FindSymbol(name)};
   if (symbol && symbol->has<SubprogramNameDetails>()) {
     symbol = FindSymbol(currScope().parent(), name);
   }
-  if (!symbol || !symbol->IsSeparateModuleProc()) {
+  if (!IsSeparateModuleProcedureInterface(symbol)) {
     Say(name, "'%s' was not declared a separate module procedure"_err_en_US);
     return false;
   }
@@ -2831,12 +3003,11 @@ bool SubprogramVisitor::BeginMpSubprogram(const parser::Name &name) {
 // A subprogram declared with SUBROUTINE or FUNCTION
 bool SubprogramVisitor::BeginSubprogram(
     const parser::Name &name, Symbol::Flag subpFlag, bool hasModulePrefix) {
-  if (hasModulePrefix && !inInterfaceBlock()) {
-    auto *symbol{FindSymbol(currScope().parent(), name)};
-    if (!symbol || !symbol->IsSeparateModuleProc()) {
-      Say(name, "'%s' was not declared a separate module procedure"_err_en_US);
-      return false;
-    }
+  if (hasModulePrefix && !inInterfaceBlock() &&
+      !IsSeparateModuleProcedureInterface(
+          FindSymbol(currScope().parent(), name))) {
+    Say(name, "'%s' was not declared a separate module procedure"_err_en_US);
+    return false;
   }
   PushSubprogramScope(name, subpFlag);
   return true;
@@ -2844,24 +3015,28 @@ bool SubprogramVisitor::BeginSubprogram(
 
 void SubprogramVisitor::EndSubprogram() { PopScope(); }
 
+void SubprogramVisitor::CheckExtantExternal(
+    const parser::Name &name, Symbol::Flag subpFlag) {
+  if (auto *prev{FindSymbol(name)}) {
+    if (prev->attrs().test(Attr::EXTERNAL) && prev->has<ProcEntityDetails>()) {
+      // this subprogram was previously called, now being declared
+      if (!prev->test(subpFlag)) {
+        Say2(name,
+            subpFlag == Symbol::Flag::Function
+                ? "'%s' was previously called as a subroutine"_err_en_US
+                : "'%s' was previously called as a function"_err_en_US,
+            *prev, "Previous call of '%s'"_en_US);
+      }
+      EraseSymbol(name);
+    }
+  }
+}
+
 Symbol &SubprogramVisitor::PushSubprogramScope(
     const parser::Name &name, Symbol::Flag subpFlag) {
   auto *symbol{GetSpecificFromGeneric(name)};
   if (!symbol) {
-    if (auto *prev{FindSymbol(name)}) {
-      if (prev->attrs().test(Attr::EXTERNAL) &&
-          prev->has<ProcEntityDetails>()) {
-        // this subprogram was previously called, now being declared
-        if (!prev->test(subpFlag)) {
-          Say2(name,
-              subpFlag == Symbol::Flag::Function
-                  ? "'%s' was previously called as a subroutine"_err_en_US
-                  : "'%s' was previously called as a function"_err_en_US,
-              *prev, "Previous call of '%s'"_en_US);
-        }
-        EraseSymbol(name);
-      }
-    }
+    CheckExtantExternal(name, subpFlag);
     symbol = &MakeSymbol(name, SubprogramDetails{});
   }
   symbol->set(subpFlag);
@@ -2877,7 +3052,7 @@ Symbol &SubprogramVisitor::PushSubprogramScope(
     }
     implicitRules().set_inheritFromParent(false);
   }
-  FindSymbol(name)->set(subpFlag);  // PushScope() created symbol
+  FindSymbol(name)->set(subpFlag); // PushScope() created symbol
   return *symbol;
 }
 
@@ -2958,7 +3133,7 @@ void DeclarationVisitor::CheckAccessibility(
 }
 
 void DeclarationVisitor::Post(const parser::TypeDeclarationStmt &) {
-  if (!GetAttrs().HasAny({Attr::POINTER, Attr::ALLOCATABLE})) {  // C702
+  if (!GetAttrs().HasAny({Attr::POINTER, Attr::ALLOCATABLE})) { // C702
     if (const auto *typeSpec{GetDeclTypeSpec()}) {
       if (typeSpec->category() == DeclTypeSpec::Character) {
         if (typeSpec->characterTypeSpec().length().isDeferred()) {
@@ -3006,7 +3181,7 @@ void DeclarationVisitor::Post(const parser::EntityDecl &x) {
     if (ConvertToObjectEntity(symbol)) {
       Initialization(name, *init, false);
     }
-  } else if (attrs.test(Attr::PARAMETER)) {  // C882, C883
+  } else if (attrs.test(Attr::PARAMETER)) { // C882, C883
     Say(name, "Missing initialization for parameter '%s'"_err_en_US);
   }
 }
@@ -3080,7 +3255,7 @@ bool DeclarationVisitor::Pre(const parser::Enumerator &enumerator) {
 
   if (auto &init{std::get<std::optional<parser::ScalarIntConstantExpr>>(
           enumerator.t)}) {
-    Walk(*init);  // Resolve names in expression before evaluation.
+    Walk(*init); // Resolve names in expression before evaluation.
     MaybeIntExpr expr{EvaluateIntExpr(*init)};
     if (auto value{evaluate::ToInt64(expr)}) {
       // Cast all init expressions to C_INT so that they can then be
@@ -3118,7 +3293,7 @@ bool DeclarationVisitor::Pre(const parser::AccessSpec &x) {
   Attr attr{AccessSpecToAttr(x)};
   const Scope &scope{
       currScope().IsDerivedType() ? currScope().parent() : currScope()};
-  if (!scope.IsModule()) {  // C817
+  if (!scope.IsModule()) { // C817
     Say(currStmtSource().value(),
         "%s attribute may only appear in the specification part of a module"_err_en_US,
         EnumToString(attr));
@@ -3147,7 +3322,7 @@ bool DeclarationVisitor::Pre(const parser::ExternalStmt &x) {
 bool DeclarationVisitor::Pre(const parser::IntentStmt &x) {
   auto &intentSpec{std::get<parser::IntentSpec>(x.t)};
   auto &names{std::get<std::list<parser::Name>>(x.t)};
-  return CheckNotInBlock("INTENT") &&  // C1107
+  return CheckNotInBlock("INTENT") && // C1107
       HandleAttributeStmt(IntentSpecToAttr(intentSpec), names);
 }
 bool DeclarationVisitor::Pre(const parser::IntrinsicStmt &x) {
@@ -3157,7 +3332,7 @@ bool DeclarationVisitor::Pre(const parser::IntrinsicStmt &x) {
     if (!ConvertToProcEntity(*symbol)) {
       SayWithDecl(
           name, *symbol, "INTRINSIC attribute not allowed on '%s'"_err_en_US);
-    } else if (symbol->attrs().test(Attr::EXTERNAL)) {  // C840
+    } else if (symbol->attrs().test(Attr::EXTERNAL)) { // C840
       Say(symbol->name(),
           "Symbol '%s' cannot have both EXTERNAL and INTRINSIC attributes"_err_en_US,
           symbol->name());
@@ -3166,14 +3341,14 @@ bool DeclarationVisitor::Pre(const parser::IntrinsicStmt &x) {
   return false;
 }
 bool DeclarationVisitor::Pre(const parser::OptionalStmt &x) {
-  return CheckNotInBlock("OPTIONAL") &&  // C1107
+  return CheckNotInBlock("OPTIONAL") && // C1107
       HandleAttributeStmt(Attr::OPTIONAL, x.v);
 }
 bool DeclarationVisitor::Pre(const parser::ProtectedStmt &x) {
   return HandleAttributeStmt(Attr::PROTECTED, x.v);
 }
 bool DeclarationVisitor::Pre(const parser::ValueStmt &x) {
-  return CheckNotInBlock("VALUE") &&  // C1107
+  return CheckNotInBlock("VALUE") && // C1107
       HandleAttributeStmt(Attr::VALUE, x.v);
 }
 bool DeclarationVisitor::Pre(const parser::VolatileStmt &x) {
@@ -3335,7 +3510,7 @@ void DeclarationVisitor::Post(const parser::CharSelector::LengthAndKind &x) {
   std::optional<std::int64_t> intKind{ToInt64(charInfo_.kind)};
   if (intKind &&
       !evaluate::IsValidKindOfIntrinsicType(
-          TypeCategory::Character, *intKind)) {  // C715, C719
+          TypeCategory::Character, *intKind)) { // C715, C719
     Say(currStmtSource().value(),
         "KIND value (%jd) not valid for CHARACTER"_err_en_US,
         static_cast<std::intmax_t>(*intKind));
@@ -3379,7 +3554,7 @@ bool DeclarationVisitor::Pre(const parser::DeclarationTypeSpec::Type &) {
 void DeclarationVisitor::Post(const parser::DeclarationTypeSpec::Type &type) {
   const parser::Name &derivedName{std::get<parser::Name>(type.derived.t)};
   if (const Symbol * derivedSymbol{derivedName.symbol}) {
-    CheckForAbstractType(*derivedSymbol);  // C706
+    CheckForAbstractType(*derivedSymbol); // C706
   }
 }
 
@@ -3392,7 +3567,7 @@ void DeclarationVisitor::Post(
     const parser::DeclarationTypeSpec::Class &parsedClass) {
   const auto &typeName{std::get<parser::Name>(parsedClass.derived.t)};
   if (auto spec{ResolveDerivedType(typeName)};
-      spec && !IsExtensibleType(&*spec)) {  // C705
+      spec && !IsExtensibleType(&*spec)) { // C705
     SayWithDecl(typeName, *typeName.symbol,
         "Non-extensible derived type '%s' may not be used with CLASS"
         " keyword"_err_en_US);
@@ -3493,21 +3668,21 @@ bool DeclarationVisitor::Pre(const parser::DerivedTypeDef &x) {
     auto *symbol{FindInScope(scope, paramName)};
     if (!symbol) {
       Say(paramName,
-          "No definition found for type parameter '%s'"_err_en_US);  // C742
+          "No definition found for type parameter '%s'"_err_en_US); // C742
     } else if (!symbol->has<TypeParamDetails>()) {
       Say2(paramName, "'%s' is not defined as a type parameter"_err_en_US,
-          *symbol, "Definition of '%s'"_en_US);  // C741
+          *symbol, "Definition of '%s'"_en_US); // C741
     }
     if (!paramNames.insert(paramName.source).second) {
       Say(paramName,
-          "Duplicate type parameter name: '%s'"_err_en_US);  // C731
+          "Duplicate type parameter name: '%s'"_err_en_US); // C731
     }
   }
   for (const auto &[name, symbol] : currScope()) {
     if (symbol->has<TypeParamDetails>() && !paramNames.count(name)) {
       SayDerivedType(name,
           "'%s' is not a type parameter of this derived type"_err_en_US,
-          currScope());  // C742
+          currScope()); // C742
     }
   }
   Walk(std::get<std::list<parser::Statement<parser::PrivateOrSequence>>>(x.t));
@@ -3515,11 +3690,11 @@ bool DeclarationVisitor::Pre(const parser::DerivedTypeDef &x) {
     details.set_sequence(true);
     if (derivedTypeInfo_.extends) {
       Say(stmt.source,
-          "A sequence type may not have the EXTENDS attribute"_err_en_US);  // C735
+          "A sequence type may not have the EXTENDS attribute"_err_en_US); // C735
     }
     if (!details.paramNames().empty()) {
       Say(stmt.source,
-          "A sequence type may not have type parameters"_err_en_US);  // C740
+          "A sequence type may not have type parameters"_err_en_US); // C740
     }
   }
   Walk(std::get<std::list<parser::Statement<parser::ComponentDefStmt>>>(x.t));
@@ -3600,14 +3775,14 @@ bool DeclarationVisitor::Pre(const parser::TypeAttrSpec::Extends &x) {
 bool DeclarationVisitor::Pre(const parser::PrivateStmt &) {
   if (!currScope().parent().IsModule()) {
     Say("PRIVATE is only allowed in a derived type that is"
-        " in a module"_err_en_US);  // C766
+        " in a module"_err_en_US); // C766
   } else if (derivedTypeInfo_.sawContains) {
     derivedTypeInfo_.privateBindings = true;
   } else if (!derivedTypeInfo_.privateComps) {
     derivedTypeInfo_.privateComps = true;
   } else {
     Say("PRIVATE may not appear more than once in"
-        " derived type components"_en_US);  // C738
+        " derived type components"_en_US); // C738
   }
   return false;
 }
@@ -3625,7 +3800,7 @@ void DeclarationVisitor::Post(const parser::ComponentDecl &x) {
   if (!attrs.HasAny({Attr::POINTER, Attr::ALLOCATABLE})) {
     if (const auto *declType{GetDeclTypeSpec()}) {
       if (const auto *derived{declType->AsDerived()}) {
-        if (derivedTypeInfo_.type == &derived->typeSymbol()) {  // C737
+        if (derivedTypeInfo_.type == &derived->typeSymbol()) { // C737
           Say("Recursive use of the derived type requires "
               "POINTER or ALLOCATABLE"_err_en_US);
         }
@@ -3723,7 +3898,7 @@ void DeclarationVisitor::Post(const parser::TypeBoundProcedurePart &) {
     }
     auto [it, inserted]{specifics.insert(bindingName->source)};
     if (!inserted) {
-      Say(*bindingName,  // C773
+      Say(*bindingName, // C773
           "Binding name '%s' was already specified for generic '%s'"_err_en_US,
           bindingName->source, generic->name())
           .Attach(*it, "Previous specification of '%s'"_en_US, *it);
@@ -3731,10 +3906,10 @@ void DeclarationVisitor::Post(const parser::TypeBoundProcedurePart &) {
     }
     auto *symbol{FindInTypeOrParents(*bindingName)};
     if (!symbol) {
-      Say(*bindingName,  // C772
+      Say(*bindingName, // C772
           "Binding name '%s' not found in this derived type"_err_en_US);
     } else if (!symbol->has<ProcBindingDetails>()) {
-      SayWithDecl(*bindingName, *symbol,  // C772
+      SayWithDecl(*bindingName, *symbol, // C772
           "'%s' is not the name of a specific binding of this type"_err_en_US);
     } else {
       generic->get<GenericDetails>().AddSpecificProc(
@@ -3746,13 +3921,13 @@ void DeclarationVisitor::Post(const parser::TypeBoundProcedurePart &) {
 
 void DeclarationVisitor::Post(const parser::ContainsStmt &) {
   if (derivedTypeInfo_.sequence) {
-    Say("A sequence type may not have a CONTAINS statement"_err_en_US);  // C740
+    Say("A sequence type may not have a CONTAINS statement"_err_en_US); // C740
   }
 }
 
 void DeclarationVisitor::Post(
     const parser::TypeBoundProcedureStmt::WithoutInterface &x) {
-  if (GetAttrs().test(Attr::DEFERRED)) {  // C783
+  if (GetAttrs().test(Attr::DEFERRED)) { // C783
     Say("DEFERRED is only allowed when an interface-name is provided"_err_en_US);
   }
   for (auto &declaration : x.declarations) {
@@ -3802,7 +3977,7 @@ void DeclarationVisitor::CheckBindings(
 
 void DeclarationVisitor::Post(
     const parser::TypeBoundProcedureStmt::WithInterface &x) {
-  if (!GetAttrs().test(Attr::DEFERRED)) {  // C783
+  if (!GetAttrs().test(Attr::DEFERRED)) { // C783
     Say("DEFERRED is required when an interface-name is provided"_err_en_US);
   }
   if (Symbol * interface{NoteInterfaceName(x.interfaceName)}) {
@@ -3835,7 +4010,7 @@ bool DeclarationVisitor::Pre(const parser::TypeBoundGenericStmt &x) {
   auto *genericSymbol{info.FindInScope(context(), currScope())};
   if (genericSymbol) {
     if (!genericSymbol->has<GenericDetails>()) {
-      genericSymbol = nullptr;  // MakeTypeSymbol will report the error below
+      genericSymbol = nullptr; // MakeTypeSymbol will report the error below
     }
   } else {
     // look in parent types:
@@ -3847,11 +4022,11 @@ bool DeclarationVisitor::Pre(const parser::TypeBoundGenericStmt &x) {
       }
     }
     if (inheritedSymbol && inheritedSymbol->has<GenericDetails>()) {
-      CheckAccessibility(symbolName, isPrivate, *inheritedSymbol);  // C771
+      CheckAccessibility(symbolName, isPrivate, *inheritedSymbol); // C771
     }
   }
   if (genericSymbol) {
-    CheckAccessibility(symbolName, isPrivate, *genericSymbol);  // C771
+    CheckAccessibility(symbolName, isPrivate, *genericSymbol); // C771
   } else {
     genericSymbol = MakeTypeSymbol(symbolName, GenericDetails{});
     if (!genericSymbol) {
@@ -3978,7 +4153,7 @@ bool DeclarationVisitor::Pre(const parser::BasedPointerStmt &x) {
 }
 
 bool DeclarationVisitor::Pre(const parser::NamelistStmt::Group &x) {
-  if (!CheckNotInBlock("NAMELIST")) {  // C1107
+  if (!CheckNotInBlock("NAMELIST")) { // C1107
     return false;
   }
 
@@ -4018,7 +4193,7 @@ bool DeclarationVisitor::Pre(const parser::IoControlSpec &x) {
 }
 
 bool DeclarationVisitor::Pre(const parser::CommonStmt::Block &x) {
-  CheckNotInBlock("COMMON");  // C1107
+  CheckNotInBlock("COMMON"); // C1107
   const auto &optName{std::get<std::optional<parser::Name>>(x.t)};
   parser::Name blankCommon;
   blankCommon.source =
@@ -4046,7 +4221,7 @@ void DeclarationVisitor::Post(const parser::CommonBlockObject &x) {
   ClearCoarraySpec();
   auto *details{symbol.detailsIf<ObjectEntityDetails>()};
   if (!details) {
-    return;  // error was reported
+    return; // error was reported
   }
   commonBlockInfo_.curr->get<CommonBlockDetails>().add_object(symbol);
   auto pair{commonBlockInfo_.names.insert(name.source)};
@@ -4061,18 +4236,18 @@ void DeclarationVisitor::Post(const parser::CommonBlockObject &x) {
 
 bool DeclarationVisitor::Pre(const parser::EquivalenceStmt &x) {
   // save equivalence sets to be processed after specification part
-  CheckNotInBlock("EQUIVALENCE");  // C1107
+  CheckNotInBlock("EQUIVALENCE"); // C1107
   for (const std::list<parser::EquivalenceObject> &set : x.v) {
     equivalenceSets_.push_back(&set);
   }
-  return false;  // don't implicitly declare names yet
+  return false; // don't implicitly declare names yet
 }
 
 void DeclarationVisitor::CheckEquivalenceSets() {
   EquivalenceSets equivSets{context()};
   for (const auto *set : equivalenceSets_) {
     const auto &source{set->front().v.value().source};
-    if (set->size() <= 1) {  // R871
+    if (set->size() <= 1) { // R871
       Say(source, "Equivalence set must have more than one object"_err_en_US);
     }
     for (const parser::EquivalenceObject &object : *set) {
@@ -4136,7 +4311,7 @@ void DeclarationVisitor::CheckSaveStmts() {
           Say(name,
               "'%s' appears as a COMMON block in a SAVE statement but not in"
               " a COMMON statement"_err_en_US);
-        } else {  // C1108
+        } else { // C1108
           Say(name,
               "SAVE statement in BLOCK construct may not contain a"
               " common block name '%s'"_err_en_US);
@@ -4314,10 +4489,10 @@ bool DeclarationVisitor::HandleUnrestrictedSpecificIntrinsicFunction(
 bool DeclarationVisitor::PassesSharedLocalityChecks(
     const parser::Name &name, Symbol &symbol) {
   if (!IsVariableName(symbol)) {
-    SayLocalMustBeVariable(name, symbol);  // C1124
+    SayLocalMustBeVariable(name, symbol); // C1124
     return false;
   }
-  if (symbol.owner() == currScope()) {  // C1125 and C1126
+  if (symbol.owner() == currScope()) { // C1125 and C1126
     SayAlreadyDeclared(name, symbol);
     return false;
   }
@@ -4327,41 +4502,41 @@ bool DeclarationVisitor::PassesSharedLocalityChecks(
 // Checks for locality-specs LOCAL and LOCAL_INIT
 bool DeclarationVisitor::PassesLocalityChecks(
     const parser::Name &name, Symbol &symbol) {
-  if (IsAllocatable(symbol)) {  // C1128
+  if (IsAllocatable(symbol)) { // C1128
     SayWithDecl(name, symbol,
         "ALLOCATABLE variable '%s' not allowed in a locality-spec"_err_en_US);
     return false;
   }
-  if (IsOptional(symbol)) {  // C1128
+  if (IsOptional(symbol)) { // C1128
     SayWithDecl(name, symbol,
         "OPTIONAL argument '%s' not allowed in a locality-spec"_err_en_US);
     return false;
   }
-  if (IsIntentIn(symbol)) {  // C1128
+  if (IsIntentIn(symbol)) { // C1128
     SayWithDecl(name, symbol,
         "INTENT IN argument '%s' not allowed in a locality-spec"_err_en_US);
     return false;
   }
-  if (IsFinalizable(symbol)) {  // C1128
+  if (IsFinalizable(symbol)) { // C1128
     SayWithDecl(name, symbol,
         "Finalizable variable '%s' not allowed in a locality-spec"_err_en_US);
     return false;
   }
-  if (IsCoarray(symbol)) {  // C1128
+  if (IsCoarray(symbol)) { // C1128
     SayWithDecl(
         name, symbol, "Coarray '%s' not allowed in a locality-spec"_err_en_US);
     return false;
   }
   if (const DeclTypeSpec * type{symbol.GetType()}) {
     if (type->IsPolymorphic() && symbol.IsDummy() &&
-        !IsPointer(symbol)) {  // C1128
+        !IsPointer(symbol)) { // C1128
       SayWithDecl(name, symbol,
           "Nonpointer polymorphic argument '%s' not allowed in a "
           "locality-spec"_err_en_US);
       return false;
     }
   }
-  if (IsAssumedSizeArray(symbol)) {  // C1128
+  if (IsAssumedSizeArray(symbol)) { // C1128
     SayWithDecl(name, symbol,
         "Assumed size array '%s' not allowed in a locality-spec"_err_en_US);
     return false;
@@ -4413,7 +4588,7 @@ Symbol *DeclarationVisitor::DeclareStatementEntity(const parser::Name &name,
   }
   Symbol &symbol{DeclareEntity<ObjectEntityDetails>(name, {})};
   if (!symbol.has<ObjectEntityDetails>()) {
-    return nullptr;  // error was reported in DeclareEntity
+    return nullptr; // error was reported in DeclareEntity
   }
   if (type) {
     declTypeSpec = ProcessTypeSpec(*type);
@@ -4435,7 +4610,7 @@ void DeclarationVisitor::SetType(
     const parser::Name &name, const DeclTypeSpec &type) {
   CHECK(name.symbol);
   auto &symbol{*name.symbol};
-  if (charInfo_.length) {  // Declaration has "*length" (R723)
+  if (charInfo_.length) { // Declaration has "*length" (R723)
     auto length{std::move(*charInfo_.length)};
     charInfo_.length.reset();
     if (type.category() == DeclTypeSpec::Character) {
@@ -4477,7 +4652,7 @@ std::optional<DerivedTypeSpec> DeclarationVisitor::ResolveDerivedType(
       DerivedTypeDetails details;
       details.set_isForwardReferenced();
       symbol->set_details(std::move(details));
-    } else {  // C883
+    } else { // C883
       Say(name, "Derived type '%s' not found"_err_en_US);
       return std::nullopt;
     }
@@ -4603,7 +4778,7 @@ ParamValue DeclarationVisitor::GetParamValue(
     const parser::TypeParamValue &x, common::TypeParamAttr attr) {
   return std::visit(
       common::visitors{
-          [=](const parser::ScalarIntExpr &x) {  // C704
+          [=](const parser::ScalarIntExpr &x) { // C704
             return ParamValue{EvaluateIntExpr(x), attr};
           },
           [=](const parser::Star &) { return ParamValue::Assumed(attr); },
@@ -4694,7 +4869,7 @@ bool ConstructVisitor::Pre(const parser::LocalitySpec::Shared &x) {
     if (PassesSharedLocalityChecks(name, prev)) {
       auto &symbol{MakeSymbol(name, HostAssocDetails{prev})};
       symbol.set(Symbol::Flag::LocalityShared);
-      name.symbol = &symbol;  // override resolution to parent
+      name.symbol = &symbol; // override resolution to parent
     }
   }
   return false;
@@ -4833,7 +5008,7 @@ void ConstructVisitor::Post(const parser::Association &x) {
     SetTypeFromAssociation(*symbol);
     SetAttrsFromAssociation(*symbol);
   }
-  GetCurrentAssociation() = {};  // clean for further parser::Association.
+  GetCurrentAssociation() = {}; // clean for further parser::Association.
 }
 
 bool ConstructVisitor::Pre(const parser::ChangeTeamStmt &x) {
@@ -4851,7 +5026,7 @@ void ConstructVisitor::Post(const parser::CoarrayAssociation &x) {
     if (auto sel{ResolveSelector(selector)}) {
       const Symbol *whole{UnwrapWholeSymbolDataRef(sel.expr)};
       if (!whole || whole->Corank() == 0) {
-        Say(sel.source,  // C1116
+        Say(sel.source, // C1116
             "Selector in coarray association must name a coarray"_err_en_US);
       } else if (auto dynType{sel.expr->GetType()}) {
         if (!symbol->GetType()) {
@@ -4888,12 +5063,12 @@ void ConstructVisitor::Post(const parser::SelectTypeStmt &x) {
         whole{UnwrapWholeSymbolDataRef(association.selector.expr)}) {
       ConvertToObjectEntity(const_cast<Symbol &>(*whole));
       if (!IsVariableName(*whole)) {
-        Say(association.selector.source,  // C901
+        Say(association.selector.source, // C901
             "Selector is not a variable"_err_en_US);
         association = {};
       }
     } else {
-      Say(association.selector.source,  // C1157
+      Say(association.selector.source, // C1157
           "Selector is not a named variable: 'associate-name =>' is required"_err_en_US);
       association = {};
     }
@@ -4949,7 +5124,7 @@ Symbol *ConstructVisitor::MakeAssocEntity() {
   if (association.name) {
     symbol = &MakeSymbol(*association.name, UnknownDetails{});
     if (symbol->has<AssocEntityDetails>() && symbol->owner() == currScope()) {
-      Say(*association.name,  // C1104
+      Say(*association.name, // C1104
           "The associate name '%s' is already used in this associate statement"_err_en_US);
       return nullptr;
     }
@@ -5055,7 +5230,8 @@ const DeclTypeSpec &ConstructVisitor::ToDeclTypeSpec(
 
       );
     }
-  case common::TypeCategory::Character: CRASH_NO_CASE;
+  case common::TypeCategory::Character:
+    CRASH_NO_CASE;
   }
 }
 
@@ -5123,7 +5299,7 @@ bool ResolveNamesVisitor::Pre(const parser::ImportStmt &x) {
       return false;
     }
     break;
-  case Scope::Kind::BlockData:  // C1415 (in part)
+  case Scope::Kind::BlockData: // C1415 (in part)
     Say("IMPORT is not allowed in a BLOCK DATA subprogram"_err_en_US);
     return false;
   default:;
@@ -5207,7 +5383,7 @@ const parser::Name *DeclarationVisitor::ResolveVariable(
 const parser::Name *DeclarationVisitor::ResolveName(const parser::Name &name) {
   if (Symbol * symbol{FindSymbol(name)}) {
     if (CheckUseError(name)) {
-      return nullptr;  // reported an error
+      return nullptr; // reported an error
     }
     if (symbol->IsDummy() ||
         (!symbol->GetType() && FindCommonBlockContaining(*symbol))) {
@@ -5249,7 +5425,7 @@ const parser::Name *DeclarationVisitor::FindComponent(
   }
   auto *type{symbol.GetType()};
   if (!type) {
-    return nullptr;  // should have already reported error
+    return nullptr; // should have already reported error
   }
   if (const IntrinsicTypeSpec * intrinsic{type->AsIntrinsic()}) {
     auto name{component.ToString()};
@@ -5448,7 +5624,7 @@ void DeclarationVisitor::PointerInitialization(
           details.set_init(*targetName->symbol);
         }
       } else {
-        details.set_init(nullptr);  // explicit NULL()
+        details.set_init(nullptr); // explicit NULL()
       }
     } else {
       Say(name,
@@ -5505,7 +5681,7 @@ void ResolveNamesVisitor::HandleProcedureName(
     symbol = &Resolve(name, symbol)->GetUltimate();
     ConvertToProcEntity(*symbol);
     if (!SetProcFlag(name, *symbol, flag)) {
-      return;  // reported error
+      return; // reported error
     }
     if (IsProcedure(*symbol) || symbol->has<DerivedTypeDetails>() ||
         symbol->has<ObjectEntityDetails>() ||
@@ -5567,7 +5743,7 @@ bool ResolveNamesVisitor::SetProcFlag(
         name, symbol, "Cannot call subroutine '%s' like a function"_err_en_US);
     return false;
   } else if (symbol.has<ProcEntityDetails>()) {
-    symbol.set(flag);  // in case it hasn't been set yet
+    symbol.set(flag); // in case it hasn't been set yet
     if (flag == Symbol::Flag::Function) {
       ApplyImplicitRules(symbol);
     }
@@ -5580,7 +5756,7 @@ bool ResolveNamesVisitor::SetProcFlag(
 
 bool ModuleVisitor::Pre(const parser::AccessStmt &x) {
   Attr accessAttr{AccessSpecToAttr(std::get<parser::AccessSpec>(x.t))};
-  if (!currScope().IsModule()) {  // C869
+  if (!currScope().IsModule()) { // C869
     Say(currStmtSource().value(),
         "%s statement may only appear in the specification part of a module"_err_en_US,
         EnumToString(accessAttr));
@@ -5588,7 +5764,7 @@ bool ModuleVisitor::Pre(const parser::AccessStmt &x) {
   }
   const auto &accessIds{std::get<std::list<parser::AccessId>>(x.t)};
   if (accessIds.empty()) {
-    if (prevAccessStmt_) {  // C869
+    if (prevAccessStmt_) { // C869
       Say("The default accessibility of this module has already been declared"_err_en_US)
           .Attach(*prevAccessStmt_, "Previous declaration"_en_US);
     }
@@ -5705,7 +5881,7 @@ void ResolveNamesVisitor::CreateGeneric(const parser::GenericSpec &x) {
   if (Symbol * existing{info.FindInScope(context(), currScope())}) {
     if (existing->has<GenericDetails>()) {
       info.Resolve(existing);
-      return;  // already have generic, add to it
+      return; // already have generic, add to it
     }
     Symbol &ultimate{existing->GetUltimate()};
     if (auto *ultimateDetails{ultimate.detailsIf<GenericDetails>()}) {
@@ -5751,7 +5927,8 @@ void ResolveNamesVisitor::FinishSpecificationPart() {
 void ResolveNamesVisitor::CheckImports() {
   auto &scope{currScope()};
   switch (scope.GetImportKind()) {
-  case common::ImportKind::None: break;
+  case common::ImportKind::None:
+    break;
   case common::ImportKind::All:
     // C8102: all entities in host must not be hidden
     for (const auto &pair : scope.parent()) {
@@ -5782,7 +5959,7 @@ void ResolveNamesVisitor::CheckImport(
 }
 
 bool ResolveNamesVisitor::Pre(const parser::ImplicitStmt &x) {
-  return CheckNotInBlock("IMPLICIT") &&  // C1107
+  return CheckNotInBlock("IMPLICIT") && // C1107
       ImplicitRulesVisitor::Pre(x);
 }
 
@@ -5834,7 +6011,7 @@ void ResolveNamesVisitor::Post(const parser::TypeGuardStmt &x) {
   ConstructVisitor::Post(x);
 }
 bool ResolveNamesVisitor::Pre(const parser::StmtFunctionStmt &x) {
-  CheckNotInBlock("STATEMENT FUNCTION");  // C1107
+  CheckNotInBlock("STATEMENT FUNCTION"); // C1107
   if (HandleStmtFunction(x)) {
     return false;
   } else {
@@ -5866,7 +6043,9 @@ bool ResolveNamesVisitor::Pre(const parser::ProgramUnit &x) {
   SetScope(context().globalScope());
   ResolveSpecificationParts(root);
   FinishSpecificationParts(root);
+  inExecutionPart_ = true;
   ResolveExecutionParts(root);
+  inExecutionPart_ = false;
   ResolveOmpParts(x);
   return false;
 }
@@ -5876,7 +6055,7 @@ bool ResolveNamesVisitor::Pre(const parser::ProgramUnit &x) {
 class ExecutionPartSkimmer {
 public:
   explicit ExecutionPartSkimmer(ResolveNamesVisitor &resolver)
-    : resolver_{resolver} {}
+      : resolver_{resolver} {}
 
   void Walk(const parser::ExecutionPart *exec) {
     if (exec) {
@@ -5884,8 +6063,8 @@ public:
     }
   }
 
-  template<typename A> bool Pre(const A &) { return true; }
-  template<typename A> void Post(const A &) {}
+  template <typename A> bool Pre(const A &) { return true; }
+  template <typename A> void Post(const A &) {}
   void Post(const parser::FunctionReference &fr) {
     resolver_.NoteExecutablePartCall(Symbol::Flag::Function, fr.v);
   }
@@ -5901,11 +6080,11 @@ private:
 // node and its children
 void ResolveNamesVisitor::ResolveSpecificationParts(ProgramTree &node) {
   if (node.isSpecificationPartResolved()) {
-    return;  // been here already
+    return; // been here already
   }
   node.set_isSpecificationPartResolved();
   if (!BeginScopeForNode(node)) {
-    return;  // an error prevented scope from being created
+    return; // an error prevented scope from being created
   }
   Scope &scope{currScope()};
   node.set_scope(scope);
@@ -5969,8 +6148,11 @@ bool ResolveNamesVisitor::BeginScopeForNode(const ProgramTree &node) {
   case ProgramTree::Kind::Subroutine:
     return BeginSubprogram(
         node.name(), node.GetSubpFlag(), node.HasModulePrefix());
-  case ProgramTree::Kind::MpSubprogram: return BeginMpSubprogram(node.name());
-  case ProgramTree::Kind::Module: BeginModule(node.name(), false); return true;
+  case ProgramTree::Kind::MpSubprogram:
+    return BeginMpSubprogram(node.name());
+  case ProgramTree::Kind::Module:
+    BeginModule(node.name(), false);
+    return true;
   case ProgramTree::Kind::Submodule:
     return BeginSubmodule(node.name(), node.GetParentId());
   case ProgramTree::Kind::BlockData:
@@ -5986,12 +6168,12 @@ bool ResolveNamesVisitor::BeginScopeForNode(const ProgramTree &node) {
 class DeferredCheckVisitor {
 public:
   explicit DeferredCheckVisitor(ResolveNamesVisitor &resolver)
-    : resolver_{resolver} {}
+      : resolver_{resolver} {}
 
-  template<typename A> void Walk(const A &x) { parser::Walk(x, *this); }
+  template <typename A> void Walk(const A &x) { parser::Walk(x, *this); }
 
-  template<typename A> bool Pre(const A &) { return true; }
-  template<typename A> void Post(const A &) {}
+  template <typename A> bool Pre(const A &) { return true; }
+  template <typename A> void Post(const A &) {}
 
   void Post(const parser::DerivedTypeStmt &x) {
     const auto &name{std::get<parser::Name>(x.t)};
@@ -6200,7 +6382,7 @@ void OmpAttributeVisitor::ResolveSeqLoopIndexInParallelOrTaskConstruct(
   if (auto *symbol{ResolveOmp(iv, Symbol::Flag::OmpPrivate, targetIt->scope)}) {
     targetIt++;
     symbol->set(Symbol::Flag::OmpPreDetermined);
-    iv.symbol = symbol;  // adjust the symbol within region
+    iv.symbol = symbol; // adjust the symbol within region
     for (auto it{ompContext_.rbegin()}; it != targetIt; ++it) {
       AddToContextObjectWithDSA(*symbol, Symbol::Flag::OmpPrivate, *it);
     }
@@ -6259,8 +6441,8 @@ std::size_t OmpAttributeVisitor::GetAssociatedLoopLevelFromClauses(
     return orderedLevel;
   } else if (!orderedLevel && collapseLevel) {
     return collapseLevel;
-  }  // orderedLevel < collapseLevel is an error handled in structural checks
-  return 1;  // default is outermost loop
+  } // orderedLevel < collapseLevel is an error handled in structural checks
+  return 1; // default is outermost loop
 }
 
 // 2.15.1.1 Data-sharing Attribute Rules - Predetermined
@@ -6292,7 +6474,7 @@ void OmpAttributeVisitor::PrivatizeAssociatedLoopIndex(
     const parser::Name &iv{GetLoopIndex(*loop)};
     if (auto *symbol{ResolveOmp(iv, ivDSA, currScope())}) {
       symbol->set(Symbol::Flag::OmpPreDetermined);
-      iv.symbol = symbol;  // adjust the symbol within region
+      iv.symbol = symbol; // adjust the symbol within region
       AddToContextObjectWithDSA(*symbol, ivDSA);
     }
 
@@ -6358,7 +6540,7 @@ void OmpAttributeVisitor::Post(const parser::Name &name) {
       //       determined data-sharing attributes (2.15.1.1).
       if (Symbol * found{currScope().FindSymbol(name.source)}) {
         if (symbol != found) {
-          name.symbol = found;  // adjust the symbol within region
+          name.symbol = found; // adjust the symbol within region
         } else if (GetContext().defaultDSA == Symbol::Flag::OmpNone) {
           context_.Say(name.source,
               "The DEFAULT(NONE) clause requires that '%s' must be listed in "
@@ -6367,7 +6549,7 @@ void OmpAttributeVisitor::Post(const parser::Name &name) {
         }
       }
     }
-  }  // within OpenMP construct
+  } // within OpenMP construct
 }
 
 bool OmpAttributeVisitor::HasDataSharingAttributeObject(const Symbol &object) {
@@ -6428,7 +6610,7 @@ void OmpAttributeVisitor::ResolveOmpObject(
               }
             }
           },
-          [&](const parser::Name &name) {  // common block
+          [&](const parser::Name &name) { // common block
             if (auto *symbol{ResolveOmpCommonBlockName(&name)}) {
               CheckMultipleAppearances(
                   name, *symbol, Symbol::Flag::OmpCommonBlock);
@@ -6444,7 +6626,7 @@ void OmpAttributeVisitor::ResolveOmpObject(
                 }
               }
             } else {
-              context_.Say(name.source,  // 2.15.3
+              context_.Say(name.source, // 2.15.3
                   "COMMON block must be declared in the same scoping unit "
                   "in which the OpenMP directive or clause appears"_err_en_US);
             }
@@ -6474,7 +6656,7 @@ Symbol *OmpAttributeVisitor::ResolveOmp(
 Symbol *OmpAttributeVisitor::DeclarePrivateAccessEntity(
     const parser::Name &name, Symbol::Flag ompFlag, Scope &scope) {
   if (!name.symbol) {
-    return nullptr;  // not resolved by Name Resolution step, do nothing
+    return nullptr; // not resolved by Name Resolution step, do nothing
   }
   name.symbol = DeclarePrivateAccessEntity(*name.symbol, ompFlag, scope);
   return name.symbol;
@@ -6542,7 +6724,7 @@ void OmpAttributeVisitor::CheckMultipleAppearances(
 // the specification parts but before any of the execution parts.
 void ResolveNamesVisitor::FinishSpecificationParts(const ProgramTree &node) {
   if (!node.scope()) {
-    return;  // error occurred creating scope
+    return; // error occurred creating scope
   }
   SetScope(*node.scope());
   // The initializers of pointers, pointer components, and non-deferred
@@ -6550,7 +6732,7 @@ void ResolveNamesVisitor::FinishSpecificationParts(const ProgramTree &node) {
   // We do that now, when any (formerly) forward references that appear
   // in those initializers will resolve to the right symbols.
   DeferredCheckVisitor{*this}.Walk(node.spec());
-  DeferredCheckVisitor{*this}.Walk(node.exec());  // for BLOCK
+  DeferredCheckVisitor{*this}.Walk(node.exec()); // for BLOCK
   for (Scope &childScope : currScope().children()) {
     if (childScope.IsDerivedType() && !childScope.symbol()) {
       FinishDerivedTypeInstantiation(childScope);
@@ -6595,13 +6777,13 @@ void ResolveNamesVisitor::FinishDerivedTypeInstantiation(Scope &scope) {
 // Resolve names in the execution part of this node and its children
 void ResolveNamesVisitor::ResolveExecutionParts(const ProgramTree &node) {
   if (!node.scope()) {
-    return;  // error occurred creating scope
+    return; // error occurred creating scope
   }
   SetScope(*node.scope());
   if (const auto *exec{node.exec()}) {
     Walk(*exec);
   }
-  PopScope();  // converts unclassified entities into objects
+  PopScope(); // converts unclassified entities into objects
   for (const auto &child : node.children()) {
     ResolveExecutionParts(child);
   }
@@ -6650,4 +6832,4 @@ void ResolveSpecificationParts(
   visitor.ResolveSpecificationParts(node);
   context.set_location(std::move(originalLocation));
 }
-}
+} // namespace Fortran::semantics

--- a/lib/Semantics/semantics.cpp
+++ b/lib/Semantics/semantics.cpp
@@ -112,10 +112,23 @@ private:
   SemanticsContext &context_;
 };
 
+class EntryChecker : public virtual BaseChecker {
+public:
+  explicit EntryChecker(SemanticsContext &context) : context_{context} {}
+  void Leave(const parser::EntryStmt &) {
+    if (!context_.constructStack().empty()) {  // C1571
+      context_.Say("ENTRY may not appear in an executable construct"_err_en_US);
+    }
+  }
+
+private:
+  SemanticsContext &context_;
+};
+
 using StatementSemanticsPass1 = ExprChecker;
 using StatementSemanticsPass2 = SemanticsVisitor<AllocateChecker,
     ArithmeticIfStmtChecker, AssignmentChecker, CoarrayChecker, DataChecker,
-    DeallocateChecker, DoForallChecker, IfStmtChecker, IoChecker,
+    DeallocateChecker, DoForallChecker, EntryChecker, IfStmtChecker, IoChecker,
     NamelistChecker, NullifyChecker, OmpStructureChecker, PurityChecker,
     ReturnStmtChecker, StopChecker>;
 

--- a/lib/Semantics/symbol.cpp
+++ b/lib/Semantics/symbol.cpp
@@ -92,6 +92,12 @@ llvm::raw_ostream &operator<<(
       os << ", " << x.result_->attrs();
     }
   }
+  if (x.entryScope_) {
+    os << " entry";
+    if (x.entryScope_->symbol()) {
+      os << " in " << x.entryScope_->symbol()->name();
+    }
+  }
   char sep{'('};
   os << ' ';
   for (const Symbol *arg : x.dummyArgs_) {
@@ -316,15 +322,6 @@ bool Symbol::IsSubprogram() const {
           [](const auto &) { return false; },
       },
       details_);
-}
-
-bool Symbol::IsSeparateModuleProc() const {
-  if (attrs().test(Attr::MODULE)) {
-    if (auto *details{detailsIf<SubprogramDetails>()}) {
-      return details->isInterface();
-    }
-  }
-  return false;
 }
 
 bool Symbol::IsFromModFile() const {

--- a/lib/Semantics/tools.cpp
+++ b/lib/Semantics/tools.cpp
@@ -690,6 +690,15 @@ bool HasIntrinsicTypeName(const Symbol &symbol) {
   }
 }
 
+bool IsSeparateModuleProcedureInterface(const Symbol *symbol) {
+  if (symbol && symbol->attrs().test(Attr::MODULE)) {
+    if (auto *details{symbol->detailsIf<SubprogramDetails>()}) {
+      return details->isInterface();
+    }
+  }
+  return false;
+}
+
 bool IsFinalizable(const Symbol &symbol) {
   if (const DeclTypeSpec * type{symbol.GetType()}) {
     if (const DerivedTypeSpec * derived{type->AsDerived()}) {
@@ -729,11 +738,9 @@ bool IsAssumedLengthCharacter(const Symbol &symbol) {
 
 // C722 and C723:  For a function to be assumed length, it must be external and
 // of CHARACTER type
-bool IsAssumedLengthExternalCharacterFunction(const Symbol &symbol) {
-  return IsAssumedLengthCharacter(symbol) &&
-      ((symbol.has<SubprogramDetails>() && symbol.owner().IsGlobal()) ||
-          (symbol.test(Symbol::Flag::Function) &&
-              symbol.attrs().test(Attr::EXTERNAL)));
+bool IsExternal(const Symbol &symbol) {
+  return (symbol.has<SubprogramDetails>() && symbol.owner().IsGlobal()) ||
+      symbol.attrs().test(Attr::EXTERNAL);
 }
 
 const Symbol *IsExternalInPureContext(
@@ -1020,6 +1027,22 @@ const DeclTypeSpec &FindOrInstantiateDerivedType(Scope &scope,
   DeclTypeSpec &type{scope.MakeDerivedType(category, std::move(spec))};
   type.derivedTypeSpec().Instantiate(scope, semanticsContext);
   return type;
+}
+
+const Symbol *FindSeparateModuleSubprogramInterface(const Symbol *proc) {
+  if (proc) {
+    if (const Symbol * submodule{proc->owner().symbol()}) {
+      if (const auto *details{submodule->detailsIf<ModuleDetails>()}) {
+        if (const Scope * ancestor{details->ancestor()}) {
+          const Symbol *iface{ancestor->FindSymbol(proc->name())};
+          if (IsSeparateModuleProcedureInterface(iface)) {
+            return iface;
+          }
+        }
+      }
+    }
+  }
+  return nullptr;
 }
 
 // ComponentIterator implementation

--- a/test/Semantics/assign04.f90
+++ b/test/Semantics/assign04.f90
@@ -14,6 +14,7 @@ end
 
 ! C901
 subroutine s2(x)
+  !ERROR: A dummy argument may not also be a named constant
   real, parameter :: x = 0.0
   real, parameter :: a(*) = [1, 2, 3]
   character, parameter :: c(2) = "ab"

--- a/test/Semantics/entry01.f90
+++ b/test/Semantics/entry01.f90
@@ -1,0 +1,184 @@
+! RUN: %S/test_errors.sh %s %flang %t
+! Tests valid and invalid ENTRY statements
+
+module m1
+  !ERROR: ENTRY may appear only in a subroutine or function
+  entry badentryinmodule
+  interface
+    module subroutine separate
+    end subroutine
+  end interface
+ contains
+  subroutine modproc
+    entry entryinmodproc ! ok
+    block
+      !ERROR: ENTRY may not appear in an executable construct
+      entry badentryinblock ! C1571
+    end block
+    if (.true.) then
+      !ERROR: ENTRY may not appear in an executable construct
+      entry ibadconstr() ! C1571
+    end if
+   contains
+    subroutine internal
+      !ERROR: ENTRY may not appear in an internal subprogram
+      entry badentryininternal ! C1571
+    end subroutine
+  end subroutine
+end module
+
+submodule(m1) m1s1
+ contains
+  module procedure separate
+    !ERROR: ENTRY may not appear in a separate module procedure
+    entry badentryinsmp ! 1571
+  end procedure
+end submodule
+
+program main
+  !ERROR: ENTRY may appear only in a subroutine or function
+  entry badentryinprogram ! C1571
+end program
+
+block data bd1
+  !ERROR: ENTRY may appear only in a subroutine or function
+  entry badentryinbd ! C1571
+end block data
+
+subroutine subr(goodarg1)
+  real, intent(in) :: goodarg1
+  real :: goodarg2
+  !ERROR: A dummy argument may not also be a named constant
+  integer, parameter :: badarg1 = 1
+  type :: badarg2
+  end type
+  common /badarg3/ x
+  namelist /badarg4/ x
+  !ERROR: A dummy argument may not have the SAVE attribute
+  integer :: badarg5 = 2
+  entry okargs(goodarg1, goodarg2)
+  !ERROR: RESULT(br1) may appear only in a function
+  entry badresult() result(br1) ! C1572
+  !ERROR: ENTRY dummy argument 'badarg2' is previously declared as an item that may not be used as a dummy argument
+  !ERROR: ENTRY dummy argument 'badarg4' is previously declared as an item that may not be used as a dummy argument
+  entry badargs(badarg1,badarg2,badarg3,badarg4,badarg5)
+end subroutine
+
+function ifunc()
+  integer :: ifunc
+  integer :: ibad1
+  type :: ibad2
+  end type
+  save :: ibad3
+  real :: weird1
+  double precision :: weird2
+  complex :: weird3
+  logical :: weird4
+  character :: weird5
+  type(ibad2) :: weird6
+  integer :: iarr(1)
+  integer, allocatable :: alloc
+  integer, pointer :: ptr
+  entry iok1()
+  !ERROR: ENTRY name 'ibad1' may not be declared when RESULT() is present
+  entry ibad1() result(ibad1res) ! C1570
+  !ERROR: 'ibad2' was previously declared as an item that may not be used as a function result
+  entry ibad2()
+  !ERROR: ENTRY in a function may not have an alternate return dummy argument
+  entry ibadalt(*) ! C1573
+  !ERROR: RESULT(ifunc) may not have the same name as the function
+  entry isameres() result(ifunc) ! C1574
+  entry iok()
+  !ERROR: RESULT(iok) may not have the same name as an ENTRY in the function
+  entry isameres2() result(iok) ! C1574
+  entry isameres3() result(iok2) ! C1574
+  entry iok2()
+  !These cases are all acceptably incompatible
+  entry iok3() result(weird1)
+  entry iok4() result(weird2)
+  entry iok5() result(weird3)
+  entry iok6() result(weird4)
+  !ERROR: Result of ENTRY is not compatible with result of containing function
+  entry ibadt1() result(weird5)
+  !ERROR: Result of ENTRY is not compatible with result of containing function
+  entry ibadt2() result(weird6)
+  !ERROR: Result of ENTRY is not compatible with result of containing function
+  entry ibadt3() result(iarr)
+  !ERROR: Result of ENTRY is not compatible with result of containing function
+  entry ibadt4() result(alloc)
+  !ERROR: Result of ENTRY is not compatible with result of containing function
+  entry ibadt5() result(ptr)
+  call isubr
+  !ERROR: 'isubr' was previously called as a subroutine
+  entry isubr()
+  continue ! force transition to execution part
+  entry implicit()
+  implicit = 666 ! ok, just ensure that it works
+end function
+
+function chfunc() result(chr)
+  character(len=1) :: chr
+  character(len=2) :: chr1
+  !ERROR: Result of ENTRY is not compatible with result of containing function
+  entry chfunc1() result(chr1)
+end function
+
+subroutine externals
+  !ERROR: 'subr' is already defined as a global identifier
+  entry subr
+  !ERROR: 'ifunc' is already defined as a global identifier
+  entry ifunc
+  !ERROR: 'm1' is already defined as a global identifier
+  entry m1
+  !ERROR: 'iok1' is already defined as a global identifier
+  entry iok1
+  integer :: ix
+  ix = iproc()
+  !ERROR: 'iproc' was previously called as a function
+  entry iproc
+end subroutine
+
+module m2
+  external m2entry2
+ contains
+  subroutine m2subr1
+    entry m2entry1 ! ok
+    entry m2entry2 ! ok
+    entry m2entry3 ! ok
+  end subroutine
+end module
+
+subroutine usem2
+  use m2
+  interface
+    subroutine simplesubr
+    end subroutine
+  end interface
+  procedure(simplesubr), pointer :: p
+  p => m2subr1 ! ok
+  p => m2entry1 ! ok
+  p => m2entry2 ! ok
+  p => m2entry3 ! ok
+end subroutine
+
+module m3
+  interface
+    module subroutine m3entry1
+    end subroutine
+  end interface
+ contains
+  subroutine m3subr1
+    !ERROR: 'm3entry1' is already declared in this scoping unit
+    entry m3entry1
+  end subroutine
+end module
+
+function inone
+  implicit none
+  integer :: inone
+  !ERROR: No explicit type declared for 'implicitbad1'
+  entry implicitbad1
+  inone = 0 ! force transition to execution part
+  !ERROR: No explicit type declared for 'implicitbad2'
+  entry implicitbad2
+end


### PR DESCRIPTION
Checks the constraints and the feasible "shalls" in 15.6.2.6 for `ENTRY` statements, their dummy arguments, and their results.

Symbols for the entry points are created in the parent scope of the containing subprogram, and point to the scope of the containing subprogram.  Symbols for `ENTRY` results, when functions, are within the scope of the containing subprogram.

This PR checks semantics only; it doesn't do anything to represent sharing of dummy arguments, storage association of function results, &c.