### PR TITLE
[OpenMP] Avoid abort when collapse clause value is negative

### DIFF
--- a/test/Semantics/omp-clause-validity01.f90
+++ b/test/Semantics/omp-clause-validity01.f90
@@ -50,6 +50,15 @@
   enddo
   !$omp end parallel
 
+  !ERROR: The parameter of the COLLAPSE clause must be a constant positive integer expression
+  !$omp do collapse(-1)
+  do i = 1, N
+    do j = 1, N
+      a = 3.14
+    enddo
+  enddo
+  !$omp end do
+
   a = 1.0
   !$omp parallel firstprivate(a)
   do i = 1, N


### PR DESCRIPTION
If the value in the `collapse` close is negative f18 abort without the correct error message. This PR change the `size_t` in name resolution to a `int64_t` and check appropriately for negative or zero before the privatization of induction variable. 
The correct error is then catch by the OpenMP structure check.   