### PR TITLE
Complete semantics for ASSIGN

### DIFF
--- a/include/flang/Parser/parse-tree.h
+++ b/include/flang/Parser/parse-tree.h
@@ -2573,9 +2573,10 @@ struct CloseStmt {
 };
 
 // R1215 format -> default-char-expr | label | *
+// deprecated(ASSIGN): | scalar-int-name
 struct Format {
   UNION_CLASS_BOILERPLATE(Format);
-  std::variant<DefaultCharExpr, Label, Star> u;
+  std::variant<Expr, Label, Star> u;
 };
 
 // R1214 id-variable -> scalar-int-variable

--- a/lib/Parser/io-parsers.cpp
+++ b/lib/Parser/io-parsers.cpp
@@ -240,8 +240,9 @@ TYPE_CONTEXT_PARSER("PRINT statement"_en_US,
         "PRINT" >> format, defaulted("," >> nonemptyList(outputItem))))
 
 // R1215 format -> default-char-expr | label | *
+// deprecated(ASSIGN): | scalar-int-name
 TYPE_PARSER(construct<Format>(label / !"_."_ch) ||
-    construct<Format>(defaultCharExpr / !"="_tok) || construct<Format>(star))
+    construct<Format>(expr / !"="_tok) || construct<Format>(star))
 
 // R1216 input-item -> variable | io-implied-do
 TYPE_PARSER(construct<InputItem>(variable) ||

--- a/lib/Semantics/check-io.h
+++ b/lib/Semantics/check-io.h
@@ -81,9 +81,9 @@ public:
 private:
   // Presence flag values.
   ENUM_CLASS(Flag, IoControlList, InternalUnit, NumberUnit, StarUnit, CharFmt,
-      LabelFmt, StarFmt, FmtOrNml, KnownAccess, AccessDirect, AccessStream,
-      AdvanceYes, AsynchronousYes, KnownStatus, StatusNew, StatusReplace,
-      StatusScratch, DataList)
+      LabelFmt, StarFmt, AssignFmt, FmtOrNml, KnownAccess, AccessDirect,
+      AccessStream, AdvanceYes, AsynchronousYes, KnownStatus, StatusNew,
+      StatusReplace, StatusScratch, DataList)
 
   template <typename R, typename T> std::optional<R> GetConstExpr(const T &x) {
     using DefaultCharConstantType =

--- a/lib/Semantics/resolve-names.cpp
+++ b/lib/Semantics/resolve-names.cpp
@@ -1387,6 +1387,8 @@ public:
   bool Pre(const parser::StmtFunctionStmt &);
   bool Pre(const parser::DefinedOpName &);
   bool Pre(const parser::ProgramUnit &);
+  void Post(const parser::AssignStmt &);
+  void Post(const parser::AssignedGotoStmt &);
 
   // These nodes should never be reached: they are handled in ProgramUnit
   bool Pre(const parser::MainProgram &) { DIE("unreachable"); }
@@ -6054,6 +6056,17 @@ bool ResolveNamesVisitor::Pre(const parser::DefinedOpName &x) {
     MakePlaceholder(name, MiscDetails::Kind::TypeBoundDefinedOp);
   }
   return false;
+}
+
+void ResolveNamesVisitor::Post(const parser::AssignStmt &x) {
+  if (auto *name{ResolveName(std::get<parser::Name>(x.t))}) {
+    ConvertToObjectEntity(DEREF(name->symbol));
+  }
+}
+void ResolveNamesVisitor::Post(const parser::AssignedGotoStmt &x) {
+  if (auto *name{ResolveName(std::get<parser::Name>(x.t))}) {
+    ConvertToObjectEntity(DEREF(name->symbol));
+  }
 }
 
 bool ResolveNamesVisitor::Pre(const parser::ProgramUnit &x) {

--- a/lib/Semantics/rewrite-parse-tree.cpp
+++ b/lib/Semantics/rewrite-parse-tree.cpp
@@ -132,7 +132,7 @@ void RewriteMutator::Post(parser::IoUnit &x) {
 template <typename READ_OR_WRITE>
 void FixMisparsedUntaggedNamelistName(READ_OR_WRITE &x) {
   if (x.iounit && x.format &&
-      std::holds_alternative<parser::DefaultCharExpr>(x.format->u)) {
+      std::holds_alternative<parser::Expr>(x.format->u)) {
     if (const parser::Name * name{parser::Unwrap<parser::Name>(x.format)}) {
       if (name->symbol && name->symbol->GetUltimate().has<NamelistDetails>()) {
         x.controls.emplace_front(parser::IoControlSpec{std::move(*name)});

--- a/test/Semantics/assign06.f90
+++ b/test/Semantics/assign06.f90
@@ -1,0 +1,47 @@
+! RUN: %B/test/Semantics/test_errors.sh %s %flang %t
+! Test ASSIGN statement, assigned GOTO, and assigned format labels
+! (see subclause 8.2.4 in Fortran 90 (*not* 2018!)
+
+program main
+  call test(0)
+ contains
+  subroutine test(n)
+    integer, intent(in) :: n
+    integer :: lab
+    integer(kind=1) :: badlab1
+    real :: badlab2
+    integer :: badlab3(1)
+    assign 1 to lab ! ok
+    assign 1 to implicitlab1 ! ok
+    !ERROR: 'badlab1' must be a default integer scalar variable
+    assign 1 to badlab1
+    !ERROR: 'badlab2' must be a default integer scalar variable
+    assign 1 to badlab2
+    !ERROR: 'badlab3' must be a default integer scalar variable
+    assign 1 to badlab3
+    !ERROR: 'test' must be a default integer scalar variable
+    assign 1 to test
+    if (n==1) goto lab ! ok
+    if (n==1) goto implicitlab2 ! ok
+    !ERROR: 'badlab1' must be a default integer scalar variable
+    if (n==1) goto badlab1
+    !ERROR: 'badlab2' must be a default integer scalar variable
+    if (n==1) goto badlab2
+    !ERROR: 'badlab3' must be a default integer scalar variable
+    if (n==1) goto badlab3
+    if (n==1) goto lab(1) ! ok
+    if (n==1) goto lab,(1) ! ok
+    if (n==1) goto lab(1,1) ! ok
+    assign 3 to lab ! ok
+    write(*,fmt=lab) ! ok
+    write(*,fmt=implicitlab3) ! ok
+    !ERROR: Format expression must be default character or integer
+    write(*,fmt=badlab1)
+    !ERROR: Format expression must be default character or integer
+    write(*,fmt=badlab2)
+    !ERROR: Format expression must be default character or integer
+    write(*,fmt=badlab2)
+1   continue
+3   format('yes')
+  end subroutine test
+end program

--- a/test/Semantics/assign07.f90
+++ b/test/Semantics/assign07.f90
@@ -1,0 +1,35 @@
+! RUN: %B/test/Semantics/test_errors.sh %s %flang %t
+! Test ASSIGN statement, assigned GOTO, and assigned format labels
+! (see subclause 8.2.4 in Fortran 90 (*not* 2018!)
+
+program main
+  call test(0)
+2 format('no')
+ contains
+  subroutine test(n)
+    !ERROR: Label '4' is not a branch target or FORMAT
+4   integer, intent(in) :: n
+    integer :: lab
+    assign 1 to lab ! ok
+    assign 1 to implicitlab1 ! ok
+    !ERROR: Label '666' was not found
+    assign 666 to lab
+    !ERROR: Label '2' was not found
+    assign 2 to lab
+    assign 4 to lab
+    if (n==1) goto lab ! ok
+    if (n==1) goto implicitlab2 ! ok
+    if (n==1) goto lab(1) ! ok
+    if (n==1) goto lab,(1) ! ok
+    if (n==1) goto lab(1,1) ! ok
+    !ERROR: Label '666' was not found
+    if (n==1) goto lab(1,666)
+    !ERROR: Label '2' was not found
+    if (n==1) goto lab(1,2)
+    assign 3 to lab
+    write(*,fmt=lab) ! ok
+    write(*,fmt=implicitlab3) ! ok
+1   continue
+3   format('yes')
+  end subroutine test
+end program

--- a/test/Semantics/if_arith03.f90
+++ b/test/Semantics/if_arith03.f90
@@ -1,19 +1,19 @@
 ! RUN: %B/test/Semantics/test_errors.sh %s %flang %t
 
 
-!ERROR: label '600' was not found
+!ERROR: Label '600' was not found
 if ( A ) 100, 200, 600
 100 CONTINUE
 200 CONTINUE
 300 CONTINUE
 
-!ERROR: label '601' was not found
+!ERROR: Label '601' was not found
 if ( A ) 101, 601, 301
 101 CONTINUE
 201 CONTINUE
 301 CONTINUE
 
-!ERROR: label '602' was not found
+!ERROR: Label '602' was not found
 if ( A ) 602, 202, 302
 102 CONTINUE
 202 CONTINUE

--- a/test/Semantics/label02.f90
+++ b/test/Semantics/label02.f90
@@ -2,11 +2,11 @@
 ! negative test -- invalid labels, out of range
 
 ! EXEC: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
-! CHECK: label '0' is out of range
-! CHECK: label '100000' is out of range
-! CHECK: label '123456' is out of range
-! CHECK: label '123456' was not found
-! CHECK: label '1000' is not distinct
+! CHECK: Label '0' is out of range
+! CHECK: Label '100000' is out of range
+! CHECK: Label '123456' is out of range
+! CHECK: Label '123456' was not found
+! CHECK: Label '1000' is not distinct
 
 subroutine sub00(a,b,n,m)
   real a(n)

--- a/test/Semantics/label03.f90
+++ b/test/Semantics/label03.f90
@@ -4,9 +4,9 @@
 ! EXEC: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
 ! CHECK: DO loop doesn't properly nest
 ! CHECK: DO loop conflicts
-! CHECK: label '30' cannot be found
-! CHECK: label '40' cannot be found
-! CHECK: label '50' doesn't lexically follow DO stmt
+! CHECK: Label '30' cannot be found
+! CHECK: Label '40' cannot be found
+! CHECK: Label '50' doesn't lexically follow DO stmt
 
 subroutine sub00(a,b,n,m)
   real a(n,m)

--- a/test/Semantics/label05.f90
+++ b/test/Semantics/label05.f90
@@ -2,10 +2,10 @@
 ! negative test -- invalid labels, out of range
 
 ! EXEC: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
-! CHECK: label '50' was not found
-! CHECK: label '55' is not in scope
-! CHECK: '70' not a branch target
-! CHECK: control flow use of '70'
+! CHECK: Label '50' was not found
+! CHECK: Label '55' is not in scope
+! CHECK: Label '70' is not a branch target
+! CHECK: Control flow use of '70'
 
 subroutine sub00(a,b,n,m)
   real a(n,m)

--- a/test/Semantics/label06.f90
+++ b/test/Semantics/label06.f90
@@ -2,12 +2,12 @@
 ! negative test -- invalid labels, out of range
 
 ! EXEC: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
-! CHECK: label '10' is not in scope
-! CHECK: label '20' was not found
-! CHECK: '30' not a branch target
-! CHECK: control flow use of '30'
-! CHECK: label '40' is not in scope
-! CHECK: label '50' is not in scope
+! CHECK: Label '10' is not in scope
+! CHECK: Label '20' was not found
+! CHECK: Label '30' is not a branch target
+! CHECK: Control flow use of '30'
+! CHECK: Label '40' is not in scope
+! CHECK: Label '50' is not in scope
 
 subroutine sub00(n)
   GOTO (10,20,30) n

--- a/test/Semantics/label07.f90
+++ b/test/Semantics/label07.f90
@@ -2,11 +2,11 @@
 ! negative test -- invalid labels, out of range
 
 ! EXEC: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
-! CHECK: '30' not a branch target
-! CHECK: control flow use of '30'
-! CHECK: label '10' is not in scope
-! CHECK: label '20' was not found
-! CHECK: label '60' was not found
+! CHECK: Label '30' is not a branch target
+! CHECK: Control flow use of '30'
+! CHECK: Label '10' is not in scope
+! CHECK: Label '20' was not found
+! CHECK: Label '60' was not found
 
 subroutine sub00(n,m)
 30 format (i6,f6.2)

--- a/test/Semantics/label09.f90
+++ b/test/Semantics/label09.f90
@@ -1,6 +1,6 @@
 ! RUN: %S/test_any.sh %s %flang %t
 ! EXEC: ${F18} -funparse-with-symbols %s 2>&1 | ${FileCheck} %s
-! CHECK: label '60' was not found
+! CHECK: Label '60' was not found
 
 subroutine s(a)
   real a(10)

--- a/test/Semantics/label14.f90
+++ b/test/Semantics/label14.f90
@@ -4,7 +4,7 @@
 !            Block Construct
 
 ! EXEC: ${F18} %s 2>&1 | ${FileCheck} %s
-! CHECK: label '20' is not in scope
+! CHECK: Label '20' is not in scope
 
 subroutine s1
   block


### PR DESCRIPTION
Ensure name resolution of names in ASSIGN and assigned GOTO statements.

Semantic checking of ASSIGN and assigned GOTO statements.

Allow an assigned scalar default integer variable as a format.

Capitalize some error messages.

Two new tests (one has label resolution errors, one has other errors; split so that label resolution errors don't preclude the other checks).