### PR TITLE
Add dependency on libSemantics to libEvaluate to solve linker issues.

### DIFF
--- a/lib/Evaluate/CMakeLists.txt
+++ b/lib/Evaluate/CMakeLists.txt
@@ -32,6 +32,7 @@ target_compile_features(FortranEvaluate PUBLIC cxx_std_17)
 target_link_libraries(FortranEvaluate
   FortranCommon
   FortranDecimal
+  FortranSemantics
   FortranParser
 )
 


### PR DESCRIPTION
When building with LLVM HEAD, the unittests fail to link with ld.bfd
or ld.gold due to a linker ordering issue. Adding libSemantics as a
dependency to libEvaluate seems to fix that issue.