### PR TITLE
Check for constrains C741 through C749

### DIFF
--- a/lib/Semantics/check-declarations.cpp
+++ b/lib/Semantics/check-declarations.cpp
@@ -385,12 +385,16 @@ void CheckHelper::CheckObjectEntity(
   symbolBeingChecked_ = nullptr;
   if (!details.coshape().empty()) {
     if (IsAllocatable(symbol)) {
-      if (!details.coshape().IsDeferredShape()) { // C827
+      if (!details.coshape().IsDeferredShape()) { // C746, C827
         messages_.Say(
             "ALLOCATABLE coarray must have a deferred coshape"_err_en_US);
       }
+    } else if (symbol.owner().IsDerivedType()) { // C746
+      messages_.Say(
+          "Coarray components must be ALLOCATABLE and have a deferred "
+          "coshape"_err_en_US);
     } else {
-      if (!details.coshape().IsAssumedSize()) { // C828
+      if (!details.coshape().IsAssumedSize()) { // C746, C828
         messages_.Say(
             "Non-ALLOCATABLE coarray must have an explicit coshape"_err_en_US);
       }

--- a/test/Semantics/allocate11.f90
+++ b/test/Semantics/allocate11.f90
@@ -5,19 +5,6 @@
 
 ! Rules I should know when working with coarrays and derived type:
 
-! C736: If EXTENDS appears and the type being defined has a coarray ultimate
-! component, its parent type shall have a coarray ultimate component.
-
-! C746: (R737) If a coarray-spec appears, it shall be a deferred-coshape-spec-list
-! and the component shall have the ALLOCATABLE attribute.
-
-! C747: If a coarray-spec appears, the component shall not be of type C_PTR or
-! C_FUNPTR from the intrinsic module ISO_C_BINDING (18.2), or of type TEAM_TYPE from the
-! intrinsic module ISO_FORTRAN_ENV (16.10.2).
-
-! C748: A data component whose type has a coarray ultimate component shall be a
-! nonpointer nonallocatable scalar and shall not be a coarray.
-
 ! 7.5.4.3 Coarray components
 ! 7.5.6 Final subroutines: C786
 
@@ -38,7 +25,6 @@ subroutine C937(var)
 
   type B
     type(A) y
-    type(B), pointer :: forward
     real :: u
   end type
 
@@ -47,7 +33,7 @@ subroutine C937(var)
   end type
 
   type D
-    type(A), pointer :: potential
+    type(A) :: potential
   end type
 
 
@@ -65,9 +51,6 @@ subroutine C937(var)
   !        => if var can be defined, it can only be unlimited polymorphic
 
   ! Also, as per C826 or C852, var can only be an allocatable, not a pointer
-
-  ! OK, x is not an ultimate component
-  allocate(D:: var)
 
   !ERROR: Type-spec in ALLOCATE must not specify a type with a coarray ultimate component
   allocate(A:: var)

--- a/test/Semantics/call12.f90
+++ b/test/Semantics/call12.f90
@@ -15,7 +15,7 @@ module m
     real, pointer :: p
   end type
   type :: hasCoarray
-    real :: co[*]
+    real, allocatable :: co[:]
   end type
  contains
   pure function test(ptr, in, hpd)

--- a/test/Semantics/call14.f90
+++ b/test/Semantics/call14.f90
@@ -3,7 +3,7 @@
 
 module m
   type :: hasCoarray
-    real :: coarray[*]
+    real, allocatable :: coarray[:]
   end type
  contains
   !ERROR: VALUE attribute may apply only to a dummy data object

--- a/test/Semantics/misc-declarations.f90
+++ b/test/Semantics/misc-declarations.f90
@@ -9,7 +9,7 @@ module m
   !ERROR: Non-ALLOCATABLE coarray must have an explicit coshape
   real :: mustBeExplicit[:]  ! C828
   type :: hasCoarray
-    real :: coarray[*]
+    real, allocatable :: coarray[:]
   end type
   real :: coarray[*]
   type(hasCoarray) :: coarrayComponent

--- a/test/Semantics/modfile24.f90
+++ b/test/Semantics/modfile24.f90
@@ -36,8 +36,8 @@ end
 ! coarray-spec in components and with non-constants bounds
 module m3
   type t
-    real :: c[1:10,1:*]
-    complex, codimension[5,*] :: d
+    real, allocatable :: c[:,:]
+    complex, allocatable, codimension[:,:] :: d
   end type
   real, allocatable :: e[:,:,:]
 contains
@@ -50,8 +50,8 @@ end
 !Expect: m3.mod
 !module m3
 ! type::t
-!  real(4)::c[1_8:10_8,1_8:*]
-!  complex(4)::d[1_8:5_8,1_8:*]
+!  real(4),allocatable::c[:,:]
+!  complex(4),allocatable::d[:,:]
 ! end type
 ! real(4),allocatable::e[:,:,:]
 !contains

--- a/test/Semantics/resolve33.f90
+++ b/test/Semantics/resolve33.f90
@@ -2,7 +2,13 @@
 ! Derived type parameters
 ! C731 The same type-param-name shall not appear more than once in a given
 ! derived-type-stmt.
-
+! C741 A type-param-name in a type-param-def-stmt in a derived-type-def shall
+! be one of the type-paramnames in the derived-type-stmt of that
+! derived-type-def.
+! C742 Each type-param-name in the derived-type-stmt in a derived-type-def
+! shall appear exactly once as a type-param-name in a type-param-def-stmt 
+! in that derived-type-def .
+ 
 module m
   !ERROR: Duplicate type parameter name: 'a'
   type t1(a, b, a)

--- a/test/Semantics/resolve44.f90
+++ b/test/Semantics/resolve44.f90
@@ -1,5 +1,8 @@
 ! RUN: %B/test/Semantics/test_errors.sh %s %flang %t
 ! Error tests for recursive use of derived types.
+! C744 If neither the POINTER nor the ALLOCATABLE attribute is specified, the
+! declaration-type-spec in the component-def-stmt shall specify an intrinsic
+! type or a previously defined derived type.
 
 program main
   type :: recursive1

--- a/test/Semantics/resolve88.f90
+++ b/test/Semantics/resolve88.f90
@@ -1,0 +1,73 @@
+! RUN: %B/test/Semantics/test_errors.sh %s %flang %t
+! C746, C747, and C748
+module m
+  use ISO_FORTRAN_ENV
+  use ISO_C_BINDING
+
+  ! C746 If a coarray-spec appears, it shall be a deferred-coshape-spec-list and
+  ! the component shall have the ALLOCATABLE attribute.
+
+  type testCoArrayType
+    real, allocatable, codimension[:] :: allocatableField
+    !ERROR: Coarray components must be ALLOCATABLE and have a deferred coshape
+    real, codimension[:] :: deferredField
+    !ERROR: 'pointerfield' may not have the POINTER attribute because it is a coarray
+    !ERROR: Coarray components must be ALLOCATABLE and have a deferred coshape
+    real, pointer, codimension[:] :: pointerField
+    !ERROR: Coarray components must be ALLOCATABLE and have a deferred coshape
+    real, codimension[*] :: realField
+  end type testCoArrayType
+
+  ! C747 If a coarray-spec appears, the component shall not be of type C_PTR or
+  ! C_FUNPTR from the intrinsic module ISO_C_BINDING (18.2), or of type 
+  ! TEAM_TYPE from the intrinsic module ISO_FORTRAN_ENV (16.10.2).
+
+  type goodCoarrayType
+    real, allocatable, codimension[:] :: field
+  end type goodCoarrayType
+
+  type goodTeam_typeCoarrayType
+    type(team_type), allocatable :: field
+  end type goodTeam_typeCoarrayType
+
+  type goodC_ptrCoarrayType
+    type(c_ptr), allocatable :: field
+  end type goodC_ptrCoarrayType
+
+  type goodC_funptrCoarrayType
+    type(c_funptr), allocatable :: field
+  end type goodC_funptrCoarrayType
+
+  type team_typeCoarrayType
+    !ERROR: A coarray component may not be of type TEAM_TYPE from ISO_FORTRAN_ENV
+    type(team_type), allocatable, codimension[:] :: field
+  end type team_typeCoarrayType
+
+  type c_ptrCoarrayType
+    !ERROR: A coarray component may not be of C_PTR or C_FUNPTR from ISO_C_BINDING when an allocatable object is a coarray
+    type(c_ptr), allocatable, codimension[:] :: field
+  end type c_ptrCoarrayType
+
+  type c_funptrCoarrayType
+    !ERROR: A coarray component may not be of C_PTR or C_FUNPTR from ISO_C_BINDING when an allocatable object is a coarray
+    type(c_funptr), allocatable, codimension[:] :: field
+  end type c_funptrCoarrayType
+
+! C748 A data component whose type has a coarray ultimate component shall be a
+! nonpointer nonallocatable scalar and shall not be a coarray.
+
+  type coarrayType
+    real, allocatable, codimension[:] :: goodCoarrayField
+  end type coarrayType
+
+  type testType
+    type(coarrayType) :: goodField
+    !ERROR: A component whose type has a coarray ultimate component cannot be a POINTER or ALLOCATABLE
+    type(coarrayType), pointer :: pointerField
+    !ERROR: A component whose type has a coarray ultimate component cannot be a POINTER or ALLOCATABLE
+    type(coarrayType), allocatable :: allocatableField
+    !ERROR: A component whose type has a coarray ultimate component cannot be an array or corray
+    type(coarrayType), dimension(3) :: arrayField
+  end type testType
+
+end module m


### PR DESCRIPTION
Most of these checks were already implemented and I just added references to
them to the code and tests.

I implemented the check for C747 to not allow coarray components in derived
types that are of type C_PTR, C_FUNPTR, or type TEAM_TYPE.

I implemented the check for C748 that requires a data component whose type has
a coarray ultimate component to be a nonpointer, nonallocatable scalar and not
be a coarray.

I also fixed some unrelated tests that got new errors when I implemented these
new checks.