### PR TITLE
Add message formatting for std::int64_t

### DIFF
--- a/include/flang/Parser/message.h
+++ b/include/flang/Parser/message.h
@@ -101,6 +101,7 @@ private:
   const char *Convert(std::string &&);
   const char *Convert(CharBlock);
   std::intmax_t Convert(std::int64_t x) { return x; }
+  std::uintmax_t Convert(std::uint64_t x) { return x; }
 
   bool isFatal_{false};
   std::string string_;

--- a/include/flang/Parser/message.h
+++ b/include/flang/Parser/message.h
@@ -100,6 +100,7 @@ private:
   const char *Convert(std::string &);
   const char *Convert(std::string &&);
   const char *Convert(CharBlock);
+  std::intmax_t Convert(std::int64_t x) { return x; }
 
   bool isFatal_{false};
   std::string string_;

--- a/lib/Evaluate/fold-implementation.h
+++ b/lib/Evaluate/fold-implementation.h
@@ -275,7 +275,7 @@ std::optional<Constant<T>> Folder<T>::ApplySubscripts(const Constant<T> &array,
       if (at[j] < lbounds[j] || at[j] >= lbounds[j] + shape[j]) {
         context_.messages().Say(
             "Subscript value (%jd) is out of range on dimension %d in reference to a constant array value"_err_en_US,
-            static_cast<std::intmax_t>(at[j]), j + 1);
+            at[j], j + 1);
         return std::nullopt;
       }
     }

--- a/lib/Evaluate/fold-integer.cpp
+++ b/lib/Evaluate/fold-integer.cpp
@@ -24,7 +24,7 @@ Expr<Type<TypeCategory::Integer, KIND>> LBOUND(FoldingContext &context,
           if (*dim64 < 1 || *dim64 > rank) {
             context.messages().Say("DIM=%jd dimension is out of range for "
                                    "rank-%d array"_en_US,
-                static_cast<std::intmax_t>(*dim64), rank);
+                *dim64, rank);
             return MakeInvalidIntrinsic<T>(std::move(funcRef));
           } else {
             dim = *dim64 - 1; // 1-based to 0-based
@@ -79,7 +79,7 @@ Expr<Type<TypeCategory::Integer, KIND>> UBOUND(FoldingContext &context,
           if (*dim64 < 1 || *dim64 > rank) {
             context.messages().Say("DIM=%jd dimension is out of range for "
                                    "rank-%d array"_en_US,
-                static_cast<std::intmax_t>(*dim64), rank);
+                *dim64, rank);
             return MakeInvalidIntrinsic<T>(std::move(funcRef));
           } else {
             dim = *dim64 - 1; // 1-based to 0-based
@@ -572,7 +572,7 @@ Expr<Type<TypeCategory::Integer, KIND>> FoldIntrinsicFunction(
           } else {
             context.messages().Say(
                 "size(array,dim=%jd) dimension is out of range for rank-%d array"_en_US,
-                static_cast<std::intmax_t>(*dim), static_cast<int>(rank));
+                *dim, rank);
           }
         }
       } else if (auto extents{common::AllElementsPresent(std::move(*shape))}) {

--- a/lib/Evaluate/shape.cpp
+++ b/lib/Evaluate/shape.cpp
@@ -642,8 +642,7 @@ bool CheckConformance(parser::ContextualMessages &messages, const Shape &left,
             if (*leftDim != *rightDim) {
               messages.Say("Dimension %1$d of %2$s has extent %3$jd, "
                            "but %4$s has extent %5$jd"_err_en_US,
-                  j + 1, leftIs, static_cast<std::intmax_t>(*leftDim), rightIs,
-                  static_cast<std::intmax_t>(*rightDim));
+                  j + 1, leftIs, *leftDim, rightIs, *rightDim);
               return false;
             }
           }

--- a/lib/Evaluate/variable.cpp
+++ b/lib/Evaluate/variable.cpp
@@ -168,8 +168,7 @@ std::optional<Expr<SomeCharacter>> Substring::Fold(FoldingContext &context) {
   std::optional<ConstantSubscript> lbi{ToInt64(lower_.value().value())};
   if (lbi && *lbi < 1) {
     context.messages().Say(
-        "Lower bound (%jd) on substring is less than one"_en_US,
-        static_cast<std::intmax_t>(*lbi));
+        "Lower bound (%jd) on substring is less than one"_en_US, *lbi);
     *lbi = 1;
     lower_ = AsExpr(Constant<SubscriptInteger>{1});
   }
@@ -200,8 +199,7 @@ std::optional<Expr<SomeCharacter>> Substring::Fold(FoldingContext &context) {
     } else if (length && *ubi > *length) {
       context.messages().Say("Upper bound (%jd) on substring is greater "
                              "than character length (%jd)"_en_US,
-          static_cast<std::intmax_t>(*ubi),
-          static_cast<std::intmax_t>(*length));
+          *ubi, *length);
       *ubi = *length;
     }
     if (lbi && literal) {

--- a/lib/Semantics/assignment.cpp
+++ b/lib/Semantics/assignment.cpp
@@ -242,7 +242,7 @@ void AssignmentContext::CheckShape(parser::CharBlock at, const SomeExpr *expr) {
           Say(at,
               "Dimension %d must have extent %jd to match prior mask or"
               " assignment of WHERE construct"_err_en_US,
-              i + 1, static_cast<std::intmax_t>(*whereExtents_[i]));
+              i + 1, *whereExtents_[i]);
         }
       }
     }

--- a/lib/Semantics/check-io.cpp
+++ b/lib/Semantics/check-io.cpp
@@ -166,7 +166,7 @@ void IoChecker::Enter(const parser::ConnectSpec::Recl &spec) {
     if (*recl <= 0) {
       context_.Say(parser::FindSourceLocation(spec),
           "RECL value (%jd) must be positive"_err_en_US,
-          std::move(static_cast<std::intmax_t>(*recl))); // 12.5.6.15
+          *recl); // 12.5.6.15
     }
   }
 }

--- a/lib/Semantics/resolve-names.cpp
+++ b/lib/Semantics/resolve-names.cpp
@@ -3508,8 +3508,7 @@ void DeclarationVisitor::Post(const parser::CharSelector::LengthAndKind &x) {
       !evaluate::IsValidKindOfIntrinsicType(
           TypeCategory::Character, *intKind)) { // C715, C719
     Say(currStmtSource().value(),
-        "KIND value (%jd) not valid for CHARACTER"_err_en_US,
-        static_cast<std::intmax_t>(*intKind));
+        "KIND value (%jd) not valid for CHARACTER"_err_en_US, *intKind);
   }
   if (x.length) {
     charInfo_.length = GetParamValue(*x.length, common::TypeParamAttr::Len);

--- a/lib/Semantics/symbol.cpp
+++ b/lib/Semantics/symbol.cpp
@@ -571,7 +571,7 @@ static const DeclTypeSpec &InstantiateIntrinsicType(Scope &scope,
       foldingContext.messages().Say(
           "KIND parameter value (%jd) of intrinsic type %s "
           "did not resolve to a supported value"_err_en_US,
-          static_cast<std::intmax_t>(*value),
+          *value,
           parser::ToUpperCaseLetters(
               common::EnumToString(intrinsic.category())));
     }


### PR DESCRIPTION
There is no printf formatting string for `std::int64_t`. Instead we have
to cast to `std::intmax_t` and use `%jd`. This change simplifies that by
automatically converting `std::int64_t` to `std::intmax_t `when formatting
messages.

This follows the pattern of `std::string` and `parser::CharBlock`, which are
formatted with `%s`.