### PR TITLE
Add dependencies on LLVM utilities (FileCheck) for running flang tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,6 +18,7 @@ set(FLANG_TEST_PARAMS
   flang_site_config=${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py)
 
 set(FLANG_TEST_DEPENDS
+  FileCheck count not
   f18
 )
 


### PR DESCRIPTION
Without this, `ninja check-flang` fails with:

llvm-project/llvm/utils/lit/lit/llvm/subst.py:134: fatal: Did not find FileCheck in...